### PR TITLE
Avoid telemetry popup from YAML extension

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,5 +20,6 @@
   "search.exclude": {
     "out": true,
     ".vscode-test": true
-  }
+  },
+  "redhat.telemetry.enabled": false
 }

--- a/test/testFixtures/settings.json
+++ b/test/testFixtures/settings.json
@@ -13,5 +13,6 @@
   "ansible.python.interpreterPath": "python3",
 
   "security.workspace.trust.enabled": false,
-  "security.workspace.trust.startupPrompt": "never"
+  "security.workspace.trust.startupPrompt": "never",
+  "redhat.telemetry.enabled": false
 }


### PR DESCRIPTION
Avoids what would be called as noisy-popup during testing from YAML extension.

Related: https://github.com/redhat-developer/vscode-yaml/blob/5467d6465eaa3a5ad804ed862423012779653073/package.json#L84