### PR TITLE
Refactor publishing to rely on reusable actions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,18 +9,38 @@ jobs:
     runs-on: ubuntu-latest
     environment: release
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Install Node.js
-        uses: actions/setup-node@v1
-        with:
-          node-version: 12.x
-      - run: npm install
-      - name: Publish to VSCode Marketplace
-        run: npx vsce publish -p $VSCE_TOKEN
-        env:
-          VSCE_TOKEN: ${{ secrets.VSCE_TOKEN }}
-      - name: Publish to Open VSX
-        run: npx ovsx publish -p $OVSX_TOKEN
-        env:
-          OVSX_TOKEN: ${{ secrets.OVSX_TOKEN }}
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Install Node.js
+      uses: actions/setup-node@v1
+      with:
+        node-version: 12.x
+    - name: Set up package deps
+      run: npm install
+
+    - name: Package the extension
+      uses: HaaLeo/publish-vscode-extension@v0
+      id: vsix_ext
+      with:
+        # "dry run" == only build (package) the extension artifact
+        dryRun: true
+        pat: N/A  # it's "required" but unnecessary with "dry run"
+    - name: Save the generated `.vsix` extension as an artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: VSIX extension package
+        path: ${{ steps.vsix_ext.outputs.vsixPath }}
+
+    - name: Publish to Open VSX Registry
+      uses: HaaLeo/publish-vscode-extension@v0
+      with:
+        extensionFile: ${{ steps.vsix_ext.outputs.vsixPath }}
+        packagePath:  # Must be empty when `extensionFile` is set
+        pat: ${{ secrets.OVSX_TOKEN }}
+    - name: Publish to Visual Studio Marketplace
+      uses: HaaLeo/publish-vscode-extension@v0
+      with:
+        extensionFile: ${{ steps.vsix_ext.outputs.vsixPath }}
+        packagePath:  # Must be empty when `extensionFile` is set
+        pat: ${{ secrets.VSCE_TOKEN }}
+        registryUrl: https://marketplace.visualstudio.com


### PR DESCRIPTION
This patch uses `HaaLeo/publish-vscode-extension` to build and publish the extension and it also uploads it as a workflow artifact for possible audit/testing.