### PR TITLE
To fix Ansible wisdom basepath empty url issue 

### DIFF
--- a/src/features/wisdom/wisdomOAuthProvider.ts
+++ b/src/features/wisdom/wisdomOAuthProvider.ts
@@ -194,8 +194,15 @@ export class WisdomAuthenticationProvider
       ["redirect_uri", this.redirectUri],
     ]);
 
+    const base_uri = getBaseUri(this.settingsManager);
+    if (!base_uri) {
+      throw new Error(
+        "Please enter the Ansible Wisdom Base Path under Ansible Wisdom settings!"
+      );
+    }
+
     const uri = Uri.parse(
-      Uri.parse(getBaseUri(this.settingsManager))
+      Uri.parse(base_uri)
         .with({
           path: "/o/authorize/",
           query: searchParams.toString(),


### PR DESCRIPTION
To fix Ansible wisdom basepath empty url issue 