### PR TITLE
Update inlinesuggestion request as per new payload

### DIFF
--- a/src/definitions/wisdom.ts
+++ b/src/definitions/wisdom.ts
@@ -3,7 +3,6 @@ export interface SuggestionResult {
 }
 
 export interface RequestParams {
-  context: string;
   prompt: string;
   userId?: string;
   suggestionId?: string;
@@ -14,11 +13,10 @@ export interface WisdomTelemetryEvent {
   requestDateTime?: string;
   response?: SuggestionResult;
   responseDateTime?: string;
+  duration?: number;
   documentUri?: string;
   suggestionDisplayed?: string;
-  userAction?: "accept" | "ignore" | "modify";
+  userAction?: "accept" | "ignore";
   suggestionId?: string;
-  feedback?: string;
-  userUIFeedbackEnabled?: boolean;
   error?: string;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -38,7 +38,6 @@ import {
   inlineSuggestionTriggerHandler,
   inlineSuggestionCommitHandler,
   inlineSuggestionHideHandler,
-  inlineSuggestionUserActionHandler,
 } from "./features/wisdom/inlineSuggestions";
 
 export let client: LanguageClient;
@@ -121,13 +120,6 @@ export async function activate(context: ExtensionContext): Promise<void> {
     vscode.commands.registerTextEditorCommand(
       WisdomCommands.WISDOM_SUGGESTION_TRIGGER,
       inlineSuggestionTriggerHandler
-    )
-  );
-
-  context.subscriptions.push(
-    vscode.commands.registerCommand(
-      WisdomCommands.WISDOM_SUGGESTION_USER_ACTION,
-      await inlineSuggestionUserActionHandler
     )
   );
 

--- a/src/features/utils/dateTime.ts
+++ b/src/features/utils/dateTime.ts
@@ -1,6 +1,6 @@
-export function getCurrentUTCDateTime(): string {
+export function getCurrentUTCDateTime(): Date {
   const date = new Date();
   const utcString = date.toUTCString();
-  const gmtTimestamp = new Date(utcString).toISOString();
+  const gmtTimestamp = new Date(utcString);
   return gmtTimestamp;
 }

--- a/src/features/utils/wisdom.ts
+++ b/src/features/utils/wisdom.ts
@@ -2,62 +2,37 @@ import * as vscode from "vscode";
 
 export function removePromptFromSuggestion(
   suggestion: string,
-  prompt: string,
-  promptDescription: string,
   position: vscode.Position
 ): string {
   const lines = suggestion.split("\n");
-  const firstLine = lines[0];
   const editor = vscode.window.activeTextEditor;
   const cursorLine = editor?.document.lineAt(position);
   const spacesBeforeCursor =
     cursorLine?.text.slice(0, position.character).match(/^ +/)?.[0].length || 0;
-  if (!firstLine.startsWith(prompt)) {
-    // if the first line doesn't start with the prompt,
-    // we don't need to remove it. Adjust the indentation
-    // for the rest of the lines to account for the spaces before cursor
-    // at the current line
-    if (spacesBeforeCursor > 0 && lines.length > 1) {
-      const newSuggestion = lines
-        .map((line, index) => {
-          // BOUNDARY: shouldn't extend into the string
-          if (line[position.character - 1]?.match(/\w/)) {
-            console.error(`ignoring malformed line, indentation: '${line}'`);
-            return "";
-          }
 
-          const newLine = line.substring(position.character);
-          if (index === 0) {
-            return newLine;
-          } else {
-            return " ".repeat(spacesBeforeCursor) + newLine;
-          }
-        })
-        .filter((s) => s)
-        .join("\n");
-      return newSuggestion;
-    } else {
-      return suggestion;
+  // adjust the spaces in suggestion line with respect to cursor position
+  lines.forEach((line, index) => {
+    if (index !== 0) {
+      lines[index] = " ".repeat(spacesBeforeCursor) + line;
     }
-  } else {
-    // if the first line starts with the prompt, remove it
-    // and adjust the indentation for the rest of the lines
-    const subString = firstLine.slice(prompt.length);
-    lines[0] = subString;
-    if (subString === "") {
-      lines.shift();
-    } else {
-      lines[0] = subString;
-    }
-    // adjust the spaces in suggestion line with respect to cursor position
-    if (lines.length > 0) {
-      const lineStartSpaceCount = lines[0].search(/\S|$/);
-      if (lineStartSpaceCount > spacesBeforeCursor) {
-        lines[0] = lines[0].substring(spacesBeforeCursor);
-      }
-    }
-    return lines.join("\n");
-  }
+  });
+  return lines.join("\n");
+}
+
+/* A utility function to convert plain text to snippet string */
+export function convertToSnippetString(suggestion: string): string {
+  // this regex matches all content inside {{  }}
+  // TODO: once a prefix is decided for using it in from of variable names, the regex
+  // can be changed to match it
+  const regex = /(?<=\{\{ ).+?(?= \}\})/gm;
+
+  let counter = 0;
+  const convertedSuggestion = suggestion.replace(regex, (item) => {
+    counter = counter + 1;
+    return `\${${counter}:${item}}`;
+  });
+
+  return convertedSuggestion;
 }
 
 /* A utility function to convert plain text to snippet string */

--- a/src/features/utils/wisdom.ts
+++ b/src/features/utils/wisdom.ts
@@ -34,19 +34,3 @@ export function convertToSnippetString(suggestion: string): string {
 
   return convertedSuggestion;
 }
-
-/* A utility function to convert plain text to snippet string */
-export function convertToSnippetString(suggestion: string): string {
-  // this regex matches all content inside {{  }}
-  // TODO: once a prefix is decided for using it in from of variable names, the regex
-  // can be changed to match it
-  const regex = /(?<=\{\{ ).+?(?= \}\})/gm;
-
-  let counter = 0;
-  const convertedSuggestion = suggestion.replace(regex, (item) => {
-    counter = counter + 1;
-    return `\${${counter}:${item}}`;
-  });
-
-  return convertedSuggestion;
-}

--- a/src/features/wisdom/base.ts
+++ b/src/features/wisdom/base.ts
@@ -45,6 +45,7 @@ export class WisdomManager {
       StatusBarAlignment.Right,
       100
     );
+    wisdomStatusBarItem.text = "Wisdom";
     this.context.subscriptions.push(wisdomStatusBarItem);
     return wisdomStatusBarItem;
   }
@@ -53,8 +54,6 @@ export class WisdomManager {
     if (!this.client.isRunning()) {
       return;
     }
-    //wisdomStatusBar.command = await window.showInputBox("Enable Wisdom")
-    this.wisdomStatusBar.text = "Wisdom";
     if (
       this.settingsManager.settings.wisdomService.enabled &&
       this.settingsManager.settings.wisdomService.suggestions.enabled
@@ -71,7 +70,10 @@ export class WisdomManager {
   }
 
   public updateWisdomStatusbar(): void {
-    if (window.activeTextEditor?.document.languageId !== "ansible") {
+    if (
+      window.activeTextEditor?.document.languageId !== "ansible" ||
+      !this.settingsManager.settings.wisdomService.enabled
+    ) {
       this.wisdomStatusBar.hide();
       return;
     }

--- a/src/features/wisdom/inlineSuggestions.ts
+++ b/src/features/wisdom/inlineSuggestions.ts
@@ -119,7 +119,7 @@ async function getInlineSuggestion(content: string): Promise<SuggestionResult> {
     suggestionId: suggestionId,
   };
   console.log(
-    `${getCurrentUTCDateTime()}: request data to wisdom service:\n${JSON.stringify(
+    `${getCurrentUTCDateTime().toISOString()}: request data to wisdom service:\n${JSON.stringify(
       inputData
     )}`
   );
@@ -128,7 +128,7 @@ async function getInlineSuggestion(content: string): Promise<SuggestionResult> {
     inputData
   );
   console.log(
-    `${getCurrentUTCDateTime()}: response data from wisdom service:\n${JSON.stringify(
+    `${getCurrentUTCDateTime().toISOString()}: response data from wisdom service:\n${JSON.stringify(
       outputData
     )}`
   );
@@ -220,7 +220,7 @@ export async function inlineSuggestionCommitHandler(
   }
 
   // Commit the suggestion
-  vscode.commands.executeCommand("editor.action.inlineSuggest.commit");
+  vscode.commands.executeCommand(WisdomCommands.WISDOM_SUGGESTION_COMMIT);
 
   // Send telemetry for accepted suggestion
   await inlineSuggestionUserActionHandler(suggestionId, true);
@@ -236,7 +236,7 @@ export async function inlineSuggestionHideHandler(
     return [];
   }
   console.log("inlineSuggestionHideHandler triggered");
-  vscode.commands.executeCommand("editor.action.inlineSuggest.hide");
+  vscode.commands.executeCommand(WisdomCommands.WISDOM_SUGGESTION_HIDE);
 
   // Send telemetry for accepted suggestion
   await inlineSuggestionUserActionHandler(suggestionId, false);


### PR DESCRIPTION
*  Update inline suggestion request to send only `prompt` key
*  Cleanup code around removing prompt from inline suggestion
*  Show `wisdom` status bar only when the service is enabled