### PR TITLE
Add verbose logging for ALS in test-e2e

### DIFF
--- a/test/helper.ts
+++ b/test/helper.ts
@@ -46,9 +46,10 @@ export const getDocUri = (p: string): vscode.Uri => {
 
 export async function updateSettings(
   setting: string,
-  value: unknown
+  value: unknown,
+  section = "ansible"
 ): Promise<void> {
-  const ansibleConfiguration = vscode.workspace.getConfiguration("ansible");
+  const ansibleConfiguration = vscode.workspace.getConfiguration(section);
   const useGlobalSettings = true;
   return ansibleConfiguration.update(setting, value, useGlobalSettings);
 }

--- a/test/testScripts/testExtensionLocal.test.ts
+++ b/test/testScripts/testExtensionLocal.test.ts
@@ -1,8 +1,17 @@
+import { updateSettings } from "../helper";
 import { testDiagnosticsAnsibleLocal } from "./diagnostics/testDiagnosticsAnsibleLocal.test";
 import { testDiagnosticsYAMLLocal } from "./diagnostics/testDiagnosticsYAMLLocal.test";
 import { testHoverLocal } from "./hover/testHoverLocal.test";
 
 describe("TEST EXTENSION IN LOCAL ENVIRONMENT", () => {
+  before(async () => {
+    await updateSettings("trace.server", "verbose", "ansibleServer");
+  });
+
+  after(async () => {
+    await updateSettings("trace.server", "off", "ansibleServer"); // Revert back the default settings
+  });
+
   testHoverLocal();
   testDiagnosticsAnsibleLocal();
   testDiagnosticsYAMLLocal();


### PR DESCRIPTION
Enable verbose logging for ansible-language-server
in the test-e2e suite