### PR TITLE
Add logic for conditional Authentication Provider registration

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -254,13 +254,13 @@ export async function activate(context: ExtensionContext): Promise<void> {
       )
   );
 
-  const session = await authentication.getSession(
-    ANSIBLE_LIGHTSPEED_AUTH_ID,
-    [],
-    {
+  let session: vscode.AuthenticationSession | undefined;
+
+  if (await workspace.getConfiguration("ansible").get("lightspeed.enabled")) {
+    session = await authentication.getSession(ANSIBLE_LIGHTSPEED_AUTH_ID, [], {
       createIfNone: false,
-    }
-  );
+    });
+  }
 
   if (session) {
     window.registerTreeDataProvider(
@@ -387,6 +387,15 @@ async function resyncAnsibleInventory(): Promise<void> {
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 async function getAuthToken(): Promise<void> {
+  if (
+    !(await workspace.getConfiguration("ansible").get("lightspeed.enabled"))
+  ) {
+    await window.showErrorMessage(
+      "Enable lightspeed services from settings to use the feature."
+    );
+    return;
+  }
+
   const session = await authentication.getSession(
     ANSIBLE_LIGHTSPEED_AUTH_ID,
     [],

--- a/src/features/lightspeed/base.ts
+++ b/src/features/lightspeed/base.ts
@@ -51,6 +51,7 @@ export class LightSpeedManager {
         ANSIBLE_LIGHTSPEED_AUTH_ID,
         ANSIBLE_LIGHTSPEED_AUTH_NAME
       );
+    this.lightSpeedAuthenticationProvider.initialize();
     this.apiInstance = new LightSpeedAPI(
       this.settingsManager,
       this.lightSpeedAuthenticationProvider
@@ -67,7 +68,19 @@ export class LightSpeedManager {
     this.updateLightSpeedStatusbar();
   }
 
-  public reInitialize(): void {
+  public async reInitialize(): Promise<void> {
+    const lightspeedEnabled = await vscode.workspace
+      .getConfiguration("ansible")
+      .get("lightspeed.enabled");
+
+    if (!lightspeedEnabled) {
+      await this.lightSpeedAuthenticationProvider.dispose();
+      this.lightSpeedStatusBar.hide();
+      return;
+    } else {
+      this.lightSpeedAuthenticationProvider.initialize();
+    }
+
     this.updateLightSpeedStatusbar();
   }
 

--- a/src/features/lightspeed/lightSpeedOAuthProvider.ts
+++ b/src/features/lightspeed/lightSpeedOAuthProvider.ts
@@ -49,7 +49,7 @@ export class LightSpeedAuthenticationProvider
   public settingsManager: SettingsManager;
   private _sessionChangeEmitter =
     new EventEmitter<AuthenticationProviderAuthenticationSessionsChangeEvent>();
-  private _disposable: Disposable;
+  private _disposable: Disposable | undefined;
   private _uriHandler = new UriEventHandler();
   private _authId: string;
   private _authName: string;
@@ -63,6 +63,16 @@ export class LightSpeedAuthenticationProvider
     this.settingsManager = settingsManager;
     this._authId = authId;
     this._authName = authName;
+  }
+
+  public initialize() {
+    if (this._disposable) {
+      console.log(
+        "[ansible-lightspeed-oauth] Auth provider already registered"
+      );
+      return;
+    }
+
     this._disposable = Disposable.from(
       authentication.registerAuthenticationProvider(
         this._authId,
@@ -186,7 +196,18 @@ export class LightSpeedAuthenticationProvider
    * Dispose the registered services
    */
   public async dispose() {
-    this._disposable.dispose();
+    if (this._disposable) {
+      const account = await this.isAuthenticated();
+
+      if (account) {
+        const sessionId = account.id;
+        this.removeSession(sessionId);
+      }
+
+      console.log("[ansible-lightspeed-oauth] Disposing auth provider");
+      await this._disposable.dispose();
+      this._disposable = undefined;
+    }
   }
 
   /* Log in to the Ansible Lightspeed auth service */

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -10,7 +10,7 @@ export async function updateConfigurationChanges(
   lightSpeedManager: LightSpeedManager
 ): Promise<void> {
   await metaData.updateAnsibleInfoInStatusbar();
-  lightSpeedManager.reInitialize();
+  await lightSpeedManager.reInitialize();
   await pythonInterpreter.updatePythonInfoInStatusbar();
 
   await extSettings.reinitialize();


### PR DESCRIPTION
The PR handles the case where users won't be able to log in unless they enable lightspeed services from the settings.
This removes the notification from the accounts icon in vscode when the settings are disabled.

Related to: https://github.com/ansible/vscode-ansible/issues/859