### PR TITLE
Move test-resources under out folder

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -8,8 +8,6 @@ doc
 node_modules
 src
 syntaxes/README.md
-test-resources
-test-resources-oldest
 tsconfig.json
 webpack.config.js
 

--- a/package.json
+++ b/package.json
@@ -440,15 +440,15 @@
     "pretest": "npm run compile",
     "//": "setup is used to configure development environment, like installing git hooks.",
     "setup": "pre-commit install-hooks",
-    "ui-test": "extest setup-and-run -i out/client/ui-test/allTestsSuite.js",
-    "ui-test-oldest": "extest setup-and-run -c 1.48.0 -s test-resources-oldest -i -u out/client/ui-test/allTestsSuite.js",
+    "ui-test": "extest setup-and-run -i -s out/test-resources out/client/ui-test/allTestsSuite.js",
+    "ui-test-oldest": "extest setup-and-run -c 1.48.0 -s out/test-resources-oldest -i -u out/client/ui-test/allTestsSuite.js",
     "vscode:prepublish": "npm run webpack",
     "watch": "tsc -b -w",
     "watch:server": "tsc -p ../ansible-language-server --outDir out/server -w",
     "webpack": "npm run clean && npm run compile && webpack --mode production --config ./webpack.config.js",
     "webpack:dev": "npm run clean && webpack --mode development --config ./webpack.config.js",
     "webpack:watch": "webpack --mode development --config ./webpack.config.js --watch",
-    "clean": "rimraf out"
+    "clean": "rimraf out/client out/server out/tsconfig.tsbuildinfo"
   },
   "version": "0.5.1"
 }


### PR DESCRIPTION
- put test-resources folder under out/ as this is already used as
  an output/cache folder.
- reduce number of files we have on project root
- avoids cleaning test-resources folders as we want to keep them
  between runs and clean runs before webpack.
