### PR TITLE
chore: prevent incorrect versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,8 +11,11 @@ repos:
   - repo: local
     hooks:
       - id: npm-ci
-        name: Run 'npm ci' to ensure deps are correct
-        entry: npm ci --ignore-scripts
+        name: Run 'npm ci' to ensure deps and versions are correct
+        entry: >-
+          bash -c 'npm ci --ignore-scripts &&
+          npm version --allow-same-version --no-commit-hooks
+          --no-git-tag-version $(npm pkg get version | sed "s/\"//g")'
         language: node
         files: "(package|package-lock).json$"
         pass_filenames: false


### PR DESCRIPTION
Basically we enforce `npm version` to run again with current version. This would bring repository into dirty state if version was out of think to be a noop otherwise.

The next command we run is a git dirty check, which would
stop the pipeline.