### PR TITLE
Remove preview label from extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -483,7 +483,6 @@
   "license": "MIT",
   "main": "./out/client/src/extension.js",
   "name": "ansible",
-  "preview": true,
   "publisher": "redhat",
   "qna": false,
   "repository": {


### PR DESCRIPTION
As preview red label confuses people since we also started to use
the pre-release feature, we remove it.
