### PR TITLE
Prepare fixtures for ansible-lint v6

### DIFF
--- a/test/testFixtures/diagnostics/ansible/1.yml
+++ b/test/testFixtures/diagnostics/ansible/1.yml
@@ -1,4 +1,4 @@
 - name: play name
   hosts: localhost
   tasks:
-    - debug:
+    - ansible.builtin.debug:

--- a/test/testFixtures/diagnostics/ansible/2.yml
+++ b/test/testFixtures/diagnostics/ansible/2.yml
@@ -1,4 +1,4 @@
 - name: play name
   tasks:
     - name: task 1
-      debug:
+      ansible.builtin.debug:


### PR DESCRIPTION
As ansible-lint v6 makes fqcn-builtins required, this small change
ensures newer version will not break our tests.
