### PR TITLE
Fix indentation when using inline vault encrypt

### DIFF
--- a/src/features/vault.ts
+++ b/src/features/vault.ts
@@ -291,12 +291,10 @@ const getIndentationLevel = (
 ): number => {
   if (!editor.options.tabSize) {
     // according to VS code docs, tabSize is always defined when getting options of an editor
-    throw 'tabSize undefined, this should never happen';
+    throw new Error('The `tabSize` option is not defined, this should never happen.');
   }
   const startLine = editor.document.lineAt(selection.start.line).text;
   const indentationMatches = startLine.match(/^\s*/);
-  const leadingWhitespaces = !!indentationMatches
-    ? indentationMatches[0].length
-    : 0;
+  const leadingWhitespaces = indentationMatches?[0].?length || 0;
   return leadingWhitespaces / Number(editor.options.tabSize);
 };

--- a/src/features/vault.ts
+++ b/src/features/vault.ts
@@ -92,8 +92,11 @@ export const toggleEncrypt = async (): Promise<void> => {
         editBuilder.replace(
           selection,
           encryptedText.replace(
-            /\n/g,
-            `\n${' '.repeat(selection.start.character)}`
+            /\n\s*/g,
+            `\n${' '.repeat(
+              (getIndentationLevel(editor, selection) + 1) *
+                Number(editor.options.tabSize)
+            )}`
           )
         );
       });
@@ -280,4 +283,20 @@ const execCwd = (cmd: string, cwd: string | undefined) => {
     return exec(cmd);
   }
   return exec(cmd, { cwd: cwd });
+};
+
+const getIndentationLevel = (
+  editor: vscode.TextEditor,
+  selection: vscode.Selection
+): number => {
+  if (!editor.options.tabSize) {
+    // according to VS code docs, tabSize is always defined when getting options of an editor
+    throw 'tabSize undefined, this should never happen';
+  }
+  const startLine = editor.document.lineAt(selection.start.line).text;
+  const indentationMatches = startLine.match(/^\s*/);
+  const leadingWhitespaces = !!indentationMatches
+    ? indentationMatches[0].length
+    : 0;
+  return leadingWhitespaces / Number(editor.options.tabSize);
 };

--- a/src/features/vault.ts
+++ b/src/features/vault.ts
@@ -88,14 +88,14 @@ export const toggleEncrypt = async (): Promise<void> => {
         vscode.window.showErrorMessage(`Inline encryption failed: ${e}`);
         return;
       }
-      const leadingWhitespaces = ' '.repeat(getIndentationLevel(editor, selection) + 1 * Number(editor.options.tabSize));
+      const leadingWhitespaces = ' '.repeat(
+        (getIndentationLevel(editor, selection) + 1) *
+          Number(editor.options.tabSize)
+      );
       editor.edit((editBuilder) => {
         editBuilder.replace(
           selection,
-          encryptedText.replace(
-            /\n\s*/g,
-            `\n${leadingWhitespaces}`
-          )
+          encryptedText.replace(/\n\s*/g, `\n${leadingWhitespaces}`)
         );
       });
     } else if (type === 'encrypted') {
@@ -289,7 +289,9 @@ const getIndentationLevel = (
 ): number => {
   if (!editor.options.tabSize) {
     // according to VS code docs, tabSize is always defined when getting options of an editor
-    throw new Error('The `tabSize` option is not defined, this should never happen.');
+    throw new Error(
+      'The `tabSize` option is not defined, this should never happen.'
+    );
   }
   const startLine = editor.document.lineAt(selection.start.line).text;
   const indentationMatches = startLine.match(/^\s*/);

--- a/src/features/vault.ts
+++ b/src/features/vault.ts
@@ -88,15 +88,13 @@ export const toggleEncrypt = async (): Promise<void> => {
         vscode.window.showErrorMessage(`Inline encryption failed: ${e}`);
         return;
       }
+      const leadingWhitespaces = ' '.repeat(getIndentationLevel(editor, selection) + 1 * Number(editor.options.tabSize));
       editor.edit((editBuilder) => {
         editBuilder.replace(
           selection,
           encryptedText.replace(
             /\n\s*/g,
-            `\n${' '.repeat(
-              (getIndentationLevel(editor, selection) + 1) *
-                Number(editor.options.tabSize)
-            )}`
+            `\n${leadingWhitespaces}`
           )
         );
       });
@@ -295,6 +293,6 @@ const getIndentationLevel = (
   }
   const startLine = editor.document.lineAt(selection.start.line).text;
   const indentationMatches = startLine.match(/^\s*/);
-  const leadingWhitespaces = indentationMatches?[0].?length || 0;
+  const leadingWhitespaces = indentationMatches?.[0]?.length || 0;
   return leadingWhitespaces / Number(editor.options.tabSize);
 };


### PR DESCRIPTION
This should fix the non-perfect indentation when using inline encrypt.