### PR TITLE
Treat webpack warnings as errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -530,6 +530,7 @@
     "ts-node": "^10.9.1",
     "typescript": "^4.9.4",
     "vscode-extension-tester": "^5.2.1",
+    "warnings-to-errors-webpack-plugin": "^2.3.0",
     "webpack": "^5.75.0",
     "webpack-cli": "^5.0.1",
     "yarn-audit-fix": "^9.3.7"

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -1,46 +1,20 @@
 "use strict";
+const WarningsToErrorsPlugin = require("warnings-to-errors-webpack-plugin");
+
 /* eslint @typescript-eslint/no-var-requires: "off" */
 const path = require("path");
 
 const config = {
-  mode: "none",
-  stats: {
-    preset: "minimal",
-    moduleTrace: true,
-    errorDetails: true,
-  },
-  target: "node", // vscode extensions run in a Node.js-context
-  node: {
-    __dirname: false, // leave the __dirname-behavior intact
-  },
+  devtool: "source-map",
   entry: {
     client: "./src/extension.ts",
     server:
       "./node_modules/@ansible/ansible-language-server/out/server/src/server.js",
   },
-  output: {
-    filename: (pathData: { chunk: { name: string } }) => {
-      return pathData.chunk.name === "client"
-        ? "[name]/src/extension.js"
-        : "[name]/src/[name].js";
-    },
-    path: path.resolve(__dirname, "out"),
-    libraryTarget: "commonjs2",
-    devtoolModuleFilenameTemplate: (info: { id: string }) => {
-      return info.id === "client"
-        ? "../[resource-path]"
-        : "../../../[resource-path]";
-    },
-  },
-  // stats: 'verbose', // doesn't help with watcher
-  devtool: "source-map",
   externals: {
     vscode: "commonjs vscode", // the vscode-module is created on-the-fly and must be excluded. Add other modules that cannot be webpack'ed
   },
-  resolve: {
-    // support reading TypeScript and JavaScript files
-    extensions: [".ts", ".js"],
-  },
+  mode: "none",
   module: {
     rules: [
       {
@@ -62,6 +36,34 @@ const config = {
       },
     ],
   },
+  node: {
+    __dirname: false, // leave the __dirname-behavior intact
+  },
+  output: {
+    filename: (pathData: { chunk: { name: string } }) => {
+      return pathData.chunk.name === "client"
+        ? "[name]/src/extension.js"
+        : "[name]/src/[name].js";
+    },
+    path: path.resolve(__dirname, "out"),
+    libraryTarget: "commonjs2",
+    devtoolModuleFilenameTemplate: (info: { id: string }) => {
+      return info.id === "client"
+        ? "../[resource-path]"
+        : "../../../[resource-path]";
+    },
+  },
+  plugins: [new WarningsToErrorsPlugin()],
+  resolve: {
+    // support reading TypeScript and JavaScript files
+    extensions: [".ts", ".js"],
+  },
+  stats: {
+    errorDetails: true,
+    moduleTrace: true,
+    preset: "minimal",
+  },
+  target: "node", // vscode extensions run in a Node.js-context
 };
 
 module.exports = config;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1279,6 +1279,7 @@ __metadata:
     untildify: ^4.0.0
     vscode-extension-tester: ^5.2.1
     vscode-languageclient: ^8.0.2
+    warnings-to-errors-webpack-plugin: ^2.3.0
     webpack: ^5.75.0
     webpack-cli: ^5.0.1
     yaml: ^2.2.1
@@ -6537,6 +6538,15 @@ __metadata:
   version: 3.0.6
   resolution: "vscode-uri@npm:3.0.6"
   checksum: 8b6a36553d089309c09f7aa2ca8dae321a1cb7ff5dcab35f0914d5155d3110722bdb6de67dcb727df15fecd83221d11bb4ab1274a9116b9ccc05b86cefe60dfc
+  languageName: node
+  linkType: hard
+
+"warnings-to-errors-webpack-plugin@npm:^2.3.0":
+  version: 2.3.0
+  resolution: "warnings-to-errors-webpack-plugin@npm:2.3.0"
+  peerDependencies:
+    webpack: ^2.2.0-rc || ^3 || ^4 || ^5
+  checksum: fb575eeb013d71bc2ba7419a8221855168a87d3cdb062e7014aff9ed3fddec56ec695915115249555f51931aa9ed786df95e65c3611e78dd71a42ca55cc839d6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This should prevent accidental regression related to use of webpack.

Related: #748
