### PR TITLE
Add generic check job to GHA

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -92,3 +92,15 @@ jobs:
       # extra safety measure that ensures code was not modified during build
       - name: Ensure git does not report dirty
         run: git diff --exit-code
+
+  check:  # This job does nothing and is only used for the branch protection
+    needs:
+    - build
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Report success of the test matrix
+        run: >-
+          print("All's good")
+        shell: python


### PR DESCRIPTION
This job is to be used in the branch protection rules. It will simplify
the branch protection maintenance by allowing the project to only
require this one job instead of enumerating every job name as they
change over time.

Related: https://github.com/ansible-community/devtools/issues/15