### PR TITLE
Fix indent issue for one line suggestion

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -80,7 +80,7 @@ repos:
             yarn.lock
           )$
   - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.30.0
+    rev: v1.31.0
     hooks:
       - id: yamllint
         files: \.(yaml|yml)$
@@ -103,7 +103,7 @@ repos:
           )$
   - repo: https://github.com/pre-commit/mirrors-prettier
     # keep it before markdownlint and eslint
-    rev: "v3.0.0-alpha.6"
+    rev: "v3.0.0-alpha.9-for-vscode"
     hooks:
       - id: prettier
         types_or: ["markdown", "json", "ts"]
@@ -122,7 +122,7 @@ repos:
       - id: commitlint
         stages: [commit-msg]
   - repo: https://github.com/pre-commit/mirrors-eslint
-    rev: v8.38.0
+    rev: v8.39.0
     hooks:
       - id: eslint
         args:

--- a/src/features/utils/lightspeed.ts
+++ b/src/features/utils/lightspeed.ts
@@ -12,7 +12,7 @@ export function adjustInlineSuggestionIndent(
 
   let newSuggestion = suggestion;
   // adjust the spaces in suggestion line with respect to cursor position
-  if (spacesBeforeCursor > 0 && lines.length > 1) {
+  if (spacesBeforeCursor > 0 && lines.length > 0) {
     newSuggestion = lines
       .map((line, index) => {
         // BOUNDARY: shouldn't extend into the string


### PR DESCRIPTION
Fix indent for one line inline suggestion.
Before:
```
---
- name: Ansible AI
  hosts: all
  tasks:
    - name: Test connection
          ansible.builtin.ping:
```

After:
```
---
- name: Ansible AI
  hosts: all
  tasks:
    - name: Test connection
      ansible.builtin.ping:
```