### PR TITLE
Update inline suggestion trigger condition

### DIFF
--- a/src/features/lightspeed/inlineSuggestions.ts
+++ b/src/features/lightspeed/inlineSuggestions.ts
@@ -99,10 +99,18 @@ export class LightSpeedInlineSuggestionProvider
     }
     const lineToExtractPrompt = document.lineAt(position.line - 1);
     const taskMatchedPattern = lineToExtractPrompt.text.match(TASK_REGEX_EP);
-
     const currentLineText = document.lineAt(position);
+    const spacesBeforeTaskNameStart =
+      lineToExtractPrompt?.text.match(/^ +/)?.[0].length || 0;
+    const spacesBeforeCursor =
+      currentLineText?.text.slice(0, position.character).match(/^ +/)?.[0]
+        .length || 0;
 
-    if (!taskMatchedPattern || !currentLineText.isEmptyOrWhitespace) {
+    if (
+      !taskMatchedPattern ||
+      !currentLineText.isEmptyOrWhitespace ||
+      spacesBeforeTaskNameStart !== spacesBeforeCursor
+    ) {
       resetInlineSuggestionDisplayed();
       return [];
     }

--- a/test/helper.ts
+++ b/test/helper.ts
@@ -17,7 +17,7 @@ export const ANSIBLE_COLLECTIONS_FIXTURES_BASE_PATH = path.resolve(
   "common",
   "collections"
 );
-const LIGHTSPEED_INLINE_SUGGESTION_WAIT_TIME = 15000;
+const LIGHTSPEED_INLINE_SUGGESTION_WAIT_TIME = 10000;
 const LIGHTSPEED_INLINE_SUGGESTION_AFTER_COMMIT_WAIT_TIME = 2000;
 /**
  * Activates the redhat.ansible extension
@@ -230,7 +230,7 @@ export async function testInlineSuggestion(
   prompt: string,
   expectedModule: string
 ): Promise<void> {
-  const editor = vscode.window.activeTextEditor;
+  let editor = vscode.window.activeTextEditor;
 
   if (!editor) {
     throw new Error("No active editor found");
@@ -253,6 +253,21 @@ export async function testInlineSuggestion(
     to: "nextBlankLine",
   });
 
+  editor = vscode.window.activeTextEditor;
+  if (editor) {
+    const currentPosition = editor.selection.active;
+    const newLine = currentPosition.line + 1;
+    const newColumn = currentPosition.character + 4;
+
+    const newPosition = new vscode.Position(newLine, newColumn);
+
+    await editor.edit((editBuilder) => {
+      editBuilder.insert(newPosition, "    ");
+    });
+
+    editor.selection = new vscode.Selection(newPosition, newPosition);
+    editor.revealRange(new vscode.Range(newPosition, newPosition));
+  }
   await vscode.commands.executeCommand(
     LightSpeedCommands.LIGHTSPEED_SUGGESTION_TRIGGER
   );
@@ -299,10 +314,88 @@ export async function testInlineSuggestionNotTriggered(
   await vscode.commands.executeCommand("cursorMove", {
     to: "nextBlankLine",
   });
+  const currentPosition = editor.selection.active;
+  const newLine = currentPosition.line + 1;
+  const newColumn = currentPosition.character + 4;
+
+  const newPosition = new vscode.Position(newLine, newColumn);
+
+  await editor.edit((editBuilder) => {
+    editBuilder.insert(newPosition, "    ");
+  });
+
+  editor.selection = new vscode.Selection(newPosition, newPosition);
+  editor.revealRange(new vscode.Range(newPosition, newPosition));
+  await vscode.commands.executeCommand(
+    LightSpeedCommands.LIGHTSPEED_SUGGESTION_TRIGGER
+  );
+  await sleep(LIGHTSPEED_INLINE_SUGGESTION_WAIT_TIME);
+  await vscode.commands.executeCommand(
+    LightSpeedCommands.LIGHTSPEED_SUGGESTION_COMMIT
+  );
+  await sleep(LIGHTSPEED_INLINE_SUGGESTION_AFTER_COMMIT_WAIT_TIME);
+
+  // get the committed suggestion
+  const suggestionRange = new vscode.Range(
+    new vscode.Position(writePosition.line + 1, writePosition.character),
+    new vscode.Position(integer.MAX_VALUE, integer.MAX_VALUE)
+  );
+
+  const docContentAfterSuggestion = doc.getText(suggestionRange).trim();
+
+  // assert
+
+  assert.include(docContentAfterSuggestion, "");
+  assert.isFalse(
+    getInlineSuggestionItemsSpy.called,
+    "getInlineSuggestionItems should not be called"
+  );
+}
+
+export async function testInlineSuggestionCursorPositions(
+  prompt: string,
+  newLineSpaces: number
+): Promise<void> {
+  const editor = vscode.window.activeTextEditor;
+
+  if (!editor) {
+    throw new Error("No active editor found");
+  }
+  const getInlineSuggestionItemsSpy = sinon.spy(getInlineSuggestionItems);
+  // this is the position where we have placeholder for the task name in the test fixture
+  // i.e., <insert task name for ansible lightspeed suggestion here>
+  const writePosition = new vscode.Position(4, 4);
+
+  // replace the placeholder with task name for suggestions
+  await editor.edit(async (edit) => {
+    const replaceRange = new vscode.Range(
+      writePosition,
+      new vscode.Position(integer.MAX_VALUE, integer.MAX_VALUE)
+    );
+    edit.replace(replaceRange, `${prompt}\n`);
+  });
+
+  await vscode.commands.executeCommand("cursorMove", {
+    to: "nextBlankLine",
+  });
+  const newLineText = " ".repeat(newLineSpaces);
+  const currentPosition = editor.selection.active;
+  const newLine = currentPosition.line + 1;
+  const newColumn = currentPosition.character + newLineSpaces;
+
+  const newPosition = new vscode.Position(newLine, newColumn);
+
+  await editor.edit((editBuilder) => {
+    editBuilder.insert(newPosition, newLineText);
+  });
+
+  editor.selection = new vscode.Selection(newPosition, newPosition);
+  editor.revealRange(new vscode.Range(newPosition, newPosition));
 
   await vscode.commands.executeCommand(
     LightSpeedCommands.LIGHTSPEED_SUGGESTION_TRIGGER
   );
+
   await sleep(LIGHTSPEED_INLINE_SUGGESTION_WAIT_TIME);
   await vscode.commands.executeCommand(
     LightSpeedCommands.LIGHTSPEED_SUGGESTION_COMMIT

--- a/test/testScripts/lightspeed/testLightspeed.test.ts
+++ b/test/testScripts/lightspeed/testLightspeed.test.ts
@@ -7,6 +7,7 @@ import {
   disableLightspeedSettings,
   canRunLightspeedTests,
   testInlineSuggestionNotTriggered,
+  testInlineSuggestionCursorPositions,
 } from "../../helper";
 
 function testSuggestionPrompts() {
@@ -30,6 +31,20 @@ function testInvalidPrompts() {
     "--name: Print hello world",
     "- -name: Print hello world",
     "-- name: Print hello world",
+  ];
+  return tests;
+}
+
+function testInvalidCursorPosition() {
+  const tests = [
+    {
+      taskName: "- name: Print hello world 1",
+      newLineSpaces: 2,
+    },
+    {
+      taskName: "- name: Print hello world 2",
+      newLineSpaces: 6,
+    },
   ];
   return tests;
 }
@@ -81,9 +96,19 @@ export function testLightspeed(): void {
           await testInlineSuggestionNotTriggered(promptName);
         });
       });
-    });
-    after(async function () {
-      disableLightspeedSettings();
+
+      const invalidCursorPosTest = testInvalidCursorPosition();
+      invalidCursorPosTest.forEach(({ taskName, newLineSpaces }) => {
+        it(`Should not give inline suggestion for task prompt '${taskName}' with new line spaces ${newLineSpaces}`, async function () {
+          await testInlineSuggestionCursorPositions(
+            taskName,
+            newLineSpaces as number
+          );
+        });
+      });
+      after(async function () {
+        disableLightspeedSettings();
+      });
     });
   });
 }


### PR DESCRIPTION
*  Currently inline suggestion is triggered after user hits new line key at end of the task name description. So on every space/tab a lightspeed request is triggered which is not expected.
*  With this fix the request will be triggered only when the number of spaces before cursor position on new line is equal to the number of spaces before `-` in the previous line (task name description).