### PR TITLE
e2e: Use a standalone settings.json file

### DIFF
--- a/src/test/helper.ts
+++ b/src/test/helper.ts
@@ -5,22 +5,6 @@ import { assert } from 'chai';
 export let doc: vscode.TextDocument;
 export let editor: vscode.TextEditor;
 
-// Default ansible configurations
-export const defaultAnsibleConfigurations = {
-  'ansible.useFullyQualifiedCollectionNames': true,
-  'ansibleLint.arguments': '',
-  'ansibleLint.enabled': true,
-  'ansibleLint.path': 'ansible-lint',
-  'ansibleNavigator.path': 'ansible-navigator',
-  'executionEnvironment.containerEngine': 'auto',
-  'executionEnvironment.enabled': false,
-  'executionEnvironment.image': 'quay.io/ansible/creator-ee:latest',
-  'executionEnvironment.pullPolicy': 'missing',
-  'python.activationScript': '',
-  'python.interpreterPath': 'python3',
-  'ansible.path': 'ansible',
-};
-
 /**
  * Activates the redhat.ansible extension
  */
@@ -66,14 +50,6 @@ export async function updateSettings(
 ): Promise<void> {
   const ansibleConfiguration = vscode.workspace.getConfiguration('ansible');
   return ansibleConfiguration.update(setting, value, false);
-}
-
-export async function resetDefaultSettings(): Promise<void> {
-  const ansibleConfiguration = vscode.workspace.getConfiguration('ansible');
-  Object.entries(defaultAnsibleConfigurations).forEach((config) => {
-    ansibleConfiguration.update(config[0], config[1], false);
-  });
-  await sleep(1000);
 }
 
 export async function testDiagnostics(

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -1,7 +1,6 @@
 import * as path from 'path';
 import Mocha from 'mocha';
 import glob from 'glob';
-import { resetDefaultSettings } from './helper';
 
 export function run(): Promise<void> {
   // Create the mocha test
@@ -19,9 +18,6 @@ export function run(): Promise<void> {
   });
 
   const testsRoot = path.resolve(__dirname, '..');
-
-  //   create default settings
-  resetDefaultSettings();
 
   return new Promise((c, e) => {
     glob('**/**.test.js', { cwd: testsRoot }, (err, files) => {

--- a/src/test/testFixtures/settings.json
+++ b/src/test/testFixtures/settings.json
@@ -1,0 +1,14 @@
+{
+    "ansible.ansible.path": "ansible",
+    "ansible.ansible.useFullyQualifiedCollectionNames": true,
+    "ansible.ansibleLint.arguments": "",
+    "ansible.ansibleLint.enabled": true,
+    "ansible.ansibleLint.path": "ansible-lint",
+    "ansible.ansibleNavigator.path": "ansible-navigator",
+    "ansible.executionEnvironment.containerEngine": "auto",
+    "ansible.executionEnvironment.enabled": false,
+    "ansible.executionEnvironment.image": "quay.io/ansible/creator-ee:latest",
+    "ansible.executionEnvironment.pullPolicy": "missing",
+    "ansible.python.activationScript": "",
+    "ansible.python.interpreterPath": "python3"
+}

--- a/src/test/testRunner.ts
+++ b/src/test/testRunner.ts
@@ -5,11 +5,36 @@ import {
   downloadAndUnzipVSCode,
   resolveCliPathFromVSCodeExecutablePath,
 } from 'vscode-test';
+import fs from 'fs';
 
 async function main(): Promise<void> {
   try {
     const executable = await downloadAndUnzipVSCode();
     const cliPath = resolveCliPathFromVSCodeExecutablePath(executable);
+
+    // Copy default user settings.json
+    const settings_src = path.join(
+      __dirname,
+      '..',
+      '..',
+      '..',
+      'src',
+      'test',
+      'testFixtures',
+      'settings.json',
+    );
+    const settings_dst = path.join(
+      __dirname,
+      '..',
+      '..',
+      '..',
+      'out',
+      'userdata',
+      'User',
+      'settings.json',
+    );
+    fs.mkdirSync(path.dirname(settings_dst), { recursive: true });
+    fs.copyFileSync(settings_src, settings_dst);
 
     // Install the latest released redhat.ansible extension
     const installLog = cp.execSync(

--- a/src/test/testScripts/testExtensionLocal.test.ts
+++ b/src/test/testScripts/testExtensionLocal.test.ts
@@ -1,8 +1,0 @@
-import { resetDefaultSettings } from '../helper';
-
-describe('TEST EXTENSION IN LOCAL ENVIRONMENT', () => {
-  after(async () => {
-    await resetDefaultSettings();
-  });
-
-});


### PR DESCRIPTION
This replaces the buggy reset settings helper with a plain simple file copy operation.

Also allows us to add other default settings that are not specific to ansible extension and allow us to test using file that do
not have a workspace.
