### PR TITLE
chore: simplify build name

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,7 @@ on:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   build:
+    name: "${{ matrix.npm-target }} @${{ matrix.os }}"
     # The type of runner that the job will run on
     runs-on: ${{ matrix.os }}
     strategy:


### PR DESCRIPTION
This makes build names easier to read and to extend, preparing for #217
