### PR TITLE
e2e: display exception when tests fail

### DIFF
--- a/src/test/testRunner.ts
+++ b/src/test/testRunner.ts
@@ -73,7 +73,7 @@ async function main(): Promise<void> {
       ],
     });
   } catch (err) {
-    console.error('Failed to run tests');
+    console.error('Failed to run tests due to exception!\n%s', err);
     process.exit(1);
   }
 }


### PR DESCRIPTION
Probably there is no need to explain why hiding an exception was not our best choice.