### PR TITLE
Fix extension broken debug capability

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,7 +13,7 @@
     {
       "name": "Both (src)",
       "stopAll": true,
-      "configurations": ["Launch Extension", "Attach to Server (source)"],
+      "configurations": ["Launch Extension", "Attach to Server (src)"],
       "presentation": {
         "order": 1
       }
@@ -61,7 +61,7 @@
       "port": 6010,
       "restart": true,
       "outFiles": ["${workspaceRoot}/out/server/src/**/*.js"],
-      "preLaunchTask": "npm: watch:server"
+      "preLaunchTask": "npm: watch-server"
     }
   ]
 }


### PR DESCRIPTION
The lauch configuration change and
pre launch task name change introduced in
PR https://github.com/ansible/vscode-ansible/pull/339
and https://github.com/ansible/vscode-ansible/pull/418
resulted in breaking of debug capability after running
`npm run compile-withserver` script.
The PR fixes the names to match the corresponding script name