### PR TITLE
Check version sanity script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@ansible/ansible-language-server": "^0.2.6",
         "@types/ini": "^1.3.30",
-        "axios": "^0.24.0",
         "ini": "^1.3.0",
         "untildify": "^4.0.0",
         "vscode-languageclient": "^7.0.0"
@@ -25,6 +24,7 @@
         "@types/vscode": "^1.48.0",
         "@typescript-eslint/eslint-plugin": "^4.28.3",
         "@typescript-eslint/parser": "^4.28.3",
+        "axios": "^0.24.0",
         "chai": "^4.3.4",
         "copyfiles": "^2.4.1",
         "eslint": "^7.30.0",
@@ -1219,6 +1219,7 @@
       "version": "0.24.0",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
       "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+      "dev": true,
       "dependencies": {
         "follow-redirects": "^1.14.4"
       }
@@ -3367,6 +3368,7 @@
       "version": "1.14.5",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.5.tgz",
       "integrity": "sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -8896,6 +8898,7 @@
       "version": "0.24.0",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
       "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+      "dev": true,
       "requires": {
         "follow-redirects": "^1.14.4"
       }
@@ -10600,7 +10603,8 @@
     "follow-redirects": {
       "version": "1.14.5",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.5.tgz",
-      "integrity": "sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA=="
+      "integrity": "sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA==",
+      "dev": true
     },
     "forever-agent": {
       "version": "0.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@ansible/ansible-language-server": "^0.2.6",
         "@types/ini": "^1.3.30",
+        "axios": "^0.24.0",
         "ini": "^1.3.0",
         "untildify": "^4.0.0",
         "vscode-languageclient": "^7.0.0"
@@ -24,7 +25,6 @@
         "@types/vscode": "^1.48.0",
         "@typescript-eslint/eslint-plugin": "^4.28.3",
         "@typescript-eslint/parser": "^4.28.3",
-        "axios": "^0.24.0",
         "chai": "^4.3.4",
         "copyfiles": "^2.4.1",
         "eslint": "^7.30.0",
@@ -1219,7 +1219,6 @@
       "version": "0.24.0",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
       "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
-      "dev": true,
       "dependencies": {
         "follow-redirects": "^1.14.4"
       }
@@ -3368,7 +3367,6 @@
       "version": "1.14.5",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.5.tgz",
       "integrity": "sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -8898,7 +8896,6 @@
       "version": "0.24.0",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
       "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
-      "dev": true,
       "requires": {
         "follow-redirects": "^1.14.4"
       }
@@ -10603,8 +10600,7 @@
     "follow-redirects": {
       "version": "1.14.5",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.5.tgz",
-      "integrity": "sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA==",
-      "dev": true
+      "integrity": "sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA=="
     },
     "forever-agent": {
       "version": "0.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@types/vscode": "^1.48.0",
         "@typescript-eslint/eslint-plugin": "^4.28.3",
         "@typescript-eslint/parser": "^4.28.3",
+        "axios": "^0.24.0",
         "chai": "^4.3.4",
         "copyfiles": "^2.4.1",
         "eslint": "^7.30.0",
@@ -1213,6 +1214,15 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
       "dev": true
+    },
+    "node_modules/axios": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
+      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+      "dev": true,
+      "dependencies": {
+        "follow-redirects": "^1.14.4"
+      }
     },
     "node_modules/azure-devops-node-api": {
       "version": "11.0.1",
@@ -3353,6 +3363,26 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.2.tgz",
       "integrity": "sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==",
       "dev": true
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.14.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.5.tgz",
+      "integrity": "sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
     },
     "node_modules/forever-agent": {
       "version": "0.6.1",
@@ -8864,6 +8894,15 @@
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
       "dev": true
     },
+    "axios": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
+      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+      "dev": true,
+      "requires": {
+        "follow-redirects": "^1.14.4"
+      }
+    },
     "azure-devops-node-api": {
       "version": "11.0.1",
       "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-11.0.1.tgz",
@@ -10559,6 +10598,12 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.2.tgz",
       "integrity": "sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==",
+      "dev": true
+    },
+    "follow-redirects": {
+      "version": "1.14.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.5.tgz",
+      "integrity": "sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA==",
       "dev": true
     },
     "forever-agent": {

--- a/package.json
+++ b/package.json
@@ -397,6 +397,7 @@
     "@types/vscode": "^1.48.0",
     "@typescript-eslint/eslint-plugin": "^4.28.3",
     "@typescript-eslint/parser": "^4.28.3",
+    "axios": "^0.24.0",
     "chai": "^4.3.4",
     "copyfiles": "^2.4.1",
     "eslint": "^7.30.0",

--- a/package.json
+++ b/package.json
@@ -383,6 +383,7 @@
   "dependencies": {
     "@ansible/ansible-language-server": "^0.2.6",
     "@types/ini": "^1.3.30",
+    "axios": "^0.24.0",
     "ini": "^1.3.0",
     "untildify": "^4.0.0",
     "vscode-languageclient": "^7.0.0"
@@ -397,7 +398,6 @@
     "@types/vscode": "^1.48.0",
     "@typescript-eslint/eslint-plugin": "^4.28.3",
     "@typescript-eslint/parser": "^4.28.3",
-    "axios": "^0.24.0",
     "chai": "^4.3.4",
     "copyfiles": "^2.4.1",
     "eslint": "^7.30.0",

--- a/package.json
+++ b/package.json
@@ -383,7 +383,6 @@
   "dependencies": {
     "@ansible/ansible-language-server": "^0.2.6",
     "@types/ini": "^1.3.30",
-    "axios": "^0.24.0",
     "ini": "^1.3.0",
     "untildify": "^4.0.0",
     "vscode-languageclient": "^7.0.0"
@@ -398,6 +397,7 @@
     "@types/vscode": "^1.48.0",
     "@typescript-eslint/eslint-plugin": "^4.28.3",
     "@typescript-eslint/parser": "^4.28.3",
+    "axios": "^0.24.0",
     "chai": "^4.3.4",
     "copyfiles": "^2.4.1",
     "eslint": "^7.30.0",

--- a/package.json
+++ b/package.json
@@ -467,7 +467,8 @@
     "webpack": "npm run clean && npm run compile && webpack --mode production --config ./webpack.config.js",
     "webpack:dev": "npm run clean && webpack --mode development --config ./webpack.config.js",
     "webpack:watch": "webpack --mode development --config ./webpack.config.js --watch",
-    "clean": "rimraf out/client out/server out/tsconfig.tsbuildinfo"
+    "clean": "rimraf out/client out/server out/tsconfig.tsbuildinfo",
+    "sanity": "ts-node src/tools/check_version.ts"
   },
   "version": "0.6.1"
 }

--- a/src/tools/check_version.ts
+++ b/src/tools/check_version.ts
@@ -1,0 +1,95 @@
+import { execSync } from 'child_process';
+import axios from 'axios';
+
+/**
+ * A function to make an API call to open VSX in order to get details about the latest release of redhat.ansible extension
+ * @param currentVersion string representing the current version against which information is required
+ * @returns version of the latest release
+ */
+function makeGetRequest() {
+  return new Promise(function (resolve, reject) {
+    axios
+      .get('https://open-vsx.org/api/redhat/ansible')
+      .catch(function (error) {
+        if (error.response) {
+          // Request made and server responded
+          console.log(error.response.status);
+          resolve(error.response.status);
+        } else if (error.request) {
+          // The request was made but no response was received
+          console.log(error.request);
+          reject(error.request);
+        } else {
+          // Something happened in setting up the request that triggered an Error
+          console.log('Error', error.message);
+          reject(error.message);
+        }
+      })
+      .then((response) => {
+        if (response) {
+          const result = response.data.version;
+          resolve(result);
+        }
+      });
+  });
+}
+
+/**
+ * A function that makes a call to the makeGetRequest and checks if the curren version of redhat.ansible is released in Open VSX or not
+ * @param currentVersion string representing the current version against which information is required
+ * @returns true if current version is released, false otherwise
+ */
+
+async function releasedInOpenVSX(currentVersion: string): Promise<boolean> {
+  const responseVersion = await makeGetRequest();
+
+  return true ? responseVersion === currentVersion : false;
+}
+
+/**
+ * A function that makes a call to the makeGetRequest and checks if the curren version of redhat.ansible is released in VSCode Marketplace or not
+ * @param currentVersion string representing the current version against which information is required
+ * @returns true if current version is released, false otherwise
+ */
+
+function releasedInVSCMarketplace(currentVersion: string): boolean {
+  // Grab the version of extension from vscode marketplace
+  const result = execSync(
+    'node ./node_modules/vsce/out/vsce show --json redhat.ansible'
+  ).toString();
+
+  const VSCMarketplaceVersion = JSON.parse(result).versions[0].version;
+
+  return true ? VSCMarketplaceVersion === currentVersion : false;
+}
+
+/**
+ * The main script logic: Simple sanity check
+ * Checks if current version of redhat.asnible is already published or not.
+ * If published, throws an error stating that the version has already been published.
+ */
+async function main() {
+  // This uses "process.env.npm_package_version" to grab the version of the project from package.json
+  // This works only in the case when the script is run using npm run command, else, returns undefined
+  const currentExtensionVersion: string | undefined =
+    process.env.npm_package_version;
+
+  // TODO: check the version from package-lock.json as well
+
+  if (!currentExtensionVersion) {
+    process.exitCode = 1;
+    throw new Error('FAILURE.\nCurrent version is undefined.');
+  }
+
+  const vscMarketPlace = releasedInVSCMarketplace(currentExtensionVersion);
+
+  const openVSX = await releasedInOpenVSX(currentExtensionVersion);
+
+  if (vscMarketPlace && openVSX) {
+    process.exitCode = 1;
+    throw new Error(
+      'FAILURE.\nCurrent version already published. Run `vsce version <x.y.z>`'
+    );
+  }
+}
+main();

--- a/src/tools/check_version.ts
+++ b/src/tools/check_version.ts
@@ -43,7 +43,7 @@ function makeGetRequest() {
 async function releasedInOpenVSX(currentVersion: string): Promise<boolean> {
   const responseVersion = await makeGetRequest();
 
-  return true ? responseVersion === currentVersion : false;
+  return responseVersion === currentVersion;
 }
 
 /**
@@ -60,7 +60,7 @@ function releasedInVSCMarketplace(currentVersion: string): boolean {
 
   const VSCMarketplaceVersion = JSON.parse(result).versions[0].version;
 
-  return true ? VSCMarketplaceVersion === currentVersion : false;
+  return VSCMarketplaceVersion === currentVersion;
 }
 
 /**


### PR DESCRIPTION
As discussed with @ssbarnea, the PR adds a script that 
1. basically checks the current project version with the latest extension version released in VSCode Marketplace and Open VSX. If it matches, then exits throwing an error that states "The version is already published".
2. runs check_version.ts using npm script called 'sanity'.
3. Resolves https://github.com/ansible/vscode-ansible/issues/302
