### PR TITLE
chore: make npm runs strict

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+# Avoid running with unsupported engines
+# https://www.stefanjudis.com/today-i-learned/prevent-npm-install-for-not-supported-node-js-versions/
+engine-strict=true

--- a/package.json
+++ b/package.json
@@ -375,7 +375,7 @@
   "engineStrict": true,
   "engines": {
     "node": ">=16.0",
-    "npm": "^7.12.1",
+    "npm": ">=7.12.1",
     "vscode": "^1.56.0",
     "yarn": "\n\nERROR: Please use npm, yarn is not supported in this repository!!!\n\n"
   },


### PR DESCRIPTION
- resolves confusing runtime warning when using npm 8.0
- changes npm requirements to allow use of 8.0
- make npm engine checks strict to avoid running when unsupported
