### PR TITLE
Recommend mocha-test-adapter vscode extension to contributors

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,8 @@
 {
   "recommendations": [
-    "esbenp.prettier-vscode",
+    "DavidAnson.vscode-markdownlint",
     "dbaeumer.vscode-eslint",
-    "DavidAnson.vscode-markdownlint"
+    "esbenp.prettier-vscode",
+    "hbenl.vscode-mocha-test-adapter"
   ]
 }


### PR DESCRIPTION
Matches configuration from https://github.com/ansible/ansible-language-server/blob/main/.vscode/extensions.json#L6 as since #397 we started supporting mocha test runner even with this repository.