### PR TITLE
Release v1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@
 
 <!-- KEEP-THIS-COMMENT -->
 
+## v1.1
+
+### Minor Changes
+
+- Add support to run ansible-navigator with execution environment (#652)
+  @ganeshrn
+- Update the extension to support disabling diagnostics (#648) @priyamsahoo
+
+### Bugfixes
+
+- Improve description of configuration options (#649) @priyamsahoo
+- Update ALS version to 1.0.1 (#656) @priyamsahoo
+- Use creator-ee v0.9.2 to fix CI failures (#653) @priyamsahoo
+- Update ansible-lint and version and e2e-tests to support changes the changes
+  (#643) @priyamsahoo
+- More refactor for ansible metadata feature (#641) @ganeshrn
+- Refactor extension.ts (#635) @priyamsahoo
+- Switch to new location of Molecule JSON Schema (#637) @ssbarnea
+
 ## v1.0.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -579,7 +579,7 @@
     "test-e2e": "yarn run test-compile && node ./out/client/test/testRunner",
     "test-e2e-withserver": "yarn run test-compile-withserver && node ./out/client/test/testRunner"
   },
-  "version": "1.0.0",
+  "version": "1.1.0",
   "packageManager": "yarn@3.3.0",
   "vsce": {
     "dependencies": false,


### PR DESCRIPTION
## v1.1

### Minor Changes

- Add support to run ansible-navigator with execution environment (#652) @ganeshrn
- Update the extension to support disabling diagnostics (#648) @priyamsahoo

### Bugfixes

- Improve description of configuration options (#649) @priyamsahoo
- Update ALS version to 1.0.1 (#656) @priyamsahoo
- Use creator-ee v0.9.2 to fix CI failures (#653) @priyamsahoo
- Update ansible-lint and version and e2e-tests to support changes the changes (#643) @priyamsahoo
- More refactor for ansible metadata feature (#641) @ganeshrn
- Refactor extension.ts (#635) @priyamsahoo
- Switch to new location of Molecule JSON Schema (#637) @ssbarnea
