### PR TITLE
Make test-setup script a standalone file

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -84,24 +84,10 @@ jobs:
         with:
           node-version: 16
 
-      # Run install dependencies
-      - name: Install dependencies
+      - name: Run ./tools/test-setup.sh
+
         run: |
-          set -ex
-          # we don't want the outdated ubuntu blend of ansible
-          if [ "$RUNNER_OS" == "Linux" ]; then
-            sudo apt-get remove -y ansible
-          fi
-          pipx install pre-commit
-          # see https://github.com/pypa/pipx/issues/88
-          pipx install ansible-lint
-          if [ "$RUNNER_OS" != "Windows" ]; then
-            pipx inject --include-apps ansible-lint yamllint ansible-core
-            ansible-lint --version
-            ansible --version
-          fi
-          npm config set fund false
-          npm ci
+          ./tools/test-setup.sh
         shell: bash
 
       - name: Link development version of ansible-language-server

--- a/tools/test-setup.sh
+++ b/tools/test-setup.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# This tool is used to setup the environment for running the tests. Its name
+# name and location is based on Zuul CI, which can automatically run it.
+set -ex
+# we don't want the outdated ubuntu blend of ansible
+if [ "$RUNNER_OS" == "Linux" ]; then
+  sudo apt-get remove -y ansible
+fi
+
+pipx install pre-commit
+# see https://github.com/pypa/pipx/issues/88
+pipx install ansible-lint
+if [ "$RUNNER_OS" != "Windows" ]; then
+  pipx inject --include-apps ansible-lint yamllint ansible-core
+  ansible-lint --version
+  ansible --version
+fi
+
+npm config set fund false
+npm ci


### PR DESCRIPTION
This would make editing of this file much easier and also allow us to use it locally. It follows use patterns from other repositories.

That is a preparatory move related to enabling WSL testing.
