### PR TITLE
Unchange insertText to snippetstring

### DIFF
--- a/src/features/lightspeed/inlineSuggestions.ts
+++ b/src/features/lightspeed/inlineSuggestions.ts
@@ -2,10 +2,7 @@ import * as vscode from "vscode";
 import { v4 as uuidv4 } from "uuid";
 import _ from "lodash";
 
-import {
-  adjustInlineSuggestionIndent,
-  convertToSnippetString,
-} from "../utils/lightspeed";
+import { adjustInlineSuggestionIndent } from "../utils/lightspeed";
 import { getCurrentUTCDateTime } from "../utils/dateTime";
 import { lightSpeedManager } from "../../extension";
 import {
@@ -213,14 +210,7 @@ export async function getInlineSuggestionItems(
     insertText = adjustInlineSuggestionIndent(prediction, currentPosition);
     insertTexts.push(insertText);
 
-    // convert into snippet string to move cursor on jinja variables directly
-    const insertTextSnippetString = new vscode.SnippetString(
-      convertToSnippetString(insertText)
-    );
-
-    const inlineSuggestionItem = new vscode.InlineCompletionItem(
-      insertTextSnippetString
-    );
+    const inlineSuggestionItem = new vscode.InlineCompletionItem(insertText);
     inlineSuggestionUserActionItems.push(inlineSuggestionItem);
   });
   // currentSuggestion is used in user action handlers

--- a/src/features/utils/lightspeed.ts
+++ b/src/features/utils/lightspeed.ts
@@ -51,7 +51,7 @@ export function convertToSnippetString(suggestion: string): string {
     modifiedSuggestion = modifiedSuggestion.replace(
       exactMatch,
       `\$\{${counter}:${exactMatch}\}`
-    ); // replace the exact match in the modified suggestion with tab stop syntax according to vscode snippet srings
+    ); // replace the exact match in the modified suggestion with tab stop syntax according to vscode snippet string
   });
 
   return modifiedSuggestion;

--- a/src/features/utils/lightspeed.ts
+++ b/src/features/utils/lightspeed.ts
@@ -39,13 +39,20 @@ export function convertToSnippetString(suggestion: string): string {
   // this regex matches the content inside {{  }} with decided vars, i.e., {{ _var_ }}
   // TODO: once a prefix is decided for using it in from of variable names, the regex
   // can be changed to match it
-  const regex = /{{ (_[a-zA-Z_]\w*_) }}/gm;
+  const regex = /({{ )(_[a-zA-Z_]\w*_)( }})/gm;
+  const matches = [...suggestion.matchAll(regex)];
+
+  let modifiedSuggestion = suggestion;
 
   let counter = 0;
-  const convertedSuggestion = suggestion.replace(regex, (item) => {
+  matches.forEach((matchArray) => {
+    const exactMatch = matchArray[2]; // get only the variable , without the braces
     counter = counter + 1;
-    return `\${${counter}:${item}}`;
+    modifiedSuggestion = modifiedSuggestion.replace(
+      exactMatch,
+      `\$\{${counter}:${exactMatch}\}`
+    ); // replace the exact match in the modified suggestion with tab stop syntax according to vscode snippet srings
   });
 
-  return convertedSuggestion;
+  return modifiedSuggestion;
 }


### PR DESCRIPTION
As we discovered that there are some bugs in the vscode extension API for snippetstring, we have decided to temporarily avoid the conversion for string to snippetstring to add tab-stops until the bug is fixed in the vscode API.

The PR also updates the method of regex match (just in case we decide to use it again).

Link to the snippetstring bug: https://github.com/microsoft/vscode/issues/190549