### PR TITLE
chore: ensure we have working ansible-lint on gha

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,7 +88,18 @@ jobs:
       - name: Install dependencies
         run: |
           set -ex
+          # we don't want the outdated ubuntu blend of ansible
+          if [ "$RUNNER_OS" == "Linux" ]; then
+            sudo apt-get remove -y ansible
+          fi
           pipx install pre-commit
+          # see https://github.com/pypa/pipx/issues/88
+          pipx install ansible-lint
+          if [ "$RUNNER_OS" != "Windows" ]; then
+            pipx inject --include-apps ansible-lint yamllint ansible-core
+            ansible-lint --version
+            ansible --version
+          fi
           npm config set fund false
           npm ci
         shell: bash


### PR DESCRIPTION
As we will want to use ansible-lint during testing of extension,
we also install it using pipx with latest version of ansible-core.

This operation requires removal of the outdated version of ansible
that GHA is including with their Ubuntu images.

Needed-By: https://github.com/ansible/vscode-ansible/pull/382