### PR TITLE
feat: rename extension to redhat.ansible

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "vscode-ansible",
+  "name": "ansible",
   "version": "0.4.5",
   "lockfileVersion": 2,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "badges": [
     {
       "description": "Ansible language support",
-      "href": "https://marketplace.visualstudio.com/items?itemName=zbr.vscode-ansible",
-      "url": "https://vsmarketplacebadge.apphb.com/version/zbr.vscode-ansible.svg"
+      "href": "https://marketplace.visualstudio.com/items?itemName=redhat.ansible",
+      "url": "https://vsmarketplacebadge.apphb.com/version/redhat.ansible.svg"
     },
     {
       "description": "CI/CD Pipeline",
@@ -241,7 +241,7 @@
   ],
   "license": "MIT",
   "main": "./out/client/extension",
-  "name": "vscode-ansible",
+  "name": "ansible",
   "preview": true,
   "publisher": "redhat",
   "qna": false,


### PR DESCRIPTION
As we will be forced to republish the extension under redhat, that a good opportunity to ensure extension id is "redhat.ansible",
avoiding the vscode- prefix which was also redundant.