### PR TITLE
Missing `ansible.completion.*` configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,8 +205,8 @@ any level (User, Remote, Workspace and/or Folder).
 - `ansible.python.activationScript`: Path to a custom `activate` script, which
   will be used instead of the setting above to run in a Python virtual
   environment.
-- `ansible.completion.provideRedirectModules`: Toggle redirected module
-  provider when completing modules.
+- `ansible.completion.provideRedirectModules`: Toggle redirected module provider
+  when completing modules.
 - `ansible.completion.provideModuleOptionAliases`: Toggle alias provider when
   completing module options.
 - `ansibleServer.trace.server`: Traces the communication between VSCode and the

--- a/README.md
+++ b/README.md
@@ -205,6 +205,10 @@ any level (User, Remote, Workspace and/or Folder).
 - `ansible.python.activationScript`: Path to a custom `activate` script, which
   will be used instead of the setting above to run in a Python virtual
   environment.
+- `ansible.completion.provideRedirectModules`: Toggle redirected module
+  provider when completing modules.
+- `ansible.completion.provideModuleOptionAliases`: Toggle alias provider when
+  completing module options.
 - `ansibleServer.trace.server`: Traces the communication between VSCode and the
   ansible language server.
 

--- a/package.json
+++ b/package.json
@@ -290,6 +290,20 @@
             }
           },
           "order": 16
+        },
+        "ansible.completion.provideRedirectModules": {
+          "scope": "resource",
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Toggle redirected module provider when completing modules.",
+          "order": 17
+        },
+        "ansible.completion.provideModuleOptionAliases": {
+          "scope": "resource",
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Toggle alias provider when completing module options.",
+          "order": 18
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -189,39 +189,53 @@
           "type": "string",
           "order": 5
         },
+        "ansible.completion.provideRedirectModules": {
+          "scope": "resource",
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Toggle redirected module provider when completing modules.",
+          "order": 6
+        },
+        "ansible.completion.provideModuleOptionAliases": {
+          "scope": "resource",
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Toggle alias provider when completing module options.",
+          "order": 7
+        },
         "ansible.validation.enabled": {
           "type": "boolean",
           "default": true,
           "markdownDescription": "If disabled no validation will be performed.",
-          "order": 6
+          "order": 8
         },
         "ansible.validation.lint.enabled": {
           "scope": "resource",
           "type": "boolean",
           "default": true,
           "markdownDescription": "Enables `ansible-lint`. If disabled only `ansible-playbook --syntax-check` will run. Requires `#ansible.validation.enabled#` to be enabled.",
-          "order": 7
+          "order": 9
         },
         "ansible.validation.lint.path": {
           "scope": "machine-overridable",
           "type": "string",
           "default": "ansible-lint",
           "markdownDescription": "Path to the ansible-lint executable.",
-          "order": 8
+          "order": 10
         },
         "ansible.validation.lint.arguments": {
           "scope": "resource",
           "type": "string",
           "default": "",
           "markdownDescription": "Command line arguments to be passed to ansible-lint.",
-          "order": 9
+          "order": 11
         },
         "ansible.executionEnvironment.enabled": {
           "scope": "resource",
           "type": "boolean",
           "default": false,
           "markdownDescription": "Enable or disable the use of an execution environment.",
-          "order": 10
+          "order": 12
         },
         "ansible.executionEnvironment.containerEngine": {
           "scope": "resource",
@@ -233,28 +247,28 @@
           ],
           "default": "auto",
           "markdownDescription": "Specify the container engine (auto=podman then docker).",
-          "order": 11
+          "order": 13
         },
         "ansible.executionEnvironment.containerOptions": {
           "scope": "resource",
           "type": "string",
           "default": "",
           "markdownDescription": "Extra parameters passed to the container engine command example: `--net=host`.",
-          "order": 12
+          "order": 14
         },
         "ansible.executionEnvironment.image": {
           "scope": "resource",
           "type": "string",
           "default": "quay.io/ansible/creator-ee:latest",
           "markdownDescription": "Specify the name of the execution environment image.",
-          "order": 13
+          "order": 15
         },
         "ansible.executionEnvironment.pull.arguments": {
           "scope": "resource",
           "type": "string",
           "default": "",
           "markdownDescription": "Specify any additional parameters that should be added to the pull command when pulling an execution environment from a container registry. e.g. `–-tls-verify=false`.",
-          "order": 14
+          "order": 16
         },
         "ansible.executionEnvironment.pull.policy": {
           "scope": "resource",
@@ -267,7 +281,7 @@
           ],
           "default": "missing",
           "markdownDescription": "Specify the image pull policy.\n**always**: Always pull the image when extension is activated or reloaded\n**missing**: Pull if not locally available\n**never**: Never pull the image\n**tag**: If the image tag is `latest`, always pull the image, otherwise pull if not locally available.",
-          "order": 15
+          "order": 17
         },
         "ansible.executionEnvironment.volumeMounts": {
           "scope": "resource",
@@ -289,20 +303,6 @@
               }
             }
           },
-          "order": 16
-        },
-        "ansible.completion.provideRedirectModules": {
-          "scope": "resource",
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "Toggle redirected module provider when completing modules.",
-          "order": 17
-        },
-        "ansible.completion.provideModuleOptionAliases": {
-          "scope": "resource",
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "Toggle alias provider when completing module options.",
           "order": 18
         }
       }


### PR DESCRIPTION
I added the missing `ansible.completion.*` based on the ALS documentation. <https://als.readthedocs.io/en/latest/settings/>

- `ansible.completion.provideRedirectModules`
- `ansible.completion.provideModuleOptionAliases`

If for some reason vscode-ansible is not intentionally adding `ansible.completion.*` settings, please close this PR.