### PR TITLE
Simplify GHA pipelines

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -1,3 +1,6 @@
+FQCN
+FQCNs
+TLDR
 alphanums
 autofix
 autoupdate
@@ -11,10 +14,9 @@ copyfiles
 cygwin
 deps
 devel
+endgroup
 eqeqeq
 extest
-FQCN
-FQCNs
 groovylint
 hostvars
 hotfixes
@@ -41,7 +43,6 @@ suboptions
 taskfile
 testhost
 testorg
-TLDR
 towerhost
 tsbuildinfo
 unstash

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,58 +16,39 @@ env:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   build:
-    name: >-
-      ${{
-        matrix.name
-        && matrix.name
-        || format(
-          '{0} ({1})',
-          matrix.npm-target,
-          matrix.os
-        )
-      }}
+    name: ${{ matrix.name }}
+    # ${{ matrix.name && matrix.name || format('{0} ({1})', matrix.task-name, matrix.os) }}
     # The type of runner that the job will run on
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        # Avoid letting github do the matrix multiplication and use manual
+        # includes for each job, this gives us fine control over job name.
         os:
           - ubuntu-latest
-          - macos-11
-        npm-target:
-          - test-ui
+        task-name:
+          - test
         upload-artifact:
           - false
         name:
-          - false
+          - test
         include:
           - name: lint
-            npm-target: lint
+            task-name: lint
             os: ubuntu-latest
             upload-artifact: true
 
-          - name: devel-ui
+          - name: devel
             # this job will install latest version of ansible-language-server
             # instead of the one mentioned in package[-lock].json
-            npm-target: test-ui
+            task-name: test
             os: ubuntu-latest
             devel: true
 
-          - name: devel-e2e
-            # this job will install latest version of ansible-language-server
-            # instead of the one mentioned in package[-lock].json
-            npm-target: test-e2e
-            os: ubuntu-latest
-            devel: true
-
-          - name: test-ui
-            npm-target: test-ui
-            os: ubuntu-latest
-            devel: false
-
-          - name: test-e2e
-            npm-target: test-e2e
-            os: ubuntu-latest
+          - name: test (macos)
+            task-name: test
+            os:  macos-11
             devel: false
 
     # Steps represent a sequence of tasks that will be executed as part of the job
@@ -85,19 +66,20 @@ jobs:
       # ~400mb, caching them should speedup test-ui execution
       - name: Enable test-resources caching
         uses: actions/cache@v3
-        if: ${{ contains(matrix.npm-target, 'test-ui') }}
+        if: ${{ contains(matrix.task-name, 'test-ui') }}
         with:
           path: |
             out/test-resources
             out/test-resources-oldest
-          key: ${{ runner.os }}-${{ matrix.npm-target }}-${{ hashFiles('package.json', 'yarn.lock') }}
+          key: ${{ runner.os }}-${{ matrix.task-name }}-${{ hashFiles('package.json', 'yarn.lock') }}
 
       - name: Use NodeJS v16
         uses: actions/setup-node@v3
         with:
           node-version: 16
 
-      - run: task setup
+      - name: task setup
+        run: task setup
 
       - name: Checkout ansible-language-server
         if: ${{ matrix.devel }}
@@ -126,15 +108,16 @@ jobs:
       ## uncomment to debug on GHA runner
       # - name: Setup tmate session
       #   uses: mxschmitt/action-tmate@v3
-      - run: task package
+      - name: task package
+        run: task package --output=group --output-group-begin='::group::{{.TASK}}' --output-group-end='::endgroup::'
 
-      - name: task ${{ matrix.npm-target }}
+      - name: task ${{ matrix.task-name }}
         # xvfb needed for chrome headless tests
         uses: GabrielBB/xvfb-action@v1.6
         with:
-          run: task ${{ matrix.npm-target }}
+          run: task ${{ matrix.task-name }} --output=group --output-group-begin='::group::{{.TASK}}' --output-group-end='::endgroup::'
 
-      - name: Publish vsix artifact
+      - name: Upload vsix artifact
         if: ${{ github.event.number && matrix.upload-artifact }}
         uses: actions/upload-artifact@v3
         with:
@@ -142,11 +125,11 @@ jobs:
           path: ansible-*.vsix
           retention-days: 15
 
-      - name: Publish test logs
+      - name: Upload test logs
         if: ${{ always() }}
         uses: actions/upload-artifact@v3
         with:
-          name: logs-${{ matrix.os }}-${{ matrix.npm-target }}.zip
+          name: logs-${{ matrix.os }}-${{ matrix.task-name }}.zip
           path: |
             out/e2eTestReport
             out/userdata/logs
@@ -155,7 +138,7 @@ jobs:
           retention-days: 15
 
       - name: Debug EE plugin cache files
-        if: ${{ contains(matrix.npm-target, 'e2e') }}
+        if: ${{ contains(matrix.task-name, 'e2e') }}
         continue-on-error: true
         run: |
           pwd

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -43,6 +43,8 @@ tasks:
     deps:
       - setup
     cmds:
+      # Workaround for https://github.com/redhat-developer/vscode-extension-tester/pull/460#issuecomment-1166315428
+      # - cd node_modules/vscode-extension-tester && npm update vsce
       - yarn run compile
     sources:
       - Taskfile.yml
@@ -96,9 +98,9 @@ tasks:
       - tools
   test:
     desc: Run all tests
-    deps:
-      - test-ui
-      - test-e2e
+    cmds:
+      - task: test-ui
+      - task: test-e2e
     interactive: true
   test-e2e:
     desc: Run e2e tests

--- a/package.json
+++ b/package.json
@@ -448,7 +448,7 @@
     "ts-node": "^10.8.0",
     "typescript": "^4.6.4",
     "vsce": "^2.9.2",
-    "vscode-extension-tester": "https://github.com/redhat-developer/vscode-extension-tester#v4.4.0",
+    "vscode-extension-tester": "https://github.com/ssbarnea/vscode-extension-tester#master",
     "vscode-test": "^1.6.1",
     "webpack": "^5.72.1",
     "webpack-cli": "^4.9.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -998,7 +998,7 @@ __metadata:
     typescript: ^4.6.4
     untildify: ^4.0.0
     vsce: ^2.9.2
-    vscode-extension-tester: "https://github.com/redhat-developer/vscode-extension-tester#v4.4.0"
+    vscode-extension-tester: "https://github.com/ssbarnea/vscode-extension-tester#master"
     vscode-languageclient: ^7.0.0
     vscode-test: ^1.6.1
     webpack: ^5.72.1
@@ -6345,36 +6345,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vsce@npm:^2.3.0":
-  version: 2.9.1
-  resolution: "vsce@npm:2.9.1"
-  dependencies:
-    azure-devops-node-api: ^11.0.1
-    chalk: ^2.4.2
-    cheerio: ^1.0.0-rc.9
-    commander: ^6.1.0
-    glob: ^7.0.6
-    hosted-git-info: ^4.0.2
-    keytar: ^7.7.0
-    leven: ^3.1.0
-    markdown-it: ^12.3.2
-    mime: ^1.3.4
-    minimatch: ^3.0.3
-    parse-semver: ^1.1.1
-    read: ^1.0.7
-    semver: ^5.1.0
-    tmp: ^0.2.1
-    typed-rest-client: ^1.8.4
-    url-join: ^4.0.1
-    xml2js: ^0.4.23
-    yauzl: ^2.3.1
-    yazl: ^2.2.2
-  bin:
-    vsce: vsce
-  checksum: c1af8d8a40139b35b23e71db4b9203ff99393754d6781dcc959df88c7d1f5f8c24c278b087f3de95e57a05e5444d93b65a0ab4b514798c8b6a396fc8a6d97afd
-  languageName: node
-  linkType: hard
-
 "vsce@npm:^2.9.2":
   version: 2.9.2
   resolution: "vsce@npm:2.9.2"
@@ -6415,9 +6385,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vscode-extension-tester@https://github.com/redhat-developer/vscode-extension-tester#v4.4.0":
-  version: 4.4.0
-  resolution: "vscode-extension-tester@https://github.com/redhat-developer/vscode-extension-tester.git#commit=aeb3241a9139bb56bb02eb11678df73e19222819"
+"vscode-extension-tester@https://github.com/ssbarnea/vscode-extension-tester#master":
+  version: 4.3.0
+  resolution: "vscode-extension-tester@https://github.com/ssbarnea/vscode-extension-tester.git#commit=4ddf9ea32e067482063c4a177275d009068d9e82"
   dependencies:
     "@types/selenium-webdriver": ^4.1.1
     commander: ^8.0.0
@@ -6432,13 +6402,13 @@ __metadata:
     selenium-webdriver: ^4.2.0
     targz: ^1.0.1
     unzip-stream: ^0.3.0
-    vsce: ^2.3.0
+    vsce: ^2.9.2
     vscode-extension-tester-locators: ^2.0.0
   peerDependencies:
     mocha: ">=5.2.0"
   bin:
     extest: out/cli.js
-  checksum: 463380f28c856827b7b1e6e4c8df748e9bd48ec3ff832260d38eac16b69756df8ccc7dd109dc2b8bdd6dfde8a9b443310d77506d89e2c527d1950b28af3bd188
+  checksum: 2c4315205bf881c79f774a3ee7ad8bc7ac984136af6d2cc5cf612da6845fbc02041fc9ce1055087fa5b7f1f8b19f707bc4b8a7788737a0a9d72f68f999b027db
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This change switches to git clone as this release is not on npm. This is fixing the failure to download code on macos during testing.