### PR TITLE
Auto-select the only vault-id

### DIFF
--- a/src/features/vault.ts
+++ b/src/features/vault.ts
@@ -20,6 +20,10 @@ async function askForVaultId(ansibleCfg: utilAnsibleCfg.AnsibleVaultConfig) {
     return undefined;
   }
 
+  if (identityList.length === 1) {
+    return identityList[0];
+  }
+
   const chosenVault = await vscode.window.showQuickPick(identityList);
   return chosenVault || vaultId;
 }


### PR DESCRIPTION
Don't ask for vault id if only one is defined (#108)