### PR TITLE
Update lightspeed user sentiment and feedback input

### DIFF
--- a/package.json
+++ b/package.json
@@ -210,6 +210,10 @@
       {
         "command": "ansible.lightspeed.clearTrainingMatches",
         "title": "Ansible Lightspeed: Clear Training Matches"
+      },
+      {
+        "command": "ansible.lightspeed.feedback",
+        "title": "Ansible Lightspeed: Feedback"
       }
     ],
     "configuration": {

--- a/src/definitions/constants.ts
+++ b/src/definitions/constants.ts
@@ -1,4 +1,8 @@
 /* eslint-disable @typescript-eslint/no-namespace */
+
+export const ANSIBLE_EXTENSION_REPOSITORY_URL =
+  "https://github.com/ansible/vscode-ansible";
+
 export namespace AnsibleCommands {
   export const ANSIBLE_VAULT = "extension.ansible.vault";
   export const ANSIBLE_INVENTORY_RESYNC = "extension.resync-ansible-inventory";
@@ -23,6 +27,7 @@ export namespace LightSpeedCommands {
     "ansible.lightspeed.fetchTrainingMatches";
   export const LIGHTSPEED_CLEAR_TRAINING_MATCHES =
     "ansible.lightspeed.clearTrainingMatches";
+  export const LIGHTSPEED_FEEDBACK = "ansible.lightspeed.feedback";
 }
 
 export const LIGHTSPEED_API_VERSION = "v0";
@@ -33,13 +38,9 @@ export const LIGHTSPEED_ME_AUTH_URL = `/api/${LIGHTSPEED_API_VERSION}/me/`;
 
 export const LIGHTSPEED_FEEDBACK_FORM_URL =
   "https://red.ht/ansible-ai-feedback";
-
 export const LIGHTSPEED_REPORT_EMAIL_ADDRESS = "ansible-content-ai@redhat.com";
 export const LIGHTSPEED_STATUS_BAR_CLICK_HANDLER =
   "ansible.lightspeed.statusBar.clickHandler";
-
-export const LIGHTSPEED_FEEDBACK_URL =
-  "https://redhatdg.co1.qualtrics.com/jfe/form/SV_e99JvA2DHp5UlWC";
 
 export const LIGHTSPEED_CLIENT_ID = "Vu2gClkeR5qUJTUGHoFAePmBznd6RZjDdy5FW2wy";
 export const LIGHTSPEED_SERVICE_LOGIN_TIMEOUT = 120000;

--- a/src/definitions/lightspeed.ts
+++ b/src/definitions/lightspeed.ts
@@ -43,9 +43,24 @@ export interface AnsibleContentEvent {
   trigger: AnsibleContentUploadTrigger;
   activityId: string | undefined;
 }
+
+export interface SentimentEvent {
+  value: number;
+  feedback: string;
+}
+
+export interface SuggestionQualityEvent {
+  prompt: string;
+  providedSuggestion: string;
+  expectedSuggestion: string;
+  additionalComment: string | undefined;
+}
+
 export interface FeedbackRequestParams {
   inlineSuggestion?: InlineSuggestionEvent;
   ansibleContent?: AnsibleContentEvent;
+  sentimentFeedback?: SentimentEvent;
+  suggestionQualityFeedback?: SuggestionQualityEvent;
 }
 
 export interface IDocumentTracker {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -143,7 +143,15 @@ export async function activate(context: ExtensionContext): Promise<void> {
   context.subscriptions.push(
     vscode.commands.registerCommand(
       LightSpeedCommands.LIGHTSPEED_STATUS_BAR_CLICK,
-      lightSpeedManager.lightSpeedStatusBarClickHandler
+      () =>
+        lightSpeedManager.statusBarProvider.lightSpeedStatusBarClickHandler()
+    )
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      LightSpeedCommands.LIGHTSPEED_FEEDBACK,
+      () => lightSpeedManager.statusBarProvider.lightSpeedFeedbackHandler()
     )
   );
 
@@ -376,7 +384,7 @@ async function updateAnsibleStatusBar(
   pythonInterpreterManager: PythonInterpreterManager
 ) {
   await metaData.updateAnsibleInfoInStatusbar();
-  lightSpeedManager.updateLightSpeedStatusbar();
+  lightSpeedManager.statusBarProvider.updateLightSpeedStatusbar();
   await pythonInterpreterManager.updatePythonInfoInStatusbar();
 }
 /**

--- a/src/features/lightspeed/base.ts
+++ b/src/features/lightspeed/base.ts
@@ -10,27 +10,23 @@ import {
   FeedbackRequestParams,
   IDocumentTracker,
 } from "../../definitions/lightspeed";
-import {
-  LightSpeedCommands,
-  LIGHTSPEED_FEEDBACK_FORM_URL,
-  LIGHTSPEED_REPORT_EMAIL_ADDRESS,
-} from "../../definitions/constants";
 import { AttributionsWebview } from "./attributionsWebview";
 import {
   ANSIBLE_LIGHTSPEED_AUTH_ID,
   ANSIBLE_LIGHTSPEED_AUTH_NAME,
 } from "./utils/webUtils";
+import { LightspeedStatusBar } from "./feedbackStatusBar";
 
 export class LightSpeedManager {
   private context;
   public client;
   public settingsManager: SettingsManager;
   public telemetry: TelemetryManager;
-  public lightSpeedStatusBar: vscode.StatusBarItem;
   public apiInstance: LightSpeedAPI;
   public lightSpeedAuthenticationProvider: LightSpeedAuthenticationProvider;
   public lightSpeedActivityTracker: IDocumentTracker;
   public attributionsProvider: AttributionsWebview;
+  public statusBarProvider: LightspeedStatusBar;
 
   constructor(
     context: vscode.ExtensionContext,
@@ -66,8 +62,12 @@ export class LightSpeedManager {
     );
 
     // create a new project lightspeed status bar item that we can manage
-    this.lightSpeedStatusBar = this.initialiseStatusBar();
-    this.updateLightSpeedStatusbar();
+    this.statusBarProvider = new LightspeedStatusBar(
+      this.apiInstance,
+      context,
+      client,
+      settingsManager
+    );
   }
 
   public async reInitialize(): Promise<void> {
@@ -77,57 +77,13 @@ export class LightSpeedManager {
 
     if (!lightspeedEnabled) {
       await this.lightSpeedAuthenticationProvider.dispose();
-      this.lightSpeedStatusBar.hide();
+      this.statusBarProvider.statusBar.hide();
       return;
     } else {
       this.lightSpeedAuthenticationProvider.initialize();
     }
 
-    this.updateLightSpeedStatusbar();
-  }
-
-  private initialiseStatusBar(): vscode.StatusBarItem {
-    // create a new status bar item that we can manage
-    const lightSpeedStatusBarItem = vscode.window.createStatusBarItem(
-      vscode.StatusBarAlignment.Right,
-      100
-    );
-    lightSpeedStatusBarItem.command =
-      LightSpeedCommands.LIGHTSPEED_STATUS_BAR_CLICK;
-    lightSpeedStatusBarItem.text = "Lightspeed";
-    this.context.subscriptions.push(lightSpeedStatusBarItem);
-    return lightSpeedStatusBarItem;
-  }
-
-  private handleStatusBar() {
-    if (!this.client.isRunning()) {
-      return;
-    }
-    if (
-      this.settingsManager.settings.lightSpeedService.enabled &&
-      this.settingsManager.settings.lightSpeedService.suggestions.enabled
-    ) {
-      this.lightSpeedStatusBar.backgroundColor = new vscode.ThemeColor(
-        "statusBarItem.prominentForeground"
-      );
-    } else {
-      this.lightSpeedStatusBar.backgroundColor = new vscode.ThemeColor(
-        "statusBarItem.warningBackground"
-      );
-    }
-    this.lightSpeedStatusBar.show();
-  }
-
-  public updateLightSpeedStatusbar(): void {
-    if (
-      vscode.window.activeTextEditor?.document.languageId !== "ansible" ||
-      !this.settingsManager.settings.lightSpeedService.enabled
-    ) {
-      this.lightSpeedStatusBar.hide();
-      return;
-    }
-
-    this.handleStatusBar();
+    this.statusBarProvider.updateLightSpeedStatusbar();
   }
 
   public ansibleContentFeedback(
@@ -172,25 +128,5 @@ export class LightSpeedManager {
       "[ansible-lightspeed-feedback] Event lightSpeedServiceAnsibleContentFeedbackEvent sent."
     );
     this.apiInstance.feedbackRequest(inputData);
-  }
-
-  public async lightSpeedStatusBarClickHandler() {
-    // show an information message feedback buttons
-    const contactButton = `Contact Us`;
-    const feedbackButton = "Take Survey";
-    const inputButton = await vscode.window.showInformationMessage(
-      "Ansible Lightspeed with Watson Code Assistant feedback",
-      //{ modal: true },
-      feedbackButton,
-      contactButton
-    );
-    if (inputButton === feedbackButton) {
-      // open a URL in the default browser
-      vscode.env.openExternal(vscode.Uri.parse(LIGHTSPEED_FEEDBACK_FORM_URL));
-    } else if (inputButton === contactButton) {
-      // open the user's default email client
-      const mailtoUrl = encodeURI(`mailto:${LIGHTSPEED_REPORT_EMAIL_ADDRESS}`);
-      vscode.env.openExternal(vscode.Uri.parse(mailtoUrl));
-    }
   }
 }

--- a/src/features/lightspeed/feedbackStatusBar.ts
+++ b/src/features/lightspeed/feedbackStatusBar.ts
@@ -1,0 +1,302 @@
+import * as vscode from "vscode";
+import { LanguageClient } from "vscode-languageclient/node";
+import { LightSpeedAPI } from "./api";
+import { SettingsManager } from "../../settings";
+import {
+  ANSIBLE_EXTENSION_REPOSITORY_URL,
+  LIGHTSPEED_FEEDBACK_FORM_URL,
+  LIGHTSPEED_REPORT_EMAIL_ADDRESS,
+  LightSpeedCommands,
+} from "../../definitions/constants";
+import { FeedbackRequestParams } from "../../definitions/lightspeed";
+
+const sentimentOptions = [
+  "😀 Very positive",
+  "🙂 Positive",
+  "😐 Neutral",
+  "🙁 Negative",
+  "😞 Very negative",
+];
+
+const sentimentMap: { [key: string]: number } = {
+  "😀 Very positive": 5,
+  "🙂 Positive": 4,
+  "😐 Neutral": 3,
+  "🙁 Negative": 2,
+  "😞 Very negative": 1,
+};
+
+export class LightspeedStatusBar {
+  private apiInstance: LightSpeedAPI;
+  private context;
+  public client;
+  public settingsManager: SettingsManager;
+  public statusBar: vscode.StatusBarItem;
+
+  constructor(
+    apiInstance: LightSpeedAPI,
+    context: vscode.ExtensionContext,
+    client: LanguageClient,
+    settingsManager: SettingsManager
+  ) {
+    this.apiInstance = apiInstance;
+    this.context = context;
+    this.client = client;
+    this.settingsManager = settingsManager;
+    // create a new project lightspeed status bar item that we can manage
+    this.statusBar = this.initialiseStatusBar();
+    this.updateLightSpeedStatusbar();
+  }
+
+  private initialiseStatusBar(): vscode.StatusBarItem {
+    // create a new status bar item that we can manage
+    const lightSpeedStatusBarItem = vscode.window.createStatusBarItem(
+      vscode.StatusBarAlignment.Right,
+      100
+    );
+    lightSpeedStatusBarItem.command =
+      LightSpeedCommands.LIGHTSPEED_STATUS_BAR_CLICK;
+    lightSpeedStatusBarItem.text = "Lightspeed";
+    this.context.subscriptions.push(lightSpeedStatusBarItem);
+    return lightSpeedStatusBarItem;
+  }
+
+  private handleStatusBar() {
+    if (!this.client.isRunning()) {
+      return;
+    }
+    if (
+      this.settingsManager.settings.lightSpeedService.enabled &&
+      this.settingsManager.settings.lightSpeedService.suggestions.enabled
+    ) {
+      this.statusBar.backgroundColor = new vscode.ThemeColor(
+        "statusBarItem.prominentForeground"
+      );
+    } else {
+      this.statusBar.backgroundColor = new vscode.ThemeColor(
+        "statusBarItem.warningBackground"
+      );
+    }
+    this.statusBar.show();
+  }
+
+  public updateLightSpeedStatusbar(): void {
+    if (
+      vscode.window.activeTextEditor?.document.languageId !== "ansible" ||
+      !this.settingsManager.settings.lightSpeedService.enabled
+    ) {
+      this.statusBar.hide();
+      return;
+    }
+
+    this.handleStatusBar();
+  }
+
+  async feedbackHandler() {
+    const takeSurveyButton = "Take Survey";
+    const codeSuggestionButton = "Code Suggestion improvement";
+    const extensionIssueButton = "Extension: Issue";
+    const extensionFeatureButton = "Extension: Feature";
+    const emailButton = "Email";
+
+    const feedbackInput = await vscode.window.showInformationMessage(
+      "Ansible Lightspeed with Watson Code Assistant",
+      { modal: true, detail: "Tell us more" },
+      takeSurveyButton,
+      codeSuggestionButton,
+      extensionIssueButton,
+      extensionFeatureButton,
+      emailButton
+    );
+    if (!feedbackInput || feedbackInput === undefined) {
+      return;
+    }
+    if (feedbackInput === takeSurveyButton) {
+      // open a URL in the default browser
+      vscode.env.openExternal(vscode.Uri.parse(LIGHTSPEED_FEEDBACK_FORM_URL));
+    } else if (feedbackInput === codeSuggestionButton) {
+      const prompt = await vscode.window.showInputBox({
+        prompt: "Prompt",
+        placeHolder:
+          "Copy and paste the file content till the end of task name description line",
+        ignoreFocusOut: true,
+        validateInput: (value: string) => {
+          if (!value) {
+            return "Prompt cannot be empty";
+          }
+        },
+      });
+      const providedSuggestion = await vscode.window.showInputBox({
+        prompt: "Suggestion provided",
+        placeHolder:
+          "Copy and paste the suggestion provided by Lightspeed here with whitespaces intact.",
+        ignoreFocusOut: true,
+        validateInput: (value: string) => {
+          if (!value) {
+            return "Suggestion provided cannot be empty";
+          }
+        },
+      });
+      const expectedSuggestion = await vscode.window.showInputBox({
+        prompt: "Expected Suggestion",
+        placeHolder: "Copy and paste the expected suggestion here.",
+        ignoreFocusOut: true,
+        validateInput: (value: string) => {
+          if (!value) {
+            return "Expected Suggestion cannot be empty";
+          }
+        },
+      });
+      const additionalComment = await vscode.window.showInputBox({
+        prompt: "Additional comment",
+        placeHolder:
+          "Please describe why the change was required in the suggestion provided by Lightspeed.",
+        ignoreFocusOut: true,
+      });
+      if (prompt && providedSuggestion && expectedSuggestion) {
+        const inputData: FeedbackRequestParams = {
+          suggestionQualityFeedback: {
+            prompt: prompt,
+            providedSuggestion: providedSuggestion,
+            expectedSuggestion: expectedSuggestion,
+            additionalComment: additionalComment,
+          },
+        };
+
+        console.log(
+          "[ansible-lightspeed-feedback] Event suggestionQualityFeedback sent."
+        );
+        this.apiInstance.feedbackRequest(inputData);
+        vscode.window.showInformationMessage(
+          "Thank you for your feedback on code suggestion."
+        );
+      }
+    } else if (feedbackInput === extensionIssueButton) {
+      const issueTitle = await vscode.window.showInputBox({
+        prompt: "Issue title",
+        placeHolder: "Describe the issue.",
+        ignoreFocusOut: true,
+        validateInput: (value: string) => {
+          if (!value) {
+            return "Issue title cannot be empty";
+          }
+        },
+      });
+      const issueDescription = await vscode.window.showInputBox({
+        prompt: "Issue description",
+        placeHolder: "Explain the issue.",
+        ignoreFocusOut: true,
+        validateInput: (value: string) => {
+          if (!value) {
+            return "Issue description cannot be empty.";
+          }
+        },
+      });
+      if (issueTitle && issueDescription) {
+        const issueUrl = `${ANSIBLE_EXTENSION_REPOSITORY_URL}/issues/new?title=${encodeURIComponent(
+          issueTitle
+        )}&body=${encodeURIComponent(issueDescription)}&labels=bug`;
+
+        vscode.env.openExternal(vscode.Uri.parse(issueUrl));
+        vscode.window.showInformationMessage(
+          "Thank you for your feedback on Ansible extension."
+        );
+      }
+    } else if (feedbackInput === extensionFeatureButton) {
+      const issueTitle = await vscode.window.showInputBox({
+        prompt: "Feature title",
+        placeHolder: "Describe the feature.",
+        ignoreFocusOut: true,
+        validateInput: (value: string) => {
+          if (!value) {
+            return "Feature title cannot be empty";
+          }
+        },
+      });
+      const issueDescription = await vscode.window.showInputBox({
+        prompt: "Feature description",
+        placeHolder: "Explain the feature.",
+        ignoreFocusOut: true,
+        validateInput: (value: string) => {
+          if (!value) {
+            return "Feature description cannot be empty.";
+          }
+        },
+      });
+      if (issueTitle && issueDescription) {
+        const issueUrl = `${ANSIBLE_EXTENSION_REPOSITORY_URL}/issues/new?title=${encodeURIComponent(
+          issueTitle
+        )}&body=${encodeURIComponent(issueDescription)}&labels=enhancement`;
+
+        vscode.env.openExternal(vscode.Uri.parse(issueUrl));
+        vscode.window.showInformationMessage(
+          "Thank you for your feedback on Ansible extension."
+        );
+      }
+    } else if (feedbackInput === emailButton) {
+      // open the user's default email client
+      const mailtoUrl = encodeURI(`mailto:${LIGHTSPEED_REPORT_EMAIL_ADDRESS}`);
+      vscode.env.openExternal(vscode.Uri.parse(mailtoUrl));
+    }
+  }
+
+  async sentimentFeedbackHandler() {
+    const sentimentInput = await vscode.window.showInformationMessage(
+      "Ansible Lightspeed with Watson Code Assistant",
+      { modal: true, detail: "How do you feel about this feature?" },
+      ...sentimentOptions
+    );
+    if (!sentimentInput || sentimentInput === undefined) {
+      return;
+    }
+    // Show the sentiment feedback form
+    const feedback = await vscode.window.showInputBox({
+      prompt: "Tell us why?",
+      placeHolder: "Type your feedback here",
+      ignoreFocusOut: true,
+      validateInput: (value: string) => {
+        if (!value) {
+          return "Feedback cannot be empty";
+        }
+      },
+    });
+    if (feedback && sentimentInput in sentimentMap) {
+      const sentimentValue = sentimentMap[sentimentInput];
+      const inputData: FeedbackRequestParams = {
+        sentimentFeedback: {
+          value: sentimentValue,
+          feedback: feedback,
+        },
+      };
+      console.log(
+        "[ansible-lightspeed-feedback] Event sentimentFeedback sent."
+      );
+      this.apiInstance.feedbackRequest(inputData);
+      // Display a success message
+      vscode.window.showInformationMessage(
+        `Thank you for your feedback! Sentiment: ${sentimentInput}`
+      );
+    }
+  }
+
+  public async lightSpeedFeedbackHandler() {
+    const feedbackButton = "Tell us more";
+    const sentimentButton = "Sentiment";
+
+    const inputButton = await vscode.window.showInformationMessage(
+      "Ansible Lightspeed",
+      { modal: false },
+      sentimentButton,
+      feedbackButton
+    );
+    if (inputButton === feedbackButton) {
+      await this.feedbackHandler();
+    } else if (inputButton === sentimentButton) {
+      await this.sentimentFeedbackHandler();
+    }
+  }
+
+  public async lightSpeedStatusBarClickHandler() {
+    await this.lightSpeedFeedbackHandler();
+  }
+}

--- a/src/features/lightspeed/inlineSuggestions.ts
+++ b/src/features/lightspeed/inlineSuggestions.ts
@@ -40,7 +40,7 @@ export class LightSpeedInlineSuggestionProvider
       return [];
     }
     if (activeTextEditor.document.languageId !== "ansible") {
-      lightSpeedManager.lightSpeedStatusBar.hide();
+      lightSpeedManager.statusBarProvider.statusBar.hide();
       resetInlineSuggestionDisplayed();
       return [];
     }
@@ -50,7 +50,7 @@ export class LightSpeedInlineSuggestionProvider
       return [];
     }
     if (document.languageId !== "ansible") {
-      lightSpeedManager.lightSpeedStatusBar.hide();
+      lightSpeedManager.statusBarProvider.statusBar.hide();
       resetInlineSuggestionDisplayed();
       return [];
     }
@@ -58,7 +58,7 @@ export class LightSpeedInlineSuggestionProvider
       lightSpeedManager.settingsManager.settings.lightSpeedService;
     if (!lightSpeedSetting.enabled || !lightSpeedSetting.suggestions.enabled) {
       console.debug("[ansible-lightspeed] Ansible Lightspeed is disabled.");
-      lightSpeedManager.updateLightSpeedStatusbar();
+      lightSpeedManager.statusBarProvider.updateLightSpeedStatusbar();
       resetInlineSuggestionDisplayed();
       return [];
     }
@@ -175,19 +175,20 @@ export async function getInlineSuggestionItems(
     if (!shouldRequestInlineSuggestions(documentContent)) {
       return [];
     }
-    lightSpeedManager.lightSpeedStatusBar.text = "$(loading~spin) Lightspeed";
+    lightSpeedManager.statusBarProvider.statusBar.text =
+      "$(loading~spin) Lightspeed";
     result = await requestInlineSuggest(
       documentContent,
       documentUri,
       activityId
     );
-    lightSpeedManager.lightSpeedStatusBar.text = "Lightspeed";
+    lightSpeedManager.statusBarProvider.statusBar.text = "Lightspeed";
   } catch (error) {
     inlineSuggestionData["error"] = `${error}`;
     vscode.window.showErrorMessage(`Error in inline suggestions: ${error}`);
     return [];
   } finally {
-    lightSpeedManager.lightSpeedStatusBar.text = "Lightspeed";
+    lightSpeedManager.statusBarProvider.statusBar.text = "Lightspeed";
   }
   if (!result || !result.predictions || result.predictions.length === 0) {
     console.error("[inline-suggestions] Inline suggestions not found.");
@@ -249,11 +250,11 @@ async function requestInlineSuggest(
   console.log(
     `[inline-suggestions] ${getCurrentUTCDateTime().toISOString()}: Completion request sent to Ansible Lightspeed.`
   );
-
-  lightSpeedManager.lightSpeedStatusBar.tooltip = "processing...";
+  lightSpeedManager.statusBarProvider.statusBar.show();
+  lightSpeedManager.statusBarProvider.statusBar.tooltip = "processing...";
   const outputData: CompletionResponseParams =
     await lightSpeedManager.apiInstance.completionRequest(completionData);
-  lightSpeedManager.lightSpeedStatusBar.tooltip = "Done";
+  lightSpeedManager.statusBarProvider.statusBar.tooltip = "Done";
 
   console.log(
     `[inline-suggestions] ${getCurrentUTCDateTime().toISOString()}: Completion response received from Ansible Lightspeed.`


### PR DESCRIPTION
*  Add `sentiment` and `Tell us more` buttons in `Lightspeed` status bar
*  The `sentiment` feedback will accept values from 1 to 5 and a free form text feedback
*  `Tell us more` option will ask users to choose from
   - `Take Survey`:  Existing Qualtrics survey
   - `Code suggestion imporvement`: Will provide input box for `prompt`, `Provided Suggestion`, `Expected Suggstion` and `Additional COmments
   - `Extension: Issue`: Raise extension releated issues
   - `Extension: Feature`: Raise extension releated feature requests