### PR TITLE
Simplify bug report

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -24,11 +24,9 @@ body:
 
         [discussions]: ../discussions
 
-  - type: checkboxes
-    id: it-is-really-this-extension
+  - type: markdown
     attributes:
-      label: Sanity check
-      description: >
+      value: >
         _Hold on, wait a second, **🛑 STOP!**_
 
 
@@ -89,12 +87,6 @@ body:
           ![❗ VS Code Ansible language selected
           ](https://user-images.githubusercontent.com/578543/141507613-ef7ec8eb-f75b-4f6e-8580-750678768b90.png)
         </details>
-      options:
-        - label: >-
-            I certify that the `redhat.ansible` extension is in use and
-            the language of the document in this bug report shows
-            up as `Ansible`
-          required: true
 
   - type: textarea
     id: summary


### PR DESCRIPTION
The PR removes the required check bow stating:
> I certify that the redhat.ansible extension is in use and the language of the document in this bug report shows up as Ansible