### PR TITLE
chore: improve vscode in-repo settings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,6 +46,7 @@ repos:
         # does not support JSON with comments
         exclude: >
           (?x)^(
+            .vscode/settings.json|
             jinja-language-configuration.json|
             ansible-language-configuration.json
           )$

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,10 +9,16 @@
   "[jsonc]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
+  "[yaml]": {
+    // Until https://github.com/ansible/vscode-ansible/pull/388 is addressed.
+    "editor.formatOnSave": false
+  },
   "files.exclude": {
-    "out": false
+    "out": true,
+    ".vscode-test": true
   },
   "search.exclude": {
-    "out": true
+    "out": true,
+    ".vscode-test": true
   }
 }


### PR DESCRIPTION
- avoid reformatting yaml on save until we decide on #388
- avoid displaying temp folders or searching in them
