### PR TITLE
Update ansible-lint and version and e2e-tests to support changes the changes

### DIFF
--- a/.config/requirements.in
+++ b/.config/requirements.in
@@ -1,5 +1,5 @@
 ansible-core>=2.13
-ansible-lint>=6.2.2
+ansible-lint>=6.8.0.dev0
 mypy # used by vscode
 pip-tools>=6.6.2
 pre-commit>=2.19

--- a/.config/requirements.txt
+++ b/.config/requirements.txt
@@ -1,6 +1,6 @@
 ansible-compat==2.2.1
 ansible-core==2.13.4
-ansible-lint==6.3.0
+ansible-lint==6.8.0b3
 attrs==21.4.0
 bracex==2.3.post1
 cffi==1.15.0
@@ -14,7 +14,7 @@ filelock==3.7.1
 identify==2.5.1
 iniconfig==1.1.1
 jinja2==3.1.2
-jsonschema==4.6.0
+jsonschema==4.16.0
 markupsafe==2.1.1
 mypy==0.961
 mypy-extensions==0.4.3

--- a/src/features/utils/applyFileInspectionForKeywords.ts
+++ b/src/features/utils/applyFileInspectionForKeywords.ts
@@ -36,6 +36,6 @@ export async function applyFileInspectionForKeywords(
       }
     }
   } catch (err) {
-    console.error(err);
+    console.error("Error loading yaml file");
   }
 }

--- a/test/testFixtures/diagnostics/ansible/without_ee/1.yml
+++ b/test/testFixtures/diagnostics/ansible/without_ee/1.yml
@@ -1,4 +1,4 @@
-- name: play name
+- name: Play name
   hosts: localhost
   tasks:
     - ansible.builtin.debug:

--- a/test/testRunner.ts
+++ b/test/testRunner.ts
@@ -13,6 +13,17 @@ export const ANSIBLE_COLLECTIONS_FIXTURES_BASE_PATH = path.resolve(
   "common",
   "collections"
 );
+const PRETEST_ERR_RC = 2;
+
+// display ansible-lint version and exit testing if ansible-lint is absent
+const command = "ansible-lint --version";
+try {
+  const result = cp.execSync(command);
+  console.info(`Detected: ${result}`);
+} catch (e) {
+  console.error(`error: test requisites not met, '${command}' returned ${e}`);
+  process.exit(PRETEST_ERR_RC);
+}
 
 async function main(): Promise<void> {
   try {

--- a/test/testScripts/diagnostics/testAnsibleWithoutEE.test.ts
+++ b/test/testScripts/diagnostics/testAnsibleWithoutEE.test.ts
@@ -47,7 +47,8 @@ export function testDiagnosticsAnsibleWithoutEE(): void {
         await testDiagnostics(docUri2, [
           {
             severity: 0,
-            message: "Ansible syntax check failed",
+            message:
+              "Unexpected error code 4 from execution of: ansible-playbook --syntax-check",
             range: new vscode.Range(
               new vscode.Position(0, 0),
               new vscode.Position(0, integer.MAX_VALUE)

--- a/test/testScripts/diagnostics/testYamlWithoutEE.test.ts
+++ b/test/testScripts/diagnostics/testYamlWithoutEE.test.ts
@@ -25,7 +25,7 @@ export function testDiagnosticsYAMLWithoutEE(): void {
         await testDiagnostics(docUri1, [
           {
             severity: 0,
-            message: "Ansible syntax check failed",
+            message: "Failed to load YAML file",
             range: new vscode.Range(
               new vscode.Position(0, 0),
               new vscode.Position(0, integer.MAX_VALUE)

--- a/tools/test-setup.sh
+++ b/tools/test-setup.sh
@@ -169,7 +169,7 @@ fi
 python3 -m pip install -q -U pip
 
 if [[ $(uname || true) != MINGW* ]]; then # if we are not on pure Windows
-    python3 -m pip install -q \
+    python3 -m pip install \
         -c .config/requirements.txt -r .config/requirements.in
 fi
 


### PR DESCRIPTION
With the latest changes coming from ansible-lint, the PR updates the e2e diagnostic tests to support the changes.

NOTE: The devel job is supposed to fail since it does not contain the changes associated with the main branch of ALS.