### PR TITLE
Make hover e2e tests fixture messages more generic

### DIFF
--- a/test/testScripts/hover/testWithEE.test.ts
+++ b/test/testScripts/hover/testWithEE.test.ts
@@ -63,7 +63,7 @@ export function testHoverEE(): void {
         await testHover(docUri1, new vscode.Position(6, 9), [
           {
             contents: [
-              "The customized message that is printed. If omitted, prints a generic message.",
+              "customized message that is printed. If omitted, prints a generic message.",
             ],
           },
         ]);
@@ -74,7 +74,7 @@ export function testHoverEE(): void {
       it("should hover over collection module name present in EE (ansible.posix.patch)", async () => {
         await testHover(docUri1, new vscode.Position(9, 7), [
           {
-            contents: ["Apply patch files using the GNU patch tool."],
+            contents: ["using the GNU patch tool."],
           },
         ]);
       });
@@ -82,9 +82,7 @@ export function testHoverEE(): void {
       it("should hover over collection module option present in EE (ansible.posix.patch -> src)", async () => {
         await testHover(docUri1, new vscode.Position(10, 9), [
           {
-            contents: [
-              "Path of the patch file as accepted by the GNU patch tool.",
-            ],
+            contents: ["accepted by the GNU patch tool."],
           },
         ]);
       });
@@ -92,7 +90,7 @@ export function testHoverEE(): void {
       it("should hover over collection module option present in EE (ansible.posix.patch -> dest)", async () => {
         await testHover(docUri1, new vscode.Position(11, 9), [
           {
-            contents: ["Path of the file on the remote machine to be patched."],
+            contents: ["remote machine to be patched."],
           },
         ]);
       });

--- a/test/testScripts/hover/testWithEE.test.ts
+++ b/test/testScripts/hover/testWithEE.test.ts
@@ -62,9 +62,7 @@ export function testHoverEE(): void {
       it("should hover over builtin module option", async () => {
         await testHover(docUri1, new vscode.Position(6, 9), [
           {
-            contents: [
-              "customized message that is printed. If omitted, prints a generic message.",
-            ],
+            contents: ["customized message"],
           },
         ]);
       });
@@ -74,7 +72,7 @@ export function testHoverEE(): void {
       it("should hover over collection module name present in EE (ansible.posix.patch)", async () => {
         await testHover(docUri1, new vscode.Position(9, 7), [
           {
-            contents: ["using the GNU patch tool."],
+            contents: ["GNU patch"],
           },
         ]);
       });
@@ -82,7 +80,7 @@ export function testHoverEE(): void {
       it("should hover over collection module option present in EE (ansible.posix.patch -> src)", async () => {
         await testHover(docUri1, new vscode.Position(10, 9), [
           {
-            contents: ["accepted by the GNU patch tool."],
+            contents: ["GNU patch"],
           },
         ]);
       });
@@ -90,7 +88,7 @@ export function testHoverEE(): void {
       it("should hover over collection module option present in EE (ansible.posix.patch -> dest)", async () => {
         await testHover(docUri1, new vscode.Position(11, 9), [
           {
-            contents: ["remote machine to be patched."],
+            contents: ["remote machine"],
           },
         ]);
       });

--- a/test/testScripts/hover/testWithoutEE.test.ts
+++ b/test/testScripts/hover/testWithoutEE.test.ts
@@ -74,9 +74,7 @@ export function testHoverWithoutEE(): void {
       it("should hover over builtin module option", async () => {
         await testHover(docUri1, new vscode.Position(6, 9), [
           {
-            contents: [
-              "customized message that is printed. If omitted, prints a generic message.",
-            ],
+            contents: ["customized message"],
           },
         ]);
       });

--- a/test/testScripts/hover/testWithoutEE.test.ts
+++ b/test/testScripts/hover/testWithoutEE.test.ts
@@ -75,7 +75,7 @@ export function testHoverWithoutEE(): void {
         await testHover(docUri1, new vscode.Position(6, 9), [
           {
             contents: [
-              "The customized message that is printed. If omitted, prints a generic message.",
+              "customized message that is printed. If omitted, prints a generic message.",
             ],
           },
         ]);


### PR DESCRIPTION
This PR makes hover e2e tests fixture messages more generic for the assertion to avoid failures because of markdown syntax.