### PR TITLE
fix: ensure path related settings are not synced

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
       "title": "Ansible",
       "properties": {
         "ansible.ansible.path": {
-          "scope": "resource",
+          "scope": "machine-overridable",
           "type": "string",
           "default": "ansible",
           "description": "Path to the ansible executable."
@@ -133,7 +133,7 @@
           "description": "Enable linting with ansible-lint on document open/save."
         },
         "ansible.ansibleLint.path": {
-          "scope": "resource",
+          "scope": "machine-overridable",
           "type": "string",
           "default": "ansible-lint",
           "description": "Path to the ansible-lint executable."
@@ -192,13 +192,13 @@
           "description": "Specify the image pull policy.\nalways: Always pull the image when extension is activated or reloaded\nmissing: Pull if not locally available\nnever: Never pull the image\ntag: If the image tag is 'latest', always pull the image, otherwise pull if not locally available"
         },
         "ansible.python.activationScript": {
-          "scope": "resource",
+          "scope": "machine-overridable",
           "type": "string",
           "default": "",
           "description": "Path to the virtual environment activation script. Use only if you have a custom activation script. It will be sourced using bash before executing Ansible commands. If set, the Interpreter Path setting is ignored."
         },
         "ansible.python.interpreterPath": {
-          "scope": "resource",
+          "scope": "machine-overridable",
           "type": "string",
           "default": "",
           "description": "Path to the Python interpreter executable. Particularly important if you are using a Python virtual environment. Leave blank to use Python from PATH."


### PR DESCRIPTION
Configurable paths are specific to each machine and by setting
machine-overridable we should help vscode prevent synching them.

Configurage Ansible Navigator path was already using correct settings for path.

https://code.visualstudio.com/api/references/contribution-points
https://code.visualstudio.com/docs/editor/settings-sync
