### PR TITLE
chore: treat eslint warnings as errors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,6 +61,9 @@ repos:
     rev: v7.31.0
     hooks:
       - id: eslint
+        args:
+          - --max-warnings
+          - "0"
         additional_dependencies:
           - "@typescript-eslint/eslint-plugin"
           - "@typescript-eslint/parser"


### PR DESCRIPTION
This change make the vscode eslint extension output match the eslint linting making development easier. Discovered while working on another PR.

Without this we could introduce warnings that we do not catch.