### PR TITLE
Expose the `ansibleServer.trace.server` option for tracing ALS activity

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ any level (User, Remote, Workspace and/or Folder).
 - `ansible.python.activationScript`: Path to a custom `activate` script, which
   will be used instead of the setting above to run in a Python virtual
   environment.
+- `ansibleServer.trace.server`: Traces the communication between VSCode and the ansible language server.
 
 ## Known limitations
 

--- a/package.json
+++ b/package.json
@@ -202,6 +202,16 @@
           "type": "string",
           "default": "",
           "description": "Path to the Python interpreter executable. Particularly important if you are using a Python virtual environment. Leave blank to use Python from PATH."
+        },
+        "ansibleServer.trace.server": {
+          "type": "string",
+          "enum": [
+            "off",
+            "messages",
+            "verbose"
+          ],
+          "default": "off",
+          "description": "Traces the communication between VSCode and the ansible language server."
         }
       }
     },


### PR DESCRIPTION
## Description

Add the `*.trace.server` setting to the configuration option, so that configuration completion also works in `settings.json`.

Added with reference to `vscode-yaml`. https://github.com/redhat-developer/vscode-yaml/blob/main/package.json#L98-L107

**Further reference**:

- <https://code.visualstudio.com/api/language-extensions/language-server-extension-guide#logging-support-for-language-server>

## DEMO (mp4)

https://user-images.githubusercontent.com/188642/138538687-b3a4e94f-2619-4199-afb6-9ec215e43a32.mp4

## Misc

I think it would be better to change it to `ansible` instead of `ansibleServer`, but I added it with ansibleServer first

adjust here if you want to change it. https://github.com/ansible/vscode-ansible/blob/main/src/extension.ts#L47

