### PR TITLE
fix: update compile withserver script

### DIFF
--- a/package.json
+++ b/package.json
@@ -365,7 +365,7 @@
   },
   "scripts": {
     "compile": "tsc -b && copyfiles -u 4 'node_modules/ansible-language-server/out/server/**/*' out/server",
-    "compile:withserver": "tsc -b && tsc -p ../ansible-language-server --outDir out/server",
+    "compile:withserver": "tsc -b && tsc -p ../ansible-language-server --outDir out/server && ln -f -s ${PWD}/../ansible-language-server/node_modules out/server/node_modules",
     "lint": "npm ci && pre-commit run -a",
     "package": "npm ci && vsce package",
     "prepare": "husky install",


### PR DESCRIPTION
Update the `compile:withserver` script to create a soft
link in the `out/sever` folder for `node_modules` directory
of `ansible-language-server` to handle new package
depedency added in the language-server code while setting
up development environment