### PR TITLE
chore: fix pre-commit.ci failure

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,9 @@ ci:
     chore: auto fixes from pre-commit.com hooks
 
     for more information, see https://pre-commit.ci
+  skip:
+    # https://github.com/pre-commit-ci/issues/issues/55
+    - npm-ci
 repos:
   - repo: local
     hooks:


### PR DESCRIPTION
Implements workaround for pre-commit.ci which runs only in
network isolated mode.
