### PR TITLE
chore: increase ui-test timeout

### DIFF
--- a/src/ui-test/extensionUITest.ts
+++ b/src/ui-test/extensionUITest.ts
@@ -23,7 +23,7 @@ export function extensionUIAssetsTest(): void {
     });
 
     it('VSCode Ansible extension is installed', async function () {
-      this.timeout(12000);
+      this.timeout(15000);
       const section = (await sideBar
         .getContent()
         .getSection('Installed')) as ExtensionsViewSection;


### PR DESCRIPTION
As Windows tests seems to be slower and timeout on activation, we
increate the timeout bit more.
