### PR TITLE
lint: enable codespell

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,6 +58,14 @@ repos:
         #   args: ['--autofix']
       - id: debug-statements
         language_version: python3
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.1.0
+    hooks:
+      - id: codespell
+        exclude: >
+          (?x)^(
+            package-lock.json
+          )$
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.30.0
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,8 +52,8 @@
 
 * **Feature**: Restored client-side support for working with ansible
   vaults (#177) @jeinwag
-* Exposed the `ansibleServer.trace.server` option for tracing ALS
-  activity (#263) @yaegassy
+* Exposed the `ansibleServer.trace.server` option for tracing language
+  server activity (#263) @yaegassy
 * Upgraded language server to 0.2.6 (#284) @ssbarnea
 
 ### Bugfixes
@@ -103,12 +103,12 @@ In particular, this:
 * Made sure that the path-related settings are not being synchronized
   (#235) @ssbarnea
 * Reintroduced the schema verification for the part of the known file
-  paths that's been lost with the initial introduction of ALS in
-  extension (#169) @ssbarnea
+  paths that's been lost with the initial introduction of ansible language
+  server in extension (#169) @ssbarnea
 * Stopped including the unused files to vsix artifacts (#239) @ssbarnea
-* Switched the debug listening port for ALS in the development mode to
-  `6010` effectively fixing the support for unbound breakpoints when
-  coding two connected projects (#212) @tomaciazek
+* Switched the debug listening port for ansible language server in the
+  development mode to `6010` effectively fixing the support for unbound
+  breakpoints when coding two connected projects (#212) @tomaciazek
 
 ### Docs
 

--- a/src/features/vault.ts
+++ b/src/features/vault.ts
@@ -191,7 +191,7 @@ const getInlineTextType = (text: string) => {
   return text.trim().startsWith('$ANSIBLE_VAULT;') ? 'encrypted' : 'plaintext';
 };
 
-// Returns wheter the file is encrypted or in plain text.
+// Returns whether the file is encrypted or in plain text.
 const getTextType = (text: string) => {
   return text.indexOf('$ANSIBLE_VAULT;') === 0 ? 'encrypted' : 'plaintext';
 };

--- a/src/test/testRunner.ts
+++ b/src/test/testRunner.ts
@@ -17,7 +17,7 @@ async function main(): Promise<void> {
     );
     console.log(installLog.toString());
 
-    // Install the dependant extensions
+    // Install the dependent extensions
     const dependencies = ['ms-python.python', 'redhat.vscode-yaml'];
     for (const dep of dependencies) {
       const installLog = cp.execSync(
@@ -57,7 +57,7 @@ async function main(): Promise<void> {
       extensionTestsPath,
       launchArgs: [
         // We want to avoid using developer data dir as this is likely to break
-        // testing and make its outcome very hard to reproduce acroos machines.
+        // testing and make its outcome very hard to reproduce across machines.
         // https://code.visualstudio.com/docs/getstarted/settings#_settings-file-locations
         `--user-data-dir=${userDataPath}`,
         '--disable-extension=ritwickdey.liveserver',

--- a/syntaxes/ansible/generated/jinja-double-quote-escape.tmLanguage
+++ b/syntaxes/ansible/generated/jinja-double-quote-escape.tmLanguage
@@ -7,7 +7,7 @@
         <key>injectionSelector</key>
         <string>L:string.quoted.double meta.embedded.inline.jinja</string>
         <key>name</key>
-        <string>Injection grammar for supproting double quote escapes in Jinja2 expressions</string>
+        <string>Injection grammar for supporting double quote escapes in Jinja2 expressions</string>
         <key>patterns</key>
         <array>
             <dict>

--- a/syntaxes/ansible/generated/jinja-single-quote-escape.tmLanguage
+++ b/syntaxes/ansible/generated/jinja-single-quote-escape.tmLanguage
@@ -7,7 +7,7 @@
         <key>injectionSelector</key>
         <string>L:string.quoted.single meta.embedded.inline.jinja</string>
         <key>name</key>
-        <string>Injection grammar for supproting single quote escapes in Jinja2 expressions</string>
+        <string>Injection grammar for supporting single quote escapes in Jinja2 expressions</string>
         <key>patterns</key>
         <array>
             <dict>

--- a/syntaxes/ansible/jinja-double-quote-escape.tmLanguage.plist
+++ b/syntaxes/ansible/jinja-double-quote-escape.tmLanguage.plist
@@ -1,7 +1,7 @@
 {
     scopeName = 'injection.ansible.jinja-double-quote-escape';
     injectionSelector = 'L:string.quoted.double meta.embedded.inline.jinja';
-    name = 'Injection grammar for supproting double quote escapes in Jinja2 expressions';
+    name = 'Injection grammar for supporting double quote escapes in Jinja2 expressions';
     patterns = (
         {
             name = 'string.quoted.double.jinja';

--- a/syntaxes/ansible/jinja-single-quote-escape.tmLanguage.plist
+++ b/syntaxes/ansible/jinja-single-quote-escape.tmLanguage.plist
@@ -1,7 +1,7 @@
 {
     scopeName = 'injection.ansible.jinja-single-quote-escape';
     injectionSelector = 'L:string.quoted.single meta.embedded.inline.jinja';
-    name = 'Injection grammar for supproting single quote escapes in Jinja2 expressions';
+    name = 'Injection grammar for supporting single quote escapes in Jinja2 expressions';
     patterns = (
         {
             name = 'string.quoted.single.jinja';


### PR DESCRIPTION
This should help us introduce less typos and spelling errors.