### PR TITLE
Require vscode 1.63 or newer (November 2021)

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -17,3 +17,22 @@ tag-template: 'v$RESOLVED_VERSION-next.0'
 # instead of 2x# we use 3x to make the outcome ready to embed into CHANGELOG.md
 category-template: '### $TITLE'
 template: '$CHANGES'
+# Due to vscode pre-release versioning limitations we cannot use the PATCH part
+# of the MAJOR.MINOR.PATCH, so both bugfixes and minor changes will affect
+# the MINOR number. Regardless this, we will still list enhancement and bugs
+# in different sections in changelog, only the versioning logic being affected.
+# https://code.visualstudio.com/api/working-with-extensions/publishing-extension
+version-resolver:
+  major:
+    labels:
+      - "major"
+  minor:
+    labels:
+      - "bug"
+      - "deprecated"
+      - "enhancement"
+      - "feature"
+      - "minor"
+      - "patch"
+      - "refactoring"
+  default: minor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Minor Changes
 
 - Add command to re-sync ansible inventory file (#522) @priyamsahoo
+- Require vscode 1.63 or newer (November 2021) (#567) @ssbarnea
 
 ### Bugfixes
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,9 @@ node('rhel8') {
 
   stage('package') {
     def packageJson = readJSON file: 'package.json'
-    sh "npx vsce package --no-dependencies --no-git-tag-version --no-update-package-json ${packageJson.version}-${env.BUILD_NUMBER}"
+    // We always replace MAJOR.MINOR.PATCH from package.json with MAJOR.MINOR.BUILD
+    def version = packageJson.version[0..packageJson.version.lastIndexOf('.') - 1] + ".${env.BUILD_NUMBER}"
+    sh "npx vsce package ${ params.publishPreRelease ? '--pre-release' : '' } --no-dependencies --no-git-tag-version --no-update-package-json ${ version }"
   }
 
   if (params.UPLOAD_LOCATION) {
@@ -49,7 +51,7 @@ node('rhel8') {
       def vsix = findFiles(glob: '**.vsix')
       // VS Code Marketplace
       withCredentials([[$class: 'StringBinding', credentialsId: 'vscode_java_marketplace', variable: 'TOKEN']]) {
-        sh "vsce publish -p $TOKEN --packagePath ${vsix[0].path}"
+        sh "vsce publish -p $TOKEN ${params.publishPreRelease ? '--pre-release' : ''} --packagePath ${vsix[0].path}"
       }
       archive includes:'**.vsix'
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   ],
   "config": {
     "//": "Oldest version known to work. Be careful updating as it is mentioned in multiple places.",
-    "min_vscode": "1.48.0"
+    "min_vscode": "1.63.0"
   },
   "contributors": [
     {
@@ -431,8 +431,8 @@
     "@types/chai": "^4.3.1",
     "@types/glob": "^7.2.0",
     "@types/mocha": "^9.1.1",
-    "@types/node": "^17.0.35",
-    "@types/vscode": "^1.48.0",
+    "@types/node": "^17.0.45",
+    "@types/vscode": "^1.63.0",
     "@typescript-eslint/eslint-plugin": "^5.30.7",
     "@typescript-eslint/parser": "^5.30.7",
     "@vscode/test-electron": "^2.1.5",
@@ -461,7 +461,7 @@
     "//": "node version affects only development, it does not affect vscode runtime",
     "node": ">=16.0",
     "npm": "\n\nERROR: Please use yarn instead of npm for this repository.!!!\n\n",
-    "vscode": "^1.48.0",
+    "vscode": "^1.63.0",
     "yarn": ">=3.2.1"
   },
   "extensionDependencies": [
@@ -497,7 +497,7 @@
     "pretest": "yarn run compile",
     "test-ui": "yarn run test-ui-current && yarn run test-ui-oldest",
     "test-ui-current": "extest setup-and-run -e out/ext -s out/test-resources out/client/test/ui-test/allTestsSuite.js",
-    "test-ui-oldest": "extest setup-and-run -e out/ext -c 1.48.0 -s out/test-resources-oldest -u out/client/test/ui-test/allTestsSuite.js",
+    "test-ui-oldest": "extest setup-and-run -e out/ext -c 1.63.0 -s out/test-resources-oldest -u out/client/test/ui-test/allTestsSuite.js",
     "vscode-prepublish": "yarn run webpack",
     "watch": "tsc -b -w",
     "watch-server": "tsc -p ../ansible-language-server --outDir out/server -w",

--- a/yarn.lock
+++ b/yarn.lock
@@ -436,10 +436,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:*, @types/node@npm:^17.0.35":
+"@types/node@npm:*":
   version: 17.0.42
   resolution: "@types/node@npm:17.0.42"
   checksum: a200cd87e4f12d4d5682a893ad6e1140720c6c074a2cd075f254b3b8306d6174f5a3630e5d2347efb5e9b80d420404b5fafc8fe3c7d4c81998cd914c50b19f75
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:^17.0.45":
+  version: 17.0.45
+  resolution: "@types/node@npm:17.0.45"
+  checksum: aa04366b9103b7d6cfd6b2ef64182e0eaa7d4462c3f817618486ea0422984c51fc69fd0d436eae6c9e696ddfdbec9ccaa27a917f7c2e8c75c5d57827fe3d95e8
   languageName: node
   linkType: hard
 
@@ -475,10 +482,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/vscode@npm:^1.48.0":
-  version: 1.68.0
-  resolution: "@types/vscode@npm:1.68.0"
-  checksum: 9866b7b3462a0bf4856a7443e4f58fa67e3bba50952940551089242b6d4b0035ff42015f403de8ae33e9e29fd00b500241e2976b745a423a9fa7a3c65c54a524
+"@types/vscode@npm:^1.63.0":
+  version: 1.69.0
+  resolution: "@types/vscode@npm:1.69.0"
+  checksum: 58d657c2c398d8ec5b8f0264f91140d182b9beddb42f1c2277c4ed6438ef5112532d450acd6eea85f16da99a6a0f39d7f417974a4a3ac47b31f175fd8a3325de
   languageName: node
   linkType: hard
 
@@ -991,8 +998,8 @@ __metadata:
     "@types/glob": ^7.2.0
     "@types/ini": ^1.3.31
     "@types/mocha": ^9.1.1
-    "@types/node": ^17.0.35
-    "@types/vscode": ^1.48.0
+    "@types/node": ^17.0.45
+    "@types/vscode": ^1.63.0
     "@typescript-eslint/eslint-plugin": ^5.30.7
     "@typescript-eslint/parser": ^5.30.7
     "@vscode/test-electron": ^2.1.5


### PR DESCRIPTION
That is required in order to be able to make use of pre-releases.
