### PR TITLE
Correct src paths

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -29,7 +29,7 @@
         "--extensionDevelopmentPath=${workspaceFolder}",
         "${workspaceFolder}/examples"
       ],
-      "outFiles": ["${workspaceFolder}/out/client/**/*.js"],
+      "outFiles": ["${workspaceFolder}/out/client/src/**/*.js"],
       "preLaunchTask": "npm: watch"
     },
     {
@@ -41,7 +41,7 @@
         "--extensionDevelopmentPath=${workspaceFolder}",
         "${workspaceFolder}/examples"
       ],
-      "outFiles": ["${workspaceFolder}/out/client/**/*.js"],
+      "outFiles": ["${workspaceFolder}/out/client/src/**/*.js"],
       "preLaunchTask": "Webpack Watch"
     },
     {

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -14,6 +14,6 @@ webpack.config.js
 images/**
 !images/logo.png
 out/**
-!out/client/extension.js
+!out/client/src/extension.js
 server/**
 !out/server/src/server.js

--- a/package.json
+++ b/package.json
@@ -450,7 +450,7 @@
     "validation"
   ],
   "license": "MIT",
-  "main": "./out/client/extension",
+  "main": "./out/client/src/extension",
   "name": "ansible",
   "preview": true,
   "publisher": "redhat",


### PR DESCRIPTION
Fixes regression from #397 which broke the ability to use vscode debugging feature as the output path got an additional src in it.
