### PR TITLE
Fix notification for lightspeed login after the setting is disabled

### DIFF
--- a/src/features/lightspeed/base.ts
+++ b/src/features/lightspeed/base.ts
@@ -77,8 +77,6 @@ export class LightSpeedManager {
 
     if (!lightspeedEnabled) {
       await this.lightSpeedAuthenticationProvider.dispose();
-      // reload the window to remove the login notification
-      await vscode.commands.executeCommand("workbench.action.reloadWindow");
       this.lightSpeedStatusBar.hide();
       return;
     } else {

--- a/src/features/lightspeed/base.ts
+++ b/src/features/lightspeed/base.ts
@@ -51,7 +51,9 @@ export class LightSpeedManager {
         ANSIBLE_LIGHTSPEED_AUTH_ID,
         ANSIBLE_LIGHTSPEED_AUTH_NAME
       );
-    this.lightSpeedAuthenticationProvider.initialize();
+    if (this.settingsManager.settings.lightSpeedService.enabled) {
+      this.lightSpeedAuthenticationProvider.initialize();
+    }
     this.apiInstance = new LightSpeedAPI(
       this.settingsManager,
       this.lightSpeedAuthenticationProvider
@@ -75,6 +77,8 @@ export class LightSpeedManager {
 
     if (!lightspeedEnabled) {
       await this.lightSpeedAuthenticationProvider.dispose();
+      // reload the window to remove the login notification
+      await vscode.commands.executeCommand("workbench.action.reloadWindow");
       this.lightSpeedStatusBar.hide();
       return;
     } else {


### PR DESCRIPTION
Fixes https://github.com/ansible/vscode-ansible/issues/859

In addition to PR https://github.com/ansible/vscode-ansible/pull/877 update the logic to initialize the Lightspeed authentication provider only after the Lightspeed setting is enabled.

Note: 
*  As Lightspeed setting is disabled by default the login notification won't appear with this fix
*  However if the setting is enabled the login notification will appear and after that if it is disabled again the user will have to reload the window for the login notification to disappear.