### PR TITLE
chore: archive build logs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -126,6 +126,14 @@ jobs:
           path: ansible-*.vsix
           retention-days: 15
 
+      - name: Publish test logs
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: userdata-logs
+          path: out/userdata/logs/
+          retention-days: 15
+
       # extra safety measure that ensures code was not modified during build
       - name: Ensure git does not report dirty
         # on devel we use `npm link --save ..` which will alter tracked files

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -130,8 +130,12 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v2
         with:
-          name: userdata-logs
-          path: out/userdata/logs/
+          name: logs-${{ matrix.os }}-${{ matrix.npm-target }}.zip
+          path: |
+            out/e2eTestReport
+            out/userdata/logs
+            out/test-resources/settings/logs
+          if-no-files-found: ignore
           retention-days: 15
 
       # extra safety measure that ensures code was not modified during build


### PR DESCRIPTION
That change is needed in order to allow us to debug test failures.

Needed-By: https://github.com/ansible/vscode-ansible/pull/412