### PR TITLE
chore: decouple linting from other npm scripts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,6 +22,9 @@ jobs:
         - test
         - ui-test
         os: [macos-latest, windows-latest, ubuntu-latest]
+        include:
+          - npm-target: lint
+            os: ubuntu-latest
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -40,15 +43,12 @@ jobs:
           npm config set fund false
           npm ci
 
-      - name: Run lint
-        run: npm run-script lint
-
       # Build extension
       - name: Run build
         run: npm run compile
 
       # Run tests
-      - name: Run test
+      - name: Run ${{ matrix.npm-target }}
         uses: GabrielBB/xvfb-action@v1.0
         with:
           run: >-

--- a/package.json
+++ b/package.json
@@ -403,10 +403,10 @@
   "scripts": {
     "compile": "tsc -b && copyfiles -u 4 'node_modules/ansible-language-server/out/server/**/*' out/server",
     "compile:withserver": "tsc -b && tsc -p ../ansible-language-server --outDir out/server && ln -f -s ${PWD}/../ansible-language-server/node_modules out/server/node_modules",
-    "lint": "npm ci && pre-commit run -a",
+    "lint": "pre-commit run -a",
     "package": "npm ci && vsce package",
     "prepare": "husky install",
-    "pretest": "npm run compile && npm run lint",
+    "pretest": "npm run compile",
     "test": "extest get-vscode && extest install-vsix",
     "ui-test": "extest setup-and-run -i out/client/ui-test/allTestsSuite.js",
     "vscode:prepublish": "npm run webpack",


### PR DESCRIPTION
- decouple linting from other npm scripts
- run linting on CI on linux as separated job
- improve execution of other npm scripts by avoiding to run linting on almost any action, especially as `pretest` is implicit.
