### PR TITLE
Update status-bar items

### DIFF
--- a/package.json
+++ b/package.json
@@ -606,7 +606,7 @@
     "@redhat-developer/vscode-redhat-telemetry": "^0.5.4",
     "@types/ini": "^1.3.31",
     "axios": "^1.3.4",
-    "ini": "^4.1.0",
+    "ini": "^4.0.0",
     "untildify": "^4.0.0",
     "uuid": "^9.0.0",
     "vscode-languageclient": "^8.1.0",

--- a/src/features/ansibleMetaData.ts
+++ b/src/features/ansibleMetaData.ts
@@ -132,7 +132,7 @@ export class MetadataManager {
           }
         } else {
           console.log("Ansible not found in the workspace");
-          this.metadataStatusBarItem.text = "$(error) Ansible Info";
+          this.metadataStatusBarItem.text = "$(error) Ansible";
           this.metadataStatusBarItem.tooltip = ansibleMetaData.markdown;
           this.metadataStatusBarItem.backgroundColor = new ThemeColor(
             "statusBarItem.errorBackground"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1382,7 +1382,7 @@ __metadata:
     eslint-plugin-prettier: ^4.2.1
     eslint-plugin-tsdoc: ^0.2.17
     glob: ^9.3.5
-    ini: ^4.1.0
+    ini: ^4.0.0
     mocha: ^10.2.0
     mochawesome: ^7.1.3
     mochawesome-report-generator: ^6.2.0
@@ -3571,10 +3571,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ini@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "ini@npm:4.1.0"
-  checksum: 12fc7c1f0a048e37398928f32513b494012b11fcec43fc3ef687445b29d959c548abef6d911686e507199c17c366c5bce7bedf02c3fc32912a71737b8291f6c5
+"ini@npm:^4.0.0":
+  version: 4.1.1
+  resolution: "ini@npm:4.1.1"
+  checksum: 0e5909554074fbc31824fa5415b0f604de4a665514c96a897a77bf77353a7ad4743927321270e9d0610a9d510ccd1f3cd77422f7cc80d8f4542dbce75476fb6d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The PR updates the status-bar items in the extension with the following changes:
1. ansible metadata: removes the `info` keyword from the label shown when ansible is not found in the environment to make it more compact.
2. python metadata: 
	- Removes redundant Python version number inside parenthesis when the Python interpreter does not belong to any virtual environment.
	- Adds current Python path info on hovering over the status-bar item.

Updated look:
![Screenshot-20230516184110-818x202](https://github.com/ansible/vscode-ansible/assets/42550351/802ae4f3-7a5c-4ea9-9708-3d51fb4b12d6)
