### PR TITLE
Update search paths for ansible.cfg based on the documentation

### DIFF
--- a/src/features/utils/ansibleCfg.ts
+++ b/src/features/utils/ansibleCfg.ts
@@ -29,7 +29,7 @@ export async function scanAnsibleCfg(
   rootPath: string | undefined = undefined
 ): Promise<AnsibleVaultConfig | undefined> {
   /*
-   * Reading order (based on the documentation: https://docs.ansible.com/ansible/2.4/intro_configuration.html):
+   * Reading order (based on the documentation: https://docs.ansible.com/ansible/latest/reference_appendices/config.html#ansible-configuration-settings):
    * 1) ANSIBLE_CONFIG
    * 2) ansible.cfg (in current workspace)
    * 3) ~/.ansible.cfg

--- a/src/features/utils/ansibleCfg.ts
+++ b/src/features/utils/ansibleCfg.ts
@@ -29,13 +29,13 @@ export async function scanAnsibleCfg(
   rootPath: string | undefined = undefined
 ): Promise<AnsibleVaultConfig | undefined> {
   /*
-   * Reading order:
+   * Reading order (based on the documentation: https://docs.ansible.com/ansible/2.4/intro_configuration.html):
    * 1) ANSIBLE_CONFIG
    * 2) ansible.cfg (in current workspace)
    * 3) ~/.ansible.cfg
-   * 4) /etc/ansible.cfg
+   * 4) /etc/ansible/ansible.cfg
    */
-  const cfgFiles = ["~/.ansible.cfg", "/etc/ansible.cfg"];
+  const cfgFiles = ["~/.ansible.cfg", "/etc/ansible/ansible.cfg"];
 
   if (!!rootPath) {
     cfgFiles.unshift(`${rootPath}/ansible.cfg`);


### PR DESCRIPTION
The extension will process the below list to order to locate the ansible configuration file and use the first file found:
-	ANSIBLE_CONFIG (an environment variable)
- ansible.cfg (in the current directory)
- .ansible.cfg (in the home directory)
- /etc/ansible/ansible.cfg

*source: https://docs.ansible.com/ansible/2.4/intro_configuration.html*

Resolves: #684