### PR TITLE
experiment: use prettier with typescript

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,8 +15,6 @@
   "plugins": ["@typescript-eslint"],
   "rules": {
     "eqeqeq": ["error", "smart"],
-    "prefer-template": "warn",
-    "quotes": ["error", "single"],
-    "indent": ["error", 2]
+    "prefer-template": "warn"
   }
 }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -80,7 +80,7 @@ repos:
     rev: "v2.5.1"
     hooks:
       - id: prettier
-        types_or: ["markdown", "json"]
+        types_or: ["markdown", "json", "ts"]
         exclude: >
           (?x)^(
             jinja-language-configuration.json|

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,10 +24,7 @@ export function activate(context: ExtensionContext): void {
   new AnsiblePlaybookRunProvider(context);
 
   context.subscriptions.push(
-    commands.registerCommand(
-      'extension.ansible.vault',
-      toggleEncrypt
-    )
+    commands.registerCommand('extension.ansible.vault', toggleEncrypt)
   );
 
   const serverModule = context.asAbsolutePath(

--- a/src/features/runner.ts
+++ b/src/features/runner.ts
@@ -1,7 +1,6 @@
 /* "stdlib" */
 import * as vscode from 'vscode';
 
-
 /**
  * A set of commands and context menu items for running Ansible playbooks using
  * `ansible-navigator run` and `ansible-playbook` commands.
@@ -14,33 +13,33 @@ export class AnsiblePlaybookRunProvider {
   }
 
   /**
-     * Register a set of command callbacks for executing Ansible playbooks
-     * within VS Code.
-     */
+   * Register a set of command callbacks for executing Ansible playbooks
+   * within VS Code.
+   */
   private configureCommands() {
     this.vsCodeExtCtx.subscriptions.push(
       vscode.commands.registerCommand(
         'extension.ansible-playbook.run',
-        fileObj => this.makeCmdRunner()(fileObj),
-      ),
+        (fileObj) => this.makeCmdRunner()(fileObj)
+      )
     );
     console.debug('Added a "Run Ansible Playbook" command...');
     this.vsCodeExtCtx.subscriptions.push(
       vscode.commands.registerCommand(
         'extension.ansible-navigator.run',
-        fileObj => this.makeCmdRunner(true)(fileObj),
-      ),
+        (fileObj) => this.makeCmdRunner(true)(fileObj)
+      )
     );
     console.debug('Added a "Run with Ansible Navigator" command...');
   }
 
   /**
-     * A factory method for creating an Ansible playbook runner.
-     *
-     * @param useNavigator A flag for preferring `ansible-navigator run`
-     *                     over `ansible-playbook`.
-     * @returns A callable for running a supplied playbook.
-     */
+   * A factory method for creating an Ansible playbook runner.
+   *
+   * @param useNavigator A flag for preferring `ansible-navigator run`
+   *                     over `ansible-playbook`.
+   * @returns A callable for running a supplied playbook.
+   */
   private makeCmdRunner(useNavigator = false) {
     const runPlaybook = useNavigator
       ? this.invokeViaAnsibleNavigator.bind(this)
@@ -51,57 +50,52 @@ export class AnsiblePlaybookRunProvider {
         vscode.window.showErrorMessage(
           `No Ansible playbook file has been specified
                     to be executed with ansible-${
-  useNavigator
-    ? 'navigator'
-    : 'playbook'
-}.`,
+                      useNavigator ? 'navigator' : 'playbook'
+                    }.`
         );
         return;
       }
       console.debug(
         `Got a request to run ansible-${
-          useNavigator
-            ? 'navigator'
-            : 'playbook'
+          useNavigator ? 'navigator' : 'playbook'
         } against`,
-        playbookFsPath,
+        playbookFsPath
       );
       runPlaybook([playbookFsPath]);
     };
   }
 
   /**
-     * A property representing the `ansible-navigator` executable.
-     */
+   * A property representing the `ansible-navigator` executable.
+   */
   private get ansibleNavigatorExecutablePath(): string {
-    return vscode.workspace
-      .getConfiguration('ansible.ansibleNavigator').path;
+    return vscode.workspace.getConfiguration('ansible.ansibleNavigator').path;
   }
 
   /**
-     * A property representing the `ansible-playbook` executable.
-     */
+   * A property representing the `ansible-playbook` executable.
+   */
   private get ansiblePlaybookExecutablePath(): string {
-    return `${vscode.workspace
-      .getConfiguration('ansible.ansible.path').path || 'ansible'  }-playbook`;
+    return `${
+      vscode.workspace.getConfiguration('ansible.ansible.path').path ||
+      'ansible'
+    }-playbook`;
   }
 
   /**
-     * A property representing the target terminal for running playbooks in.
-     */
+   * A property representing the target terminal for running playbooks in.
+   */
   private get terminal(): vscode.Terminal {
     if (typeof this.disposableTerminal === 'undefined') {
       const terminal = vscode.window.createTerminal('Ansible Terminal');
       this.vsCodeExtCtx.subscriptions.push(terminal);
       this.vsCodeExtCtx.subscriptions.push(
-        vscode.window.onDidCloseTerminal(
-          (term: vscode.Terminal) => {
-            if (term !== terminal) {
-              return;
-            }
-            this.disposableTerminal = undefined;
+        vscode.window.onDidCloseTerminal((term: vscode.Terminal) => {
+          if (term !== terminal) {
+            return;
           }
-        )
+          this.disposableTerminal = undefined;
+        })
       );
       this.disposableTerminal = terminal;
     }
@@ -109,48 +103,48 @@ export class AnsiblePlaybookRunProvider {
   }
 
   /**
-     * A helper method for executing commands in terminal.
-     */
+   * A helper method for executing commands in terminal.
+   */
   private invokeInTerminal(cmd: string) {
     this.terminal.show();
     this.terminal.sendText(cmd);
   }
 
   /**
-     * A helper method for running `ansible-playbook`.
-     * @param argv Arguments to the `ansible-playbook` command.
-     */
+   * A helper method for running `ansible-playbook`.
+   * @param argv Arguments to the `ansible-playbook` command.
+   */
   private invokeViaAnsiblePlaybook(argv: string[]) {
     const runExecutable = this.ansiblePlaybookExecutablePath;
-    const cmdArgs = argv.map(arg => `'${arg}'`).join(' ');
+    const cmdArgs = argv.map((arg) => `'${arg}'`).join(' ');
     this.invokeInTerminal(`${runExecutable} ${cmdArgs}`);
   }
 
   /**
-     * A helper method for running `ansible-navigator run`.
-     * @param argv Arguments to the `ansible-navigator run` command.
-     */
+   * A helper method for running `ansible-navigator run`.
+   * @param argv Arguments to the `ansible-navigator run` command.
+   */
   private invokeViaAnsibleNavigator(argv: string[]) {
     const runExecutable = this.ansibleNavigatorExecutablePath;
-    const cmdArgs = argv.map(arg => `'${arg}'`).join(' ');
+    const cmdArgs = argv.map((arg) => `'${arg}'`).join(' ');
     this.invokeInTerminal(`${runExecutable} run ${cmdArgs}`);
   }
 }
-
 
 /**
  * A helper function for inferring selected file from the context.
  * @param priorityPathObjs Target file path candidates.
  * @returns A path to the currently selected file.
  */
-function extractTargetFsPath(...priorityPathObjs: vscode.Uri[] | undefined[]):
-        string | undefined {
+function extractTargetFsPath(
+  ...priorityPathObjs: vscode.Uri[] | undefined[]
+): string | undefined {
   const pathCandidates: vscode.Uri[] = [
     ...priorityPathObjs,
     vscode.window.activeTextEditor?.document.uri,
   ]
-    .filter(p => p instanceof vscode.Uri)
-    .map(p => <vscode.Uri>p)
-    .filter(p => p.scheme === 'file');
+    .filter((p) => p instanceof vscode.Uri)
+    .map((p) => <vscode.Uri>p)
+    .filter((p) => p.scheme === 'file');
   return pathCandidates[0]?.fsPath;
 }

--- a/src/features/utils/ansibleCfg.ts
+++ b/src/features/utils/ansibleCfg.ts
@@ -57,7 +57,7 @@ export async function scanAnsibleCfg(
   console.log(
     typeof cfg != 'undefined'
       ? `Found 'defaults.vault_identity_list' within '${cfg.path}'`
-      : 'Found no \'defaults.vault_identity_list\' within config files'
+      : "Found no 'defaults.vault_identity_list' within config files"
   );
 
   return cfg;

--- a/src/features/vault.ts
+++ b/src/features/vault.ts
@@ -45,7 +45,7 @@ function displayInvalidConfigError(): void {
 }
 
 function ansibleVaultPath(config: vscode.WorkspaceConfiguration): string {
-  return `${config.ansible.path || 'ansible'  }-vault`
+  return `${config.ansible.path || 'ansible'}-vault`;
 }
 
 export const toggleEncrypt = async (): Promise<void> => {
@@ -273,7 +273,9 @@ const encryptText = (
   config: vscode.WorkspaceConfiguration
 ): Promise<string> => {
   const cmd = !!vaultId
-    ? `${ansibleVaultPath(config)} encrypt_string --encrypt-vault-id="${vaultId}"`
+    ? `${ansibleVaultPath(
+        config
+      )} encrypt_string --encrypt-vault-id="${vaultId}"`
     : `${ansibleVaultPath(config)} encrypt_string`;
   return pipeTextThrougCmd(text, rootPath, cmd);
 };
@@ -296,7 +298,9 @@ const encryptFile = (
   console.log(`Encrypt file: ${f}`);
 
   const cmd = !!vaultId
-    ? `${ansibleVaultPath(config)} encrypt --encrypt-vault-id="${vaultId}" "${f}"`
+    ? `${ansibleVaultPath(
+        config
+      )} encrypt --encrypt-vault-id="${vaultId}" "${f}"`
     : `${ansibleVaultPath(config)} encrypt "${f}"`;
 
   return execCwd(cmd, rootPath);

--- a/test/testRunner.ts
+++ b/test/testRunner.ts
@@ -18,7 +18,7 @@ async function main(): Promise<void> {
     // https://code.visualstudio.com/docs/getstarted/settings#_settings-file-locations
     const cliArgs = [
       `--user-data-dir=${userDataPath}`,
-      `--extensions-dir=${extPath}`
+      `--extensions-dir=${extPath}`,
     ];
 
     // Copy default user settings.json
@@ -29,7 +29,7 @@ async function main(): Promise<void> {
       '..',
       'test',
       'testFixtures',
-      'settings.json',
+      'settings.json'
     );
     const settings_dst = path.join(
       __dirname,
@@ -39,14 +39,16 @@ async function main(): Promise<void> {
       'out',
       'userdata',
       'User',
-      'settings.json',
+      'settings.json'
     );
     fs.mkdirSync(path.dirname(settings_dst), { recursive: true });
     fs.copyFileSync(settings_src, settings_dst);
 
     // Install the latest released redhat.ansible extension
     const installLog = cp.execSync(
-      `"${cliPath}" ${cliArgs.join(' ')} --install-extension redhat.ansible --force`
+      `"${cliPath}" ${cliArgs.join(
+        ' '
+      )} --install-extension redhat.ansible --force`
     );
     console.log(installLog.toString());
 
@@ -60,7 +62,9 @@ async function main(): Promise<void> {
     }
 
     // Display active extensions
-    const cmd = `"${cliPath}" ${cliArgs.join(' ')} --list-extensions --show-versions`
+    const cmd = `"${cliPath}" ${cliArgs.join(
+      ' '
+    )} --list-extensions --show-versions`;
     const extLog = cp.execSync(cmd);
     console.warn('%s\n%s', cmd, extLog.toString());
 


### PR DESCRIPTION
Experiment, not ready for review. Findings so far:

* it seems that both `prettier` and `eslint` to prefer double quotes in javascate in their default settings, but our repository was configured to prefer single ones
* the above customization seems to cause a conflict between the two tools where eslint is trying to add single quotes on a string where it should do not that like: `"That's cool"`, where the logical expectation that use of double is normal as the contained string already has a quote inside.  Prettier seems to know to prefer avoiding escaping when possible.
* I was not able to find a way to change eslint behavior
* Out of curiosity I also tried to remove the custom rule about quotes on both tools and it seems that in that case they do not conflict.
* I also had to remove the custom indent rule on eslint because it was in conflict with prettier config.

I hope that @tomaciazek will be able to provide some insights regarding why the single quotes were added to the config as I suspect that came from the language server extension.