### PR TITLE
Partially revert "Declare support for NodeJS 12 in the package metadata"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,7 +37,6 @@ jobs:
         - ui-test
         - ui-test-oldest
         nodejs-version:
-        - 12
         - 16
         upload-artifact:
         - false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,6 @@ In particular, this:
 
 ### Misc
 
-* Explicitly declared support for NodeJS 12 in metadata (#255) @webknjaz
 * Made sure that the path-related settings are not being synchronized
   (#235) @ssbarnea
 * Reintroduced the schema verification for the part of the known file

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "webpack-cli": "^4.7.2"
       },
       "engines": {
-        "node": ">=12.0",
+        "node": ">=16.0",
         "npm": ">=7.12.1",
         "vscode": "^1.48.0",
         "yarn": "\n\nERROR: Please use npm, yarn is not supported in this repository!!!\n\n"

--- a/package.json
+++ b/package.json
@@ -386,7 +386,7 @@
   "displayName": "Ansible",
   "engineStrict": true,
   "engines": {
-    "node": ">=12.0",
+    "node": ">=16.0",
     "npm": ">=7.12.1",
     "vscode": "^1.48.0",
     "yarn": "\n\nERROR: Please use npm, yarn is not supported in this repository!!!\n\n"


### PR DESCRIPTION
This partially reverts commit 7c0ed81ef59eec07052eed4c335a04d105fcc88e.

In particular, this patch only removes NodeJS 12 from the CI matrix
while keeping the matrix collapse in.