### PR TITLE
Release v2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
 ### Minor Changes
 
 - Upgrade als to v1.2.1 (#950) @priyamsahoo
-- Add ability to select and set cursor on vars following `_var_` pattern (#884) @priyamsahoo
+- Add ability to select and set cursor on vars following `_var_` pattern (#884)
+  @priyamsahoo
 - Upgrade ALS to v1.1.0 (#932) @priyamsahoo
 - Upgrade yaml package to 2.x (#925) @priyamsahoo
 
@@ -17,7 +18,7 @@
 
 - Upgrade als to v1.2.1 (#950) @priyamsahoo
 - Fix command runner (#949) @priyamsahoo
-- Update lightspeed task name regex match condition  (#947) (#948) @ganeshrn
+- Update lightspeed task name regex match condition (#947) (#948) @ganeshrn
 - Fix ansibleContent feedback event trigger (#940) @ganeshrn
 - Update runner.ts to correctly get the path of ansible (#945) @priyamsahoo
 - Make hover e2e tests fixture messages more generic (#934) @priyamsahoo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,19 @@
 
 ### Minor Changes
 
-- Lightspeed UI feedback and sentiment (#924) @ganeshrn
+- Upgrade als to v1.2.1 (#950) @priyamsahoo
+- Add ability to select and set cursor on vars following `_var_` pattern (#884) @priyamsahoo
+- Upgrade ALS to v1.1.0 (#932) @priyamsahoo
+- Upgrade yaml package to 2.x (#925) @priyamsahoo
 
 ### Bugfixes
 
-- Update readme with lightspeed section (#926) @ganeshrn
+- Upgrade als to v1.2.1 (#950) @priyamsahoo
+- Fix command runner (#949) @priyamsahoo
+- Update lightspeed task name regex match condition  (#947) (#948) @ganeshrn
+- Fix ansibleContent feedback event trigger (#940) @ganeshrn
+- Update runner.ts to correctly get the path of ansible (#945) @priyamsahoo
+- Make hover e2e tests fixture messages more generic (#934) @priyamsahoo
 
 ## v2.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 <!-- KEEP-THIS-COMMENT -->
 
+## v2.5
+
+### Minor Changes
+
+- Lightspeed UI feedback and sentiment (#924) @ganeshrn
+
+### Bugfixes
+
+- Update readme with lightspeed section (#926) @ganeshrn
+
 ## v2.4
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -723,7 +723,7 @@
     "test-e2e": "yarn run test-compile && node ./out/client/test/testRunner",
     "test-e2e-withserver": "yarn run test-compile-withserver && node ./out/client/test/testRunner"
   },
-  "version": "2.4.0",
+  "version": "2.5.0",
   "packageManager": "yarn@3.6.1",
   "vsce": {
     "dependencies": false,


### PR DESCRIPTION
## v2.5

### Minor Changes

- Upgrade als to v1.2.1 (#950) @priyamsahoo
- Add ability to select and set cursor on vars following `_var_` pattern (#884) @priyamsahoo
- Upgrade ALS to v1.1.0 (#932) @priyamsahoo
- Upgrade yaml package to 2.x (#925) @priyamsahoo

### Bugfixes

- Upgrade als to v1.2.1 (#950) @priyamsahoo
- Fix command runner (#949) @priyamsahoo
- Update lightspeed task name regex match condition  (#947) (#948) @ganeshrn
- Fix ansibleContent feedback event trigger (#940) @ganeshrn
- Update runner.ts to correctly get the path of ansible (#945) @priyamsahoo
- Make hover e2e tests fixture messages more generic (#934) @priyamsahoo
