### PR TITLE
[Lightspeed] Fix connect button working

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -64,11 +64,14 @@ export let lightSpeedManager: LightSpeedManager;
 const lsName = "Ansible Support";
 
 export async function activate(context: ExtensionContext): Promise<void> {
-  // set correct python interpreter
-  await setPythonInterpreter();
-
   // dynamically associate "ansible" language to the yaml file
   await languageAssociation(context);
+
+  // set correct python interpreter
+  const workspaceFolders = workspace.workspaceFolders;
+  if (workspaceFolders) {
+    await setPythonInterpreter();
+  }
 
   // Create Telemetry Service
   const telemetry = new TelemetryManager(context);

--- a/src/features/utils/setPythonInterpreter.ts
+++ b/src/features/utils/setPythonInterpreter.ts
@@ -2,6 +2,14 @@ import { commands, window, workspace } from "vscode";
 import { getInterpreterDetails } from "./python";
 
 export async function setPythonInterpreter() {
+  // set interpreter only when a doc with ansible language id is found
+  const activeDocument = window.activeTextEditor?.document;
+  if (activeDocument?.languageId !== "ansible") {
+    return;
+  }
+
+  console.log("Language ID: ", activeDocument.languageId);
+
   const ansibleSettings = workspace.getConfiguration("ansible");
   const pythonExistingInterpreterPath = await ansibleSettings.get(
     "python.interpreterPath"
@@ -15,15 +23,16 @@ export async function setPythonInterpreter() {
 
     if (pythonExtensionDetails.path) {
       const interpreter = pythonExtensionDetails.path;
-      window.showInformationMessage(
-        `Python interpreter set: ${interpreter}. \n
-        You  can change it by selecting a different interpreter anytime.`
-      );
 
       await ansibleSettings.update(
         "python.interpreterPath",
         interpreter,
         false
+      );
+
+      window.showInformationMessage(
+        `Python interpreter set: ${interpreter} at User level \n
+        You  can change it by selecting a different interpreter anytime.`
       );
     }
   }


### PR DESCRIPTION
The PR is a fix for the setInterpreter function, which caused the extension activation to fail, due to which the `Connect` button for the lightspeed service login did not work.