### PR TITLE
chore: fix linting warnings w/ quotes @ commitlint

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  "extends": [
-    "@commitlint/config-conventional"
+  'extends': [
+    '@commitlint/config-conventional'
   ]
 }


### PR DESCRIPTION
This change basically deals with one of the warnings that one of the pre-commit check produces. No review is needed.