### PR TITLE
Change extension status-bar icon

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -168,8 +168,8 @@ function updateAnsibleInfo(): void {
             ansibleMetaData.metaData["ansible information"]["ansible version"];
           const tooltip = ansibleMetaData.markdown;
           myStatusBarItem.text = ansibleMetaData.eeEnabled
-            ? `$(pass-filled) [EE] ${cachedAnsibleVersion}`
-            : `$(pass-filled) ${cachedAnsibleVersion}`;
+            ? `$(bracket-dot) [EE] ${cachedAnsibleVersion}`
+            : `$(bracket-dot) ${cachedAnsibleVersion}`;
           myStatusBarItem.backgroundColor = "";
           myStatusBarItem.tooltip = tooltip;
 


### PR DESCRIPTION
Adopts the new ansible-lint icon for status-bar icon instead of the previous pass-filled icon, which was already used by other extensions, like Grammarly.

Related: https://github.com/ansible/ansible-lint/pull/2424