### PR TITLE
Fix e2e testing

### DIFF
--- a/test/testRunner.ts
+++ b/test/testRunner.ts
@@ -44,11 +44,11 @@ async function main(): Promise<void> {
     fs.mkdirSync(path.dirname(settings_dst), { recursive: true });
     fs.copyFileSync(settings_src, settings_dst);
 
-    // Install the latest released redhat.ansible extension
+    // Install the ansible extension from generated .vsix
     const installLog = cp.execSync(
       `"${cliPath}" ${cliArgs.join(
         " "
-      )} --install-extension redhat.ansible --force`
+      )} --install-extension ansible-*.vsix --force`
     );
     console.log(installLog.toString());
 

--- a/test/testScripts/diagnostics/testDiagnosticsAnsibleLocal.test.ts
+++ b/test/testScripts/diagnostics/testDiagnosticsAnsibleLocal.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable quotes */
 import * as vscode from "vscode";
+import { integer } from "vscode-languageclient";
 import {
   getDocUri,
   activate,
@@ -30,7 +31,7 @@ export function testDiagnosticsAnsibleLocal(): void {
             message: "All tasks should be named",
             range: new vscode.Range(
               new vscode.Position(3, 0),
-              new vscode.Position(3, Number.MAX_SAFE_INTEGER)
+              new vscode.Position(3, integer.MAX_VALUE)
             ),
             source: "Ansible",
           },
@@ -49,7 +50,7 @@ export function testDiagnosticsAnsibleLocal(): void {
             message: "Ansible syntax check failed",
             range: new vscode.Range(
               new vscode.Position(0, 0),
-              new vscode.Position(0, Number.MAX_SAFE_INTEGER)
+              new vscode.Position(0, integer.MAX_VALUE)
             ),
             source: "Ansible",
           },
@@ -90,7 +91,7 @@ export function testDiagnosticsAnsibleLocal(): void {
             message: "the field 'hosts' is required but was not set",
             range: new vscode.Range(
               new vscode.Position(0, 0),
-              new vscode.Position(0, Number.MAX_SAFE_INTEGER)
+              new vscode.Position(0, integer.MAX_VALUE)
             ),
             source: "Ansible",
           },

--- a/test/testScripts/diagnostics/testDiagnosticsYAMLLocal.test.ts
+++ b/test/testScripts/diagnostics/testDiagnosticsYAMLLocal.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable quotes */
 import * as vscode from "vscode";
+import { integer } from "vscode-languageclient";
 import {
   getDocUri,
   activate,
@@ -27,7 +28,7 @@ export function testDiagnosticsYAMLLocal(): void {
             message: "Ansible syntax check failed",
             range: new vscode.Range(
               new vscode.Position(0, 0),
-              new vscode.Position(0, Number.MAX_SAFE_INTEGER)
+              new vscode.Position(0, integer.MAX_VALUE)
             ),
             source: "Ansible",
           },
@@ -80,7 +81,7 @@ export function testDiagnosticsYAMLLocal(): void {
               "  mapping values are not allowed in this context\n",
             range: new vscode.Range(
               new vscode.Position(6, 21),
-              new vscode.Position(6, Number.MAX_SAFE_INTEGER)
+              new vscode.Position(6, integer.MAX_VALUE)
             ),
             source: "Ansible",
           },


### PR DESCRIPTION
This PR does fixes the e2e testing on the extension by doing the following things:
- Runs tests on generated `ansible-*.vsix`.
- Adopts the changes from server to use `integer.MAX_VALUE` while testing. (Refer: https://github.com/ansible/ansible-language-server/pull/261)