### PR TITLE
Release v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@
 
 <!-- KEEP-THIS-COMMENT -->
 
+## v0.14.0
+
+### Minor Changes
+
+- Add feature to dynamically associate yaml files to `ansible` language (#600)
+  @priyamsahoo
+
+### Bugfixes
+
+- Use new location of ansible-lint config JSON Schema (#608) @ssbarnea
+- Fix the display of double `Ansible` in status-bar text (#605) @priyamsahoo
+- Disable python debugger when running external commands (#603) @ssbarnea
+
 ## v0.13.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -521,7 +521,7 @@
     "test-e2e": "yarn run test-compile && node ./out/client/test/testRunner",
     "test-e2e-withserver": "yarn run test-compile-withserver && node ./out/client/test/testRunner"
   },
-  "version": "0.13.0",
+  "version": "0.14.0",
   "packageManager": "yarn@3.2.1",
   "vsce": {
     "dependencies": false,


### PR DESCRIPTION
## v0.14.0

### Minor Changes

- Add feature to dynamically associate yaml files to `ansible` language (#600) @priyamsahoo

### Bugfixes

- Use new location of ansible-lint config JSON Schema (#608) @ssbarnea
- Fix the display of double `Ansible` in status-bar text (#605) @priyamsahoo
- Disable python debugger when running external commands (#603) @ssbarnea
