### PR TITLE
chore: cleaning codeowners files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Global Owners
-* @ssbarnea @webknjaz @joshuawilson @JPinkney @tomaciazek @ansible/devtools
+* @ansible/devtools @tomaciazek


### PR DESCRIPTION
Keeping devtools team as default reviewer and removing our
redhat-devtools friends as we now have enough people to
perform reviews. We will add the manually to the reviews
where we need their expertise.