### PR TITLE
Increase test timeouts

### DIFF
--- a/.mocharc.yml
+++ b/.mocharc.yml
@@ -2,3 +2,4 @@ extension: ["ts"]
 require: ts-node/register
 spec: './test/ui-test/*.ts'
 package: "./package.json"
+timeout: 3001 # default is 2000

--- a/test/ui-test/allTestsSuite.ts
+++ b/test/ui-test/allTestsSuite.ts
@@ -3,6 +3,7 @@ import { extensionUIAssetsTest } from "./extensionUITest";
 /**
  * @author Ondrej Dockal <odockal@redhat.com>
  */
-describe("VSCode Ansible - UI tests", () => {
+describe("VSCode Ansible - UI tests", function () {
+  this.timeout(30000);
   extensionUIAssetsTest();
 });

--- a/test/ui-test/extensionUITest.ts
+++ b/test/ui-test/extensionUITest.ts
@@ -15,7 +15,7 @@ export function extensionUIAssetsTest(): void {
     let sideBar: SideBarView;
 
     before(async function () {
-      this.timeout(6000);
+      this.timeout(10000);
       view = (await new ActivityBar().getViewControl(
         "Extensions"
       )) as ViewControl;
@@ -34,7 +34,7 @@ export function extensionUIAssetsTest(): void {
     });
 
     after(async function () {
-      this.timeout(4000);
+      this.timeout(8000);
       if (sideBar && (await sideBar.isDisplayed())) {
         const viewControl = (await new ActivityBar().getViewControl(
           "Extensions"


### PR DESCRIPTION
This should help making macos pipeline random timeout less likely.