### PR TITLE
feat: update default setting value for using FQCN

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
         "ansible.ansible.useFullyQualifiedCollectionNames": {
           "scope": "resource",
           "type": "boolean",
-          "default": false,
+          "default": true,
           "description": "Always use fully qualified collection names (FQCN) when inserting a module name. Disabling it will only use FQCNs when necessary."
         },
         "ansible.ansibleLint.enabled": {


### PR DESCRIPTION
As discussed in the team meetings, to ensure best practices, the default value for `ansible.ansible.useFullyQualifiedCollectionNames` is set to `true`.

That means, by default, the auto-completion in the editor would produce FQCNs for module names.