### PR TITLE
Upgrade ansible-language-server to 0.4.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,11 +18,7 @@ repos:
         # `npm ci` does install deps but fails to update locked engines, thus
         # running `npm install --production` produces a better result, as it
         # will update engines if needed.
-        entry: >-
-          bash -c 'npm install --production --ignore-scripts &&
-          npm install "@ansible/ansible-language-server@latest" --save &&
-          npm version --allow-same-version --no-commit-hooks
-          --no-git-tag-version $(npm pkg get version | sed "s/\"//g")'
+        entry: npm run sanity
         language: node
         files: "(package|package-lock).json$"
         pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -5,11 +5,6 @@ This extension adds language support for Ansible to
 and [OpenVSX](https://open-vsx.org/extension/redhat/ansible) compatible editors
 by leveraging [ansible-language-server](https://github.com/ansible/ansible-language-server).
 
-Keep it mind that due to [ALS#117](https://github.com/ansible/ansible-language-server/issues/117)
-this extension works only when a workspace is present. If you open a standalone
-file outside a vscode workspace, you will not be able to use most of the
-features of this extension.
-
 ## Features
 
 ### Syntax highlighting

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
-        "@ansible/ansible-language-server": "^0.3.0",
+        "@ansible/ansible-language-server": "^0.4.0",
         "@types/ini": "^1.3.31",
         "ini": "^2.0.0",
         "untildify": "^4.0.0",
@@ -49,9 +49,9 @@
       }
     },
     "node_modules/@ansible/ansible-language-server": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@ansible/ansible-language-server/-/ansible-language-server-0.3.0.tgz",
-      "integrity": "sha512-oJaNyTWUOGa7rJRtvc3W9AYPRODnSOqwPLgOkIxqdPviq+AnEkZ98LfAyejbnZTRtqSS1j/bYVPEU6X4ZsS8PQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@ansible/ansible-language-server/-/ansible-language-server-0.4.0.tgz",
+      "integrity": "sha512-QB5DI6gIHn4Zdu5xGKG75jXi9roNzi1YDoRP3VxHLyXSgeGIPxTRTOMcDtXot+V6iagadcuTYlzhtC6rl61Nhw==",
       "dependencies": {
         "@flatten-js/interval-tree": "^1.0.14",
         "globby": "^11.0.4",
@@ -9702,9 +9702,9 @@
   },
   "dependencies": {
     "@ansible/ansible-language-server": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@ansible/ansible-language-server/-/ansible-language-server-0.3.0.tgz",
-      "integrity": "sha512-oJaNyTWUOGa7rJRtvc3W9AYPRODnSOqwPLgOkIxqdPviq+AnEkZ98LfAyejbnZTRtqSS1j/bYVPEU6X4ZsS8PQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@ansible/ansible-language-server/-/ansible-language-server-0.4.0.tgz",
+      "integrity": "sha512-QB5DI6gIHn4Zdu5xGKG75jXi9roNzi1YDoRP3VxHLyXSgeGIPxTRTOMcDtXot+V6iagadcuTYlzhtC6rl61Nhw==",
       "requires": {
         "@flatten-js/interval-tree": "^1.0.14",
         "globby": "^11.0.4",

--- a/package.json
+++ b/package.json
@@ -360,7 +360,7 @@
     ]
   },
   "dependencies": {
-    "@ansible/ansible-language-server": "^0.3.0",
+    "@ansible/ansible-language-server": "^0.4.0",
     "@types/ini": "^1.3.31",
     "ini": "^2.0.0",
     "untildify": "^4.0.0",
@@ -437,6 +437,7 @@
     "package": "npm ci && rimraf *.vsix && vsce package && vsce ls",
     "prepare": "git config --unset core.hooksPath || true && rimraf .husky",
     "pretest": "npm run compile",
+    "sanity": "npm ci && npm install --ignore-scripts && ncu upgrade '@ansible/ansible-language-server@latest' && npm version --allow-same-version --no-commit-hooks --no-git-tag-version $npm_package_version",
     "//setup": "setup is used to configure development environment, like installing git hooks.",
     "setup": "pre-commit install-hooks",
     "test:ui": "extest setup-and-run -i -s out/test-resources out/client/ui-test/allTestsSuite.js",


### PR DESCRIPTION
We also remove the README warning as 0.4.0 is fixing that bug.

We fix the bug in npm-sanity which picked any newer ALS version
instead of picking the last stable release. Using `ncu` tool instead
ensures only desirable versions are picked.

That change cannot be split due to the circular dependency between
pre-commit bug and the need to update ALS.