### PR TITLE
Update wisdom feedback to use service feedback API and changes

### DIFF
--- a/src/definitions/constants.ts
+++ b/src/definitions/constants.ts
@@ -15,6 +15,13 @@ export namespace WisdomCommands {
     "ansible.wisdom.inlineSuggest.trigger";
   export const WISDOM_SUGGESTION_ON_ENTER =
     "ansible.wisdom.inlineSuggest.triggerOnEnter";
-  export const WISDOM_SUGGESTION_USER_ACTION =
-    "extension.inlineSuggestionUserAction";
+  export const WISDOM_STATUS_BAR_CLICK = "ansible.wisdom.statusBar.click";
 }
+
+export const WISDOM_SUGGESTION_COMPLETION_URL = "/ai/completions/";
+export const WISDOM_SUGGESTION_FEEDBACK_URL = "/ai/feedback/";
+
+export const WISDOM_FEEDBACK_FORM_URL =
+  "https://redhatdg.co1.qualtrics.com/jfe/form/SV_e99JvA2DHp5UlWC";
+
+export const WISDOM_REPORT_EMAIL_ADDRESS = "ansible-content-ai@redhat.com";

--- a/src/definitions/wisdom.ts
+++ b/src/definitions/wisdom.ts
@@ -1,22 +1,42 @@
-export interface SuggestionResult {
+export interface CompletionResponseParams {
   predictions: string[];
 }
 
-export interface RequestParams {
+export interface CompletionRequestParams {
   prompt: string;
-  userId?: string;
   suggestionId?: string;
 }
 
-export interface WisdomTelemetryEvent {
-  request?: RequestParams;
-  requestDateTime?: string;
-  response?: SuggestionResult;
-  responseDateTime?: string;
-  duration?: number;
+export enum UserAction {
+  ACCEPT = 0,
+  IGNORE = 1,
+}
+
+export enum AnsibleContentUploadTrigger {
+  FILE_OPEN = 0,
+  FILE_CLOSE = 1,
+  TAB_CHANGE = 2,
+}
+
+export interface FeedbackResponseParams {
+  message: string;
+}
+
+export interface InlineSuggestionEvent {
+  latency?: number;
+  userActionTime?: number;
   documentUri?: string;
-  suggestionDisplayed?: string;
-  userAction?: "accept" | "ignore";
-  suggestionId?: string;
+  action?: UserAction;
   error?: string;
+  suggestionId?: string;
+}
+
+export interface AnsibleContentEvent {
+  content: string;
+  documentUri: string;
+  trigger: AnsibleContentUploadTrigger;
+}
+export interface FeedbackRequestParams {
+  inlineSuggestion?: InlineSuggestionEvent;
+  ansibleContent?: AnsibleContentEvent;
 }

--- a/src/features/ansibleMetaData.ts
+++ b/src/features/ansibleMetaData.ts
@@ -111,7 +111,7 @@ export class MetadataManager {
             eventData["ansibleLintVersion"] =
               ansibleMetaData.metaData["ansible-lint information"]["version"];
           }
-          // send telemtry event only when ansible metadata changes
+          // send telemetry event only when ansible metadata changes
           if (!compareObjects(eventData, prevEventData)) {
             this.telemetry.sendTelemetry("ansibleMetadata", eventData);
             prevEventData = eventData;

--- a/src/features/ansibleMetaData.ts
+++ b/src/features/ansibleMetaData.ts
@@ -11,12 +11,18 @@ import { NotificationType } from "vscode-languageclient";
 import { LanguageClient } from "vscode-languageclient/node";
 import { TelemetryManager } from "../utils/telemetryUtils";
 import { formatAnsibleMetaData } from "./utils/formatAnsibleMetaData";
+import { compareObjects } from "./utils/data";
 
 interface ansibleMetadataEvent {
   ansibleVersion: string;
   ansibleLintVersion?: string;
   eeEnabled: boolean;
 }
+
+let prevEventData: ansibleMetadataEvent = {
+  ansibleVersion: "",
+  eeEnabled: false,
+};
 
 export class MetadataManager {
   private context;
@@ -105,7 +111,11 @@ export class MetadataManager {
             eventData["ansibleLintVersion"] =
               ansibleMetaData.metaData["ansible-lint information"]["version"];
           }
-          this.telemetry.sendTelemetry("ansibleMetadata", eventData);
+          // send telemtry event only when ansible metadata changes
+          if (!compareObjects(eventData, prevEventData)) {
+            this.telemetry.sendTelemetry("ansibleMetadata", eventData);
+            prevEventData = eventData;
+          }
         } else {
           console.log("Ansible not found in the workspace");
           this.metadataStatusBarItem.text = "$(error) Ansible Info";

--- a/src/features/utils/data.ts
+++ b/src/features/utils/data.ts
@@ -1,16 +1,16 @@
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function compareObjects(obj1: any, obj2: any): boolean {
+export function compareObjects(baseObject: any, newObject: any): boolean {
   // compare the number of keys
-  const obj1Keys = Object.keys(obj1);
-  const obj2Keys = Object.keys(obj2);
+  const baseObjectKeys = Object.keys(baseObject);
+  const newObjectKeys = Object.keys(newObject);
 
-  if (obj1Keys.length !== obj2Keys.length) {
+  if (baseObjectKeys.length !== newObjectKeys.length) {
     return false;
   }
 
   // compare the values for each key
-  for (const key of obj1Keys) {
-    if (obj1[key] !== obj2[key]) {
+  for (const key of baseObjectKeys) {
+    if (baseObject[key] !== newObject[key]) {
       return false;
     }
   }

--- a/src/features/utils/data.ts
+++ b/src/features/utils/data.ts
@@ -1,0 +1,20 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function compareObjects(obj1: any, obj2: any): boolean {
+  // compare the number of keys
+  const obj1Keys = Object.keys(obj1);
+  const obj2Keys = Object.keys(obj2);
+
+  if (obj1Keys.length !== obj2Keys.length) {
+    return false;
+  }
+
+  // compare the values for each key
+  for (const key of obj1Keys) {
+    if (obj1[key] !== obj2[key]) {
+      return false;
+    }
+  }
+
+  // all keys and values are equal
+  return true;
+}

--- a/src/features/utils/dateTime.ts
+++ b/src/features/utils/dateTime.ts
@@ -1,6 +1,6 @@
 export function getCurrentUTCDateTime(): Date {
   const date = new Date();
   const utcString = date.toUTCString();
-  const gmtTimestamp = new Date(utcString);
-  return gmtTimestamp;
+  const utcTimeStamp = new Date(utcString);
+  return utcTimeStamp;
 }

--- a/src/features/utils/wisdom.ts
+++ b/src/features/utils/wisdom.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 
-export function removePromptFromSuggestion(
+export function adjustInlineSuggestionIndent(
   suggestion: string,
   position: vscode.Position
 ): string {
@@ -10,13 +10,28 @@ export function removePromptFromSuggestion(
   const spacesBeforeCursor =
     cursorLine?.text.slice(0, position.character).match(/^ +/)?.[0].length || 0;
 
+  let newSuggestion = suggestion;
   // adjust the spaces in suggestion line with respect to cursor position
-  lines.forEach((line, index) => {
-    if (index !== 0) {
-      lines[index] = " ".repeat(spacesBeforeCursor) + line;
-    }
-  });
-  return lines.join("\n");
+  if (spacesBeforeCursor > 0 && lines.length > 1) {
+    newSuggestion = lines
+      .map((line, index) => {
+        // BOUNDARY: shouldn't extend into the string
+        if (line[position.character - 1]?.match(/\w/)) {
+          console.error(`ignoring malformed line, indentation: '${line}'`);
+          return "";
+        }
+
+        const newLine = line.substring(position.character);
+        if (index === 0) {
+          return newLine;
+        } else {
+          return " ".repeat(spacesBeforeCursor) + newLine;
+        }
+      })
+      .filter((s) => s)
+      .join("\n");
+  }
+  return newSuggestion;
 }
 
 /* A utility function to convert plain text to snippet string */

--- a/src/features/wisdom/base.ts
+++ b/src/features/wisdom/base.ts
@@ -1,27 +1,30 @@
-import {
-  ExtensionContext,
-  window,
-  StatusBarAlignment,
-  StatusBarItem,
-  ThemeColor,
-} from "vscode";
+import * as vscode from "vscode";
 import { LanguageClient } from "vscode-languageclient/node";
 import { WisdomAPI } from "./api";
 import { TelemetryManager } from "../../utils/telemetryUtils";
 import { SettingsManager } from "../../settings";
 import { WisdomAuthenticationProvider } from "./wisdomOAuthProvider";
+import {
+  AnsibleContentUploadTrigger,
+  FeedbackRequestParams,
+} from "../../definitions/wisdom";
+import {
+  WisdomCommands,
+  WISDOM_FEEDBACK_FORM_URL,
+  WISDOM_REPORT_EMAIL_ADDRESS,
+} from "../../definitions/constants";
 
 export class WisdomManager {
   private context;
   public client;
   public settingsManager: SettingsManager;
   public telemetry: TelemetryManager;
-  public wisdomStatusBar: StatusBarItem;
+  public wisdomStatusBar: vscode.StatusBarItem;
   public apiInstance: WisdomAPI;
   public wisdomAuthenticationProvider: WisdomAuthenticationProvider;
 
   constructor(
-    context: ExtensionContext,
+    context: vscode.ExtensionContext,
     client: LanguageClient,
     settingsManager: SettingsManager,
     telemetry: TelemetryManager
@@ -46,12 +49,13 @@ export class WisdomManager {
     this.updateWisdomStatusbar();
     this.apiInstance.reInitialize();
   }
-  private initialiseStatusBar(): StatusBarItem {
+  private initialiseStatusBar(): vscode.StatusBarItem {
     // create a new status bar item that we can manage
-    const wisdomStatusBarItem = window.createStatusBarItem(
-      StatusBarAlignment.Right,
+    const wisdomStatusBarItem = vscode.window.createStatusBarItem(
+      vscode.StatusBarAlignment.Right,
       100
     );
+    wisdomStatusBarItem.command = WisdomCommands.WISDOM_STATUS_BAR_CLICK;
     wisdomStatusBarItem.text = "Wisdom";
     this.context.subscriptions.push(wisdomStatusBarItem);
     return wisdomStatusBarItem;
@@ -65,11 +69,11 @@ export class WisdomManager {
       this.settingsManager.settings.wisdomService.enabled &&
       this.settingsManager.settings.wisdomService.suggestions.enabled
     ) {
-      this.wisdomStatusBar.backgroundColor = new ThemeColor(
+      this.wisdomStatusBar.backgroundColor = new vscode.ThemeColor(
         "statusBarItem.prominentForeground"
       );
     } else {
-      this.wisdomStatusBar.backgroundColor = new ThemeColor(
+      this.wisdomStatusBar.backgroundColor = new vscode.ThemeColor(
         "statusBarItem.warningBackground"
       );
     }
@@ -78,7 +82,7 @@ export class WisdomManager {
 
   public updateWisdomStatusbar(): void {
     if (
-      window.activeTextEditor?.document.languageId !== "ansible" ||
+      vscode.window.activeTextEditor?.document.languageId !== "ansible" ||
       !this.settingsManager.settings.wisdomService.enabled
     ) {
       this.wisdomStatusBar.hide();
@@ -86,5 +90,46 @@ export class WisdomManager {
     }
 
     this.handleStatusBar();
+  }
+
+  public ansibleContentFeedback(
+    document: vscode.TextDocument,
+    trigger: AnsibleContentUploadTrigger
+  ): void {
+    if (
+      document.languageId !== "ansible" ||
+      !this.settingsManager.settings.wisdomService.enabled
+    ) {
+      return;
+    }
+    const inputData: FeedbackRequestParams = {
+      ansibleContent: {
+        content: document.getText(),
+        documentUri: document.uri.toString(),
+        trigger: trigger,
+      },
+    };
+    console.log("Sending ansible content feedback event: ", inputData);
+    this.apiInstance.feedbackRequest(inputData);
+  }
+
+  public async wisdomStatusBarClickHandler() {
+    // show an information message feedback buttons
+    const contactButton = `Contact Us`;
+    const feedbackButton = "Take Survey";
+    const inputButton = await vscode.window.showInformationMessage(
+      "Ansible wisdom feedback",
+      //{ modal: true },
+      feedbackButton,
+      contactButton
+    );
+    if (inputButton === feedbackButton) {
+      // open a URL in the default browser
+      vscode.env.openExternal(vscode.Uri.parse(WISDOM_FEEDBACK_FORM_URL));
+    } else if (inputButton === contactButton) {
+      // open the user's default email client
+      const mailtoUrl = encodeURI(`mailto:${WISDOM_REPORT_EMAIL_ADDRESS}`);
+      vscode.env.openExternal(vscode.Uri.parse(mailtoUrl));
+    }
   }
 }

--- a/src/features/wisdom/inlineSuggestions.ts
+++ b/src/features/wisdom/inlineSuggestions.ts
@@ -1,20 +1,17 @@
 import * as vscode from "vscode";
-import { window } from "vscode";
 
 import { v4 as uuidv4 } from "uuid";
 
-import {
-  convertToSnippetString,
-  removePromptFromSuggestion,
-} from "../utils/wisdom";
+import { adjustInlineSuggestionIndent } from "../utils/wisdom";
 import { getCurrentUTCDateTime } from "../utils/dateTime";
 import { wisdomManager } from "../../extension";
 import { WisdomCommands } from "../../definitions/constants";
 import { resetKeyInput, getKeyInput } from "../../utils/keyInputUtils";
 import {
-  SuggestionResult,
-  WisdomTelemetryEvent,
-  RequestParams,
+  CompletionResponseParams,
+  InlineSuggestionEvent,
+  CompletionRequestParams,
+  UserAction,
 } from "../../definitions/wisdom";
 
 let suggestionId = "";
@@ -22,31 +19,43 @@ let currentSuggestion = "";
 const taskRegexEp =
   /(?<blank>\s*)(?<list>-\s*name\s*:\s*)(?<description>.*)(?<end>$)/;
 
-let telemetryData: WisdomTelemetryEvent = {};
-export function inlineSuggestionProvider(): vscode.InlineCompletionItemProvider {
-  const provider: vscode.InlineCompletionItemProvider = {
-    provideInlineCompletionItems: async (
-      document,
-      position,
-      context,
-      token
-    ) => {
-      if (token.isCancellationRequested) {
-        return [];
-      }
-      const keyInput = getKeyInput();
-      if (keyInput !== "enter") {
-        return [];
-      }
-      resetKeyInput();
-      if (window.activeTextEditor?.document.languageId !== "ansible") {
-        wisdomManager.wisdomStatusBar.hide();
-        return [];
-      }
-      return getInlineSuggestionItems(document, position);
-    },
-  };
-  return provider;
+let inlineSuggestionData: InlineSuggestionEvent = {};
+let inlineSuggestionDisplayed = false;
+let inlineSuggestionDisplayTime: Date;
+
+export class WisdomInlineSuggestionProvider
+  implements vscode.InlineCompletionItemProvider
+{
+  provideInlineCompletionItems(
+    document: vscode.TextDocument,
+    position: vscode.Position,
+    context: vscode.InlineCompletionContext,
+    token: vscode.CancellationToken
+  ): vscode.ProviderResult<vscode.InlineCompletionItem[]> {
+    if (token.isCancellationRequested) {
+      return [];
+    }
+    // If users continue to without pressing configured keystroes to
+    // either accept or reject the suggestion, we will consider it as ignored.
+    if (inlineSuggestionDisplayed) {
+      vscode.commands.executeCommand(WisdomCommands.WISDOM_SUGGESTION_HIDE);
+      inlineSuggestionDisplayed = false;
+    }
+    const keyInput = getKeyInput();
+    if (keyInput !== "enter") {
+      return [];
+    }
+    resetKeyInput();
+    // reset the feedback data
+    inlineSuggestionData = {};
+    if (vscode.window.activeTextEditor?.document.languageId !== "ansible") {
+      wisdomManager.wisdomStatusBar.hide();
+      return [];
+    }
+    inlineSuggestionDisplayed = true;
+    inlineSuggestionDisplayTime = getCurrentUTCDateTime();
+    return getInlineSuggestionItems(document, position);
+  }
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -104,29 +113,26 @@ async function getInlineSuggestionItems(
 }
 export async function requestInlineSuggest(
   documentContent: string
-): Promise<SuggestionResult> {
+): Promise<CompletionResponseParams> {
   wisdomManager.wisdomStatusBar.tooltip = "processing...";
   const result = await getInlineSuggestion(documentContent);
   wisdomManager.wisdomStatusBar.tooltip = "Done";
   return result;
 }
-async function getInlineSuggestion(content: string): Promise<SuggestionResult> {
-  const inputData: RequestParams = {
+async function getInlineSuggestion(
+  content: string
+): Promise<CompletionResponseParams> {
+  const completionData: CompletionRequestParams = {
     prompt: content,
-    userId: await (
-      await wisdomManager.telemetry.redhatService.getIdManager()
-    ).getRedHatUUID(),
     suggestionId: suggestionId,
   };
   console.log(
     `${getCurrentUTCDateTime().toISOString()}: request data to wisdom service:\n${JSON.stringify(
-      inputData
+      completionData
     )}`
   );
-  const outputData: SuggestionResult = await wisdomManager.apiInstance.postData(
-    "/completions/",
-    inputData
-  );
+  const outputData: CompletionResponseParams =
+    await wisdomManager.apiInstance.completionRequest(completionData);
   console.log(
     `${getCurrentUTCDateTime().toISOString()}: response data from wisdom service:\n${JSON.stringify(
       outputData
@@ -139,60 +145,45 @@ async function getInlineSuggestions(
   document: vscode.TextDocument,
   currentPosition: vscode.Position
 ): Promise<vscode.InlineCompletionItem[]> {
-  let result: SuggestionResult = {
+  let result: CompletionResponseParams = {
     predictions: [],
   };
-  telemetryData = {};
+  inlineSuggestionData = {};
+  suggestionId = "";
   const requestTime = getCurrentUTCDateTime();
-  telemetryData["requestDateTime"] = requestTime.toISOString();
   try {
     suggestionId = uuidv4();
-    telemetryData["suggestionId"] = suggestionId;
-    telemetryData["documentUri"] = document.uri.toString();
+    inlineSuggestionData["suggestionId"] = suggestionId;
+    inlineSuggestionData["documentUri"] = document.uri.toString();
     const range = new vscode.Range(new vscode.Position(0, 0), currentPosition);
 
     const documentContent = range.isEmpty ? "" : document.getText(range).trim();
-    telemetryData["request"] = {
-      prompt: documentContent,
-    };
 
     wisdomManager.wisdomStatusBar.text = "Processing...";
     result = await requestInlineSuggest(documentContent);
     wisdomManager.wisdomStatusBar.text = "Wisdom";
   } catch (error) {
     console.error(error);
-    telemetryData["error"] = `${error}`;
+    inlineSuggestionData["error"] = `${error}`;
     vscode.window.showErrorMessage(`Error in inline suggestions: ${error}`);
     return [];
   } finally {
     wisdomManager.wisdomStatusBar.text = "Wisdom";
   }
 
-  telemetryData["response"] = result;
   const responseTime = getCurrentUTCDateTime();
-  telemetryData["responseDateTime"] = responseTime.toISOString();
-  telemetryData["duration"] = responseTime.getTime() - requestTime.getTime();
-  wisdomManager.telemetry.sendTelemetry(
-    "wisdomInlineSuggestionTriggerEvent",
-    telemetryData
-  );
-  // Note: Do not reset suggestionId here as it is used to track user action
-  //       and will be rest in the user action handlers.
-  // reset telemetry data
-  telemetryData = {};
+  inlineSuggestionData["latency"] =
+    responseTime.getTime() - requestTime.getTime();
+
   const inlineSuggestionUserActionItems: vscode.InlineCompletionItem[] = [];
   const insertTexts: string[] = [];
   if (result && result.predictions.length > 0) {
     result.predictions.forEach((prediction) => {
       let insertText = prediction;
-      insertText = removePromptFromSuggestion(prediction, currentPosition);
+      insertText = adjustInlineSuggestionIndent(prediction, currentPosition);
       insertTexts.push(insertText);
 
-      // completion item is converted from PLAIN-TEXT to SNIPPET-STRING
-      // in order to support tab-stops for automatically placing and switching cursor positions
-      const inlineSuggestionItem = new vscode.InlineCompletionItem(
-        new vscode.SnippetString(convertToSnippetString(insertText))
-      );
+      const inlineSuggestionItem = new vscode.InlineCompletionItem(insertText);
       inlineSuggestionUserActionItems.push(inlineSuggestionItem);
     });
     // currently we only support one inline suggestion
@@ -210,7 +201,7 @@ export async function inlineSuggestionCommitHandler(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   edit: vscode.TextEditorEdit
 ) {
-  if (window.activeTextEditor?.document.languageId !== "ansible") {
+  if (vscode.window.activeTextEditor?.document.languageId !== "ansible") {
     return [];
   }
   console.log("inlineSuggestionCommitHandler triggered");
@@ -218,11 +209,10 @@ export async function inlineSuggestionCommitHandler(
   if (!editor) {
     return;
   }
-
   // Commit the suggestion
-  vscode.commands.executeCommand(WisdomCommands.WISDOM_SUGGESTION_COMMIT);
+  vscode.commands.executeCommand("editor.action.inlineSuggest.commit");
 
-  // Send telemetry for accepted suggestion
+  // Send feedback for accepted suggestion
   await inlineSuggestionUserActionHandler(suggestionId, true);
 }
 
@@ -232,13 +222,14 @@ export async function inlineSuggestionHideHandler(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   edit: vscode.TextEditorEdit
 ) {
-  if (window.activeTextEditor?.document.languageId !== "ansible") {
+  console.log("inlineSuggestionHideHandler triggered");
+  if (vscode.window.activeTextEditor?.document.languageId !== "ansible") {
     return [];
   }
-  console.log("inlineSuggestionHideHandler triggered");
-  vscode.commands.executeCommand(WisdomCommands.WISDOM_SUGGESTION_HIDE);
 
-  // Send telemetry for accepted suggestion
+  vscode.commands.executeCommand("editor.action.inlineSuggest.hide");
+
+  // Send feedback for accepted suggestion
   await inlineSuggestionUserActionHandler(suggestionId, false);
 }
 export async function inlineSuggestionUserActionHandler(
@@ -246,21 +237,27 @@ export async function inlineSuggestionUserActionHandler(
   isSuggestionAccepted = false
 ) {
   console.log(`User gave feedback on suggestion with ID: ${suggestionId}`);
-  telemetryData = {};
+  inlineSuggestionData["userActionTime"] =
+    getCurrentUTCDateTime().getTime() - inlineSuggestionDisplayTime.getTime();
+
+  // since user has either accepted or ignored the suggestion
+  // inline suggestion is no longer displayed and we can reset the
+  // the flag here
+  inlineSuggestionDisplayed = false;
   if (isSuggestionAccepted) {
-    telemetryData["userAction"] = "accept";
+    inlineSuggestionData["action"] = UserAction.ACCEPT;
   } else {
-    telemetryData["userAction"] = "ignore";
+    inlineSuggestionData["action"] = UserAction.IGNORE;
   }
-  telemetryData["suggestionId"] = suggestionId;
-  wisdomManager.telemetry.sendTelemetry(
-    "wisdomInlineSuggestionUserActionEvent",
-    telemetryData
-  );
+  inlineSuggestionData["suggestionId"] = suggestionId;
+  const inlineSuggestionFeedbackPayload = {
+    inlineSuggestion: inlineSuggestionData,
+  };
+  wisdomManager.apiInstance.feedbackRequest(inlineSuggestionFeedbackPayload);
   console.debug(
-    `Sent wisdomInlineSuggestionUserActionEvent telemetry event data: ${JSON.stringify(
-      telemetryData
+    `Sent wisdomInlineSuggestionFeedbackEvent data: ${JSON.stringify(
+      inlineSuggestionFeedbackPayload
     )}`
   );
-  telemetryData = {};
+  inlineSuggestionData = {};
 }

--- a/src/features/wisdom/inlineSuggestions.ts
+++ b/src/features/wisdom/inlineSuggestions.ts
@@ -35,7 +35,7 @@ export class WisdomInlineSuggestionProvider
     if (token.isCancellationRequested) {
       return [];
     }
-    // If users continue to without pressing configured keystroes to
+    // If users continue to without pressing configured keys to
     // either accept or reject the suggestion, we will consider it as ignored.
     if (inlineSuggestionDisplayed) {
       vscode.commands.executeCommand(WisdomCommands.WISDOM_SUGGESTION_HIDE);


### PR DESCRIPTION
*  Refactor to use the wisdom service feedback API to collect wisdom data
*  Identify user ignored the suggestion by pressing other keys and send it as feedback data
*  Adjust suggestion ident based on newer contract with wisdom service
*  Add user feedback/survey link and contact button when user clicks on `Wisdom` status bar
*  Send ansibleMetadata event only when the value is changed, previously it was send every time user switched the tabs