### PR TITLE
Remove the need to configure ansible-playbook location

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,6 @@ on any level (User, Remote, Workspace and/or Folder).
 - `ansible.ansibleLint.enabled`: Enables/disables use of `ansible-lint`.
 - `ansible.ansibleLint.path`: Path to the `ansible-lint` executable.
 - `ansible.ansibleNavigator.path`: Path to the `ansible-navigator` executable.
-- `ansible.ansiblePlaybook.path`: Path to the `ansible-playbook` executable.
 - `ansible.executionEnvironment.containerEngine`: The container engine to be
   used while running with execution environment. Valid values are `auto`,
   `podman` and `docker`. For `auto` it will look for `podman` then `docker`.

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
           "scope": "machine-overridable",
           "type": "string",
           "default": "ansible",
-          "description": "Path to the ansible executable."
+          "description": "Path to the ansible executable. All subcommands are expected to have adjacent locations."
         },
         "ansible.ansible.useFullyQualifiedCollectionNames": {
           "scope": "resource",
@@ -147,12 +147,6 @@
         "ansible.ansibleNavigator.path": {
           "default": "ansible-navigator",
           "description": "%configuration.navigate.executablePath%",
-          "scope": "machine-overridable",
-          "type": "string"
-        },
-        "ansible.ansiblePlaybook.path": {
-          "default": "ansible-playbook",
-          "description": "%configuration.run.executablePath%",
           "scope": "machine-overridable",
           "type": "string"
         },

--- a/src/features/runner.ts
+++ b/src/features/runner.ts
@@ -82,8 +82,8 @@ export class AnsiblePlaybookRunProvider {
      * A property representing the `ansible-playbook` executable.
      */
   private get ansiblePlaybookExecutablePath(): string {
-    return (vscode.workspace
-      .getConfiguration('ansible.ansible.path').path || 'ansible') + '-playbook';
+    return `${vscode.workspace
+      .getConfiguration('ansible.ansible.path').path || 'ansible'  }-playbook`;
   }
 
   /**

--- a/src/features/runner.ts
+++ b/src/features/runner.ts
@@ -82,8 +82,8 @@ export class AnsiblePlaybookRunProvider {
      * A property representing the `ansible-playbook` executable.
      */
   private get ansiblePlaybookExecutablePath(): string {
-    return vscode.workspace
-      .getConfiguration('ansible.ansiblePlaybook').path;
+    return (vscode.workspace
+      .getConfiguration('ansible.ansible.path').path || 'ansible') + '-playbook';
   }
 
   /**


### PR DESCRIPTION
As ansible-playbook and all the other ansible commands are always
located alongside ansible executable itself, we have no use of
separated configuration options for them.
