### PR TITLE
Replace vsce with @vscode/vsce

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,7 @@ node('rhel8') {
     def packageJson = readJSON file: 'package.json'
     // We always replace MAJOR.MINOR.PATCH from package.json with MAJOR.MINOR.BUILD
     def version = packageJson.version[0..packageJson.version.lastIndexOf('.') - 1] + ".${env.BUILD_NUMBER}"
-    sh "npx vsce package ${ params.publishPreRelease ? '--pre-release' : '' } --no-dependencies --no-git-tag-version --no-update-package-json ${ version }"
+    sh "yarn run vsce package ${ params.publishPreRelease ? '--pre-release' : '' } --no-dependencies --no-git-tag-version --no-update-package-json ${ version }"
   }
 
   if (params.UPLOAD_LOCATION) {
@@ -52,14 +52,13 @@ node('rhel8') {
       def vsix = findFiles(glob: '**.vsix')
       // VS Code Marketplace
       withCredentials([[$class: 'StringBinding', credentialsId: 'vscode_java_marketplace', variable: 'TOKEN']]) {
-        sh "vsce publish -p $TOKEN ${params.publishPreRelease ? '--pre-release' : ''} --packagePath ${vsix[0].path}"
+        sh "yarn run vsce publish -p $TOKEN ${params.publishPreRelease ? '--pre-release' : ''} --packagePath ${vsix[0].path}"
       }
       archive includes:'**.vsix'
 
       // Open-vsx Marketplace
-      sh 'npm install -g ovsx'
       withCredentials([[$class: 'StringBinding', credentialsId: 'open-vsx-access-token', variable: 'OVSX_TOKEN']]) {
-        sh "ovsx publish -p $OVSX_TOKEN ${vsix[0].path}"
+        sh "yarn run ovsx publish -p $OVSX_TOKEN ${vsix[0].path}"
       }
     }
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -180,7 +180,7 @@ tasks:
       - yarn run webpack
       # --pre-release not supported until we do VS Code >=1.63
       # --no-dependencies and --no-yarn needed due to https://github.com/microsoft/vscode-vsce/issues/439
-      - npx vsce package --no-dependencies --no-git-tag-version --no-update-package-json {{.VERSION}}-next-1
+      - yarn run vsce package --no-dependencies --no-git-tag-version --no-update-package-json {{.VERSION}}-next-1
       # Using zipinfo instead of `npx vsce ls` due to https://github.com/microsoft/vscode-vsce/issues/517
       - zipinfo -1 *.vsix
       - tools/dirty.sh

--- a/package.json
+++ b/package.json
@@ -9,11 +9,6 @@
   ],
   "badges": [
     {
-      "description": "Ansible language support",
-      "href": "https://marketplace.visualstudio.com/items?itemName=redhat.ansible",
-      "url": "https://vsmarketplacebadge.apphb.com/version/redhat.ansible.svg"
-    },
-    {
       "description": "CI/CD Pipeline",
       "href": "https://github.com/ansible/vscode-ansible/actions/workflows/ci.yaml",
       "url": "https://img.shields.io/github/workflow/status/ansible/vscode-ansible/ci.png"
@@ -498,6 +493,7 @@
     "@typescript-eslint/eslint-plugin": "^5.47.0",
     "@typescript-eslint/parser": "^5.47.0",
     "@vscode/test-electron": "^2.2.1",
+    "@vscode/vsce": "^2.16.0",
     "chai": "^4.3.7",
     "copyfiles": "^2.4.1",
     "eslint": "^8.30.0",
@@ -505,13 +501,13 @@
     "mocha": "^10.2.0",
     "mochawesome": "^7.1.3",
     "mochawesome-report-generator": "^6.2.0",
+    "ovsx": "^0.7.1",
     "prettier": "^2.8.1",
     "rimraf": "^3.0.2",
     "standard-version": "^9.5.0",
     "ts-loader": "^9.4.2",
     "ts-node": "^10.9.1",
     "typescript": "^4.9.4",
-    "vsce": "^2.15.0",
     "vscode-extension-tester": "^5.2.0",
     "webpack": "^5.75.0",
     "webpack-cli": "^5.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -637,6 +637,39 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vscode/vsce@npm:^2.15.0, @vscode/vsce@npm:^2.16.0":
+  version: 2.16.0
+  resolution: "@vscode/vsce@npm:2.16.0"
+  dependencies:
+    azure-devops-node-api: ^11.0.1
+    chalk: ^2.4.2
+    cheerio: ^1.0.0-rc.9
+    commander: ^6.1.0
+    glob: ^7.0.6
+    hosted-git-info: ^4.0.2
+    keytar: ^7.7.0
+    leven: ^3.1.0
+    markdown-it: ^12.3.2
+    mime: ^1.3.4
+    minimatch: ^3.0.3
+    parse-semver: ^1.1.1
+    read: ^1.0.7
+    semver: ^5.1.0
+    tmp: ^0.2.1
+    typed-rest-client: ^1.8.4
+    url-join: ^4.0.1
+    xml2js: ^0.4.23
+    yauzl: ^2.3.1
+    yazl: ^2.2.2
+  dependenciesMeta:
+    keytar:
+      optional: true
+  bin:
+    vsce: vsce
+  checksum: dcab780b75292637d5c916f98f4e4d110e2dd8285fb7fae1d36d47cb4c5da6db2b6bc509f5b9e73ed3b8c4543ab3ba3dcb86b368404dfd15b7a474a34b7a9071
+  languageName: node
+  linkType: hard
+
 "@webassemblyjs/ast@npm:1.11.1":
   version: 1.11.1
   resolution: "@webassemblyjs/ast@npm:1.11.1"
@@ -999,6 +1032,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": ^5.47.0
     "@typescript-eslint/parser": ^5.47.0
     "@vscode/test-electron": ^2.2.1
+    "@vscode/vsce": ^2.16.0
     chai: ^4.3.7
     copyfiles: ^2.4.1
     eslint: ^8.30.0
@@ -1007,6 +1041,7 @@ __metadata:
     mocha: ^10.2.0
     mochawesome: ^7.1.3
     mochawesome-report-generator: ^6.2.0
+    ovsx: ^0.7.1
     prettier: ^2.8.1
     rimraf: ^3.0.2
     standard-version: ^9.5.0
@@ -1014,7 +1049,6 @@ __metadata:
     ts-node: ^10.9.1
     typescript: ^4.9.4
     untildify: ^4.0.0
-    vsce: ^2.15.0
     vscode-extension-tester: ^5.2.0
     vscode-languageclient: ^8.0.2
     webpack: ^5.75.0
@@ -1547,6 +1581,13 @@ __metadata:
   version: 1.0.3
   resolution: "chrome-trace-event@npm:1.0.3"
   checksum: cb8b1fc7e881aaef973bd0c4a43cd353c2ad8323fb471a041e64f7c2dd849cde4aad15f8b753331a32dda45c973f032c8a03b8177fc85d60eaa75e91e08bfb97
+  languageName: node
+  linkType: hard
+
+"ci-info@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "ci-info@npm:2.0.0"
+  checksum: 3b374666a85ea3ca43fa49aa3a048d21c9b475c96eb13c133505d2324e7ae5efd6a454f41efe46a152269e9b6a00c9edbe63ec7fa1921957165aae16625acd67
   languageName: node
   linkType: hard
 
@@ -2776,6 +2817,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"follow-redirects@npm:^1.14.6":
+  version: 1.15.2
+  resolution: "follow-redirects@npm:1.15.2"
+  peerDependenciesMeta:
+    debug:
+      optional: true
+  checksum: faa66059b66358ba65c234c2f2a37fcec029dc22775f35d9ad6abac56003268baf41e55f9ee645957b32c7d9f62baf1f0b906e68267276f54ec4b4c597c2b190
+  languageName: node
+  linkType: hard
+
 "fs-constants@npm:^1.0.0":
   version: 1.0.0
   resolution: "fs-constants@npm:1.0.0"
@@ -3411,6 +3462,17 @@ __metadata:
   dependencies:
     binary-extensions: ^2.0.0
   checksum: 84192eb88cff70d320426f35ecd63c3d6d495da9d805b19bc65b518984b7c0760280e57dbf119b7e9be6b161784a5a673ab2c6abe83abb5198a432232ad5b35c
+  languageName: node
+  linkType: hard
+
+"is-ci@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "is-ci@npm:2.0.0"
+  dependencies:
+    ci-info: ^2.0.0
+  bin:
+    is-ci: bin.js
+  checksum: 77b869057510f3efa439bbb36e9be429d53b3f51abd4776eeea79ab3b221337fe1753d1e50058a9e2c650d38246108beffb15ccfd443929d77748d8c0cc90144
   languageName: node
   linkType: hard
 
@@ -4605,6 +4667,22 @@ __metadata:
     type-check: ^0.4.0
     word-wrap: ^1.2.3
   checksum: dbc6fa065604b24ea57d734261914e697bd73b69eff7f18e967e8912aa2a40a19a9f599a507fa805be6c13c24c4eae8c71306c239d517d42d4c041c942f508a0
+  languageName: node
+  linkType: hard
+
+"ovsx@npm:^0.7.1":
+  version: 0.7.1
+  resolution: "ovsx@npm:0.7.1"
+  dependencies:
+    "@vscode/vsce": ^2.15.0
+    commander: ^6.1.0
+    follow-redirects: ^1.14.6
+    is-ci: ^2.0.0
+    leven: ^3.1.0
+    tmp: ^0.2.1
+  bin:
+    ovsx: lib/ovsx
+  checksum: 4fa21db237d73e7856f172839967997ec1d51b66fd29effc6c70f564241aa39d94e4da1a1891ff7b42e284bd9c75a13c1014dc3f53cd7c8f2978cef8e0c1725d
   languageName: node
   linkType: hard
 
@@ -6382,7 +6460,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vsce@npm:^2.14.0, vsce@npm:^2.15.0":
+"vsce@npm:^2.14.0":
   version: 2.15.0
   resolution: "vsce@npm:2.15.0"
   dependencies:


### PR DESCRIPTION
Also removes no-longer supported badge. Fixes:
```
$ yarn run vsce package
 ERROR  Badge SVGs are restricted. Please use other file image formats, such as PNG: https://vsmarketplacebadge.apphb.com/version/redhat.ansible.svg
FAIL: 1
```

