### PR TITLE
Add language configuration files in vsix package

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -4,10 +4,12 @@
 *
 */**
 **/.DS_Store
+!ansible-language-configuration.json
 !CHANGELOG.md
 !LICENSE
 !README.md
 !images/logo.png
+!jinja-language-configuration.json
 !out/client/extension.js
 !out/server/src/server.js
 !package.json


### PR DESCRIPTION
Fixes https://github.com/ansible/vscode-ansible/issues/453
Fixes https://github.com/ansible/vscode-ansible/issues/450

Changes in PR https://github.com/ansible/vscode-ansible/pull/437
resulted in excluding language specific configuration files.
Update `.vscodeignore` file to add `ansible-language-configuration.json`
and `jinja-language-configuration.json` as part of final package