### PR TITLE
Add activity tracker id from wisdom user interaction

### DIFF
--- a/src/definitions/wisdom.ts
+++ b/src/definitions/wisdom.ts
@@ -2,9 +2,14 @@ export interface CompletionResponseParams {
   predictions: string[];
 }
 
+export interface MetadataParams {
+  documentUri: string;
+  activityId: string;
+}
 export interface CompletionRequestParams {
   prompt: string;
   suggestionId?: string;
+  metadata?: MetadataParams;
 }
 
 export enum UserAction {
@@ -29,14 +34,20 @@ export interface InlineSuggestionEvent {
   action?: UserAction;
   error?: string;
   suggestionId?: string;
+  activityId?: string;
 }
 
 export interface AnsibleContentEvent {
   content: string;
   documentUri: string;
   trigger: AnsibleContentUploadTrigger;
+  activityId: string | undefined;
 }
 export interface FeedbackRequestParams {
   inlineSuggestion?: InlineSuggestionEvent;
   ansibleContent?: AnsibleContentEvent;
+}
+
+export interface IDocumentTracker {
+  [key: string]: string;
 }

--- a/src/features/wisdom/inlineSuggestions.ts
+++ b/src/features/wisdom/inlineSuggestions.ts
@@ -232,7 +232,7 @@ export async function inlineSuggestionCommitHandler(
   vscode.commands.executeCommand("editor.action.inlineSuggest.commit");
 
   // Send feedback for accepted suggestion
-  await inlineSuggestionUserActionHandler(suggestionId, true);
+  await inlineSuggestionUserActionHandler(document, suggestionId, true);
 }
 
 export async function inlineSuggestionHideHandler(

--- a/src/features/wisdom/inlineSuggestions.ts
+++ b/src/features/wisdom/inlineSuggestions.ts
@@ -232,7 +232,7 @@ export async function inlineSuggestionCommitHandler(
   vscode.commands.executeCommand("editor.action.inlineSuggest.commit");
 
   // Send feedback for accepted suggestion
-  await inlineSuggestionUserActionHandler(document, suggestionId, true);
+  await inlineSuggestionUserActionHandler(suggestionId, true);
 }
 
 export async function inlineSuggestionHideHandler(


### PR DESCRIPTION
*  Add activity id to identify the user interaction within document which will be used to link different feedback events to identify is user accepted, ignored or modified the inline suggestion