### PR TITLE
Activate extension when running ansible-vault

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "activationEvents": [
     "onCommand:extension.ansible-navigator.run",
     "onCommand:extension.ansible-playbook.run",
+    "onCommand:extension.ansible.vault",
     "onLanguage:ansible"
   ],
   "badges": [


### PR DESCRIPTION
The command `extension.ansible.vault`was missing from the list of activation events.

Fixes: #289.