### PR TITLE
Enables reuse of existing ansible terminals

### DIFF
--- a/.config/requirements.txt
+++ b/.config/requirements.txt
@@ -1,6 +1,6 @@
-ansible-compat==2.2.1
+ansible-compat==2.2.4
 ansible-core==2.13.5
-ansible-lint==6.8.2
+ansible-lint==6.8.6
 attrs==21.4.0
 black==22.10.0
 bracex==2.3.post1

--- a/src/features/runner.ts
+++ b/src/features/runner.ts
@@ -125,6 +125,10 @@ export class AnsiblePlaybookRunProvider {
   private createTerminal(
     runEnv: NodeJS.ProcessEnv | undefined
   ): vscode.Terminal {
+    const reuse_terminal = vscode.window.terminals.find(terminal => terminal.name == "Ansible Terminal")
+    if (reuse_terminal) {
+      return reuse_terminal as vscode.Terminal;
+    }
     const terminal = vscode.window.createTerminal({
       name: "Ansible Terminal",
       env: runEnv,

--- a/src/features/runner.ts
+++ b/src/features/runner.ts
@@ -125,7 +125,9 @@ export class AnsiblePlaybookRunProvider {
   private createTerminal(
     runEnv: NodeJS.ProcessEnv | undefined
   ): vscode.Terminal {
-    const reuse_terminal = vscode.window.terminals.find(terminal => terminal.name == "Ansible Terminal")
+    const reuse_terminal = vscode.window.terminals.find(
+      (terminal) => terminal.name === "Ansible Terminal"
+    );
     if (reuse_terminal) {
       return reuse_terminal as vscode.Terminal;
     }


### PR DESCRIPTION
When using vscode commands to run ansible-playbook or ansible-navigator as seen in this image:
![image](https://user-images.githubusercontent.com/37709886/202169218-7c367bf8-78b2-4b58-aaff-37ec4ab43b99.png)

It will create a new terminal for each time you run the command.
![image](https://user-images.githubusercontent.com/37709886/202169685-be0b3be1-e71c-406f-a508-5a1c0da2734e.png)

Perhaps this is as expected, you want to run multiple playbooks via vscode at the same time, but I would argue it's not the best experience for most use cases.

Another way could be to have an option to enable/disable this behavior?