### PR TITLE
Add ability to select and set cursor on vars

### DIFF
--- a/src/features/lightspeed/inlineSuggestions.ts
+++ b/src/features/lightspeed/inlineSuggestions.ts
@@ -2,7 +2,10 @@ import * as vscode from "vscode";
 import { v4 as uuidv4 } from "uuid";
 import _ from "lodash";
 
-import { adjustInlineSuggestionIndent } from "../utils/lightspeed";
+import {
+  adjustInlineSuggestionIndent,
+  convertToSnippetString,
+} from "../utils/lightspeed";
 import { getCurrentUTCDateTime } from "../utils/dateTime";
 import { lightSpeedManager } from "../../extension";
 import {
@@ -179,7 +182,14 @@ export async function getInlineSuggestionItems(
     insertText = adjustInlineSuggestionIndent(prediction, currentPosition);
     insertTexts.push(insertText);
 
-    const inlineSuggestionItem = new vscode.InlineCompletionItem(insertText);
+    // convert into snippet string to move cursor on jinja variables directly
+    const insertTextSnippetString = new vscode.SnippetString(
+      convertToSnippetString(insertText)
+    );
+
+    const inlineSuggestionItem = new vscode.InlineCompletionItem(
+      insertTextSnippetString
+    );
     inlineSuggestionUserActionItems.push(inlineSuggestionItem);
   });
   // currentSuggestion is used in user action handlers

--- a/src/features/utils/lightspeed.ts
+++ b/src/features/utils/lightspeed.ts
@@ -36,10 +36,10 @@ export function adjustInlineSuggestionIndent(
 
 /* A utility function to convert plain text to snippet string */
 export function convertToSnippetString(suggestion: string): string {
-  // this regex matches all content inside {{  }}
+  // this regex matches the content inside {{  }} with decided vars, i.e., {{ _var_ }}
   // TODO: once a prefix is decided for using it in from of variable names, the regex
   // can be changed to match it
-  const regex = /(?<=\{\{ ).+?(?= \}\})/gm;
+  const regex = /(?:^|)[^@#\s_]*(_([^_]+)_)/gm;
 
   let counter = 0;
   const convertedSuggestion = suggestion.replace(regex, (item) => {


### PR DESCRIPTION
The PR finds the vars inside jinja inline brackets with _`_var_`_ pattern (returned from the lightspeed service), highlights, and sets the cursor on them.