### PR TITLE
Upgrade ALS to 1.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -477,7 +477,7 @@
     ]
   },
   "dependencies": {
-    "@ansible/ansible-language-server": "^1.0.2",
+    "@ansible/ansible-language-server": "^1.0.4",
     "@types/ini": "^1.3.31",
     "ini": "^3.0.1",
     "untildify": "^4.0.0",

--- a/src/features/ansibleMetaData.ts
+++ b/src/features/ansibleMetaData.ts
@@ -67,7 +67,7 @@ export class MetadataManager {
         if (ansibleMetaData.ansiblePresent) {
           console.log("Ansible found in the workspace");
           this.cachedAnsibleVersion =
-            ansibleMetaData.metaData["ansible information"]["version"];
+            ansibleMetaData.metaData["ansible information"]["core version"];
           const tooltip = ansibleMetaData.markdown;
           this.metadataStatusBarItem.text = ansibleMetaData.eeEnabled
             ? `$(bracket-dot) [EE] ${this.cachedAnsibleVersion}`

--- a/src/features/ansibleMetaData.ts
+++ b/src/features/ansibleMetaData.ts
@@ -98,7 +98,7 @@ export class MetadataManager {
           this.metadataStatusBarItem.show();
           const eventData: ansibleMetadataEvent = {
             ansibleVersion:
-              ansibleMetaData.metaData["ansible information"]["version"],
+              ansibleMetaData.metaData["ansible information"]["core version"],
             eeEnabled: ansibleMetaData.eeEnabled,
           };
           if (ansibleMetaData.ansibleLintPresent) {

--- a/src/features/utils/formatAnsibleMetaData.ts
+++ b/src/features/utils/formatAnsibleMetaData.ts
@@ -9,6 +9,8 @@ export function formatAnsibleMetaData(ansibleMetaData: any) {
   let ansibleLintPresent = true;
   let eeEnabled = false;
 
+  const WARNING_STYLE = 'style="color:#FFEF4A;"';
+
   // check if ansible is missing
   if (Object.keys(ansibleMetaData["ansible information"]).length === 0) {
     ansiblePresent = false;
@@ -17,7 +19,7 @@ export function formatAnsibleMetaData(ansibleMetaData: any) {
     // if python exists
     if (Object.keys(ansibleMetaData["python information"]).length !== 0) {
       const obj = ansibleMetaData["python information"];
-      mdString += `Python version used: \`${obj["python version"]}\` from \`${obj["python location"]}\``;
+      mdString += `Python version used: \`${obj["version"]}\` from \`${obj["location"]}\``;
     }
 
     const markdown = new MarkdownString(mdString, true);
@@ -62,13 +64,17 @@ export function formatAnsibleMetaData(ansibleMetaData: any) {
     // put a marker stating ansible-lint setting is disabled
     if (mainKey === "ansible-lint information" && !lintEnabled) {
       mdString += `\n**${mainKey}:** `;
-      mdString += `*<span style="color:#FFEF4A;">(disabled)*\n`;
+      mdString += `*<span ${WARNING_STYLE}>(disabled)*\n`;
     } else {
       mdString += `\n**${mainKey}:** \n`;
     }
 
     const valueObj = ansibleMetaData[mainKey];
     Object.keys(valueObj).forEach((key) => {
+      if (key === "upgrade status") {
+        mdString += ` <span ${WARNING_STYLE}>${valueObj[key]}`;
+        return;
+      }
       mdString += `\n   - ${key}: `;
       const value = valueObj[key];
       if (typeof value === "object") {
@@ -110,7 +116,7 @@ export function formatAnsibleMetaData(ansibleMetaData: any) {
 
   if (!ansibleLintPresent) {
     markdown.appendMarkdown(
-      `\n<p><span style="color:#FFEF4A;">$(warning) Warning(s):</p></h5>`
+      `\n<p><span ${WARNING_STYLE}>$(warning) Warning(s):</p></h5>`
     );
     markdown.appendMarkdown(`Ansible lint is missing in the environment`);
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,9 +5,9 @@ __metadata:
   version: 6
   cacheKey: 8
 
-"@ansible/ansible-language-server@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "@ansible/ansible-language-server@npm:1.0.2"
+"@ansible/ansible-language-server@npm:^1.0.4":
+  version: 1.0.4
+  resolution: "@ansible/ansible-language-server@npm:1.0.4"
   dependencies:
     "@flatten-js/interval-tree": ^1.0.18
     glob: ^8.0.1
@@ -20,7 +20,7 @@ __metadata:
     yaml: ^1.10.2 <2.0
   bin:
     ansible-language-server: bin/ansible-language-server
-  checksum: f1914d35bbe1095d20e12dc02cb11be58b36b67221f10cb1a1d879744c36ea89d494099c612560687b562ba82b6762788636302391f82bc154f958feb3e26c31
+  checksum: cc7499af2163b302d02e926fa84e3e0e413492218148fe20fb641a71a71bce69667c10c06cc2e80c227be5749432145526006862b7735e1ed11deaa3eceb1eb8
   languageName: node
   linkType: hard
 
@@ -1022,7 +1022,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "ansible@workspace:."
   dependencies:
-    "@ansible/ansible-language-server": ^1.0.2
+    "@ansible/ansible-language-server": ^1.0.4
     "@types/chai": ^4.3.4
     "@types/glob": ^8.0.0
     "@types/ini": ^1.3.31


### PR DESCRIPTION
Additionally, The PR adds necessary changes for the ansible metadata status-bar to support ALS v1.0.4