### PR TITLE
feat: add context menus and commands for running playbooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,7 @@
 {
   "activationEvents": [
+    "onCommand:extension.ansible-navigator.run",
+    "onCommand:extension.ansible-playbook.run",
     "onLanguage:ansible"
   ],
   "badges": [
@@ -30,6 +32,18 @@
     }
   ],
   "contributes": {
+    "commands": [
+      {
+        "category": "%commands.category.ansible-playbook%",
+        "command": "extension.ansible-playbook.run",
+        "title": "%commands.title.ansible-playbook%"
+      },
+      {
+        "category": "%commands.category.ansible-playbook%",
+        "command": "extension.ansible-navigator.run",
+        "title": "%commands.title.ansible-navigator%"
+      }
+    ],
     "configuration": {
       "type": "object",
       "title": "Ansible",
@@ -75,6 +89,24 @@
           "type": "string",
           "default": "",
           "description": "Path to the virtual environment activation script. Use only if you have a custom activation script. It will be sourced using bash before executing Ansible commands. If set, the Interpreter Path setting is ignored."
+        },
+        "ansible.ansibleNavigator.path": {
+          "default": "ansible-navigator",
+          "description": "%configuration.navigate.executablePath%",
+          "scope": "machine-overridable",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "ansible.ansiblePlaybook.path": {
+          "default": "ansible-playbook",
+          "description": "%configuration.run.executablePath%",
+          "scope": "machine-overridable",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       }
     },
@@ -95,6 +127,36 @@
         "comments": "unfortunately this dummy entry is necessary for embedding to work",
         "id": "ansible-jinja",
         "configuration": "./jinja-language-configuration.json"
+      }
+    ],
+    "menus": {
+      "ansible.playbook.run": [
+        {
+          "command": "extension.ansible-navigator.run"
+        },
+        {
+          "command": "extension.ansible-playbook.run"
+        }
+      ],
+      "editor/context": [
+        {
+          "group": "2_main@1",
+          "submenu": "ansible.playbook.run",
+          "when": "isFileSystemResource && editorLangId == ansible"
+        }
+      ],
+      "explorer/context": [
+        {
+          "group": "2_main@1",
+          "submenu": "ansible.playbook.run",
+          "when": "isFileSystemResource && resourceLangId == ansible"
+        }
+      ]
+    },
+    "submenus": [
+      {
+        "id": "ansible.playbook.run",
+        "label": "%submenus.ansible.run-via%"
       }
     ],
     "grammars": [

--- a/package.nls.json
+++ b/package.nls.json
@@ -1,5 +1,10 @@
 {
   "command.untrustValidationExecutable": "Disallow ansible-lint validation executable (defined as workspace setting)",
+  "commands.category.ansible-playbook": "Ansible Playbook",
+  "commands.title.ansible-navigator": "Run playbook via `ansible-navigator run`",
+  "commands.title.ansible-playbook": "Run playbook via `ansible-playbook`",
+  "configuration.navigate.executablePath": "Points to the ansible-navigator executable.",
+  "configuration.run.executablePath": "Points to the ansible-playbook executable.",
   "configuration.suggest.basic": "Controls whether the built-in Ansible language suggestions are enabled. The support suggests Ansible globals and variables.",
   "configuration.title": "Ansible",
   "configuration.validate.enable": "Enable/disable ansible-lint validation.",
@@ -7,5 +12,6 @@
   "configuration.validate.run": "Whether the linter is run on save or on type.",
   "configuration.vault.executablePath": "Points to the ansible-vault executable.",
   "description": "Provides rich language support for Ansible files.",
-  "displayName": "Ansible Language Features"
+  "displayName": "Ansible Language Features",
+  "submenus.ansible.run-via": "Run Ansible Playbook via..."
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,8 @@
+/* "stdlib" */
 import * as path from 'path';
 import { ExtensionContext } from 'vscode';
 
+/* third-party */
 import {
   LanguageClient,
   LanguageClientOptions,
@@ -8,9 +10,15 @@ import {
   TransportKind,
 } from 'vscode-languageclient/node';
 
+/* local */
+import { AnsiblePlaybookRunProvider } from './features/runner';
+
+
 let client: LanguageClient;
 
 export function activate(context: ExtensionContext): void {
+  new AnsiblePlaybookRunProvider(context);
+
   const serverModule = context.asAbsolutePath(
     path.join('out', 'server', 'src', 'server.js')
   );

--- a/src/features/runner.ts
+++ b/src/features/runner.ts
@@ -1,0 +1,156 @@
+/* "stdlib" */
+import * as vscode from 'vscode';
+
+
+/**
+ * A set of commands and context menu items for running Ansible playbooks using
+ * `ansible-navigator run` and `ansible-playbook` commands.
+ */
+export class AnsiblePlaybookRunProvider {
+    private disposableTerminal: vscode.Terminal | undefined;
+    constructor(private vsCodeExtCtx: vscode.ExtensionContext) {
+        // this.disposableTerminal = this.makeTerminal();
+        this.configureCommands();
+    }
+
+    /**
+     * Register a set of command callbacks for executing Ansible playbooks
+     * within VS Code.
+     */
+    private configureCommands() {
+        this.vsCodeExtCtx.subscriptions.push(
+            vscode.commands.registerCommand(
+                'extension.ansible-playbook.run',
+                fileObj => this.makeCmdRunner()(fileObj),
+            ),
+        );
+        console.debug('Added a "Run Ansible Playbook" command...');
+        this.vsCodeExtCtx.subscriptions.push(
+            vscode.commands.registerCommand(
+                'extension.ansible-navigator.run',
+                fileObj => this.makeCmdRunner(true)(fileObj),
+            ),
+        );
+        console.debug('Added a "Run with Ansible Navigator" command...');
+    }
+
+    /**
+     * A factory method for creating an Ansible playbook runner.
+     *
+     * @param useNavigator A flag for preferring `ansible-navigator run`
+     *                     over `ansible-playbook`.
+     * @returns A callable for running a supplied playbook.
+     */
+    private makeCmdRunner(useNavigator = false) {
+        const runPlaybook = useNavigator
+            ? this.invokeViaAnsibleNavigator.bind(this)
+            : this.invokeViaAnsiblePlaybook.bind(this);
+        return (...fileObj: vscode.Uri[] | undefined[]) => {
+            const playbookFsPath = extractTargetFsPath(...fileObj);
+            if (typeof playbookFsPath === 'undefined') {
+                vscode.window.showErrorMessage(
+                    `No Ansible playbook file has been specified
+                    to be executed with ansible-${
+                        useNavigator
+                        ? 'navigator'
+                        : 'playbook'
+                    }.`,
+                );
+                return;
+            }
+            console.debug(
+                `Got a request to run ansible-${
+                    useNavigator
+                    ? 'navigator'
+                    : 'playbook'
+                } against`,
+                playbookFsPath,
+            );
+            runPlaybook([playbookFsPath]);
+        };
+    }
+
+    /**
+     * A property representing the `ansible-navigator` executable.
+     */
+    private get ansibleNavigatorExecutablePath(): string {
+        return vscode.workspace
+            .getConfiguration('ansible.ansibleNavigator').path;
+    }
+
+    /**
+     * A property representing the `ansible-playbook` executable.
+     */
+    private get ansiblePlaybookExecutablePath(): string {
+        return vscode.workspace
+            .getConfiguration('ansible.ansiblePlaybook').path;
+    }
+
+    /**
+     * A property representing the target terminal for running playbooks in.
+     */
+    private get terminal(): vscode.Terminal {
+        if (typeof this.disposableTerminal === 'undefined') {
+            const terminal = vscode.window.createTerminal('Ansible Terminal');
+            this.vsCodeExtCtx.subscriptions.push(terminal);
+            this.vsCodeExtCtx.subscriptions.push(
+                vscode.window.onDidCloseTerminal(
+                    (term: vscode.Terminal) => {
+                        if (term !== terminal) {
+                            return;
+                        }
+                        this.disposableTerminal = undefined;
+                    }
+                )
+            );
+            this.disposableTerminal = terminal;
+        }
+        return this.disposableTerminal as vscode.Terminal;
+    }
+
+    /**
+     * A helper method for executing commands in terminal.
+     */
+    private invokeInTerminal(cmd: string) {
+        this.terminal.show();
+        this.terminal.sendText(cmd);
+    }
+
+    /**
+     * A helper method for running `ansible-playbook`.
+     * @param argv Arguments to the `ansible-playbook` command.
+     */
+    private invokeViaAnsiblePlaybook(argv: string[]) {
+        const runExecutable = this.ansiblePlaybookExecutablePath;
+        const cmdArgs = argv.map(arg => `'${arg}'`).join(' ');
+        this.invokeInTerminal(`${runExecutable} ${cmdArgs}`);
+    }
+
+    /**
+     * A helper method for running `ansible-navigator run`.
+     * @param argv Arguments to the `ansible-navigator run` command.
+     */
+    private invokeViaAnsibleNavigator(argv: string[]) {
+        const runExecutable = this.ansibleNavigatorExecutablePath;
+        const cmdArgs = argv.map(arg => `'${arg}'`).join(' ');
+        this.invokeInTerminal(`${runExecutable} run ${cmdArgs}`);
+    }
+}
+
+
+/**
+ * A helper function for inferring selected file from the context.
+ * @param priorityPathObjs Target file path candidates.
+ * @returns A path to the currently selected file.
+ */
+function extractTargetFsPath(...priorityPathObjs: vscode.Uri[] | undefined[]):
+        string | undefined {
+    const pathCandidates: vscode.Uri[] = [
+        ...priorityPathObjs,
+        vscode.window.activeTextEditor?.document.uri,
+    ]
+        .filter(p => p instanceof vscode.Uri)
+        .map(p => <vscode.Uri>p)
+        .filter(p => p.scheme === 'file');
+    return pathCandidates[0]?.fsPath;
+}


### PR DESCRIPTION
In particular, the commands can be invoked via:
* pallete
* file explorer context menu
* open editor context menu

The commands allow choosing between running:
* `ansible-navigator run`
* `ansible-playbook`

Resolves #132