### PR TITLE
feat: add setting options for execution environment

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,17 +111,75 @@
           "default": true,
           "description": "Always use fully qualified collection names (FQCN) when inserting a module name. Disabling it will only use FQCNs when necessary."
         },
+        "ansible.executionEnvironment.containerEngine": {
+          "scope": "resource",
+          "type": "string",
+          "enum": [
+            "auto",
+            "podman",
+            "docker"
+          ],
+          "default": "auto",
+          "description": "Specify the container engine (auto=podman then docker)."
+        },
+        "ansible.executionEnvironment.enabled": {
+          "scope": "resource",
+          "type": "boolean",
+          "default": false,
+          "description": "Enable or disable the use of an execution environment."
+        },
+        "ansible.executionEnvironment.image": {
+          "scope": "resource",
+          "type": "string",
+          "default": "quay.io/ansible/ansible-navigator-demo-ee:0.6.0",
+          "description": "Specify the name of the execution environment image."
+        },
+        "ansible.executionEnvironment.environmentVariables.pass": {
+          "scope": "resource",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "description": "Specify an exiting environment variable to be passed through to and set within the execution environment."
+        },
+        "ansible.executionEnvironment.pullPolicy": {
+          "scope": "resource",
+          "type": "array",
+          "enum": [
+            "always",
+            "missing",
+            "never",
+            "tag"
+          ],
+          "default": "tag",
+          "description": "Specify the image pull policy.\nalways: Always pull the image when extension is activated or reloaded\nmissing: Pull if not locally available\nnever: Never pull the image\ntag: If the image tag is 'latest', always pull the image, otherwise pull if not locally available"
+        },
+        "ansible.executionEnvironment.environmentVariables.set": {
+          "scope": "resource",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "title": "Specify name of environment variables and it's value",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Name of the environment variable."
+              },
+              "value": {
+                "type": "string",
+                "description": "Value to be set for the environment variable."
+              }
+            }
+          },
+          "default": [],
+          "description": "Specify an environment variable and a value to be set within the execution environment."
+        },
         "ansible.ansibleLint.enabled": {
           "scope": "resource",
           "type": "boolean",
           "default": true,
           "description": "Enable linting with ansible-lint on document open/save."
-        },
-        "ansible.ansibleLint.path": {
-          "scope": "resource",
-          "type": "string",
-          "default": "ansible-lint",
-          "description": "Path to the ansible-lint executable."
         },
         "ansible.ansibleLint.arguments": {
           "scope": "resource",
@@ -129,17 +187,11 @@
           "default": "",
           "description": "Command line arguments to be passed to ansible-lint."
         },
-        "ansible.python.interpreterPath": {
+        "ansible.ansibleLint.path": {
           "scope": "resource",
           "type": "string",
-          "default": "",
-          "description": "Path to the Python interpreter executable. Particularly important if you are using a Python virtual environment. Leave blank to use Python from PATH."
-        },
-        "ansible.python.activationScript": {
-          "scope": "resource",
-          "type": "string",
-          "default": "",
-          "description": "Path to the virtual environment activation script. Use only if you have a custom activation script. It will be sourced using bash before executing Ansible commands. If set, the Interpreter Path setting is ignored."
+          "default": "ansible-lint",
+          "description": "Path to the ansible-lint executable."
         },
         "ansible.ansibleNavigator.path": {
           "default": "ansible-navigator",
@@ -159,6 +211,18 @@
             "null"
           ]
         }
+      },
+      "ansible.python.interpreterPath": {
+        "scope": "resource",
+        "type": "string",
+        "default": "",
+        "description": "Path to the Python interpreter executable. Particularly important if you are using a Python virtual environment. Leave blank to use Python from PATH."
+      },
+      "ansible.python.activationScript": {
+        "scope": "resource",
+        "type": "string",
+        "default": "",
+        "description": "Path to the virtual environment activation script. Use only if you have a custom activation script. It will be sourced using bash before executing Ansible commands. If set, the Interpreter Path setting is ignored."
       }
     },
     "languages": [
@@ -301,7 +365,10 @@
   },
   "dependencies": {
     "ansible-language-server": "^0.1.1-0",
-    "vscode-languageclient": "^7.0.0"
+    "clean": "^4.0.2",
+    "uuid": "^8.3.2",
+    "vscode-languageclient": "^7.0.0",
+    "vscode-uri": "^3.0.2"
   },
   "description": "Ansible language support",
   "devDependencies": {
@@ -310,7 +377,7 @@
     "@types/chai": "^4.2.21",
     "@types/glob": "^7.1.3",
     "@types/mocha": "^8.2.3",
-    "@types/node": "^14.17.5",
+    "@types/node": "^16.9.1",
     "@types/vscode": "^1.56.0",
     "@typescript-eslint/eslint-plugin": "^4.28.3",
     "@typescript-eslint/parser": "^4.28.3",
@@ -333,7 +400,7 @@
   "displayName": "Ansible",
   "engineStrict": true,
   "engines": {
-    "node": ">=16.0",
+    "node": ">=16.7.0",
     "npm": "^7.12.1",
     "vscode": "^1.56.0",
     "yarn": "\n\nERROR: Please use npm, yarn is not supported in this repository!!!\n\n"

--- a/package.json
+++ b/package.json
@@ -134,15 +134,6 @@
           "default": "quay.io/ansible/ansible-navigator-demo-ee:0.6.0",
           "description": "Specify the name of the execution environment image."
         },
-        "ansible.executionEnvironment.environmentVariables.pass": {
-          "scope": "resource",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "default": [],
-          "description": "Specify an exiting environment variable to be passed through to and set within the execution environment."
-        },
         "ansible.executionEnvironment.pullPolicy": {
           "scope": "resource",
           "type": "array",
@@ -152,28 +143,8 @@
             "never",
             "tag"
           ],
-          "default": "tag",
+          "default": "missing",
           "description": "Specify the image pull policy.\nalways: Always pull the image when extension is activated or reloaded\nmissing: Pull if not locally available\nnever: Never pull the image\ntag: If the image tag is 'latest', always pull the image, otherwise pull if not locally available"
-        },
-        "ansible.executionEnvironment.environmentVariables.set": {
-          "scope": "resource",
-          "type": "array",
-          "items": {
-            "type": "object",
-            "title": "Specify name of environment variables and it's value",
-            "properties": {
-              "name": {
-                "type": "string",
-                "description": "Name of the environment variable."
-              },
-              "value": {
-                "type": "string",
-                "description": "Value to be set for the environment variable."
-              }
-            }
-          },
-          "default": [],
-          "description": "Specify an environment variable and a value to be set within the execution environment."
         },
         "ansible.ansibleLint.enabled": {
           "scope": "resource",
@@ -365,10 +336,7 @@
   },
   "dependencies": {
     "ansible-language-server": "^0.1.1-0",
-    "clean": "^4.0.2",
-    "uuid": "^8.3.2",
-    "vscode-languageclient": "^7.0.0",
-    "vscode-uri": "^3.0.2"
+    "vscode-languageclient": "^7.0.0"
   },
   "description": "Ansible language support",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -111,17 +111,17 @@
           "default": true,
           "description": "Always use fully qualified collection names (FQCN) when inserting a module name. Disabling it will only use FQCNs when necessary."
         },
-        "ansible.ansibleLint.enabled": {
-          "scope": "resource",
-          "type": "boolean",
-          "default": true,
-          "description": "Enable linting with ansible-lint on document open/save."
-        },
         "ansible.ansibleLint.arguments": {
           "scope": "resource",
           "type": "string",
           "default": "",
           "description": "Command line arguments to be passed to ansible-lint."
+        },
+        "ansible.ansibleLint.enabled": {
+          "scope": "resource",
+          "type": "boolean",
+          "default": true,
+          "description": "Enable linting with ansible-lint on document open/save."
         },
         "ansible.ansibleLint.path": {
           "scope": "resource",
@@ -182,17 +182,17 @@
           "default": "missing",
           "description": "Specify the image pull policy.\nalways: Always pull the image when extension is activated or reloaded\nmissing: Pull if not locally available\nnever: Never pull the image\ntag: If the image tag is 'latest', always pull the image, otherwise pull if not locally available"
         },
-        "ansible.python.interpreterPath": {
-          "scope": "resource",
-          "type": "string",
-          "default": "",
-          "description": "Path to the Python interpreter executable. Particularly important if you are using a Python virtual environment. Leave blank to use Python from PATH."
-        },
         "ansible.python.activationScript": {
           "scope": "resource",
           "type": "string",
           "default": "",
           "description": "Path to the virtual environment activation script. Use only if you have a custom activation script. It will be sourced using bash before executing Ansible commands. If set, the Interpreter Path setting is ignored."
+        },
+        "ansible.python.interpreterPath": {
+          "scope": "resource",
+          "type": "string",
+          "default": "",
+          "description": "Path to the Python interpreter executable. Particularly important if you are using a Python virtual environment. Leave blank to use Python from PATH."
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -345,7 +345,7 @@
     "@types/chai": "^4.2.21",
     "@types/glob": "^7.1.3",
     "@types/mocha": "^8.2.3",
-    "@types/node": "^16.9.1",
+    "@types/node": "^14.17.5",
     "@types/vscode": "^1.56.0",
     "@typescript-eslint/eslint-plugin": "^4.28.3",
     "@typescript-eslint/parser": "^4.28.3",
@@ -368,7 +368,7 @@
   "displayName": "Ansible",
   "engineStrict": true,
   "engines": {
-    "node": ">=16.7.0",
+    "node": ">=16.0",
     "npm": "^7.12.1",
     "vscode": "^1.56.0",
     "yarn": "\n\nERROR: Please use npm, yarn is not supported in this repository!!!\n\n"

--- a/package.json
+++ b/package.json
@@ -181,19 +181,19 @@
             "string",
             "null"
           ]
+        },
+        "ansible.python.interpreterPath": {
+          "scope": "resource",
+          "type": "string",
+          "default": "",
+          "description": "Path to the Python interpreter executable. Particularly important if you are using a Python virtual environment. Leave blank to use Python from PATH."
+        },
+        "ansible.python.activationScript": {
+          "scope": "resource",
+          "type": "string",
+          "default": "",
+          "description": "Path to the virtual environment activation script. Use only if you have a custom activation script. It will be sourced using bash before executing Ansible commands. If set, the Interpreter Path setting is ignored."
         }
-      },
-      "ansible.python.interpreterPath": {
-        "scope": "resource",
-        "type": "string",
-        "default": "",
-        "description": "Path to the Python interpreter executable. Particularly important if you are using a Python virtual environment. Leave blank to use Python from PATH."
-      },
-      "ansible.python.activationScript": {
-        "scope": "resource",
-        "type": "string",
-        "default": "",
-        "description": "Path to the virtual environment activation script. Use only if you have a custom activation script. It will be sourced using bash before executing Ansible commands. If set, the Interpreter Path setting is ignored."
       }
     },
     "languages": [

--- a/package.json
+++ b/package.json
@@ -111,41 +111,6 @@
           "default": true,
           "description": "Always use fully qualified collection names (FQCN) when inserting a module name. Disabling it will only use FQCNs when necessary."
         },
-        "ansible.executionEnvironment.containerEngine": {
-          "scope": "resource",
-          "type": "string",
-          "enum": [
-            "auto",
-            "podman",
-            "docker"
-          ],
-          "default": "auto",
-          "description": "Specify the container engine (auto=podman then docker)."
-        },
-        "ansible.executionEnvironment.enabled": {
-          "scope": "resource",
-          "type": "boolean",
-          "default": false,
-          "description": "Enable or disable the use of an execution environment."
-        },
-        "ansible.executionEnvironment.image": {
-          "scope": "resource",
-          "type": "string",
-          "default": "quay.io/ansible/ansible-navigator-demo-ee:0.6.0",
-          "description": "Specify the name of the execution environment image."
-        },
-        "ansible.executionEnvironment.pullPolicy": {
-          "scope": "resource",
-          "type": "array",
-          "enum": [
-            "always",
-            "missing",
-            "never",
-            "tag"
-          ],
-          "default": "missing",
-          "description": "Specify the image pull policy.\nalways: Always pull the image when extension is activated or reloaded\nmissing: Pull if not locally available\nnever: Never pull the image\ntag: If the image tag is 'latest', always pull the image, otherwise pull if not locally available"
-        },
         "ansible.ansibleLint.enabled": {
           "scope": "resource",
           "type": "boolean",
@@ -181,6 +146,41 @@
             "string",
             "null"
           ]
+        },
+        "ansible.executionEnvironment.containerEngine": {
+          "scope": "resource",
+          "type": "string",
+          "enum": [
+            "auto",
+            "podman",
+            "docker"
+          ],
+          "default": "auto",
+          "description": "Specify the container engine (auto=podman then docker)."
+        },
+        "ansible.executionEnvironment.enabled": {
+          "scope": "resource",
+          "type": "boolean",
+          "default": false,
+          "description": "Enable or disable the use of an execution environment."
+        },
+        "ansible.executionEnvironment.image": {
+          "scope": "resource",
+          "type": "string",
+          "default": "quay.io/ansible/ansible-navigator-demo-ee:0.6.0",
+          "description": "Specify the name of the execution environment image."
+        },
+        "ansible.executionEnvironment.pullPolicy": {
+          "scope": "resource",
+          "type": "array",
+          "enum": [
+            "always",
+            "missing",
+            "never",
+            "tag"
+          ],
+          "default": "missing",
+          "description": "Specify the image pull policy.\nalways: Always pull the image when extension is activated or reloaded\nmissing: Pull if not locally available\nnever: Never pull the image\ntag: If the image tag is 'latest', always pull the image, otherwise pull if not locally available"
         },
         "ansible.python.interpreterPath": {
           "scope": "resource",


### PR DESCRIPTION

*  Add setting in package.json file to configure execution
   environment related setting.
   Example client `settings.json` for EE options (default)
   ```
   {
    "ansible.executionEnvironment.enabled": false,
    "ansible.executionEnvironment.image": "quay.io/ansible/ansible-navigator-demo-ee:0.6.0",
    "ansible.executionEnvironment.containerEngine": "auto",
    "ansible.executionEnvironment.pullPolicy: "missing"  
   }
   ```

 Related to ansible-langauge-server PR https://github.com/ansible/ansible-language-server/pull/42