### PR TITLE
chore: avoid changing quotes on yaml files

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,0 @@
-{
-  "tabWidth": 2,
-  "useTabs": false,
-  "semi": true,
-  "singleQuote": true
-}

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,0 +1,10 @@
+tabWidth: 2
+useTabs: false
+overrides:
+  - files:
+      - '*.yaml'
+      - '*.yml'
+    options:
+      singleQuote: false
+semi: true
+singleQuote: true


### PR DESCRIPTION
- fixes bug observed with #204 when prettier changed quotes on edited file without needing do so
- switch prettier config to yaml to make it editable by humans
- configures prettier to avoid changing quotes on yaml files

Related: https://github.com/ansible/ansible-language-server/pull/46
