### PR TITLE
Add support to run ansible-navigator with execution environment

### DIFF
--- a/src/features/runner.ts
+++ b/src/features/runner.ts
@@ -1,15 +1,24 @@
 /* "stdlib" */
 import * as vscode from "vscode";
 
+/* local */
+import { withInterpreter } from "./utils/commandRunner";
+import { ExtensionSettings } from "../interfaces/extensionSettings";
+import { getContainerEngine } from "../utils/executionEnvironment";
+
 /**
  * A set of commands and context menu items for running Ansible playbooks using
  * `ansible-navigator run` and `ansible-playbook` commands.
  */
 export class AnsiblePlaybookRunProvider {
-  private disposableTerminal: vscode.Terminal | undefined;
-  constructor(private vsCodeExtCtx: vscode.ExtensionContext) {
-    // this.disposableTerminal = this.makeTerminal();
+  private settings: ExtensionSettings;
+
+  constructor(
+    private vsCodeExtCtx: vscode.ExtensionContext,
+    settings: ExtensionSettings
+  ) {
     this.configureCommands();
+    this.settings = settings;
   }
 
   /**
@@ -45,6 +54,7 @@ export class AnsiblePlaybookRunProvider {
       ? this.invokeViaAnsibleNavigator.bind(this)
       : this.invokeViaAnsiblePlaybook.bind(this);
     return (...fileObj: vscode.Uri[] | undefined[]) => {
+      const commandLineArgs: string[] = [];
       const playbookFsPath = extractTargetFsPath(...fileObj);
       if (typeof playbookFsPath === "undefined") {
         let tool_name = "ansible-playbook";
@@ -56,14 +66,40 @@ export class AnsiblePlaybookRunProvider {
         );
         return;
       }
+      commandLineArgs.push(playbookFsPath);
+      if (useNavigator) {
+        this.addEEArgs(commandLineArgs);
+      }
       console.debug(
         `Got a request to run ansible-${
           useNavigator ? "navigator" : "playbook"
         } against`,
         playbookFsPath
       );
-      runPlaybook([playbookFsPath]);
+      runPlaybook(commandLineArgs);
     };
+  }
+
+  private addEEArgs(commandLineArgs: string[]): void {
+    const eeSettings = this.settings.executionEnvironment;
+    if (!eeSettings.enabled) {
+      return;
+    }
+    commandLineArgs.push("--ee true");
+    commandLineArgs.push(
+      `--ce ${getContainerEngine(eeSettings.containerEngine)}`
+    );
+    commandLineArgs.push(`--eei ${eeSettings.image}`);
+    if (eeSettings.containerOptions !== "") {
+      commandLineArgs.push(`--co ${eeSettings.containerOptions}`);
+    }
+    eeSettings.volumeMounts.forEach((volumeMount) => {
+      let mountPath = `${volumeMount.src}:${volumeMount.dest}`;
+      if (volumeMount.options !== undefined) {
+        mountPath += `:${volumeMount.options}`;
+      }
+      commandLineArgs.push(`--eev ${mountPath}`);
+    });
   }
 
   /**
@@ -86,29 +122,31 @@ export class AnsiblePlaybookRunProvider {
   /**
    * A property representing the target terminal for running playbooks in.
    */
-  private get terminal(): vscode.Terminal {
-    if (typeof this.disposableTerminal === "undefined") {
-      const terminal = vscode.window.createTerminal("Ansible Terminal");
-      this.vsCodeExtCtx.subscriptions.push(terminal);
-      this.vsCodeExtCtx.subscriptions.push(
-        vscode.window.onDidCloseTerminal((term: vscode.Terminal) => {
-          if (term !== terminal) {
-            return;
-          }
-          this.disposableTerminal = undefined;
-        })
-      );
-      this.disposableTerminal = terminal;
-    }
-    return this.disposableTerminal as vscode.Terminal;
+  private createTerminal(
+    runEnv: NodeJS.ProcessEnv | undefined
+  ): vscode.Terminal {
+    const terminal = vscode.window.createTerminal({
+      name: "Ansible Terminal",
+      env: runEnv,
+    });
+    this.vsCodeExtCtx.subscriptions.push(terminal);
+    this.vsCodeExtCtx.subscriptions.push(
+      vscode.window.onDidCloseTerminal((term: vscode.Terminal) => {
+        if (term !== terminal) {
+          return;
+        }
+      })
+    );
+    return terminal as vscode.Terminal;
   }
 
   /**
    * A helper method for executing commands in terminal.
    */
-  private invokeInTerminal(cmd: string) {
-    this.terminal.show();
-    this.terminal.sendText(cmd);
+  private invokeInTerminal(cmd: string, runEnv: NodeJS.ProcessEnv | undefined) {
+    const newTerminal = this.createTerminal(runEnv);
+    newTerminal.show();
+    newTerminal.sendText(cmd);
   }
 
   /**
@@ -116,9 +154,12 @@ export class AnsiblePlaybookRunProvider {
    * @param argv Arguments to the `ansible-playbook` command.
    */
   private invokeViaAnsiblePlaybook(argv: string[]) {
+    let command: string;
+    let runEnv: NodeJS.ProcessEnv | undefined;
     const runExecutable = this.ansiblePlaybookExecutablePath;
-    const cmdArgs = argv.map((arg) => `'${arg}'`).join(" ");
-    this.invokeInTerminal(`${runExecutable} ${cmdArgs}`);
+    const cmdArgs = argv.map((arg) => arg).join(" ");
+    [command, runEnv] = withInterpreter(this.settings, runExecutable, cmdArgs);
+    this.invokeInTerminal(command, runEnv);
   }
 
   /**
@@ -126,9 +167,17 @@ export class AnsiblePlaybookRunProvider {
    * @param argv Arguments to the `ansible-navigator run` command.
    */
   private invokeViaAnsibleNavigator(argv: string[]) {
+    let command: string;
+    let runEnv: NodeJS.ProcessEnv | undefined;
     const runExecutable = this.ansibleNavigatorExecutablePath;
-    const cmdArgs = argv.map((arg) => `'${arg}'`).join(" ");
-    this.invokeInTerminal(`${runExecutable} run ${cmdArgs}`);
+    const cmdArgs = argv.map((arg) => arg).join(" ");
+    const runCmdArgs = `run ${cmdArgs}`;
+    [command, runEnv] = withInterpreter(
+      this.settings,
+      runExecutable,
+      runCmdArgs
+    );
+    this.invokeInTerminal(command, runEnv);
   }
 }
 

--- a/src/features/utils/commandRunner.ts
+++ b/src/features/utils/commandRunner.ts
@@ -1,0 +1,52 @@
+/* stdlib */
+import * as path from "path";
+
+/* local */
+import { ExtensionSettings } from "../../interfaces/extensionSettings";
+
+/**
+ * A helper method to get interpreter path related settings to
+ * while running the command.
+ * @param settings The extension setting.
+ * @param runExecutable The name of the executable to run.
+ * @param runArgs The arguments to the executable.
+ * @returns The complete command to be executed.
+ */
+export function withInterpreter(
+  settings: ExtensionSettings,
+  runExecutable: string,
+  cmdArgs: string
+): [string, NodeJS.ProcessEnv | undefined] {
+  let command = `${runExecutable} ${cmdArgs}`; // base case
+
+  const newEnv = Object.assign({}, process.env, {
+    ANSIBLE_FORCE_COLOR: "0", // ensure output is parseable (no ANSI)
+    PYTHONBREAKPOINT: "0", // We want to be sure that python debugger is never
+    // triggered, even if we mistakenly left a breakpoint() there while
+    // debugging ansible- lint, or another tool we call.
+  });
+
+  const activationScript = settings.activationScript;
+  if (activationScript) {
+    command = `bash -c 'source ${activationScript} && ${runExecutable} ${cmdArgs}'`;
+    return [command, undefined];
+  }
+
+  const interpreterPath = settings.interpreterPath;
+  if (interpreterPath && interpreterPath !== "") {
+    const virtualEnv = path.resolve(interpreterPath, "../..");
+
+    const pathEntry = path.join(virtualEnv, "bin");
+    if (path.isAbsolute(runExecutable)) {
+      // if both interpreter path and absolute command path are provided, we can
+      // bolster the chances of success by letting the interpreter execute the
+      // command
+      command = `${interpreterPath} ${runExecutable} ${cmdArgs}`;
+    }
+    // emulating virtual environment activation script
+    newEnv["VIRTUAL_ENV"] = virtualEnv;
+    newEnv["PATH"] = `${pathEntry}:${process.env.PATH}`;
+    delete newEnv.PYTHONHOME;
+  }
+  return [command, newEnv];
+}

--- a/src/interfaces/extensionSettings.ts
+++ b/src/interfaces/extensionSettings.ts
@@ -1,0 +1,24 @@
+export type IPullPolicy = "always" | "missing" | "never" | "tag";
+
+export type IContainerEngine = "auto" | "podman" | "docker";
+
+export interface ExtensionSettings {
+  activationScript: string;
+  interpreterPath: string
+  executionEnvironment: ExecutionEnvironmentSettings;
+}
+
+export interface IVolumeMounts {
+  src: string;
+  dest: string;
+  options: string | undefined;
+}
+
+export interface ExecutionEnvironmentSettings {
+  enabled: boolean;
+  containerEngine: IContainerEngine;
+  containerOptions: string;
+  image: string;
+  pull: { arguments: string; policy: IPullPolicy };
+  volumeMounts: Array<IVolumeMounts>;
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,0 +1,45 @@
+import * as vscode from "vscode";
+
+import { ExtensionSettings } from "./interfaces/extensionSettings";
+
+export class SettingsManager {
+  public settings = {} as ExtensionSettings;
+
+  constructor() {
+    this.initialize();
+    console.log("Initialiased extension settings");
+  }
+
+  /**
+   * Initialize the extension settings required at the client
+   * side
+   */
+  public initialize(): void {
+    const ansibleSettings = vscode.workspace.getConfiguration("ansible");
+    const eeSettings = vscode.workspace.getConfiguration(
+      "ansible.executionEnvironment"
+    );
+    this.settings = {
+      activationScript: ansibleSettings.get("python.activationScript") as string,
+      interpreterPath: ansibleSettings.get("python.interpreterPath") as string,
+      executionEnvironment: {
+        enabled: eeSettings.get("enabled", false),
+        containerEngine: eeSettings.get("containerEngine", "auto"),
+        containerOptions: eeSettings.get("containerOptions", ""),
+        image: eeSettings.get("image", "quay.io/ansible/creator-ee:latest"),
+        pull: {
+          arguments: eeSettings.get("pull.arguments", ""),
+          policy: eeSettings.get("pull.policy", "missing"),
+        },
+        volumeMounts: eeSettings.get("volumeMounts", []),
+      },
+    };
+    return;
+  }
+
+  public reinitialize(): void {
+    this.initialize();
+    console.log("Reinitialiased extension settings");
+    return;
+  }
+}

--- a/src/utils/executionEnvironment.ts
+++ b/src/utils/executionEnvironment.ts
@@ -1,0 +1,30 @@
+import * as child_process from "child_process";
+
+export function getContainerEngine(containerEngine: string): string {
+  let engine = containerEngine;
+  if (engine !== "auto") {
+    return engine;
+  }
+
+  let isCEFound = false;
+  for (const ce of ["podman", "docker"]) {
+    try {
+      child_process.execSync(`which ${ce}`, {
+        encoding: "utf-8",
+      });
+    } catch (error) {
+      continue;
+    }
+    engine = ce;
+    isCEFound = true;
+    break;
+  }
+  if (!isCEFound) {
+    console.error(
+      "Supported container engine not found, set it explicitly to podman"
+    );
+    engine = "podman";
+  }
+  console.log(`Container engine set to: '${engine}'`);
+  return engine;
+}


### PR DESCRIPTION
*  Add settingManager to extract execution-environment settings for the extension
*  Modify ansible-navigator command line execution in terminal to update EE parameters if EE is enabled
*  Add support to run playbook with virtual env enabled