### PR TITLE
Follow-up changes for supporting semantic markup

### DIFF
--- a/package.json
+++ b/package.json
@@ -623,7 +623,7 @@
     ]
   },
   "dependencies": {
-    "@ansible/ansible-language-server": "^1.1.0",
+    "@ansible/ansible-language-server": "^1.2.0",
     "@redhat-developer/vscode-redhat-telemetry": "^0.5.4",
     "@types/ini": "^1.3.31",
     "@vscode/webview-ui-toolkit": "^1.2.2",

--- a/test/testScripts/hover/testWithoutEE.test.ts
+++ b/test/testScripts/hover/testWithoutEE.test.ts
@@ -75,7 +75,7 @@ export function testHoverWithoutEE(): void {
         await testHover(docUri1, new vscode.Position(6, 9), [
           {
             contents: [
-              "The customized message that is printed. If omitted, prints a generic message.",
+              "The customized message that is printed\\. If omitted\\, prints a generic message\\.",
             ],
           },
         ]);


### PR DESCRIPTION
Ref: https://github.com/ansible/ansible-language-server/pull/563

This won't work until a new release of ansible-language-server is out. (My *guess* is that the next release will be 1.2.0, since there are new features.)