### PR TITLE
chore: remove redundant test jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,6 @@ jobs:
     strategy:
       matrix:
         npm-target:
-        - test
         - ui-test
         - ui-test-oldest
         os: [macos-latest, windows-latest, ubuntu-latest]

--- a/package.json
+++ b/package.json
@@ -416,7 +416,6 @@
     "package": "npm ci && vsce package",
     "prepare": "husky install",
     "pretest": "npm run compile",
-    "test": "extest get-vscode && extest install-vsix",
     "ui-test": "extest setup-and-run -i out/client/ui-test/allTestsSuite.js",
     "ui-test-oldest": "extest setup-and-run -c 1.48.0 -s test-resources-oldest -i -u out/client/ui-test/allTestsSuite.js",
     "vscode:prepublish": "npm run webpack",


### PR DESCRIPTION
Remove `test` jobs as they do not do anything else not already done by `ui-test`. We will add them back once we have a particular use for them, like running tests that are not part of ui-test.

Needed-By: https://github.com/ansible/vscode-ansible/pull/206