### PR TITLE
Ensure npm link uses --save

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -94,7 +94,7 @@ jobs:
         run: |
           set -ex
           mv ansible-language-server ..
-          npm link ../ansible-language-server
+          npm link --save ../ansible-language-server
           pushd ../ansible-language-server
           npm ci
           npm run compile
@@ -124,6 +124,8 @@ jobs:
 
       # extra safety measure that ensures code was not modified during build
       - name: Ensure git does not report dirty
+        # on devel we use `npm link --save ..` which will alter tracked files
+        if: ${{ !matrix.devel }}
         run: git diff --exit-code
 
   check:  # This job does nothing and is only used for the branch protection


### PR DESCRIPTION
To prevent `npm install` from overriding `npm link` outcomes or getting
errors when running `npm ls` we must be sure we do always add `--save`

Related: https://github.com/npm/cli/issues/2380
Related: https://github.com/ansible/ansible-language-server/pull/130
