### PR TITLE
Remove option to configure ansible-vault path

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,6 @@ on any level (User, Remote, Workspace and/or Folder).
 - `ansible.python.interpreterPath`: Path to the `python`/`python3` executable.
   This setting may be used to make the extension work with `ansible` and
   `ansible-lint` installations in a Python virtual environment.
-- `ansible.vault.executablePath`: Path to the `ansible-vault` executable.
 - `ansible.python.activationScript`: Path to a custom `activate` script, which
   will be used instead of the setting above to run in a Python virtual
   environment.

--- a/package.json
+++ b/package.json
@@ -191,12 +191,6 @@
           "default": "",
           "description": "Path to the virtual environment activation script. Use only if you have a custom activation script. It will be sourced using bash before executing Ansible commands. When set, the Interpreter Path setting is ignored."
         },
-        "ansible.vault.executablePath": {
-          "default": "ansible-vault",
-          "description": "%configuration.vault.executablePath%",
-          "scope": "machine-overridable",
-          "type": "string"
-        },
         "ansible.python.interpreterPath": {
           "scope": "machine-overridable",
           "type": "string",

--- a/package.nls.json
+++ b/package.nls.json
@@ -12,7 +12,6 @@
   "configuration.validate.enable": "Enable/disable ansible-lint validation.",
   "configuration.validate.executablePath": "Points to the ansible-lint executable.",
   "configuration.validate.run": "Whether the linter is run on save or on type.",
-  "configuration.vault.executablePath": "Points to the ansible-vault executable.",
   "description": "Provides rich language support for Ansible files.",
   "displayName": "Ansible Language Features",
   "submenus.ansible.run-via": "Run Ansible Playbook via..."

--- a/src/features/vault.ts
+++ b/src/features/vault.ts
@@ -34,6 +34,10 @@ function displayInvalidConfigError(): void {
   );
 }
 
+function ansibleVaultPath(config: vscode.WorkspaceConfiguration): string {
+  return `${config.ansible.path || 'ansible'  }-vault`
+}
+
 export const toggleEncrypt = async (): Promise<void> => {
   const editor = vscode.window.activeTextEditor;
   if (!editor) {
@@ -45,7 +49,7 @@ export const toggleEncrypt = async (): Promise<void> => {
     return;
   }
 
-  const config = vscode.workspace.getConfiguration('ansible.vault');
+  const config = vscode.workspace.getConfiguration('ansible');
   const doc = editor.document;
 
   // Read `ansible.cfg` or environment variable
@@ -234,8 +238,8 @@ const encryptText = (
   config: vscode.WorkspaceConfiguration
 ): Promise<string> => {
   const cmd = !!vaultId
-    ? `${config.executablePath} encrypt_string --encrypt-vault-id="${vaultId}"`
-    : `${config.executablePath} encrypt_string`;
+    ? `${ansibleVaultPath(config)} encrypt_string --encrypt-vault-id="${vaultId}"`
+    : `${ansibleVaultPath(config)} encrypt_string`;
   return pipeTextThrougCmd(text, rootPath, cmd);
 };
 
@@ -244,7 +248,7 @@ const decryptText = (
   rootPath: string | undefined,
   config: vscode.WorkspaceConfiguration
 ): Promise<string> => {
-  const cmd = `${config.executablePath} decrypt`;
+  const cmd = `${ansibleVaultPath(config)} decrypt`;
   return pipeTextThrougCmd(text, rootPath, cmd);
 };
 
@@ -257,8 +261,8 @@ const encryptFile = (
   console.log(`Encrypt file: ${f}`);
 
   const cmd = !!vaultId
-    ? `${config.executablePath} encrypt --encrypt-vault-id="${vaultId}" "${f}"`
-    : `${config.executablePath} encrypt "${f}"`;
+    ? `${ansibleVaultPath(config)} encrypt --encrypt-vault-id="${vaultId}" "${f}"`
+    : `${ansibleVaultPath(config)} encrypt "${f}"`;
 
   return execCwd(cmd, rootPath);
 };
@@ -270,7 +274,7 @@ const decryptFile = (
 ) => {
   console.log(`Decrypt file: ${f}`);
 
-  const cmd = `${config.executablePath} decrypt "${f}"`;
+  const cmd = `${ansibleVaultPath(config)} decrypt "${f}"`;
 
   return execCwd(cmd, rootPath);
 };


### PR DESCRIPTION
As all ansible subcommands are in in the same path, we no longer
need this user setting.

Related: https://github.com/ansible/vscode-ansible/pull/317