### PR TITLE
chore: use prettier with markdown

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,10 +66,16 @@ repos:
           (?x)^(
             package-lock.json
           )$
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    # keep it before markdownlint and eslint
+    rev: "v2.5.1"
+    hooks:
+      - id: prettier
+        types: ["markdown"]
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.30.0
     hooks:
-    - id: markdownlint
+      - id: markdownlint
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
     rev: v6.0.0
     hooks:

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -2,9 +2,14 @@ tabWidth: 2
 useTabs: false
 overrides:
   - files:
-      - '*.yaml'
-      - '*.yml'
+      - "*.yaml"
+      - "*.yml"
     options:
       singleQuote: false
+  - files:
+      - "*.md"
+    options:
+      proseWrap: always
+      printWidth: 80
 semi: true
 singleQuote: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,17 @@
 <!-- markdownlint-disable no-duplicate-heading -->
+
 # Change Log
 
 ## 0.7.1
 
 ### Bugfixes
 
-* Fixed inline encryption of multiline strings (#337) @jeinwag
-* Prevented throwing an unhandled exception caused by the undefined linter
+- Fixed inline encryption of multiline strings (#337) @jeinwag
+- Prevented throwing an unhandled exception caused by the undefined linter
   arguments settings
   ([ansible/ansible-language-server#142](https://github.com/ansible/ansible-language-server/pull/142))
   @ssbarnea
-* Implemented opening standalone Ansible files that have no workspace
-  associated
+- Implemented opening standalone Ansible files that have no workspace associated
   ([ansible/ansible-language-server#140](https://github.com/ansible/ansible-language-server/pull/140))
   @ganeshrn
 
@@ -19,158 +19,155 @@
 
 ### Removals
 
-* Dropped the option to configure ansible-vault path (#318) @ssbarnea
-* Dropped the option to configure ansible-playbook location (#317) @ssbarnea
+- Dropped the option to configure ansible-vault path (#318) @ssbarnea
+- Dropped the option to configure ansible-playbook location (#317) @ssbarnea
 
 ### Minor Changes
 
-* Upgraded the `@ansible/ansible-language-server` dependency to 0.3.0 (#333) @ssbarnea
-  * Added support for nested module options (suboptions) @tomaciazek
-  * Updated container cleanup logic for execution environment @ganeshrn
-* Switched the default execution environment to `ansible/creator-ee:latest`
+- Upgraded the `@ansible/ansible-language-server` dependency to 0.3.0 (#333)
+  @ssbarnea
+  - Added support for nested module options (suboptions) @tomaciazek
+  - Updated container cleanup logic for execution environment @ganeshrn
+- Switched the default execution environment to `ansible/creator-ee:latest`
   (#331) @ganeshrn @ssbarnea
-* Enabled auto-selecttion of the only vault-id (#298) @jeinwag
+- Enabled auto-selecttion of the only vault-id (#298) @jeinwag
 
 ### Bugfixes
 
-* Corrected some unspecified configurable settings (#307) @ssbarnea
-* Started invoking inactive extension when running ansible-vault (#296) @jeinwag
+- Corrected some unspecified configurable settings (#307) @ssbarnea
+- Started invoking inactive extension when running ansible-vault (#296) @jeinwag
 
 ### Documentation
 
-* Documented the need to have an open workspace for the extension to work @ssbarnea
+- Documented the need to have an open workspace for the extension to work
+  @ssbarnea
 
 ## 0.6.1
 
 ### Bugfixes
 
-* Fix indentation when using inline vault encrypt (#288) @jeinwag
+- Fix indentation when using inline vault encrypt (#288) @jeinwag
 
 ## 0.6.0
 
 ### Minor Changes
 
-* **Feature**: Restored client-side support for working with ansible
-  vaults (#177) @jeinwag
-* Exposed the `ansibleServer.trace.server` option for tracing language
-  server activity (#263) @yaegassy
-* Upgraded language server to 0.2.6 (#284) @ssbarnea
+- **Feature**: Restored client-side support for working with ansible vaults
+  (#177) @jeinwag
+- Exposed the `ansibleServer.trace.server` option for tracing language server
+  activity (#263) @yaegassy
+- Upgraded language server to 0.2.6 (#284) @ssbarnea
 
 ### Bugfixes
 
-* Fixed autocompletion of the built-in modules with EE
+- Fixed autocompletion of the built-in modules with EE
   (ansible/ansible-language-server#94) @ganeshrn
-* Corrected `pullPolicy` setting type to string (#279) @ganeshrn
-* Enabled editor suggestions for `ansible` files by default
-  (#274) @ssbarnea
+- Corrected `pullPolicy` setting type to string (#279) @ganeshrn
+- Enabled editor suggestions for `ansible` files by default (#274) @ssbarnea
 
 ## 0.5.1
 
 ### Hotfixes
 
-* Increased the minimum required `@ansible/ansible-language-server`
-  version to 0.2.5. It has added a guard for linting only playbook
-  files with the Ansible's built-in syntax-check when `ansible-lint`
-  is unavailable. This is used for providing the diagnostics
-  information to the client (VS Code editor instance) (#259)
-  @ganeshrn
+- Increased the minimum required `@ansible/ansible-language-server` version to
+  0.2.5. It has added a guard for linting only playbook files with the Ansible's
+  built-in syntax-check when `ansible-lint` is unavailable. This is used for
+  providing the diagnostics information to the client (VS Code editor instance)
+  (#259) @ganeshrn
 
 ## 0.5.0
 
 ### Major changes
 
 The most notable change that happened was the migration to using
-`@ansible/ansible-language-server` v0.2.4 via PR #142 by @tomaciazek.
-In particular, this:
+`@ansible/ansible-language-server` v0.2.4 via PR #142 by @tomaciazek. In
+particular, this:
 
-* Added the brand new Ansible Language Server
-* Removed the support for working with the valuted content
+- Added the brand new Ansible Language Server
+- Removed the support for working with the valuted content
 
 ### Changes
 
-* Decreased the minimal required version of VS Code to v1.48.0 (July
-  2020) (#206) @ssbarnea
-* Added setting options for working with execution environments (#200)
-  @ganeshrn
-* Added a prompt to uninstall incompatible extensions (#170) @ssbarnea
-* Updated the default setting value to use FQCN in autocompletion (#196)
+- Decreased the minimal required version of VS Code to v1.48.0 (July 2020)
+  (#206) @ssbarnea
+- Added setting options for working with execution environments (#200) @ganeshrn
+- Added a prompt to uninstall incompatible extensions (#170) @ssbarnea
+- Updated the default setting value to use FQCN in autocompletion (#196)
   @priyamsahoo
-* Added context menus and commands for running playbooks via
-  `ansible-playbook` and `ansible-navigator run` (#137) @webknjaz
+- Added context menus and commands for running playbooks via `ansible-playbook`
+  and `ansible-navigator run` (#137) @webknjaz
 
 ### Misc
 
-* Made sure that the path-related settings are not being synchronized
-  (#235) @ssbarnea
-* Reintroduced the schema verification for the part of the known file
-  paths that's been lost with the initial introduction of ansible language
-  server in extension (#169) @ssbarnea
-* Stopped including the unused files to vsix artifacts (#239) @ssbarnea
-* Switched the debug listening port for ansible language server in the
+- Made sure that the path-related settings are not being synchronized (#235)
+  @ssbarnea
+- Reintroduced the schema verification for the part of the known file paths
+  that's been lost with the initial introduction of ansible language server in
+  extension (#169) @ssbarnea
+- Stopped including the unused files to vsix artifacts (#239) @ssbarnea
+- Switched the debug listening port for ansible language server in the
   development mode to `6010` effectively fixing the support for unbound
   breakpoints when coding two connected projects (#212) @tomaciazek
 
 ### Docs
 
-* Added a link to the language server repository into README
-  (#173) @ganeshrn
-* Added descriptions for the configuration settings section in README
-  (#242) @ganeshrn
+- Added a link to the language server repository into README (#173) @ganeshrn
+- Added descriptions for the configuration settings section in README (#242)
+  @ganeshrn
 
 ## 0.4.5
 
-* Clean old violations when running the linter again
+- Clean old violations when running the linter again
 
 ## 0.4.4
 
-* Revalidate documents on save (#95) @ssbarnea
+- Revalidate documents on save (#95) @ssbarnea
 
 ## 0.4.3
 
-* Auto-add missing Ansible YAML tags like `!vault`
-* Recognize Ansible files using `.yaml` extension in addition to `.yml`
+- Auto-add missing Ansible YAML tags like `!vault`
+- Recognize Ansible files using `.yaml` extension in addition to `.yml`
 
 ## 0.4.2
 
-* Reduce minimal version of vscode that is required (#90) @ssbarnea
+- Reduce minimal version of vscode that is required (#90) @ssbarnea
 
 ## 0.4.0
 
-* Added vaults encryption and decryption support via `ansible-vault`
-  command (#78) @FlorianLaunay
+- Added vaults encryption and decryption support via `ansible-vault` command
+  (#78) @FlorianLaunay
 
 ## 0.3.2
 
-* Use ansible-lint severity for VSCode diagnostics (#68) @FloSchwalm
-* Match found problems to source files (#70) @FloSchwalm
-* docs: added instructions on how to integrate `ansible-lint` in venv
-  w… (#67) @stopendy
+- Use ansible-lint severity for VSCode diagnostics (#68) @FloSchwalm
+- Match found problems to source files (#70) @FloSchwalm
+- docs: added instructions on how to integrate `ansible-lint` in venv w… (#67)
+  @stopendy
 
 ## 0.3.1
 
-* docs: mention YAML tags configuration (#61) @ssbarnea
-* [pre-commit.ci] pre-commit autoupdate (#55) @pre-commit-ci
-* feat: add logging information (#62) @ssbarnea
-* fix: advertise Microsoft Python extension as required (#54) @ssbarnea
-* Create LICENSE (#52) @ssbarnea
-* chore: fix pre-commit eslint dependencies (#53) @ssbarnea
-* Add an explicit extension dependency on vscode-yaml (#45) @JPinkney
-* Fix typo in README.md (#46) @fgierlinger
+- docs: mention YAML tags configuration (#61) @ssbarnea
+- [pre-commit.ci] pre-commit autoupdate (#55) @pre-commit-ci
+- feat: add logging information (#62) @ssbarnea
+- fix: advertise Microsoft Python extension as required (#54) @ssbarnea
+- Create LICENSE (#52) @ssbarnea
+- chore: fix pre-commit eslint dependencies (#53) @ssbarnea
+- Add an explicit extension dependency on vscode-yaml (#45) @JPinkney
+- Fix typo in README.md (#46) @fgierlinger
 
 ## 0.3.0
 
-* Added file associations for common files found on Ansible
-  and Python repos
-* Added schema verification for galaxy.yml files
+- Added file associations for common files found on Ansible and Python repos
+- Added schema verification for galaxy.yml files
 
 ## 0.2.0
 
-* Add JSON schema for Zuul CI config files
-* Add JSON schema for ansible-lint config files
-* Add JSON schema for molecule scenarios
-* Fix badge urls for marketplace
+- Add JSON schema for Zuul CI config files
+- Add JSON schema for ansible-lint config files
+- Add JSON schema for molecule scenarios
+- Fix badge urls for marketplace
 
 ## 0.1.0
 
-* Enable schema verification
-* Fixed screenshot markdown image url
+- Enable schema verification
+- Fixed screenshot markdown image url

--- a/README.md
+++ b/README.md
@@ -3,20 +3,23 @@
 This extension adds language support for Ansible to
 [Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=redhat.ansible)
 and [OpenVSX](https://open-vsx.org/extension/redhat/ansible) compatible editors
-by leveraging [ansible-language-server](https://github.com/ansible/ansible-language-server).
+by leveraging
+[ansible-language-server](https://github.com/ansible/ansible-language-server).
 
 ## Activating Red Hat Ansible extension
 
-It is recommended to open a folder containing Ansible files with a VS Code workspace.
+It is recommended to open a folder containing Ansible files with a VS Code
+workspace.
 
 ![Linter support](https://raw.githubusercontent.com/wiki/ansible/vscode-ansible/images/activate-extension.gif)
 
 Note:
 
-* For Ansible files open in an editor window ensure the language mode is
-  set to `Ansible` (bottom right of VS Code window).
-* The runtime status of extension should be in activate state. It can
-  be verified in the `Extension` window `Runtime Status` tab for `Ansible` extension.
+- For Ansible files open in an editor window ensure the language mode is set to
+  `Ansible` (bottom right of VS Code window).
+- The runtime status of extension should be in activate state. It can be
+  verified in the `Extension` window `Runtime Status` tab for `Ansible`
+  extension.
 
 ## Features
 
@@ -48,8 +51,8 @@ is provided instantaneously.
 
 On opening and saving a document, `ansible-lint` is executed in the background
 and any findings are presented as errors. You might find it useful that
-rules/tags added to `warn_list`
-(see [Ansible Lint Documentation](https://ansible-lint.readthedocs.io/en/latest/configuring.html))
+rules/tags added to `warn_list` (see
+[Ansible Lint Documentation](https://ansible-lint.readthedocs.io/en/latest/configuring.html))
 are shown as warnings instead.
 
 ### Smart autocompletion
@@ -60,12 +63,12 @@ The extension tries to detect whether the cursor is on a play, block or task
 etc. and provides suggestions accordingly. There are also a few other rules that
 improve user experience:
 
-* the `name` property is always suggested first
-* on module options, the required properties are shown first, and aliases are
+- the `name` property is always suggested first
+- on module options, the required properties are shown first, and aliases are
   shown last, otherwise ordering from the documentation is preserved
-* FQCNs (fully qualified collection names) are inserted only when necessary;
+- FQCNs (fully qualified collection names) are inserted only when necessary;
   collections configured with the
-  [`collections` keyword]([LINK](https://docs.ansible.com/ansible/latest/user_guide/collections_using.html#simplifying-module-names-with-the-collections-keyword))
+  [`collections` keyword](<[LINK](https://docs.ansible.com/ansible/latest/user_guide/collections_using.html#simplifying-module-names-with-the-collections-keyword)>)
   are honored. This behavior can be disabled in extension settings.
 
 #### Auto-closing Jinja expressions
@@ -88,14 +91,14 @@ the documentation straight from the Python implementation of the modules.
 
 ![Go to code on Ctrl+click](images/go-to-definition.gif)
 
-You may also open the implementation of any module using the standard *Go to
-Definition* operation, for instance, by clicking on the module name while
+You may also open the implementation of any module using the standard _Go to
+Definition_ operation, for instance, by clicking on the module name while
 holding `ctrl`/`cmd`.
 
 ## Requirements
 
-* [Ansible 2.9+](https://docs.ansible.com/ansible/latest/index.html)
-* [Ansible Lint](https://ansible-lint.readthedocs.io/en/latest/) (required,
+- [Ansible 2.9+](https://docs.ansible.com/ansible/latest/index.html)
+- [Ansible Lint](https://ansible-lint.readthedocs.io/en/latest/) (required,
   unless you disable linter support; install without `yamllint`)
 
 For Windows users, this extension works perfectly well with extensions such as
@@ -106,50 +109,51 @@ For Windows users, this extension works perfectly well with extensions such as
 
 ## Configuration
 
-This extension supports multi-root workspaces, and as such, can be configured
-on any level (User, Remote, Workspace and/or Folder).
+This extension supports multi-root workspaces, and as such, can be configured on
+any level (User, Remote, Workspace and/or Folder).
 
-* `ansible.ansible.path`: Path to the `ansible` executable.
-* `ansible.ansible.useFullyQualifiedCollectionNames`: Toggles use of
-  fully qualified collection names (FQCN) when inserting a module name.
-  Disabling it will only use FQCNs when necessary, that is when the collection
-  isn't configured for the task.
-* `ansible.ansibleLint.arguments`: Optional command line arguments to be
+- `ansible.ansible.path`: Path to the `ansible` executable.
+- `ansible.ansible.useFullyQualifiedCollectionNames`: Toggles use of fully
+  qualified collection names (FQCN) when inserting a module name. Disabling it
+  will only use FQCNs when necessary, that is when the collection isn't
+  configured for the task.
+- `ansible.ansibleLint.arguments`: Optional command line arguments to be
   appended to `ansible-lint` invocation. See `ansible-lint` documentation.
-* `ansible.ansibleLint.enabled`: Enables/disables use of `ansible-lint`.
-* `ansible.ansibleLint.path`: Path to the `ansible-lint` executable.
-* `ansible.ansibleNavigator.path`: Path to the `ansible-navigator` executable.
-* `ansible.executionEnvironment.containerEngine`: The container engine to be
+- `ansible.ansibleLint.enabled`: Enables/disables use of `ansible-lint`.
+- `ansible.ansibleLint.path`: Path to the `ansible-lint` executable.
+- `ansible.ansibleNavigator.path`: Path to the `ansible-navigator` executable.
+- `ansible.executionEnvironment.containerEngine`: The container engine to be
   used while running with execution environment. Valid values are `auto`,
   `podman` and `docker`. For `auto` it will look for `podman` then `docker`.
-* `ansible.executionEnvironment.enabled`: Enable or disable the use of an
-   execution environment.
-* `ansible.executionEnvironment.image`: Specify the name of the execution
+- `ansible.executionEnvironment.enabled`: Enable or disable the use of an
+  execution environment.
+- `ansible.executionEnvironment.image`: Specify the name of the execution
   environment image.
-* `ansible.executionEnvironment.pullPolicy`: Specify the image pull policy.
-  Valid values are `always`, `missing`, `never` and `tag`. Setting `always`
-  will always pull the image when extension is activated or reloaded. Setting
+- `ansible.executionEnvironment.pullPolicy`: Specify the image pull policy.
+  Valid values are `always`, `missing`, `never` and `tag`. Setting `always` will
+  always pull the image when extension is activated or reloaded. Setting
   `missing` will pull if not locally available. Setting `never` will never pull
   the image and setting tag will always pull if the image tag is 'latest',
   otherwise pull if not locally available.
-* `ansible.python.interpreterPath`: Path to the `python`/`python3` executable.
+- `ansible.python.interpreterPath`: Path to the `python`/`python3` executable.
   This setting may be used to make the extension work with `ansible` and
   `ansible-lint` installations in a Python virtual environment.
-* `ansible.python.activationScript`: Path to a custom `activate` script, which
+- `ansible.python.activationScript`: Path to a custom `activate` script, which
   will be used instead of the setting above to run in a Python virtual
   environment.
-* `ansibleServer.trace.server`: Traces the communication between VSCode and the
+- `ansibleServer.trace.server`: Traces the communication between VSCode and the
   ansible language server.
 
 ## Known limitations
 
-* The shorthand syntax for module options (key=value pairs) is not supported.
-* Nested module options are not supported yet.
-* Only Jinja *expressions* inside Ansible YAML files are supported. In order to
+- The shorthand syntax for module options (key=value pairs) is not supported.
+- Nested module options are not supported yet.
+- Only Jinja _expressions_ inside Ansible YAML files are supported. In order to
   have syntax highlighting of Jinja template files, you'll need to install other
   extension.
-* Jinja *blocks* (inside Ansible YAML files) are not supported yet.
+- Jinja _blocks_ (inside Ansible YAML files) are not supported yet.
 
 ## Credit
 
-Based on the good work done by [Tomasz Maciążek](https://github.com/tomaciazek/vscode-ansible)
+Based on the good work done by
+[Tomasz Maciążek](https://github.com/tomaciazek/vscode-ansible)

--- a/doc/development.md
+++ b/doc/development.md
@@ -2,10 +2,10 @@
 
 ## Running & debugging the extension locally
 
-There are multiple ways to run this extension in debug mode, depending on
-your needs and setup.
+There are multiple ways to run this extension in debug mode, depending on your
+needs and setup.
 
-### Debug with language server from *npm*
+### Debug with language server from _npm_
 
 In that mode, the code of the client is compiled and watched, while the language
 server's code is copied from the `node_modules`. You'll be able to debug
@@ -18,7 +18,7 @@ configuration, or just **Launch Extension**.
 ### Debug with local language server source code
 
 For this mode to work, you'll first need to clone the repository containing the
-language server code into the `ansible-language-server` directory *next to* the
+language server code into the `ansible-language-server` directory _next to_ the
 root directory of this repository. Remember to `npm install` in that directory.
 
 Once the language server directory is prepared, you may compile both client and
@@ -55,23 +55,23 @@ vsce package
 
 ## Publish extension (obsolete)
 
-Obviously that you need to be able to publish, likely you will
-need to run `vsce login redhat` first (needs publisher name).
+Obviously that you need to be able to publish, likely you will need to run
+`vsce login redhat` first (needs publisher name).
 
 ```shell
 vsce publish
 ```
 
-As it is likely that you are not logged in or your PAT is expired, the magic
-url to visit to regenerate one should be something like:
+As it is likely that you are not logged in or your PAT is expired, the magic url
+to visit to regenerate one should be something like:
 
 <https://dev.azure.com/USERNAME/_usersSettings/tokens>
 
 When creating a PAT, the Scopes needed are Marketplace Acquire + Publish.
 
-The funny bit is you need to give access to "All organizations" because
-the only organization listed there was "myuser", which produced a token
-that gave 401 (access denied).
+The funny bit is you need to give access to "All organizations" because the only
+organization listed there was "myuser", which produced a token that gave 401
+(access denied).
 
 ## Release and publication of extension
 
@@ -79,5 +79,5 @@ Any push made to the `main` branch will trigger an
 [jenkins job](https://studio-jenkins-csb-codeready.apps.ocp4.prod.psi.redhat.com/job/ansible/)
 that produces an artifact. The new version will be uploaded to
 [marketplace.visualstudio.com](https://marketplace.visualstudio.com/) and
-[open-vsx.org](https://open-vsx.org/) stores only when the pipeline is
-approved by a core developer from Jenkins interface.
+[open-vsx.org](https://open-vsx.org/) stores only when the pipeline is approved
+by a core developer from Jenkins interface.

--- a/doc/topics/integrate_ansible-lint_in_venv/README.md
+++ b/doc/topics/integrate_ansible-lint_in_venv/README.md
@@ -14,10 +14,10 @@ system-wide as below:
 ## sudo apt install ansible-lint
 ```
 
-However, installing Python packages system-wide is not always preferable
-because the it affects the whole system behavior. You can install
-`ansible-lint` in venv with normal permission, and integrate it with Ansible
-Language Extension instead.
+However, installing Python packages system-wide is not always preferable because
+the it affects the whole system behavior. You can install `ansible-lint` in venv
+with normal permission, and integrate it with Ansible Language Extension
+instead.
 
 ## How to use `ansible-lint` in venv
 
@@ -25,4 +25,5 @@ The outline is fairly simple.
 
 1. Create a venv.
 2. Install `ansible-lint` in the venv.
-3. Configure path to `ansible-lint` and `ansible` executables in the extension settings.
+3. Configure path to `ansible-lint` and `ansible` executables in the extension
+   settings.

--- a/examples/REAME.md
+++ b/examples/REAME.md
@@ -1,7 +1,7 @@
 # Examples
 
-This folder resembles a generic Ansible project that the users
-of our extension would be expected to use.
+This folder resembles a generic Ansible project that the users of our extension
+would be expected to use.
 
 We open this folder as a workspace when starting the extension in development
 mode and expect to use it for UI testing.


### PR DESCRIPTION
That is enabling use of prettier with markdownfiles, so we do get surprise-reformatting when we edit .md files in our repo.

This should prevent recent problems that were seen with at least two incoming pull-requests, where prettier reformatted unrelated changes.
