### PR TITLE
Make ansible/creator-ee:latest default execution environment

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "image": "quay.io/ansible/toolset:main",
+  "image": "quay.io/ansible/creator-ee:latest",
   "workspaceFolder": "/workspace",
   "workspaceMount": "source=remote-workspace,target=/workspace,type=volume"
 }

--- a/package.json
+++ b/package.json
@@ -170,7 +170,7 @@
         "ansible.executionEnvironment.image": {
           "scope": "resource",
           "type": "string",
-          "default": "quay.io/ansible/ansible-devtools-demo-ee:v0.1.0",
+          "default": "quay.io/ansible/creator-ee:latest",
           "description": "Specify the name of the execution environment image."
         },
         "ansible.executionEnvironment.pullPolicy": {


### PR DESCRIPTION
Especially as we are under heavy development, we should have a default
value that uses the latest creator-ee, so we avoid extra maintenance
when we update it.

This corrects https://github.com/ansible/vscode-ansible/pull/300 which used a temporary name.

Partial: https://github.com/ansible-community/devtools/issues/16