### PR TITLE
ci: use fs-safe names for npm scripts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,8 +36,8 @@ jobs:
           - macos-11
           - windows-latest
         npm-target:
-          - test:ui
-          - test:ui-oldest
+          - test-ui
+          - test-ui-oldest
         upload-artifact:
           - false
         name:
@@ -50,11 +50,11 @@ jobs:
           - name: devel
             # this job will install latest version of ansible-language-server
             # instead of the one mentioned in package[-lock].json
-            npm-target: test:ui
+            npm-target: test-ui
             os: ubuntu-latest
             devel: true
-          - name: test:e2e
-            npm-target: test:e2e
+          - name: test-e2e
+            npm-target: test-e2e
             os: ubuntu-latest
             experimental: true
 
@@ -72,10 +72,10 @@ jobs:
           # We will later move this folder to ../ due to below bug:
           # https://github.com/actions/checkout/issues/197
 
-      # ~400mb, caching them should speedup test:ui execution
+      # ~400mb, caching them should speedup test-ui execution
       - name: Enable test-resources caching
         uses: actions/cache@v2
-        if: ${{ contains(matrix.npm-target, 'test:ui') }}
+        if: ${{ contains(matrix.npm-target, 'test-ui') }}
         with:
           path: |
             out/test-resources

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,7 @@ def installBuildRequirements(){
 
 def buildVscodeExtension(){
   sh "npm install"
-  sh "npm run vscode:prepublish"
+  sh "npm run vscode-prepublish"
 }
 
 node("rhel8"){

--- a/doc/development.md
+++ b/doc/development.md
@@ -22,7 +22,7 @@ language server code into the `ansible-language-server` directory _next to_ the
 root directory of this repository. Remember to `npm install` in that directory.
 
 Once the language server directory is prepared, you may compile both client and
-server using the `npm run compile:withserver` command. Then you may launch the
+server using the `npm run compile-withserver` command. Then you may launch the
 **Client + Server (source)** configuration.
 
 ### Debug a web-packed application
@@ -32,7 +32,7 @@ In rare cases, you might want to debug the application code compiled with
 the client, while the sourcemaps for the server point to the JavaScript files of
 the `ansible-language-server` under `node_modules`.
 
-To launch in this mode, first run webpack (`npm run webpack:dev`). Then you may
+To launch in this mode, first run webpack (`npm run webpack-dev`). Then you may
 launch the **Launch Extension (webpacked)** configuration, followed by the
 **Attach to Server** configuration.
 

--- a/package.json
+++ b/package.json
@@ -462,7 +462,7 @@
   "scripts": {
     "code": "npm run package && code --force --install-extension *.vsix",
     "compile": "tsc -b && copyfiles -u 4 'node_modules/@ansible/ansible-language-server/out/server/**/*' out/server",
-    "compile:withserver": "tsc -b && tsc -p ../ansible-language-server --outDir out/server && ln -f -s ${PWD}/../ansible-language-server/node_modules out/server/node_modules",
+    "compile-withserver": "tsc -b && tsc -p ../ansible-language-server --outDir out/server && ln -f -s ${PWD}/../ansible-language-server/node_modules out/server/node_modules",
     "//deps": "Update all dependencies",
     "deps": "ncu -u && npm install",
     "lint": "pre-commit run -a",
@@ -472,17 +472,17 @@
     "sanity": "npm ci && npm install --ignore-scripts && ncu upgrade '@ansible/ansible-language-server@latest' && npm version --allow-same-version --no-commit-hooks --no-git-tag-version $npm_package_version",
     "//setup": "setup is used to configure development environment, like installing git hooks.",
     "setup": "pre-commit install-hooks",
-    "test:ui": "extest setup-and-run -e out/ext -i -s out/test-resources out/client/test/ui-test/allTestsSuite.js",
-    "test:ui-oldest": "extest setup-and-run -e out/ext -c 1.48.0 -s out/test-resources-oldest -i -u out/client/test/ui-test/allTestsSuite.js",
-    "vscode:prepublish": "npm run webpack",
+    "test-ui": "extest setup-and-run -e out/ext -i -s out/test-resources out/client/test/ui-test/allTestsSuite.js",
+    "test-ui-oldest": "extest setup-and-run -e out/ext -c 1.48.0 -s out/test-resources-oldest -i -u out/client/test/ui-test/allTestsSuite.js",
+    "vscode-prepublish": "npm run webpack",
     "watch": "tsc -b -w",
-    "watch:server": "tsc -p ../ansible-language-server --outDir out/server -w",
+    "watch-server": "tsc -p ../ansible-language-server --outDir out/server -w",
     "webpack": "npm run clean && npm run compile && webpack --mode production --config ./webpack.config.js",
-    "webpack:dev": "npm run clean && webpack --mode development --config ./webpack.config.js",
-    "webpack:watch": "webpack --mode development --config ./webpack.config.js --watch",
+    "webpack-dev": "npm run clean && webpack --mode development --config ./webpack.config.js",
+    "webpack-watch": "webpack --mode development --config ./webpack.config.js --watch",
     "clean": "rimraf out/client out/server out/tsconfig.tsbuildinfo",
-    "test:compile": "npm run clean && tsc -p ./",
-    "test:e2e": "npm run test:compile && node ./out/client/test/testRunner"
+    "test-compile": "npm run clean && tsc -p ./",
+    "test-e2e": "npm run test-compile && node ./out/client/test/testRunner"
   },
   "version": "0.7.1"
 }


### PR DESCRIPTION
Avoid using ":" on npm script names because these are not safe to use in filenames and lack of native string replace on GHA expressions makes very hard to generate safe filenames.

This would allow use to add extra complexity to out GHA job definitions.

Related: https://github.com/ansible/vscode-ansible/actions/runs/1777574892