### PR TITLE
Add support for tox-ansible plugin test discovery

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -102,6 +102,8 @@ stopendy
 suboptions
 sysninja
 taskfile
+Testenvs
+testenv
 testhost
 testorg
 timonwong

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "onCommand:extension.ansible.vault",
     "onLanguage:ansible",
     "onLanguage:yaml",
-    "onCommand:extension.resync-ansible-inventory"
+    "onCommand:extension.resync-ansible-inventory",
+    "workspaceContains:tox-ansible.ini"
   ],
   "badges": [
     {
@@ -598,6 +599,17 @@
         "injectTo": [
           "source.ansible"
         ]
+      }
+    ],
+    "taskDefinitions": [
+      {
+        "type": "Ansible Tox",
+        "properties": {
+          "ansible": {
+            "type": "string",
+            "description": "The testenv to execute"
+          }
+        }
       }
     ]
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -55,6 +55,9 @@ import {
   setPythonInterpreterWithCommand,
 } from "./features/utils/setPythonInterpreter";
 import { PythonInterpreterManager } from "./features/pythonMetadata";
+import { AnsibleToxController } from "./features/ansibleTox/controller";
+import { AnsibleToxProvider } from "./features/ansibleTox/provider";
+import { findProjectDir } from "./features/ansibleTox/utils";
 
 export let client: LanguageClient;
 export let lightSpeedManager: LightSpeedManager;
@@ -266,6 +269,22 @@ export async function activate(context: ExtensionContext): Promise<void> {
     window.registerTreeDataProvider(
       "lightspeed-explorer-treeview",
       new TreeDataProvider(session)
+    );
+  }
+
+  // handle Ansible Tox
+  const ansibleToxController = new AnsibleToxController();
+  context.subscriptions.push(await ansibleToxController.create());
+
+  const workspaceTox = findProjectDir();
+
+  if (workspaceTox) {
+    const testProvider = new AnsibleToxProvider(workspaceTox);
+    context.subscriptions.push(
+      vscode.tasks.registerTaskProvider(
+        AnsibleToxProvider.toxType,
+        testProvider
+      )
     );
   }
 }

--- a/src/features/ansibleTox/constants.ts
+++ b/src/features/ansibleTox/constants.ts
@@ -1,0 +1,6 @@
+export const TOX_TYPE = "Ansible Tox";
+export const ANSIBLE_TOX_FILE_NAME = "tox-ansible.ini";
+export const ANSIBLE_TOX_LIST_ENV_COMMAND =
+  "tox -l --ansible --conf tox-ansible.ini";
+
+export const ANSIBLE_TOX_RUN_COMMAND = "tox -e";

--- a/src/features/ansibleTox/controller.ts
+++ b/src/features/ansibleTox/controller.ts
@@ -1,0 +1,213 @@
+/* Inspired by https://github.com/The-Compiler/vscode-python-tox */
+
+import * as vscode from "vscode";
+import * as path from "path";
+import * as util from "util";
+import { runTox, getToxEnvs } from "./runner";
+import { getTerminal, getRootParentLabelDesc } from "./utils";
+import { ANSIBLE_TOX_FILE_NAME } from "./constants";
+
+export class AnsibleToxController {
+  public controller: vscode.TestController;
+
+  constructor() {
+    this.controller = vscode.tests.createTestController(
+      "ansibleToxController",
+      "Ansible Tox"
+    );
+  }
+
+  public create() {
+    this.controller.resolveHandler = async (test) => {
+      if (!test) {
+        await this.discoverAllFilesInWorkspace();
+      } else {
+        await this.parseTestsInFileContents(test);
+      }
+    };
+    this.controller.createRunProfile(
+      "Ansible Tox",
+      vscode.TestRunProfileKind.Run,
+      (request, token) => {
+        this.runHandler(request, token);
+      }
+    );
+    this.controller.refreshHandler = async () => {
+      await this.discoverAllFilesInWorkspace();
+    };
+    // Check all existing documents
+    for (const document of vscode.workspace.textDocuments) {
+      this.parseTestsInAnsibleToxFile(document);
+    }
+
+    // Check for tox.ini files when a new document is opened or saved.
+    vscode.workspace.onDidOpenTextDocument(this.parseTestsInAnsibleToxFile);
+    vscode.workspace.onDidSaveTextDocument(this.parseTestsInAnsibleToxFile);
+
+    return this.controller;
+  }
+
+  async discoverAllFilesInWorkspace() {
+    if (!vscode.workspace.workspaceFolders) {
+      return [];
+    }
+    const watchers: vscode.FileSystemWatcher[] = [];
+
+    for (const workspaceFolder of vscode.workspace.workspaceFolders) {
+      const pattern = new vscode.RelativePattern(
+        workspaceFolder,
+        ANSIBLE_TOX_FILE_NAME
+      );
+      const watcher = vscode.workspace.createFileSystemWatcher(pattern);
+      watcher.onDidCreate((uri) => this.getOrCreateFile(uri));
+      watcher.onDidChange((uri) =>
+        this.parseTestsInFileContents(this.getOrCreateFile(uri))
+      );
+      watcher.onDidDelete((uri) =>
+        this.controller.items.delete(uri.toString())
+      );
+      const files = await vscode.workspace.findFiles(pattern);
+      files.forEach(this.getOrCreateFile);
+      watchers.push(watcher);
+    }
+    return watchers;
+  }
+
+  private getOrCreateFile(uri: vscode.Uri): vscode.TestItem {
+    const existing = this.controller.items.get(uri.toString());
+    if (existing) {
+      return existing;
+    }
+
+    const splittedPath = uri.path.split("/");
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const fileName = splittedPath.pop()!;
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const parentFolderName = splittedPath.pop()!;
+
+    const file = this.controller.createTestItem(uri.toString(), fileName, uri);
+    file.description = `(${parentFolderName})`;
+    this.controller.items.add(file);
+
+    file.canResolveChildren = true;
+    return file;
+  }
+
+  async parseTestsInFileContents(
+    file: vscode.TestItem,
+    contents?: string
+  ): Promise<vscode.TestItem[]> {
+    if (file.uri === undefined) {
+      return [];
+    }
+    if (contents === undefined) {
+      const rawContent = await vscode.workspace.fs.readFile(file.uri);
+      contents = new util.TextDecoder().decode(rawContent);
+    }
+
+    const listOfChildren: vscode.TestItem[] = [];
+    const testRegex = /^(\[ansible):(.*)\]/gm;
+    const lines = contents.split("\n");
+
+    const toxTests = await getToxEnvs(path.dirname(file.uri.path));
+
+    if (toxTests) {
+      for (let lineNo = 0; lineNo < lines.length; lineNo++) {
+        const line = lines[lineNo];
+        const regexResult = testRegex.exec(line);
+        if (!regexResult) {
+          continue;
+        }
+
+        const envName = regexResult[2];
+        if (envName.includes("{")) {
+          continue;
+        }
+
+        for (let testNo = 0; testNo < toxTests.length; testNo++) {
+          const toxTest = toxTests[testNo];
+
+          if (toxTest === envName) {
+            const newTestItem = this.controller.createTestItem(
+              envName,
+              envName,
+              file.uri
+            );
+            newTestItem.range = new vscode.Range(
+              new vscode.Position(lineNo, 0),
+              new vscode.Position(lineNo, regexResult[0].length)
+            );
+            listOfChildren.push(newTestItem);
+            toxTests.splice(testNo, 1);
+            break;
+          }
+        }
+      }
+
+      for (const toxTest of toxTests) {
+        const newTestItem = this.controller.createTestItem(
+          toxTest,
+          toxTest,
+          file.uri
+        );
+        newTestItem.range = new vscode.Range(
+          new vscode.Position(0, 0),
+          new vscode.Position(0, 0)
+        );
+        listOfChildren.push(newTestItem);
+      }
+    }
+
+    return listOfChildren;
+  }
+
+  async parseTestsInAnsibleToxFile(
+    document: vscode.TextDocument,
+    filename: string = ANSIBLE_TOX_FILE_NAME
+  ) {
+    if (
+      document.uri.scheme === "file" &&
+      path.basename(document.uri.fsPath) === filename
+    ) {
+      const file = this.getOrCreateFile(document.uri);
+      const content = document.getText();
+
+      const listOfChildren = await this.parseTestsInFileContents(file, content);
+      file.children.replace(listOfChildren);
+    }
+  }
+
+  async runHandler(
+    request: vscode.TestRunRequest,
+    token: vscode.CancellationToken
+  ) {
+    const run = this.controller.createTestRun(request);
+    const queue: vscode.TestItem[] = [...(request.include || [])];
+
+    while (queue.length > 0 && !token.isCancellationRequested) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const test = queue.pop()!;
+
+      if (request.exclude?.includes(test)) {
+        continue;
+      }
+
+      const start = Date.now();
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const cwd = vscode.workspace.getWorkspaceFolder(test.uri!)?.uri.path;
+        runTox(
+          [test.label.split("->")[0].trim()],
+          "",
+          getTerminal(cwd, getRootParentLabelDesc(test))
+        );
+        run.passed(test, Date.now() - start);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } catch (e: any) {
+        run.failed(test, new vscode.TestMessage(e.message), Date.now() - start);
+      }
+    }
+
+    run.end();
+  }
+}

--- a/src/features/ansibleTox/provider.ts
+++ b/src/features/ansibleTox/provider.ts
@@ -1,0 +1,119 @@
+/* Inspired by https://github.com/The-Compiler/vscode-python-tox */
+
+import * as path from "path";
+import * as fs_promises from "fs/promises";
+import * as fs from "fs";
+import * as vscode from "vscode";
+import { getToxEnvs } from "./runner";
+import {
+  ANSIBLE_TOX_FILE_NAME,
+  ANSIBLE_TOX_RUN_COMMAND,
+  TOX_TYPE,
+} from "./constants";
+
+export class AnsibleToxProvider implements vscode.TaskProvider {
+  static readonly toxType = TOX_TYPE;
+  static readonly ansibleToxIni = ANSIBLE_TOX_FILE_NAME;
+  private toxPromise: Thenable<vscode.Task[]> | undefined = undefined;
+
+  constructor(workspaceRoot: string) {
+    const pattern = path.join(workspaceRoot, AnsibleToxProvider.ansibleToxIni);
+    const fileWatcher = vscode.workspace.createFileSystemWatcher(pattern);
+    fileWatcher.onDidChange(() => (this.toxPromise = undefined));
+    fileWatcher.onDidCreate(() => (this.toxPromise = undefined));
+    fileWatcher.onDidDelete(() => (this.toxPromise = undefined));
+  }
+
+  public provideTasks(): Thenable<vscode.Task[]> | undefined {
+    if (!this.toxPromise) {
+      this.toxPromise = getToxTestTasks();
+    }
+    return this.toxPromise;
+  }
+
+  public resolveTask(_task: vscode.Task): vscode.Task | undefined {
+    const testenv = _task.definition.ansible;
+    if (testenv) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const definition: ToxTaskDefinition = <any>_task.definition;
+      return new vscode.Task(
+        definition,
+        _task.scope ?? vscode.TaskScope.Workspace,
+        definition.ansible,
+        AnsibleToxProvider.toxType,
+        new vscode.ShellExecution(
+          `${ANSIBLE_TOX_RUN_COMMAND} ${definition.ansible} --ansible --conf tox-ansible.ini`
+        )
+      );
+    }
+    return undefined;
+  }
+}
+
+interface ToxTaskDefinition extends vscode.TaskDefinition {
+  /**
+   * The environment name
+   */
+  testenv: string;
+}
+
+const buildTaskNames: string[] = ["build", "compile", "watch"];
+const testTaskNames: string[] = ["test"];
+function inferTaskGroup(taskName: string): vscode.TaskGroup | undefined {
+  if (buildTaskNames.includes(taskName)) {
+    return vscode.TaskGroup.Build;
+  } else if (testTaskNames.includes(taskName)) {
+    return vscode.TaskGroup.Test;
+  } else {
+    return undefined;
+  }
+}
+
+async function getToxTestTasks(): Promise<vscode.Task[]> {
+  const workspaceFolders = vscode.workspace.workspaceFolders;
+  const result: vscode.Task[] = [];
+
+  if (!workspaceFolders || workspaceFolders.length === 0) {
+    return result;
+  }
+  for (const workspaceFolder of workspaceFolders) {
+    const folderString = workspaceFolder.uri.fsPath;
+    if (!folderString) {
+      continue;
+    }
+    const toxFile = path.join(folderString, AnsibleToxProvider.ansibleToxIni);
+    try {
+      await fs_promises.access(toxFile, fs.constants.R_OK);
+    } catch {
+      continue;
+    }
+
+    const toxTestenvs = await getToxEnvs(folderString);
+
+    if (toxTestenvs !== undefined) {
+      for (const toxTestenv of toxTestenvs) {
+        if (toxTestenv.length === 0) {
+          continue;
+        }
+
+        const kind: ToxTaskDefinition = {
+          type: AnsibleToxProvider.toxType,
+          testenv: toxTestenv,
+        };
+
+        const task = new vscode.Task(
+          kind,
+          workspaceFolder,
+          toxTestenv,
+          AnsibleToxProvider.toxType,
+          new vscode.ShellExecution(
+            `${ANSIBLE_TOX_RUN_COMMAND} ${toxTestenv} --ansible --conf tox-ansible.ini`
+          )
+        );
+        task.group = inferTaskGroup(toxTestenv.toLowerCase());
+        result.push(task);
+      }
+    }
+  }
+  return result;
+}

--- a/src/features/ansibleTox/runner.ts
+++ b/src/features/ansibleTox/runner.ts
@@ -1,0 +1,86 @@
+/* Inspired by https://github.com/The-Compiler/vscode-python-tox */
+
+import * as vscode from "vscode";
+import * as child_process from "child_process";
+import * as util from "util";
+import * as os from "os";
+import { getTerminal } from "./utils";
+import {
+  ANSIBLE_TOX_FILE_NAME,
+  ANSIBLE_TOX_LIST_ENV_COMMAND,
+  ANSIBLE_TOX_RUN_COMMAND,
+} from "./constants";
+import path from "path";
+
+const exec = util.promisify(child_process.exec);
+
+export async function getToxEnvs(
+  projDir: string,
+  command: string = ANSIBLE_TOX_LIST_ENV_COMMAND
+) {
+  const newEnv = { ...process.env };
+  const ansibleSettings = vscode.workspace.getConfiguration("ansible");
+  const activationScript = (await ansibleSettings.get(
+    "python.activationScript"
+  )) as string;
+  const interpreterPath = (await ansibleSettings.get(
+    "python.interpreterPath"
+  )) as string;
+
+  if (activationScript) {
+    command = `bash -c 'source ${activationScript} && ${command}'`;
+  }
+  if (interpreterPath && interpreterPath !== "") {
+    const virtualEnv = path.resolve(interpreterPath, "../..");
+
+    const pathEntry = path.join(virtualEnv, "bin");
+    newEnv["VIRTUAL_ENV"] = virtualEnv;
+    newEnv["PATH"] = `${pathEntry}:${process.env.PATH}`;
+  }
+  try {
+    const { stdout, stderr } = await exec(command, {
+      cwd: projDir,
+      env: newEnv,
+    });
+    if (stderr && stderr.length > 0) {
+      const channel = getOutputChannel();
+      channel.appendLine(stderr);
+      channel.show(true);
+    }
+    return stdout?.trim().split(os.EOL);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } catch (err: any) {
+    const channel = getOutputChannel();
+    channel.appendLine(err.stderr || "");
+    channel.appendLine(err.stdout || "");
+    if (err.stderr.includes("unrecognized arguments: --ansible")) {
+      channel.appendLine(
+        "Ansible Tox plugin is not installed in Python environment. Install tox-ansible plugin by running command 'pip install tox-ansible'."
+      );
+    }
+    channel.appendLine("Failed to detect Ansible tox environment.");
+    channel.show(true);
+  }
+
+  return undefined;
+}
+
+export function runTox(
+  envs: string[],
+  toxArguments: string,
+  terminal: vscode.Terminal = getTerminal(),
+  command: string = ANSIBLE_TOX_RUN_COMMAND
+) {
+  const envArg = envs.join(",");
+  terminal.show(true);
+  const terminalCommand = `${command} ${envArg} ${toxArguments} --ansible --conf ${ANSIBLE_TOX_FILE_NAME}`;
+  terminal.sendText(terminalCommand);
+}
+
+let _channel: vscode.OutputChannel;
+function getOutputChannel(): vscode.OutputChannel {
+  if (!_channel) {
+    _channel = vscode.window.createOutputChannel("Ansible Tox Auto Detection");
+  }
+  return _channel;
+}

--- a/src/features/ansibleTox/utils.ts
+++ b/src/features/ansibleTox/utils.ts
@@ -1,0 +1,44 @@
+import * as vscode from "vscode";
+import * as path from "path";
+
+export function findProjectDir() {
+  const docUri = vscode.window.activeTextEditor?.document.uri;
+
+  if (!docUri) {
+    throw new Error("No active editor found.");
+  }
+
+  const workspace = vscode.workspace.getWorkspaceFolder(docUri);
+
+  if (workspace) {
+    const folder = workspace.uri.fsPath;
+    console.log(`tox workspace folder: ${folder}`);
+    return folder;
+  }
+
+  const docDir = path.dirname(docUri.fsPath);
+  console.log(`tox doc path: ${docUri.fsPath} -> ${docDir}`);
+  return docDir;
+}
+
+export function getTerminal(
+  projDir: string = findProjectDir(),
+  name = "Ansible Tox"
+): vscode.Terminal {
+  for (const terminal of vscode.window.terminals) {
+    if (terminal.name === name) {
+      return terminal;
+    }
+  }
+  return vscode.window.createTerminal({ cwd: projDir, name: name });
+}
+
+export function getRootParentLabelDesc(test: vscode.TestItem): string {
+  let root = test;
+
+  while (root.parent !== undefined) {
+    root = root.parent;
+  }
+
+  return `${root.label} ${root.description}`;
+}

--- a/src/features/ansibleTox/utils.ts
+++ b/src/features/ansibleTox/utils.ts
@@ -3,26 +3,32 @@ import * as path from "path";
 
 export function findProjectDir() {
   const docUri = vscode.window.activeTextEditor?.document.uri;
+  if (docUri) {
+    const workspace = vscode.workspace.getWorkspaceFolder(docUri);
+    if (workspace) {
+      const folder = workspace.uri.fsPath;
+      console.log(`tox workspace folder: ${folder}`);
+      return folder;
+    } else {
+      const docDir = path.dirname(docUri.fsPath);
+      console.log(`tox doc path: ${docUri.fsPath} -> ${docDir}`);
+      return docDir;
+    }
+  } else {
+    console.log("tox ansible no active editor found");
 
-  if (!docUri) {
-    throw new Error("No active editor found.");
+    // Fixme: this is not working for multi-root workspaces
+    const workspaceFolders = vscode.workspace.workspaceFolders;
+    if (workspaceFolders) {
+      const rootPath = workspaceFolders[0].uri.fsPath;
+      console.log("Workspace root directory:", rootPath);
+      return rootPath;
+    }
   }
-
-  const workspace = vscode.workspace.getWorkspaceFolder(docUri);
-
-  if (workspace) {
-    const folder = workspace.uri.fsPath;
-    console.log(`tox workspace folder: ${folder}`);
-    return folder;
-  }
-
-  const docDir = path.dirname(docUri.fsPath);
-  console.log(`tox doc path: ${docUri.fsPath} -> ${docDir}`);
-  return docDir;
 }
 
 export function getTerminal(
-  projDir: string = findProjectDir(),
+  projDir: string | undefined = findProjectDir(),
   name = "Ansible Tox"
 ): vscode.Terminal {
   for (const terminal of vscode.window.terminals) {


### PR DESCRIPTION
Fixes https://github.com/ansible/vscode-ansible/issues/882

*  To provide Ansible test matrix using tox in the test
   explorer, install [tox-ansible](https://pypi.org/project/tox-ansible/).
*  Add `tox-ansible.ini` file in root folder of workspace which should have
   a section called `[ansible]`.
*  Run test from the test explorer.

Known issues:
*  Test run indicates success in explorer window 
   immediately after test start running without 
   waiting for the actual test result
*  Test explorer refresh does not work proprely and
   the create the test in explorer reload the VSCode window