### PR TITLE
Declare lextudio.restructuredtext ext as conflicting

### DIFF
--- a/src/extensionConflicts.ts
+++ b/src/extensionConflicts.ts
@@ -7,6 +7,7 @@ import { commands, Extension, extensions, window } from 'vscode';
 // A set of VSCode extension ID's that conflict with our extension
 const conflictingIDs = [
   'haaaad.ansible',
+  'lextudio.restructuredtext', // https://github.com/vscode-restructuredtext/vscode-restructuredtext/issues/286
   'sysninja.vscode-ansible-mod',
   'tomaciazek.ansible',
   'vscoss.vscode-ansible',


### PR DESCRIPTION
As this extension has a serious known bug that was not addressed
for a very long time, it is better to suggest its removal.

Related: https://github.com/vscode-restructuredtext/vscode-restructuredtext/issues/286