### PR TITLE
Fix _var_ capturing regex

### DIFF
--- a/src/features/utils/lightspeed.ts
+++ b/src/features/utils/lightspeed.ts
@@ -39,7 +39,7 @@ export function convertToSnippetString(suggestion: string): string {
   // this regex matches the content inside {{  }} with decided vars, i.e., {{ _var_ }}
   // TODO: once a prefix is decided for using it in from of variable names, the regex
   // can be changed to match it
-  const regex = /(?:^|)[^@#\s_]*(_([^_]+)_)/gm;
+  const regex = /{{ (_[^{}]+_) }}/gm;
 
   let counter = 0;
   const convertedSuggestion = suggestion.replace(regex, (item) => {


### PR DESCRIPTION
The PR simplify regex to capture `_var_` inside jinja brackets.