### PR TITLE
Temporary make macos testing non-voting

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,6 +24,8 @@ jobs:
     # ${{ matrix.name && matrix.name || format('{0} ({1})', matrix.task-name, matrix.os) }}
     # The type of runner that the job will run on
     runs-on: ${{ matrix.os }}
+    # see https://github.com/containers/podman/issues/13609
+    continue-on-error: ${{ contains(matrix.name, 'macos') && true || false }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Due to podman bootrapping flakiness on Github Runners, we make
the macos testing non-voting for the final outcome. We continue to
run it order to see how it evolves in time, hopefully find a permanent
fix for it.

Related: https://github.com/containers/podman/issues/13609
