### PR TITLE
Check for valid YAML for wisdom

### DIFF
--- a/src/features/wisdom/inlineSuggestions.ts
+++ b/src/features/wisdom/inlineSuggestions.ts
@@ -12,6 +12,7 @@ import {
   UserAction,
 } from "../../definitions/wisdom";
 import { WisdomCommands } from "../../definitions/constants";
+import { shouldRequestInlineSuggestions } from "./utils/data";
 
 const TASK_REGEX_EP =
   /(?<blank>\s*)(?<list>-\s*name\s*:\s*)(?<description>.*)(?<end>$)/;
@@ -137,6 +138,9 @@ async function getInlineSuggestionItems(
       ? ""
       : document.getText(range).trimEnd();
 
+    if (!shouldRequestInlineSuggestions(documentContent)) {
+      return [];
+    }
     wisdomManager.wisdomStatusBar.text = "$(loading~spin) Wisdom";
     result = await requestInlineSuggest(
       documentContent,

--- a/src/features/wisdom/utils/data.ts
+++ b/src/features/wisdom/utils/data.ts
@@ -9,7 +9,7 @@ export function shouldRequestInlineSuggestions(
     parsedAnsibleDocument = yaml.parse(documentContent, { keepCstNodes: true });
   } catch (err) {
     vscode.window.showErrorMessage(
-      `Project Wisdom expects valid YAML synatax to provide inline suggestions. Error: ${err}`
+      `Project Wisdom expects valid YAML syntax to provide inline suggestions. Error: ${err}`
     );
     return false;
   }

--- a/src/features/wisdom/utils/data.ts
+++ b/src/features/wisdom/utils/data.ts
@@ -1,0 +1,44 @@
+import * as vscode from "vscode";
+import * as yaml from "yaml";
+
+export function shouldRequestInlineSuggestions(
+  documentContent: string
+): boolean {
+  let parsedAnsibledocument = undefined;
+  try {
+    parsedAnsibledocument = yaml.parse(documentContent, { keepCstNodes: true });
+  } catch (err) {
+    vscode.window.showErrorMessage(
+      `Project Wisdom expects valid YAML synatax to provide inline suggestions. Error: ${err}`
+    );
+    return false;
+  }
+  // if the file is empty, we don't want to request inline suggestions
+  if (parsedAnsibledocument === undefined) {
+    return false;
+  }
+
+  // check if YAML is a list, if not it is not a valid Ansible document
+  if (
+    typeof parsedAnsibledocument === "object" &&
+    !Array.isArray(parsedAnsibledocument)
+  ) {
+    return false;
+  }
+
+  const lastObject = parsedAnsibledocument[parsedAnsibledocument.length - 1];
+  if (typeof lastObject !== "object") {
+    return false;
+  }
+  // for the last entry in list check if the inline suggestion
+  // triggered is in Ansible play context by checking for "hosts" keyword.
+  const objectKeys = Object.keys(lastObject);
+  if (
+    objectKeys[objectKeys.length - 1] === "name" &&
+    objectKeys.includes("hosts")
+  ) {
+    return false;
+  }
+
+  return true;
+}

--- a/src/features/wisdom/utils/data.ts
+++ b/src/features/wisdom/utils/data.ts
@@ -4,9 +4,9 @@ import * as yaml from "yaml";
 export function shouldRequestInlineSuggestions(
   documentContent: string
 ): boolean {
-  let parsedAnsibledocument = undefined;
+  let parsedAnsibleDocument = undefined;
   try {
-    parsedAnsibledocument = yaml.parse(documentContent, { keepCstNodes: true });
+    parsedAnsibleDocument = yaml.parse(documentContent, { keepCstNodes: true });
   } catch (err) {
     vscode.window.showErrorMessage(
       `Project Wisdom expects valid YAML synatax to provide inline suggestions. Error: ${err}`
@@ -14,19 +14,19 @@ export function shouldRequestInlineSuggestions(
     return false;
   }
   // if the file is empty, we don't want to request inline suggestions
-  if (parsedAnsibledocument === undefined) {
+  if (parsedAnsibleDocument === undefined) {
     return false;
   }
 
   // check if YAML is a list, if not it is not a valid Ansible document
   if (
-    typeof parsedAnsibledocument === "object" &&
-    !Array.isArray(parsedAnsibledocument)
+    typeof parsedAnsibleDocument === "object" &&
+    !Array.isArray(parsedAnsibleDocument)
   ) {
     return false;
   }
 
-  const lastObject = parsedAnsibledocument[parsedAnsibledocument.length - 1];
+  const lastObject = parsedAnsibleDocument[parsedAnsibleDocument.length - 1];
   if (typeof lastObject !== "object") {
     return false;
   }


### PR DESCRIPTION
* Parse yaml string to check if it is a valid YAML and add it as a check to trigger inline suggestion
* Add logic to check is cursor is in play context to avoid sending inline suggestion request