### PR TITLE
Remove Zuul schema definition from extension config

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,14 +98,6 @@
       },
       {
         "fileMatch": [
-          "zuul.d/*.yaml",
-          "zuul-tests.d/*.yaml",
-          ".zuul.yaml"
-        ],
-        "url": "https://raw.githubusercontent.com/ansible-community/schemas/main/f/zuul.json"
-      },
-      {
-        "fileMatch": [
           ".ansible-lint"
         ],
         "url": "https://raw.githubusercontent.com/ansible-community/schemas/main/f/ansible-lint.json"


### PR DESCRIPTION
As our extension does not have any link to Zuul CI, we remove this file mapping from our configuration, relying on default behavior of yaml extension, which will rely on schemastore.

Related: https://github.com/SchemaStore/schemastore/pull/2156