### PR TITLE
e2e: disable popup for workspace trust

### DIFF
--- a/src/test/testFixtures/settings.json
+++ b/src/test/testFixtures/settings.json
@@ -1,14 +1,19 @@
 {
-    "ansible.ansible.path": "ansible",
-    "ansible.ansible.useFullyQualifiedCollectionNames": true,
-    "ansible.ansibleLint.arguments": "",
-    "ansible.ansibleLint.enabled": true,
-    "ansible.ansibleLint.path": "ansible-lint",
-    "ansible.ansibleNavigator.path": "ansible-navigator",
-    "ansible.executionEnvironment.containerEngine": "auto",
-    "ansible.executionEnvironment.enabled": false,
-    "ansible.executionEnvironment.image": "quay.io/ansible/creator-ee:latest",
-    "ansible.executionEnvironment.pullPolicy": "missing",
-    "ansible.python.activationScript": "",
-    "ansible.python.interpreterPath": "python3"
+  // ansible settings
+  "ansible.ansible.path": "ansible",
+  "ansible.ansible.useFullyQualifiedCollectionNames": true,
+  "ansible.ansibleLint.arguments": "",
+  "ansible.ansibleLint.enabled": true,
+  "ansible.ansibleLint.path": "ansible-lint",
+  "ansible.ansibleNavigator.path": "ansible-navigator",
+  "ansible.executionEnvironment.containerEngine": "auto",
+  "ansible.executionEnvironment.enabled": false,
+  "ansible.executionEnvironment.image": "quay.io/ansible/creator-ee:latest",
+  "ansible.executionEnvironment.pullPolicy": "missing",
+  "ansible.python.activationScript": "",
+  "ansible.python.interpreterPath": "python3",
+
+  // security settings
+  "security.workspace.trust.enabled": false,
+  "security.workspace.trust.startupPrompt": "never"
 }

--- a/src/test/testFixtures/settings.json
+++ b/src/test/testFixtures/settings.json
@@ -1,5 +1,4 @@
 {
-  // ansible settings
   "ansible.ansible.path": "ansible",
   "ansible.ansible.useFullyQualifiedCollectionNames": true,
   "ansible.ansibleLint.arguments": "",
@@ -13,7 +12,6 @@
   "ansible.python.activationScript": "",
   "ansible.python.interpreterPath": "python3",
 
-  // security settings
   "security.workspace.trust.enabled": false,
   "security.workspace.trust.startupPrompt": "never"
 }


### PR DESCRIPTION
The PR does the followings:
1. Adds settings to `disable workspace trust` pop up that requires an action.
	- Basically, the tests don't run if an action is not made on the workspace trust pop up and exits.
	- Two settings have been added in order to disable workspace trust and stop the popup to automate the entire process without any actions from the user.
2. Categorizes the settings in the `settings.json` file (separated by a new line character).