### PR TITLE
fix: switch debug listening port to fix unbound breakpoints

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -24,18 +24,18 @@
       "type": "node",
       "request": "attach",
       "timeout": 30000,
-      "port": 6009,
+      "port": 6010,
       "restart": true,
-      "outFiles": ["${workspaceRoot}/out/server/**/*.js"]
+      "outFiles": ["${workspaceRoot}/out/server/src/**/*.js"]
     },
     {
       "name": "Attach to Server (source)",
       "type": "node",
       "request": "attach",
       "timeout": 30000,
-      "port": 6009,
+      "port": 6010,
       "restart": true,
-      "outFiles": ["${workspaceRoot}/out/server/**/*.js"],
+      "outFiles": ["${workspaceRoot}/out/server/src/**/*.js"],
       "preLaunchTask": "npm: watch:server"
     }
   ],

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,8 +12,10 @@ import {
 
 /* local */
 import { AnsiblePlaybookRunProvider } from './features/runner';
-import { getConflictingExtensions, showUninstallConflictsNotification } from './extensionConflicts';
-
+import {
+  getConflictingExtensions,
+  showUninstallConflictsNotification,
+} from './extensionConflicts';
 
 let client: LanguageClient;
 
@@ -25,7 +27,7 @@ export function activate(context: ExtensionContext): void {
   );
 
   // server is run at port 6009 for debugging
-  const debugOptions = { execArgv: ['--nolazy', '--inspect=6009'] };
+  const debugOptions = { execArgv: ['--nolazy', '--inspect=6010'] };
 
   const serverOptions: ServerOptions = {
     run: { module: serverModule, transport: TransportKind.ipc },


### PR DESCRIPTION
This fixes the issue with unbound breakpoints in new VS Code versions, reported by @ganeshrn. Apparently something else overshadows language server on the 6009 debug port, but I haven't been able to pinpoint what or why (or how).

VS Code was now also reporting long times searching for source-maps, which was caused by recently added mechanism linking `node_modules`. I've narrowed the `outFiles` configuration down to `src` avoid this problem.