### PR TITLE
Reformat typescript using prettier

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,11 +12,10 @@
     "ecmaVersion": 2019,
     "sourceType": "module"
   },
-  "plugins": ["@typescript-eslint"],
+  "plugins": ["@typescript-eslint", "prettier"],
   "rules": {
     "eqeqeq": ["error", "smart"],
     "prefer-template": "warn",
-    "quotes": ["error", "single"],
-    "indent": ["error", 2]
+    "prettier/prettier": "error"
   }
 }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -93,7 +93,7 @@ repos:
     rev: "v2.5.1"
     hooks:
       - id: prettier
-        types_or: ["markdown", "json"]
+        types_or: ["markdown", "json", "ts"]
         exclude: >
           (?x)^(
             jinja-language-configuration.json|

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -12,4 +12,3 @@ overrides:
       proseWrap: always
       printWidth: 80
 semi: true
-singleQuote: true

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  'rules': {
-    'header-max-length': [0, 'always', 72],
-  }
-}
+  rules: {
+    "header-max-length": [0, "always", 72],
+  },
+};

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,7 @@
 /* "stdlib" */
-import * as path from 'path';
-import { commands, ExtensionContext, extensions } from 'vscode';
-import { toggleEncrypt } from './features/vault';
+import * as path from "path";
+import { commands, ExtensionContext, extensions } from "vscode";
+import { toggleEncrypt } from "./features/vault";
 
 /* third-party */
 import {
@@ -9,14 +9,14 @@ import {
   LanguageClientOptions,
   ServerOptions,
   TransportKind,
-} from 'vscode-languageclient/node';
+} from "vscode-languageclient/node";
 
 /* local */
-import { AnsiblePlaybookRunProvider } from './features/runner';
+import { AnsiblePlaybookRunProvider } from "./features/runner";
 import {
   getConflictingExtensions,
   showUninstallConflictsNotification,
-} from './extensionConflicts';
+} from "./extensionConflicts";
 
 let client: LanguageClient;
 
@@ -24,18 +24,15 @@ export function activate(context: ExtensionContext): void {
   new AnsiblePlaybookRunProvider(context);
 
   context.subscriptions.push(
-    commands.registerCommand(
-      'extension.ansible.vault',
-      toggleEncrypt
-    )
+    commands.registerCommand("extension.ansible.vault", toggleEncrypt)
   );
 
   const serverModule = context.asAbsolutePath(
-    path.join('out', 'server', 'src', 'server.js')
+    path.join("out", "server", "src", "server.js")
   );
 
   // server is run at port 6009 for debugging
-  const debugOptions = { execArgv: ['--nolazy', '--inspect=6010'] };
+  const debugOptions = { execArgv: ["--nolazy", "--inspect=6010"] };
 
   const serverOptions: ServerOptions = {
     run: { module: serverModule, transport: TransportKind.ipc },
@@ -48,12 +45,12 @@ export function activate(context: ExtensionContext): void {
 
   const clientOptions: LanguageClientOptions = {
     // register the server for Ansible documents
-    documentSelector: [{ scheme: 'file', language: 'ansible' }],
+    documentSelector: [{ scheme: "file", language: "ansible" }],
   };
 
   client = new LanguageClient(
-    'ansibleServer',
-    'Ansible Server',
+    "ansibleServer",
+    "Ansible Server",
     serverOptions,
     clientOptions
   );

--- a/src/extensionConflicts.ts
+++ b/src/extensionConflicts.ts
@@ -2,16 +2,16 @@
  *  Copyright (c) Red Hat, Inc. All rights reserved..
  *  Licensed under the MIT License. See LICENSE in the project root for details.
  *--------------------------------------------------------------------------------------------*/
-import { commands, Extension, extensions, window } from 'vscode';
+import { commands, Extension, extensions, window } from "vscode";
 
 // A set of VSCode extension ID's that conflict with our extension
 const conflictingIDs = [
-  'haaaad.ansible',
-  'lextudio.restructuredtext', // https://github.com/vscode-restructuredtext/vscode-restructuredtext/issues/286
-  'sysninja.vscode-ansible-mod',
-  'tomaciazek.ansible',
-  'vscoss.vscode-ansible',
-  'zbr.vscode-ansible',
+  "haaaad.ansible",
+  "lextudio.restructuredtext", // https://github.com/vscode-restructuredtext/vscode-restructuredtext/issues/286
+  "sysninja.vscode-ansible-mod",
+  "tomaciazek.ansible",
+  "vscoss.vscode-ansible",
+  "zbr.vscode-ansible",
 ];
 
 // A set of VSCode extension ID's that are currently uninstalling
@@ -19,7 +19,7 @@ const uninstallingIDs = new Set();
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function isExtensionPresent(obj: any): obj is Extension<any> {
-  return typeof obj !== 'undefined' && !uninstallingIDs.has(obj.id);
+  return typeof obj !== "undefined" && !uninstallingIDs.has(obj.id);
 }
 
 /**
@@ -49,13 +49,13 @@ export async function showUninstallConflictsNotification(
     uninstallingIDs.add(ext.id);
   }
 
-  const uninstallMsg = 'Uninstall';
+  const uninstallMsg = "Uninstall";
 
   if (!conflictingExts.length) {
     return;
   }
   // Gather all the conflicting display names
-  let conflictMsg = '';
+  let conflictMsg = "";
   if (conflictingExts.length === 1) {
     conflictMsg = `${conflictingExts[0].packageJSON.displayName} (${conflictingExts[0].id}) extension is incompatible with redhat.ansible. Please uninstall it.`;
   } else {
@@ -63,7 +63,7 @@ export async function showUninstallConflictsNotification(
       (ext) => `${ext.packageJSON.displayName} (${ext.id})`
     );
     conflictMsg = `The ${extNames.join(
-      ', '
+      ", "
     )} extensions are incompatible with redhat.ansible. Please uninstall them.`;
   }
 
@@ -75,7 +75,7 @@ export async function showUninstallConflictsNotification(
       }
       for (const ext of conflictingExts) {
         commands.executeCommand(
-          'workbench.extensions.uninstallExtension',
+          "workbench.extensions.uninstallExtension",
           ext.id
         );
         uninstallingIDs.delete(ext.id);

--- a/src/features/runner.ts
+++ b/src/features/runner.ts
@@ -1,6 +1,5 @@
 /* "stdlib" */
-import * as vscode from 'vscode';
-
+import * as vscode from "vscode";
 
 /**
  * A set of commands and context menu items for running Ansible playbooks using
@@ -14,43 +13,43 @@ export class AnsiblePlaybookRunProvider {
   }
 
   /**
-     * Register a set of command callbacks for executing Ansible playbooks
-     * within VS Code.
-     */
+   * Register a set of command callbacks for executing Ansible playbooks
+   * within VS Code.
+   */
   private configureCommands() {
     this.vsCodeExtCtx.subscriptions.push(
       vscode.commands.registerCommand(
-        'extension.ansible-playbook.run',
-        fileObj => this.makeCmdRunner()(fileObj),
-      ),
+        "extension.ansible-playbook.run",
+        (fileObj) => this.makeCmdRunner()(fileObj)
+      )
     );
     console.debug('Added a "Run Ansible Playbook" command...');
     this.vsCodeExtCtx.subscriptions.push(
       vscode.commands.registerCommand(
-        'extension.ansible-navigator.run',
-        fileObj => this.makeCmdRunner(true)(fileObj),
-      ),
+        "extension.ansible-navigator.run",
+        (fileObj) => this.makeCmdRunner(true)(fileObj)
+      )
     );
     console.debug('Added a "Run with Ansible Navigator" command...');
   }
 
   /**
-     * A factory method for creating an Ansible playbook runner.
-     *
-     * @param useNavigator A flag for preferring `ansible-navigator run`
-     *                     over `ansible-playbook`.
-     * @returns A callable for running a supplied playbook.
-     */
+   * A factory method for creating an Ansible playbook runner.
+   *
+   * @param useNavigator A flag for preferring `ansible-navigator run`
+   *                     over `ansible-playbook`.
+   * @returns A callable for running a supplied playbook.
+   */
   private makeCmdRunner(useNavigator = false) {
     const runPlaybook = useNavigator
       ? this.invokeViaAnsibleNavigator.bind(this)
       : this.invokeViaAnsiblePlaybook.bind(this);
     return (...fileObj: vscode.Uri[] | undefined[]) => {
       const playbookFsPath = extractTargetFsPath(...fileObj);
-      if (typeof playbookFsPath === 'undefined') {
-        let tool_name = 'ansible-playbook';
+      if (typeof playbookFsPath === "undefined") {
+        let tool_name = "ansible-playbook";
         if (useNavigator) {
-          tool_name = 'ansible-navigator';
+          tool_name = "ansible-navigator";
         }
         vscode.window.showErrorMessage(
           `No Ansible playbook file has been specified to be executed with ${tool_name}.`
@@ -59,48 +58,45 @@ export class AnsiblePlaybookRunProvider {
       }
       console.debug(
         `Got a request to run ansible-${
-          useNavigator
-            ? 'navigator'
-            : 'playbook'
+          useNavigator ? "navigator" : "playbook"
         } against`,
-        playbookFsPath,
+        playbookFsPath
       );
       runPlaybook([playbookFsPath]);
     };
   }
 
   /**
-     * A property representing the `ansible-navigator` executable.
-     */
+   * A property representing the `ansible-navigator` executable.
+   */
   private get ansibleNavigatorExecutablePath(): string {
-    return vscode.workspace
-      .getConfiguration('ansible.ansibleNavigator').path;
+    return vscode.workspace.getConfiguration("ansible.ansibleNavigator").path;
   }
 
   /**
-     * A property representing the `ansible-playbook` executable.
-     */
+   * A property representing the `ansible-playbook` executable.
+   */
   private get ansiblePlaybookExecutablePath(): string {
-    return `${vscode.workspace
-      .getConfiguration('ansible.ansible.path').path || 'ansible'  }-playbook`;
+    return `${
+      vscode.workspace.getConfiguration("ansible.ansible.path").path ||
+      "ansible"
+    }-playbook`;
   }
 
   /**
-     * A property representing the target terminal for running playbooks in.
-     */
+   * A property representing the target terminal for running playbooks in.
+   */
   private get terminal(): vscode.Terminal {
-    if (typeof this.disposableTerminal === 'undefined') {
-      const terminal = vscode.window.createTerminal('Ansible Terminal');
+    if (typeof this.disposableTerminal === "undefined") {
+      const terminal = vscode.window.createTerminal("Ansible Terminal");
       this.vsCodeExtCtx.subscriptions.push(terminal);
       this.vsCodeExtCtx.subscriptions.push(
-        vscode.window.onDidCloseTerminal(
-          (term: vscode.Terminal) => {
-            if (term !== terminal) {
-              return;
-            }
-            this.disposableTerminal = undefined;
+        vscode.window.onDidCloseTerminal((term: vscode.Terminal) => {
+          if (term !== terminal) {
+            return;
           }
-        )
+          this.disposableTerminal = undefined;
+        })
       );
       this.disposableTerminal = terminal;
     }
@@ -108,48 +104,48 @@ export class AnsiblePlaybookRunProvider {
   }
 
   /**
-     * A helper method for executing commands in terminal.
-     */
+   * A helper method for executing commands in terminal.
+   */
   private invokeInTerminal(cmd: string) {
     this.terminal.show();
     this.terminal.sendText(cmd);
   }
 
   /**
-     * A helper method for running `ansible-playbook`.
-     * @param argv Arguments to the `ansible-playbook` command.
-     */
+   * A helper method for running `ansible-playbook`.
+   * @param argv Arguments to the `ansible-playbook` command.
+   */
   private invokeViaAnsiblePlaybook(argv: string[]) {
     const runExecutable = this.ansiblePlaybookExecutablePath;
-    const cmdArgs = argv.map(arg => `'${arg}'`).join(' ');
+    const cmdArgs = argv.map((arg) => `'${arg}'`).join(" ");
     this.invokeInTerminal(`${runExecutable} ${cmdArgs}`);
   }
 
   /**
-     * A helper method for running `ansible-navigator run`.
-     * @param argv Arguments to the `ansible-navigator run` command.
-     */
+   * A helper method for running `ansible-navigator run`.
+   * @param argv Arguments to the `ansible-navigator run` command.
+   */
   private invokeViaAnsibleNavigator(argv: string[]) {
     const runExecutable = this.ansibleNavigatorExecutablePath;
-    const cmdArgs = argv.map(arg => `'${arg}'`).join(' ');
+    const cmdArgs = argv.map((arg) => `'${arg}'`).join(" ");
     this.invokeInTerminal(`${runExecutable} run ${cmdArgs}`);
   }
 }
-
 
 /**
  * A helper function for inferring selected file from the context.
  * @param priorityPathObjs Target file path candidates.
  * @returns A path to the currently selected file.
  */
-function extractTargetFsPath(...priorityPathObjs: vscode.Uri[] | undefined[]):
-        string | undefined {
+function extractTargetFsPath(
+  ...priorityPathObjs: vscode.Uri[] | undefined[]
+): string | undefined {
   const pathCandidates: vscode.Uri[] = [
     ...priorityPathObjs,
     vscode.window.activeTextEditor?.document.uri,
   ]
-    .filter(p => p instanceof vscode.Uri)
-    .map(p => <vscode.Uri>p)
-    .filter(p => p.scheme === 'file');
+    .filter((p) => p instanceof vscode.Uri)
+    .map((p) => <vscode.Uri>p)
+    .filter((p) => p.scheme === "file");
   return pathCandidates[0]?.fsPath;
 }

--- a/src/features/utils/ansibleCfg.ts
+++ b/src/features/utils/ansibleCfg.ts
@@ -1,16 +1,16 @@
 /* node "stdlib" */
-import * as fs from 'fs';
+import * as fs from "fs";
 
 /* vscode"stdlib" */
-import * as vscode from 'vscode';
+import * as vscode from "vscode";
 
 /* third-party */
-import untildify from 'untildify';
-import * as ini from 'ini';
+import untildify from "untildify";
+import * as ini from "ini";
 
 // Get rootPath based on multi-workspace API
 export function getRootPath(editorDocumentUri: vscode.Uri): string | undefined {
-  if (typeof vscode.workspace.getWorkspaceFolder !== 'function') {
+  if (typeof vscode.workspace.getWorkspaceFolder !== "function") {
     return vscode.workspace.workspaceFolders?.[0]?.name;
   }
 
@@ -35,7 +35,7 @@ export async function scanAnsibleCfg(
    * 3) ~/.ansible.cfg
    * 4) /etc/ansible.cfg
    */
-  const cfgFiles = ['~/.ansible.cfg', '/etc/ansible.cfg'];
+  const cfgFiles = ["~/.ansible.cfg", "/etc/ansible.cfg"];
 
   if (!!rootPath) {
     cfgFiles.unshift(`${rootPath}/ansible.cfg`);
@@ -55,9 +55,9 @@ export async function scanAnsibleCfg(
       !!c?.defaults?.vault_identity_list || !!c?.defaults?.vault_password_file
   );
   console.log(
-    typeof cfg != 'undefined'
+    typeof cfg != "undefined"
       ? `Found 'defaults.vault_identity_list' within '${cfg.path}'`
-      : 'Found no \'defaults.vault_identity_list\' within config files'
+      : "Found no 'defaults.vault_identity_list' within config files"
   );
 
   return cfg;
@@ -74,7 +74,7 @@ export async function getValueByCfg(
     return undefined;
   }
 
-  const parsedConfig = ini.parse(await fs.promises.readFile(path, 'utf-8'));
+  const parsedConfig = ini.parse(await fs.promises.readFile(path, "utf-8"));
   const vault_identity_list = parsedConfig?.defaults?.vault_identity_list;
   const vault_password_file = parsedConfig?.defaults?.vault_password_file;
 
@@ -93,7 +93,7 @@ export async function getAnsibleCfg(
 ): Promise<AnsibleVaultConfig | undefined> {
   if (!!process.env.ANSIBLE_VAULT_IDENTITY_LIST) {
     return {
-      path: 'ANSIBLE_VAULT_IDENTITY_LIST',
+      path: "ANSIBLE_VAULT_IDENTITY_LIST",
       defaults: {
         vault_identity_list: process.env.ANSIBLE_VAULT_IDENTITY_LIST,
         vault_password_file: undefined,

--- a/src/features/vault.ts
+++ b/src/features/vault.ts
@@ -1,31 +1,31 @@
 /* node "stdlib" */
-import * as cp from 'child_process';
-import * as util from 'util';
+import * as cp from "child_process";
+import * as util from "util";
 
 /* vscode"stdlib" */
-import * as vscode from 'vscode';
+import * as vscode from "vscode";
 
 /* local */
-import * as utilAnsibleCfg from './utils/ansibleCfg';
+import * as utilAnsibleCfg from "./utils/ansibleCfg";
 
 const execAsync = util.promisify(cp.exec);
 
 enum MultilineStyle {
-  Literal = '|',
-  Folding = '>',
+  Literal = "|",
+  Folding = ">",
 }
 
 enum ChompingStyle {
-  Strip = '-',
-  Keep = '+',
+  Strip = "-",
+  Keep = "+",
 }
 
 async function askForVaultId(ansibleCfg: utilAnsibleCfg.AnsibleVaultConfig) {
-  const vaultId = 'default';
+  const vaultId = "default";
 
   const identityList = ansibleCfg.defaults?.vault_identity_list
-    ?.split(',')
-    .map((id: string) => id.split('@', 2)[0].trim());
+    ?.split(",")
+    .map((id: string) => id.split("@", 2)[0].trim());
   if (!identityList) {
     return undefined;
   }
@@ -40,12 +40,12 @@ async function askForVaultId(ansibleCfg: utilAnsibleCfg.AnsibleVaultConfig) {
 
 function displayInvalidConfigError(): void {
   vscode.window.showErrorMessage(
-    'no valid ansible vault config found, cannot de/-encrypt'
+    "no valid ansible vault config found, cannot de/-encrypt"
   );
 }
 
 function ansibleVaultPath(config: vscode.WorkspaceConfiguration): string {
-  return `${config.ansible.path || 'ansible'  }-vault`
+  return `${config.ansible.path || "ansible"}-vault`;
 }
 
 export const toggleEncrypt = async (): Promise<void> => {
@@ -59,7 +59,7 @@ export const toggleEncrypt = async (): Promise<void> => {
     return;
   }
 
-  const config = vscode.workspace.getConfiguration('ansible');
+  const config = vscode.workspace.getConfiguration("ansible");
   const doc = editor.document;
 
   // Read `ansible.cfg` or environment variable
@@ -89,8 +89,8 @@ export const toggleEncrypt = async (): Promise<void> => {
     const type = getInlineTextType(text);
     const indentationLevel = getIndentationLevel(editor, selection);
     const tabSize = Number(editor.options.tabSize);
-    if (type === 'plaintext') {
-      console.log('Encrypt selected text');
+    if (type === "plaintext") {
+      console.log("Encrypt selected text");
 
       const vaultId: string | undefined = useVaultIDs
         ? await askForVaultId(ansibleConfig)
@@ -114,15 +114,15 @@ export const toggleEncrypt = async (): Promise<void> => {
         vscode.window.showErrorMessage(`Inline encryption failed: ${e}`);
         return;
       }
-      const leadingSpaces = ' '.repeat((indentationLevel + 1) * tabSize);
+      const leadingSpaces = " ".repeat((indentationLevel + 1) * tabSize);
       editor.edit((editBuilder) => {
         editBuilder.replace(
           selection,
           encryptedText.replace(/\n\s*/g, `\n${leadingSpaces}`)
         );
       });
-    } else if (type === 'encrypted') {
-      console.log('Decrypt selected text');
+    } else if (type === "encrypted") {
+      console.log("Decrypt selected text");
       let decryptedText: string;
       try {
         decryptedText = await decryptInline(
@@ -144,8 +144,8 @@ export const toggleEncrypt = async (): Promise<void> => {
     const document = await vscode.workspace.openTextDocument(doc.fileName);
     const type = getTextType(document.getText());
 
-    if (type === 'plaintext') {
-      console.log('Encrypt entire file');
+    if (type === "plaintext") {
+      console.log("Encrypt entire file");
       const vaultId: string | undefined = useVaultIDs
         ? await askForVaultId(ansibleConfig)
         : undefined;
@@ -164,8 +164,8 @@ export const toggleEncrypt = async (): Promise<void> => {
           `Encryption of ${doc.fileName} failed: ${e}`
         );
       }
-    } else if (type === 'encrypted') {
-      console.log('Decrypt entire file');
+    } else if (type === "encrypted") {
+      console.log("Decrypt entire file");
       vscode.window.activeTextEditor?.document.save();
       try {
         await decryptFile(doc.fileName, rootPath, config);
@@ -178,22 +178,22 @@ export const toggleEncrypt = async (): Promise<void> => {
         );
       }
     }
-    vscode.commands.executeCommand('workbench.action.files.revert');
+    vscode.commands.executeCommand("workbench.action.files.revert");
   }
 };
 
 // Returns whether the selected text is encrypted or in plain text.
 const getInlineTextType = (text: string) => {
-  if (text.trim().startsWith('!vault |')) {
-    text = text.replace('!vault |', '');
+  if (text.trim().startsWith("!vault |")) {
+    text = text.replace("!vault |", "");
   }
 
-  return text.trim().startsWith('$ANSIBLE_VAULT;') ? 'encrypted' : 'plaintext';
+  return text.trim().startsWith("$ANSIBLE_VAULT;") ? "encrypted" : "plaintext";
 };
 
 // Returns whether the file is encrypted or in plain text.
 const getTextType = (text: string) => {
-  return text.indexOf('$ANSIBLE_VAULT;') === 0 ? 'encrypted' : 'plaintext';
+  return text.indexOf("$ANSIBLE_VAULT;") === 0 ? "encrypted" : "plaintext";
 };
 
 const encryptInline = async (
@@ -224,9 +224,9 @@ const decryptInline = async (
 ) => {
   // Delete inline vault prefix, then trim spaces and newline from the entire string and, at last, trim the spaces in the multiline string.
   text = text
-    .replace('!vault |', '')
+    .replace("!vault |", "")
     .trim()
-    .replace(/[^\S\r\n]+/gm, '');
+    .replace(/[^\S\r\n]+/gm, "");
 
   const decryptedText = reindentText(
     await decryptText(text, rootPath, config),
@@ -243,17 +243,17 @@ const pipeTextThroughCmd = (
 ): Promise<string> => {
   return new Promise<string>((resolve, reject) => {
     const child = !!rootPath ? cp.exec(cmd, { cwd: rootPath }) : cp.exec(cmd);
-    child.stdout?.setEncoding('utf8');
-    let outputText = '';
-    let errorText = '';
+    child.stdout?.setEncoding("utf8");
+    let outputText = "";
+    let errorText = "";
     if (!child?.stdin || !child?.stdout || !child?.stderr) {
       return undefined;
     }
 
-    child.stdout.on('data', (data) => (outputText += data));
-    child.stderr.on('data', (data) => (errorText += data));
+    child.stdout.on("data", (data) => (outputText += data));
+    child.stderr.on("data", (data) => (errorText += data));
 
-    child.on('close', (code) => {
+    child.on("close", (code) => {
       if (code !== 0) {
         console.log(`error when running ansible-vault: ${errorText}`);
         reject(errorText);
@@ -297,7 +297,9 @@ const encryptFile = (
   console.log(`Encrypt file: ${f}`);
 
   const cmd = !!vaultId
-    ? `${ansibleVaultPath(config)} encrypt --encrypt-vault-id="${vaultId}" "${f}"`
+    ? `${ansibleVaultPath(
+        config
+      )} encrypt --encrypt-vault-id="${vaultId}" "${f}"`
     : `${ansibleVaultPath(config)} encrypt "${f}"`;
 
   return execCwd(cmd, rootPath);
@@ -334,7 +336,7 @@ const getIndentationLevel = (
   if (!editor.options.tabSize) {
     // according to VS code docs, tabSize is always defined when getting options of an editor
     throw new Error(
-      'The `tabSize` option is not defined, this should never happen.'
+      "The `tabSize` option is not defined, this should never happen."
     );
   }
   const startLine = editor.document.lineAt(selection.start.line).text;
@@ -350,13 +352,13 @@ const foldedMultilineReducer = (
   array: string[]
 ): string => {
   if (
-    currentValue === '' ||
+    currentValue === "" ||
     currentValue.match(/^\s/) ||
     array[currentIndex - 1].match(/^\s/)
   ) {
     return `${accumulator}\n${currentValue}`;
   }
-  if (accumulator.charAt(accumulator.length - 1) !== '\n') {
+  if (accumulator.charAt(accumulator.length - 1) !== "\n") {
     return `${accumulator} ${currentValue}`;
   }
   return `${accumulator}${currentValue}`;
@@ -366,14 +368,14 @@ const handleLiteralMultiline = (
   lines: string[],
   leadingSpacesCount: number
 ) => {
-  const text = prepareMultiline(lines, leadingSpacesCount).join('\n');
+  const text = prepareMultiline(lines, leadingSpacesCount).join("\n");
   const chompingStyle = getChompingStyle(lines);
   if (chompingStyle === ChompingStyle.Strip) {
-    return text.replace(/\n*$/, '');
+    return text.replace(/\n*$/, "");
   } else if (chompingStyle === ChompingStyle.Keep) {
     return `${text}\n`;
   } else {
-    return text.replace(/\n*$/, '\n');
+    return text.replace(/\n*$/, "\n");
   }
 };
 
@@ -383,11 +385,11 @@ const handleFoldedMultiline = (lines: string[], leadingSpacesCount: number) => {
   );
   const chompingStyle = getChompingStyle(lines);
   if (chompingStyle === ChompingStyle.Strip) {
-    return text.replace(/\n*$/g, '');
+    return text.replace(/\n*$/g, "");
   } else if (chompingStyle === ChompingStyle.Keep) {
     return `${text}\n`;
   } else {
-    return `${text.replace(/\n$/gm, '')}\n`;
+    return `${text.replace(/\n$/gm, "")}\n`;
   }
 };
 
@@ -396,7 +398,7 @@ const handleMultiline = (
   indentationLevel: number,
   tabSize: number
 ) => {
-  const lines = text.replace(/\r\n/g, '\n').split('\n');
+  const lines = text.replace(/\r\n/g, "\n").split("\n");
   if (lines.length > 1) {
     const leadingSpacesCount = (indentationLevel + 1) * tabSize;
     const multilineStyle = getMultilineStyle(lines);
@@ -405,7 +407,7 @@ const handleMultiline = (
     } else if (multilineStyle === MultilineStyle.Folding) {
       return handleFoldedMultiline(lines, leadingSpacesCount);
     } else {
-      throw new Error('this type of multiline text is not supported');
+      throw new Error("this type of multiline text is not supported");
     }
   }
   return text;
@@ -417,10 +419,10 @@ const reindentText = (
   tabSize: number
 ) => {
   const leadingSpacesCount = (indentationLevel + 1) * tabSize;
-  const lines = text.split('\n');
+  const lines = text.split("\n");
   let trailingNewlines = 0;
   for (const line of lines.reverse()) {
-    if (line === '') {
+    if (line === "") {
       trailingNewlines++;
     } else {
       break;
@@ -428,11 +430,11 @@ const reindentText = (
   }
   lines.reverse();
   if (lines.length > 1) {
-    const leadingWhitespaces = ' '.repeat(leadingSpacesCount);
+    const leadingWhitespaces = " ".repeat(leadingSpacesCount);
     const rejoinedLines = lines
       .map((line) => `${leadingWhitespaces}${line}`)
-      .join('\n');
-    rejoinedLines.replace(/\n$/, '');
+      .join("\n");
+    rejoinedLines.replace(/\n$/, "");
     if (trailingNewlines > 1) {
       return `${MultilineStyle.Literal}${ChompingStyle.Keep}\n${rejoinedLines}`;
     } else if (trailingNewlines === 0) {
@@ -444,8 +446,8 @@ const reindentText = (
 };
 
 const prepareMultiline = (lines: string[], leadingSpacesCount: number) => {
-  const re = new RegExp(`^\\s{${leadingSpacesCount}}`, '');
-  return lines.slice(1, lines.length).map((line) => line.replace(re, ''));
+  const re = new RegExp(`^\\s{${leadingSpacesCount}}`, "");
+  return lines.slice(1, lines.length).map((line) => line.replace(re, ""));
 };
 
 function getMultilineStyle(lines: string[]) {

--- a/test/helper.ts
+++ b/test/helper.ts
@@ -1,6 +1,6 @@
-import * as vscode from 'vscode';
-import * as path from 'path';
-import { assert } from 'chai';
+import * as vscode from "vscode";
+import * as path from "path";
+import { assert } from "chai";
 
 export let doc: vscode.TextDocument;
 export let editor: vscode.TextEditor;
@@ -10,7 +10,7 @@ export let editor: vscode.TextEditor;
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export async function activate(docUri: vscode.Uri): Promise<any> {
-  const extension = vscode.extensions.getExtension('redhat.ansible');
+  const extension = vscode.extensions.getExtension("redhat.ansible");
   const activation = await extension?.activate();
 
   try {
@@ -19,13 +19,13 @@ export async function activate(docUri: vscode.Uri): Promise<any> {
       preview: true,
       preserveFocus: false,
     });
-    await vscode.languages.setTextDocumentLanguage(doc, 'ansible');
+    await vscode.languages.setTextDocumentLanguage(doc, "ansible");
 
     await sleep(5000); // Wait for server activation
 
     return activation;
   } catch (e) {
-    console.error('Error from activation -> ', e);
+    console.error("Error from activation -> ", e);
   }
 }
 
@@ -36,7 +36,7 @@ export async function sleep(ms: number): Promise<void> {
 export const getDocPath = (p: string): string => {
   return path.resolve(
     __dirname,
-    path.join('..', '..', '..', 'test', 'testFixtures', p)
+    path.join("..", "..", "..", "test", "testFixtures", p)
   );
 };
 
@@ -48,7 +48,7 @@ export async function updateSettings(
   setting: string,
   value: unknown
 ): Promise<void> {
-  const ansibleConfiguration = vscode.workspace.getConfiguration('ansible');
+  const ansibleConfiguration = vscode.workspace.getConfiguration("ansible");
   const useGlobalSettings = true;
   return ansibleConfiguration.update(setting, value, useGlobalSettings);
 }
@@ -80,7 +80,7 @@ export async function testHover(
   expectedHover: vscode.Hover[]
 ): Promise<void> {
   const actualHover = (await vscode.commands.executeCommand(
-    'vscode.executeHoverProvider',
+    "vscode.executeHoverProvider",
     docUri,
     position
   )) as vscode.Hover[];

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,28 +1,28 @@
-import * as path from 'path';
-import Mocha from 'mocha';
-import glob from 'glob';
+import * as path from "path";
+import Mocha from "mocha";
+import glob from "glob";
 
 export function run(): Promise<void> {
   // Create the mocha test
   const mocha = new Mocha({
     color: true,
-    ui: 'bdd',
+    ui: "bdd",
     timeout: 30000,
-    reporter: 'mochawesome',
+    reporter: "mochawesome",
     reporterOptions: {
-      reportFilename: 'e2e_test_report',
-      reportDir: 'out/e2eTestReport',
-      reportTitle: 'vscode-ansible e2e test',
-      reportPageTitle: 'vscode-ansible e2e test report',
+      reportFilename: "e2e_test_report",
+      reportDir: "out/e2eTestReport",
+      reportTitle: "vscode-ansible e2e test",
+      reportPageTitle: "vscode-ansible e2e test report",
       cdn: true,
       charts: true,
     },
   });
 
-  const testsRoot = path.resolve(__dirname, '..');
+  const testsRoot = path.resolve(__dirname, "..");
 
   return new Promise((c, e) => {
-    glob('**/**.test.js', { cwd: testsRoot }, (err, files) => {
+    glob("**/**.test.js", { cwd: testsRoot }, (err, files) => {
       if (err) {
         return e(err);
       }

--- a/test/testRunner.ts
+++ b/test/testRunner.ts
@@ -1,93 +1,97 @@
-import * as path from 'path';
-import * as cp from 'child_process';
+import * as path from "path";
+import * as cp from "child_process";
 import {
   runTests,
   downloadAndUnzipVSCode,
   resolveCliPathFromVSCodeExecutablePath,
-} from 'vscode-test';
-import fs from 'fs';
+} from "vscode-test";
+import fs from "fs";
 
 async function main(): Promise<void> {
   try {
     const executable = await downloadAndUnzipVSCode();
     const cliPath = resolveCliPathFromVSCodeExecutablePath(executable);
-    const userDataPath = path.resolve(__dirname, '../../userdata');
-    const extPath = path.resolve(__dirname, '../../ext');
+    const userDataPath = path.resolve(__dirname, "../../userdata");
+    const extPath = path.resolve(__dirname, "../../ext");
     // We want to avoid using developer data dir as this is likely to break
     // testing and make its outcome very hard to reproduce across machines.
     // https://code.visualstudio.com/docs/getstarted/settings#_settings-file-locations
     const cliArgs = [
       `--user-data-dir=${userDataPath}`,
-      `--extensions-dir=${extPath}`
+      `--extensions-dir=${extPath}`,
     ];
 
     // Copy default user settings.json
     const settings_src = path.join(
       __dirname,
-      '..',
-      '..',
-      '..',
-      'test',
-      'testFixtures',
-      'settings.json',
+      "..",
+      "..",
+      "..",
+      "test",
+      "testFixtures",
+      "settings.json"
     );
     const settings_dst = path.join(
       __dirname,
-      '..',
-      '..',
-      '..',
-      'out',
-      'userdata',
-      'User',
-      'settings.json',
+      "..",
+      "..",
+      "..",
+      "out",
+      "userdata",
+      "User",
+      "settings.json"
     );
     fs.mkdirSync(path.dirname(settings_dst), { recursive: true });
     fs.copyFileSync(settings_src, settings_dst);
 
     // Install the latest released redhat.ansible extension
     const installLog = cp.execSync(
-      `"${cliPath}" ${cliArgs.join(' ')} --install-extension redhat.ansible --force`
+      `"${cliPath}" ${cliArgs.join(
+        " "
+      )} --install-extension redhat.ansible --force`
     );
     console.log(installLog.toString());
 
     // Install the dependent extensions
-    const dependencies = ['ms-python.python', 'redhat.vscode-yaml'];
+    const dependencies = ["ms-python.python", "redhat.vscode-yaml"];
     for (const dep of dependencies) {
       const installLog = cp.execSync(
-        `"${cliPath}" ${cliArgs.join(' ')} --install-extension ${dep} --force`
+        `"${cliPath}" ${cliArgs.join(" ")} --install-extension ${dep} --force`
       );
       console.log(installLog.toString());
     }
 
     // Display active extensions
-    const cmd = `"${cliPath}" ${cliArgs.join(' ')} --list-extensions --show-versions`
+    const cmd = `"${cliPath}" ${cliArgs.join(
+      " "
+    )} --list-extensions --show-versions`;
     const extLog = cp.execSync(cmd);
-    console.warn('%s\n%s', cmd, extLog.toString());
+    console.warn("%s\n%s", cmd, extLog.toString());
 
     // Set collections_path in env
     const FIXTURES_COLLECTION_DIR = path.join(
       __dirname,
-      '..',
-      '..',
-      '..',
-      'test',
-      'testFixtures',
-      'common',
-      'collections'
+      "..",
+      "..",
+      "..",
+      "test",
+      "testFixtures",
+      "common",
+      "collections"
     );
-    process.env['ANSIBLE_COLLECTIONS_PATH'] = FIXTURES_COLLECTION_DIR;
+    process.env["ANSIBLE_COLLECTIONS_PATH"] = FIXTURES_COLLECTION_DIR;
 
     // This is necessary to prevent failures.
     // For more details regarding the cause, check https://github.com/ansible/vscode-ansible/issues/373
-    process.env['ANSIBLE_FORCE_COLOR'] = '0';
+    process.env["ANSIBLE_FORCE_COLOR"] = "0";
 
     // The folder containing the Extension Manifest package.json
     // Passed to `--extensionDevelopmentPath`
-    const extensionDevelopmentPath = path.resolve(__dirname, '../../');
+    const extensionDevelopmentPath = path.resolve(__dirname, "../../");
 
     // The path to test runner
     // Passed to --extensionTestsPath
-    const extensionTestsPath = path.resolve(__dirname, './index');
+    const extensionTestsPath = path.resolve(__dirname, "./index");
 
     // Download VS Code, unzip it and run the integration test
     await runTests({
@@ -95,20 +99,20 @@ async function main(): Promise<void> {
       extensionDevelopmentPath,
       extensionTestsPath,
       launchArgs: cliArgs.concat([
-        '--disable-extension=ritwickdey.liveserver',
-        '--disable-extension=redhat.fabric8-analytics',
-        '--disable-extension=lextudio.restructuredtext',
-        '--disable-extension=ms-vsliveshare.vsliveshare',
-        '--disable-extension=GitHub.vscode-pull-request-github',
-        '--disable-extension=eamodio.gitlens',
-        '--disable-extension=streetsidesoftware.code-spell-checker',
-        '--disable-extension=alefragnani.project-manager',
-        '--disable-extension=GitHub.copilot',
-        './test/testFixtures/',
+        "--disable-extension=ritwickdey.liveserver",
+        "--disable-extension=redhat.fabric8-analytics",
+        "--disable-extension=lextudio.restructuredtext",
+        "--disable-extension=ms-vsliveshare.vsliveshare",
+        "--disable-extension=GitHub.vscode-pull-request-github",
+        "--disable-extension=eamodio.gitlens",
+        "--disable-extension=streetsidesoftware.code-spell-checker",
+        "--disable-extension=alefragnani.project-manager",
+        "--disable-extension=GitHub.copilot",
+        "./test/testFixtures/",
       ]),
     });
   } catch (err) {
-    console.error('Failed to run tests due to exception!\n%s', err);
+    console.error("Failed to run tests due to exception!\n%s", err);
     process.exit(1);
   }
 }

--- a/test/testScripts/diagnostics/testDiagnosticsAnsibleLocal.test.ts
+++ b/test/testScripts/diagnostics/testDiagnosticsAnsibleLocal.test.ts
@@ -1,86 +1,86 @@
 /* eslint-disable quotes */
-import * as vscode from 'vscode';
+import * as vscode from "vscode";
 import {
   getDocUri,
   activate,
   testDiagnostics,
   sleep,
   updateSettings,
-} from '../../helper';
+} from "../../helper";
 
 export function testDiagnosticsAnsibleLocal(): void {
-  describe('TEST FOR ANSIBLE DIAGNOSTICS', () => {
-    const docUri1 = getDocUri('diagnostics/ansible/1.yml');
-    const docUri2 = getDocUri('diagnostics/ansible/2.yml');
+  describe("TEST FOR ANSIBLE DIAGNOSTICS", () => {
+    const docUri1 = getDocUri("diagnostics/ansible/1.yml");
+    const docUri2 = getDocUri("diagnostics/ansible/2.yml");
 
     before(async () => {
-      await vscode.commands.executeCommand('workbench.action.closeAllEditors');
+      await vscode.commands.executeCommand("workbench.action.closeAllEditors");
     });
 
-    describe('Diagnostic test with ansible-lint', () => {
-      it('should complain about no task names', async () => {
+    describe("Diagnostic test with ansible-lint", () => {
+      it("should complain about no task names", async () => {
         await activate(docUri1);
-        await vscode.commands.executeCommand('workbench.action.files.save');
+        await vscode.commands.executeCommand("workbench.action.files.save");
 
         await sleep(2000); // Wait for the diagnostics to compute on this file
 
         await testDiagnostics(docUri1, [
           {
             severity: 0,
-            message: 'All tasks should be named',
+            message: "All tasks should be named",
             range: new vscode.Range(
               new vscode.Position(3, 0),
               new vscode.Position(3, Number.MAX_SAFE_INTEGER)
             ),
-            source: 'Ansible',
+            source: "Ansible",
           },
         ]);
       });
 
-      it('should complain about command syntax-check failed', async function () {
+      it("should complain about command syntax-check failed", async function () {
         await activate(docUri2);
-        await vscode.commands.executeCommand('workbench.action.files.save');
+        await vscode.commands.executeCommand("workbench.action.files.save");
 
         await sleep(2000); // Wait for the diagnostics to compute on this file
 
         await testDiagnostics(docUri2, [
           {
             severity: 0,
-            message: 'Ansible syntax check failed',
+            message: "Ansible syntax check failed",
             range: new vscode.Range(
               new vscode.Position(0, 0),
               new vscode.Position(0, Number.MAX_SAFE_INTEGER)
             ),
-            source: 'Ansible',
+            source: "Ansible",
           },
         ]);
       });
     });
 
-    describe('Diagnostic test with ansible-syntax-check', () => {
+    describe("Diagnostic test with ansible-syntax-check", () => {
       before(async () => {
-        await updateSettings('ansibleLint.enabled', false);
+        await updateSettings("ansibleLint.enabled", false);
         await vscode.commands.executeCommand(
-          'workbench.action.closeAllEditors'
+          "workbench.action.closeAllEditors"
         );
       });
 
       after(async () => {
-        await updateSettings('ansibleLint.enabled', true); // Revert back the setting to default
+        await updateSettings("ansibleLint.enabled", true); // Revert back the setting to default
       });
 
-      it('should return no diagnostics', async function () {
+      it("should return no diagnostics", async function () {
         await activate(docUri1);
-        await vscode.commands.executeCommand('workbench.action.files.save');
+        await vscode.commands.executeCommand("workbench.action.files.save");
 
         await sleep(2000); // Wait for the diagnostics to compute on this file
 
         await testDiagnostics(docUri1, []);
       });
 
-      it('should complain about missing `hosts` key', async function () {
+      it("should complain about missing `hosts` key", async function () {
         await activate(docUri2);
-        await vscode.commands.executeCommand('workbench.action.files.save');
+        await vscode.commands.executeCommand("workbench.action.files.save");
 
         await sleep(2000); // Wait for the diagnostics to compute on this file
 
@@ -92,7 +92,7 @@ export function testDiagnosticsAnsibleLocal(): void {
               new vscode.Position(0, 0),
               new vscode.Position(0, Number.MAX_SAFE_INTEGER)
             ),
-            source: 'Ansible',
+            source: "Ansible",
           },
         ]);
       });

--- a/test/testScripts/diagnostics/testDiagnosticsYAMLLocal.test.ts
+++ b/test/testScripts/diagnostics/testDiagnosticsYAMLLocal.test.ts
@@ -1,74 +1,74 @@
 /* eslint-disable quotes */
-import * as vscode from 'vscode';
+import * as vscode from "vscode";
 import {
   getDocUri,
   activate,
   sleep,
   testDiagnostics,
   updateSettings,
-} from '../../helper';
+} from "../../helper";
 
 export function testDiagnosticsYAMLLocal(): void {
-  describe('TEST FOR YAML DIAGNOSTICS', () => {
-    const docUri1 = getDocUri('diagnostics/yaml/invalid_yaml.yml');
+  describe("TEST FOR YAML DIAGNOSTICS", () => {
+    const docUri1 = getDocUri("diagnostics/yaml/invalid_yaml.yml");
 
     before(async () => {
-      await vscode.commands.executeCommand('workbench.action.closeAllEditors');
+      await vscode.commands.executeCommand("workbench.action.closeAllEditors");
     });
 
-    describe('YAML diagnostics in the presence of ansible-lint', () => {
-      it('should provide diagnostics with YAML validation (with ansible-lint)', async () => {
+    describe("YAML diagnostics in the presence of ansible-lint", () => {
+      it("should provide diagnostics with YAML validation (with ansible-lint)", async () => {
         await activate(docUri1);
         await sleep(2000); // Wait for the diagnostics to compute on this file
 
         await testDiagnostics(docUri1, [
           {
             severity: 0,
-            message: 'Ansible syntax check failed',
+            message: "Ansible syntax check failed",
             range: new vscode.Range(
               new vscode.Position(0, 0),
               new vscode.Position(0, Number.MAX_SAFE_INTEGER)
             ),
-            source: 'Ansible',
+            source: "Ansible",
           },
           {
             severity: 0,
-            message: 'Nested mappings are not allowed in compact mappings',
+            message: "Nested mappings are not allowed in compact mappings",
             range: new vscode.Range(
               new vscode.Position(6, 13),
               new vscode.Position(6, 13)
             ),
-            source: 'Ansible [YAML]',
+            source: "Ansible [YAML]",
           },
           {
             severity: 0,
             message:
-              'Document contains trailing content not separated by a ... or --- line',
+              "Document contains trailing content not separated by a ... or --- line",
             range: new vscode.Range(
               new vscode.Position(7, 0),
               new vscode.Position(8, 0)
             ),
-            source: 'Ansible [YAML]',
+            source: "Ansible [YAML]",
           },
         ]);
       });
     });
 
-    describe('YAML diagnostics in the absence of ansible-lint', () => {
+    describe("YAML diagnostics in the absence of ansible-lint", () => {
       before(async () => {
-        await updateSettings('ansibleLint.enabled', false);
+        await updateSettings("ansibleLint.enabled", false);
         await vscode.commands.executeCommand(
-          'workbench.action.closeAllEditors'
+          "workbench.action.closeAllEditors"
         );
       });
 
       after(async () => {
-        await updateSettings('ansibleLint.enabled', true); // Revert back the setting to default
+        await updateSettings("ansibleLint.enabled", true); // Revert back the setting to default
       });
 
-      it('should provide diagnostics with YAML validation (with --syntax-check)', async () => {
+      it("should provide diagnostics with YAML validation (with --syntax-check)", async () => {
         await activate(docUri1);
-        await vscode.commands.executeCommand('workbench.action.files.save');
+        await vscode.commands.executeCommand("workbench.action.files.save");
 
         await sleep(2000); // Wait for the diagnostics to compute on this file
 
@@ -76,32 +76,32 @@ export function testDiagnosticsYAMLLocal(): void {
           {
             severity: 0,
             message:
-              'Syntax Error while loading YAML.\n' +
-              '  mapping values are not allowed in this context\n',
+              "Syntax Error while loading YAML.\n" +
+              "  mapping values are not allowed in this context\n",
             range: new vscode.Range(
               new vscode.Position(6, 21),
               new vscode.Position(6, Number.MAX_SAFE_INTEGER)
             ),
-            source: 'Ansible',
+            source: "Ansible",
           },
           {
             severity: 0,
-            message: 'Nested mappings are not allowed in compact mappings',
+            message: "Nested mappings are not allowed in compact mappings",
             range: new vscode.Range(
               new vscode.Position(6, 13),
               new vscode.Position(6, 13)
             ),
-            source: 'Ansible [YAML]',
+            source: "Ansible [YAML]",
           },
           {
             severity: 0,
             message:
-              'Document contains trailing content not separated by a ... or --- line',
+              "Document contains trailing content not separated by a ... or --- line",
             range: new vscode.Range(
               new vscode.Position(7, 0),
               new vscode.Position(8, 0)
             ),
-            source: 'Ansible [YAML]',
+            source: "Ansible [YAML]",
           },
         ]);
       });

--- a/test/testScripts/hover/testHoverLocal.test.ts
+++ b/test/testScripts/hover/testHoverLocal.test.ts
@@ -1,114 +1,114 @@
-import * as vscode from 'vscode';
-import { getDocUri, activate, testHover } from '../../helper';
+import * as vscode from "vscode";
+import { getDocUri, activate, testHover } from "../../helper";
 
 export function testHoverLocal(): void {
-  describe('TEST FOR HOVER', () => {
-    const docUri1 = getDocUri('hover/1.yml');
+  describe("TEST FOR HOVER", () => {
+    const docUri1 = getDocUri("hover/1.yml");
 
     before(async () => {
-      await vscode.commands.executeCommand('workbench.action.closeAllEditors');
+      await vscode.commands.executeCommand("workbench.action.closeAllEditors");
       await activate(docUri1);
     });
 
-    describe('Hover for play keywords', () => {
-      it('should hover over `name` keyword', async () => {
+    describe("Hover for play keywords", () => {
+      it("should hover over `name` keyword", async () => {
         await testHover(docUri1, new vscode.Position(0, 4), [
           {
             contents: [
-              'Identifier. Can be used for documentation, or in tasks/handlers.',
+              "Identifier. Can be used for documentation, or in tasks/handlers.",
             ],
           },
         ]);
       });
 
-      it('should hover over `hosts` keyword', async () => {
+      it("should hover over `hosts` keyword", async () => {
         await testHover(docUri1, new vscode.Position(2, 4), [
           {
             contents: [
-              'A list of groups, hosts or host pattern that translates into a list of hosts that are the play’s target.',
+              "A list of groups, hosts or host pattern that translates into a list of hosts that are the play’s target.",
             ],
           },
         ]);
       });
 
-      it('should hover over `tasks` keyword', async () => {
+      it("should hover over `tasks` keyword", async () => {
         await testHover(docUri1, new vscode.Position(3, 4), [
           {
             contents: [
-              'Main list of tasks to execute in the play, they run after roles and before post_tasks.',
+              "Main list of tasks to execute in the play, they run after roles and before post_tasks.",
             ],
           },
         ]);
       });
     });
 
-    describe('Hover for task keywords', () => {
-      it('should hover over builtin module name', async () => {
+    describe("Hover for task keywords", () => {
+      it("should hover over builtin module name", async () => {
         await testHover(docUri1, new vscode.Position(5, 7), [
           {
-            contents: ['Print statements during execution'],
+            contents: ["Print statements during execution"],
           },
         ]);
       });
 
-      it('should hover over collection module name', async () => {
+      it("should hover over collection module name", async () => {
         await testHover(docUri1, new vscode.Position(9, 7), [
           {
-            contents: ['Test module'],
+            contents: ["Test module"],
           },
         ]);
       });
 
-      it('should hover over task keyword', async () => {
+      it("should hover over task keyword", async () => {
         await testHover(docUri1, new vscode.Position(25, 7), [
           {
             contents: [
-              'Name of variable that will contain task status and module return data.',
+              "Name of variable that will contain task status and module return data.",
             ],
           },
         ]);
       });
     });
 
-    describe('Hover for module options and sub-options', () => {
-      it('should hover over builtin module option', async () => {
+    describe("Hover for module options and sub-options", () => {
+      it("should hover over builtin module option", async () => {
         await testHover(docUri1, new vscode.Position(6, 9), [
           {
             contents: [
-              'The customized message that is printed. If omitted, prints a generic message.',
+              "The customized message that is printed. If omitted, prints a generic message.",
             ],
           },
         ]);
       });
 
-      it('should hover over collection module option (opt_1)', async () => {
+      it("should hover over collection module option (opt_1)", async () => {
         await testHover(docUri1, new vscode.Position(10, 9), [
           {
-            contents: ['Option 1'],
+            contents: ["Option 1"],
           },
         ]);
       });
 
-      it('should hover over collection module sub-option (opt_1 -> sub_opt_1)', async () => {
+      it("should hover over collection module sub-option (opt_1 -> sub_opt_1)", async () => {
         await testHover(docUri1, new vscode.Position(14, 13), [
           {
-            contents: ['Sub option 1'],
+            contents: ["Sub option 1"],
           },
         ]);
       });
 
-      it('should hover over collection module sub-option (opt_1 -> sub_opt_2 -> sub_sub_opt_2)', async () => {
+      it("should hover over collection module sub-option (opt_1 -> sub_opt_2 -> sub_sub_opt_2)", async () => {
         await testHover(docUri1, new vscode.Position(17, 17), [
           {
-            contents: ['Sub sub option 2'],
+            contents: ["Sub sub option 2"],
           },
         ]);
       });
 
-      it('should hover over collection module sub-option (opt_1 -> sub_opt_2 -> sub_sub_opt_2 -> sub_sub_sub_opt_1)', async () => {
+      it("should hover over collection module sub-option (opt_1 -> sub_opt_2 -> sub_sub_opt_2 -> sub_sub_sub_opt_1)", async () => {
         await testHover(docUri1, new vscode.Position(19, 21), [
           {
-            contents: ['Sub sub sub option 1'],
+            contents: ["Sub sub sub option 1"],
           },
         ]);
       });

--- a/test/testScripts/testExtensionLocal.test.ts
+++ b/test/testScripts/testExtensionLocal.test.ts
@@ -1,8 +1,8 @@
-import { testDiagnosticsAnsibleLocal } from './diagnostics/testDiagnosticsAnsibleLocal.test';
-import { testDiagnosticsYAMLLocal } from './diagnostics/testDiagnosticsYAMLLocal.test';
-import { testHoverLocal } from './hover/testHoverLocal.test';
+import { testDiagnosticsAnsibleLocal } from "./diagnostics/testDiagnosticsAnsibleLocal.test";
+import { testDiagnosticsYAMLLocal } from "./diagnostics/testDiagnosticsYAMLLocal.test";
+import { testHoverLocal } from "./hover/testHoverLocal.test";
 
-describe('TEST EXTENSION IN LOCAL ENVIRONMENT', () => {
+describe("TEST EXTENSION IN LOCAL ENVIRONMENT", () => {
   testHoverLocal();
   testDiagnosticsAnsibleLocal();
   testDiagnosticsYAMLLocal();

--- a/test/ui-test/allTestsSuite.ts
+++ b/test/ui-test/allTestsSuite.ts
@@ -1,8 +1,8 @@
-import { extensionUIAssetsTest } from './extensionUITest';
+import { extensionUIAssetsTest } from "./extensionUITest";
 
 /**
  * @author Ondrej Dockal <odockal@redhat.com>
  */
-describe('VSCode Ansible - UI tests', () => {
+describe("VSCode Ansible - UI tests", () => {
   extensionUIAssetsTest();
 });

--- a/test/ui-test/extensionUITest.ts
+++ b/test/ui-test/extensionUITest.ts
@@ -1,48 +1,48 @@
-import { expect } from 'chai';
+import { expect } from "chai";
 import {
   ActivityBar,
   SideBarView,
   ViewControl,
   ExtensionsViewSection,
-} from 'vscode-extension-tester';
+} from "vscode-extension-tester";
 
 /**
  * @author Ondrej Dockal <odockal@redhat.com>
  */
 export function extensionUIAssetsTest(): void {
-  describe('Verify base assets are available after installation', () => {
+  describe("Verify base assets are available after installation", () => {
     let view: ViewControl;
     let sideBar: SideBarView;
 
     before(async function () {
       this.timeout(6000);
       view = (await new ActivityBar().getViewControl(
-        'Extensions'
+        "Extensions"
       )) as ViewControl;
       sideBar = await view.openView();
     });
 
-    it('VSCode Ansible extension is installed', async function () {
+    it("VSCode Ansible extension is installed", async function () {
       this.retries(3);
       this.timeout(20000); // even 18s failed
       const section = (await sideBar
         .getContent()
-        .getSection('Installed')) as ExtensionsViewSection;
-      const item = await section.findItem('@installed Ansible');
-      expect(item, 'Failed to find Ansible extension').not.undefined;
-      expect(await item?.getText()).to.contain('Red Hat');
+        .getSection("Installed")) as ExtensionsViewSection;
+      const item = await section.findItem("@installed Ansible");
+      expect(item, "Failed to find Ansible extension").not.undefined;
+      expect(await item?.getText()).to.contain("Red Hat");
     });
 
     after(async function () {
       this.timeout(4000);
       if (sideBar && (await sideBar.isDisplayed())) {
         const viewControl = (await new ActivityBar().getViewControl(
-          'Extensions'
+          "Extensions"
         )) as ViewControl;
         sideBar = await viewControl.openView();
         const titlePart = sideBar.getTitlePart();
         const actionButton = await titlePart.getAction(
-          'Clear Extensions Search Results'
+          "Clear Extensions Search Results"
         );
         if (await actionButton.isEnabled()) {
           await actionButton.click();

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,43 +1,44 @@
 //@ts-check
 /** @typedef {import('webpack').Configuration} WebpackConfig **/
 
-'use strict';
+"use strict";
 /* eslint @typescript-eslint/no-var-requires: "off" */
-const path = require('path');
+const path = require("path");
 
 /** @type WebpackConfig */
 const config = {
-  mode: 'none',
-  target: 'node', // vscode extensions run in a Node.js-context
+  mode: "none",
+  target: "node", // vscode extensions run in a Node.js-context
   node: {
     __dirname: false, // leave the __dirname-behavior intact
   },
   entry: {
-    client: './src/extension.ts',
-    server: './node_modules/@ansible/ansible-language-server/out/server/src/server.js',
+    client: "./src/extension.ts",
+    server:
+      "./node_modules/@ansible/ansible-language-server/out/server/src/server.js",
   },
   output: {
     filename: (pathData) => {
-      return pathData.chunk.name === 'client'
-        ? '[name]/extension.js'
-        : '[name]/src/[name].js';
+      return pathData.chunk.name === "client"
+        ? "[name]/extension.js"
+        : "[name]/src/[name].js";
     },
-    path: path.resolve(__dirname, 'out'),
-    libraryTarget: 'commonjs2',
+    path: path.resolve(__dirname, "out"),
+    libraryTarget: "commonjs2",
     devtoolModuleFilenameTemplate: (info) => {
-      return info.id === 'client'
-        ? '../[resource-path]'
-        : '../../../[resource-path]';
+      return info.id === "client"
+        ? "../[resource-path]"
+        : "../../../[resource-path]";
     },
   },
   // stats: 'verbose', // doesn't help with watcher
-  devtool: 'source-map',
+  devtool: "source-map",
   externals: {
-    vscode: 'commonjs vscode', // the vscode-module is created on-the-fly and must be excluded. Add other modules that cannot be webpack'ed
+    vscode: "commonjs vscode", // the vscode-module is created on-the-fly and must be excluded. Add other modules that cannot be webpack'ed
   },
   resolve: {
     // support reading TypeScript and JavaScript files
-    extensions: ['.ts', '.js'],
+    extensions: [".ts", ".js"],
   },
   module: {
     rules: [
@@ -49,7 +50,7 @@ const config = {
             // configure TypeScript loader:
             // * enable sources maps for end-to-end source maps
             // * does not work for server code
-            loader: 'ts-loader',
+            loader: "ts-loader",
             options: {
               compilerOptions: {
                 sourceMap: true,


### PR DESCRIPTION
That enables typescript on pre-commit prettier run as currently almost
any attempt to edit .ts files using vscode would introduce undesired
reformatting. That is because we recommend prettier extension which
auto-reformats.

The only manually made change is the one line in pre-commit config,
the rest is just pre-commit itself.

Sister change: https://github.com/ansible/ansible-language-server/pull/196
Related: https://github.com/ansible-community/devtools/issues/28