### PR TITLE
bump vscode-languageclient from 7.x to 8.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -436,7 +436,7 @@
     "@types/ini": "^1.3.31",
     "ini": "^3.0.1",
     "untildify": "^4.0.0",
-    "vscode-languageclient": "^7.0.0"
+    "vscode-languageclient": "^8.0.2"
   },
   "description": "Ansible language support",
   "devDependencies": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -122,6 +122,7 @@ export function deactivate(): Thenable<void> | undefined {
   if (!client) {
     return undefined;
   }
+  isActiveClient = false;
   return client.stop();
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -33,6 +33,7 @@ import { formatAnsibleMetaData } from "./features/utils/formatAnsibleMetaData";
 import { languageAssociation } from "./features/fileAssociation";
 
 let client: LanguageClient;
+let isActiveClient = false;
 let cachedAnsibleVersion: string;
 
 // status bar item
@@ -91,21 +92,31 @@ export function activate(context: ExtensionContext): void {
   );
 
   // start the client and the server
-  client.start();
+  startClient();
 
   notifyAboutConflicts();
-  client.onReady().then(() => {
+
+  // Update ansible meta data in the statusbar tooltip (client-server)
+  window.onDidChangeActiveTextEditor(updateAnsibleInfo);
+  workspace.onDidOpenTextDocument(updateAnsibleInfo);
+}
+
+const startClient = async () => {
+  try {
+    await client.start();
+    isActiveClient = true;
+
     // If the extensions change, fire this notification again to pick up on any association changes
     extensions.onDidChange(() => {
       notifyAboutConflicts();
     });
-  });
 
-  // Update ansible meta data in the statusbar tooltip (client-server)
-  client.onReady().then(updateAnsibleInfo);
-  window.onDidChangeActiveTextEditor(updateAnsibleInfo);
-  workspace.onDidOpenTextDocument(updateAnsibleInfo);
-}
+    // Update ansible meta data in the statusbar tooltip (client-server)
+    updateAnsibleInfo();
+  } catch (error) {
+    console.error("Language Client initialization failed");
+  }
+};
 
 export function deactivate(): Thenable<void> | undefined {
   if (!client) {
@@ -131,7 +142,7 @@ function notifyAboutConflicts(): void {
  * And resync the ansible inventory
  */
 function resyncAnsibleInventory(): void {
-  client.onReady().then(() => {
+  if (isActiveClient) {
     client.onNotification(
       new NotificationType(`resync/ansible-inventory`),
       (event) => {
@@ -139,7 +150,7 @@ function resyncAnsibleInventory(): void {
       }
     );
     client.sendNotification(new NotificationType(`resync/ansible-inventory`));
-  });
+  }
 }
 
 /**
@@ -152,7 +163,7 @@ function updateAnsibleInfo(): void {
     return;
   }
 
-  client.onReady().then(() => {
+  if (isActiveClient) {
     myStatusBarItem.tooltip = new MarkdownString(
       ` $(sync~spin) Fetching... `,
       true
@@ -196,5 +207,5 @@ function updateAnsibleInfo(): void {
     client.sendNotification(new NotificationType(`update/ansible-metadata`), [
       activeFileUri,
     ]);
-  });
+  }
 }

--- a/src/extensionConflicts.ts
+++ b/src/extensionConflicts.ts
@@ -59,12 +59,10 @@ export async function showUninstallConflictsNotification(
   if (conflictingExts.length === 1) {
     conflictMsg = `${conflictingExts[0].packageJSON.displayName} (${conflictingExts[0].id}) extension is incompatible with redhat.ansible. Please uninstall it.`;
   } else {
-    const extNames: string[] = conflictingExts.map(
-      (ext) => `${ext.packageJSON.displayName} (${ext.id})`
-    );
-    conflictMsg = `The ${extNames.join(
-      ", "
-    )} extensions are incompatible with redhat.ansible. Please uninstall them.`;
+    const extNames: string = conflictingExts
+      .map((ext) => `${ext.packageJSON.displayName} (${ext.id})`)
+      .join(", ");
+    conflictMsg = `The ${extNames} extensions are incompatible with redhat.ansible. Please uninstall them.`;
   }
 
   await window

--- a/yarn.lock
+++ b/yarn.lock
@@ -1028,7 +1028,7 @@ __metadata:
     untildify: ^4.0.0
     vsce: ^2.11.0
     vscode-extension-tester: ^4.4.1
-    vscode-languageclient: ^7.0.0
+    vscode-languageclient: ^8.0.2
     webpack: ^5.74.0
     webpack-cli: ^4.10.0
     yarn-audit-fix: ^9.3.5
@@ -6467,14 +6467,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vscode-languageclient@npm:^7.0.0":
-  version: 7.0.0
-  resolution: "vscode-languageclient@npm:7.0.0"
+"vscode-jsonrpc@npm:8.0.2":
+  version: 8.0.2
+  resolution: "vscode-jsonrpc@npm:8.0.2"
+  checksum: 9d055fd4c87ef1093b0eecb5370bfaf3402179b6639149b6d0f7e0bde60cf580091c7e07b0caff868f10f90331b17e7383c087217c077fdd1b5ae7bc23b72f77
+  languageName: node
+  linkType: hard
+
+"vscode-languageclient@npm:^8.0.2":
+  version: 8.0.2
+  resolution: "vscode-languageclient@npm:8.0.2"
   dependencies:
     minimatch: ^3.0.4
-    semver: ^7.3.4
-    vscode-languageserver-protocol: 3.16.0
-  checksum: fde7122e96838f0de1940dba80fc4b6bb80717695dbfaff005b9d44eeea371b7f09daedefaebcbf0ff278f67446e37837ec0730ddbc7dbd82aca5d8567065594
+    semver: ^7.3.5
+    vscode-languageserver-protocol: 3.17.2
+  checksum: 3a145605a3cdb2855a2a771d6b8e75e72a1ca5aa32e091933c2f0e6f7b8fc1a45a9ea79b434001ad8af6b8cdb4ef88ff92fbb128b37988ebb21cac1b60cd44c3
   languageName: node
   linkType: hard
 
@@ -6485,6 +6492,16 @@ __metadata:
     vscode-jsonrpc: 6.0.0
     vscode-languageserver-types: 3.16.0
   checksum: ac30cbe4b778344f7b93defbaa1332dcb5a5a3a0afda6b88618a9ed44093c1ae1d2f11548bdcff42a73bb46943df025d4fe721559144dd7bf25ae60663aabe06
+  languageName: node
+  linkType: hard
+
+"vscode-languageserver-protocol@npm:3.17.2":
+  version: 3.17.2
+  resolution: "vscode-languageserver-protocol@npm:3.17.2"
+  dependencies:
+    vscode-jsonrpc: 8.0.2
+    vscode-languageserver-types: 3.17.2
+  checksum: f4a05d3a631af315a32a3700953c2117fa4e5c44bc03764154c6605da9cbbcb50a1b01b46f11b2f6948916d01b4948bebf1a84c135fc73b27fa839c58d0847ab
   languageName: node
   linkType: hard
 
@@ -6499,6 +6516,13 @@ __metadata:
   version: 3.16.0
   resolution: "vscode-languageserver-types@npm:3.16.0"
   checksum: 7a44fb10b9fbeb9529f832337b7f0430fc6275d62945b86851d425a950e22da3917ef5f6c552688191769dd1eae047c6ee9ec3d9f2280498353007c2dfe0725c
+  languageName: node
+  linkType: hard
+
+"vscode-languageserver-types@npm:3.17.2":
+  version: 3.17.2
+  resolution: "vscode-languageserver-types@npm:3.17.2"
+  checksum: ef2d862d22f622b64de0f428773d50a5928ec6cdd485960a7564ebe4fd4a3c8bcd956f29eb15bc45a0f353846e62f39f6c764d2ab85ce774b8724411ba84342f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
fixes [#625](https://github.com/ansible/vscode-ansible/issues/625)

Update vscode-languageclient from 7.x to 8.0.2