### PR TITLE
Add additional context for lightspeed suggestions

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -119,6 +119,7 @@ untildify
 userdata
 usermod
 uuidv4
+varInfiles
 venvs
 vscoss
 vsix

--- a/package.json
+++ b/package.json
@@ -680,15 +680,18 @@
     "@vscode/webview-ui-toolkit": "^1.2.2",
     "axios": "^1.3.4",
     "ini": "^4.0.0",
+    "minimatch": "^9.0.3",
     "untildify": "^4.0.0",
     "uuid": "^9.0.0",
     "vscode-languageclient": "^8.1.0",
+    "vscode-uri": "^3.0.7",
     "yaml": "^2.2.2"
   },
   "description": "Ansible language support",
   "devDependencies": {
     "@types/chai": "^4.3.5",
     "@types/glob": "^8.1.0",
+    "@types/minimatch": "^5.1.2",
     "@types/mocha": "^10.0.1",
     "@types/node": "^18.16.3",
     "@types/sinon": "^10.0.14",

--- a/src/definitions/constants.ts
+++ b/src/definitions/constants.ts
@@ -1,5 +1,7 @@
 /* eslint-disable @typescript-eslint/no-namespace */
 
+import { IAnsibleFileTypes } from "../interfaces/lightspeed";
+
 export namespace AnsibleCommands {
   export const ANSIBLE_VAULT = "extension.ansible.vault";
   export const ANSIBLE_INVENTORY_RESYNC = "extension.resync-ansible-inventory";
@@ -9,36 +11,30 @@ export namespace AnsibleCommands {
     "ansible.python.set.interpreter";
 }
 
-// eslint-disable-next-line @typescript-eslint/no-namespace
-export namespace LightSpeedCommands {
-  export const LIGHTSPEED_AUTH_REQUEST = "ansible.lightspeed.oauth";
-  export const LIGHTSPEED_SUGGESTION_COMMIT =
-    "ansible.lightspeed.inlineSuggest.accept";
-  export const LIGHTSPEED_SUGGESTION_HIDE =
-    "ansible.lightspeed.inlineSuggest.hide";
-  export const LIGHTSPEED_SUGGESTION_TRIGGER =
-    "ansible.lightspeed.inlineSuggest.trigger";
-  export const LIGHTSPEED_STATUS_BAR_CLICK =
-    "ansible.lightspeed.statusBar.click";
-  export const LIGHTSPEED_FETCH_TRAINING_MATCHES =
-    "ansible.lightspeed.fetchTrainingMatches";
-  export const LIGHTSPEED_CLEAR_TRAINING_MATCHES =
-    "ansible.lightspeed.clearTrainingMatches";
-  export const LIGHTSPEED_FEEDBACK = "ansible.lightspeed.feedback";
-}
+export const AnsibleFileTypes: IAnsibleFileTypes = {
+  "**/playbooks/*.{yml,yaml}": "playbook",
+  "**/*playbook*.{yml,yaml}": "playbook",
+  "**/roles/**/tasks/**/*.{yml,yaml}": "tasks_in_role",
+  "**/tasks/**/*.{yaml,yml}": "tasks",
+};
 
-export const LIGHTSPEED_API_VERSION = "v0";
-export const LIGHTSPEED_SUGGESTION_COMPLETION_URL = `${LIGHTSPEED_API_VERSION}/ai/completions/`;
-export const LIGHTSPEED_SUGGESTION_FEEDBACK_URL = `${LIGHTSPEED_API_VERSION}/ai/feedback/`;
-export const LIGHTSPEED_SUGGESTION_ATTRIBUTIONS_URL = `${LIGHTSPEED_API_VERSION}/ai/attributions/`;
-export const LIGHTSPEED_ME_AUTH_URL = `/api/${LIGHTSPEED_API_VERSION}/me/`;
+export const PlaybookKeywords = [
+  "hosts",
+  "tasks",
+  "vars_files",
+  "roles",
+  "pre_tasks",
+  "post_tasks",
+];
 
-export const LIGHTSPEED_FEEDBACK_FORM_URL =
-  "https://red.ht/ansible-ai-feedback";
+export const StandardRolePaths = [
+  "~/.ansible/roles",
+  "/usr/share/ansible/roles",
+  "/etc/ansible/roles",
+];
 
-export const LIGHTSPEED_REPORT_EMAIL_ADDRESS = "ansible-content-ai@redhat.com";
-export const LIGHTSPEED_STATUS_BAR_CLICK_HANDLER =
-  "ansible.lightspeed.statusBar.clickHandler";
-
-export const LIGHTSPEED_CLIENT_ID = "Vu2gClkeR5qUJTUGHoFAePmBznd6RZjDdy5FW2wy";
-export const LIGHTSPEED_SERVICE_LOGIN_TIMEOUT = 120000;
+export const IncludeVarValidTaskName = [
+  "include_vars",
+  "ansible.builtin.include_vars",
+  "ansible.legacy.include_vars",
+];

--- a/src/definitions/lightspeed.ts
+++ b/src/definitions/lightspeed.ts
@@ -24,80 +24,36 @@ export enum AnsibleContentUploadTrigger {
   TAB_CHANGE = 2,
 }
 
-export interface FeedbackResponseParams {
-  message: string;
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export namespace LightSpeedCommands {
+  export const LIGHTSPEED_AUTH_REQUEST = "ansible.lightspeed.oauth";
+  export const LIGHTSPEED_SUGGESTION_COMMIT =
+    "ansible.lightspeed.inlineSuggest.accept";
+  export const LIGHTSPEED_SUGGESTION_HIDE =
+    "ansible.lightspeed.inlineSuggest.hide";
+  export const LIGHTSPEED_SUGGESTION_TRIGGER =
+    "ansible.lightspeed.inlineSuggest.trigger";
+  export const LIGHTSPEED_STATUS_BAR_CLICK =
+    "ansible.lightspeed.statusBar.click";
+  export const LIGHTSPEED_FETCH_TRAINING_MATCHES =
+    "ansible.lightspeed.fetchTrainingMatches";
+  export const LIGHTSPEED_CLEAR_TRAINING_MATCHES =
+    "ansible.lightspeed.clearTrainingMatches";
+  export const LIGHTSPEED_FEEDBACK = "ansible.lightspeed.feedback";
 }
 
-export interface InlineSuggestionEvent {
-  latency?: number;
-  userActionTime?: number;
-  documentUri?: string;
-  action?: UserAction;
-  error?: string;
-  suggestionId?: string;
-  activityId?: string;
-}
+export const LIGHTSPEED_API_VERSION = "v0";
+export const LIGHTSPEED_SUGGESTION_COMPLETION_URL = `${LIGHTSPEED_API_VERSION}/ai/completions/`;
+export const LIGHTSPEED_SUGGESTION_FEEDBACK_URL = `${LIGHTSPEED_API_VERSION}/ai/feedback/`;
+export const LIGHTSPEED_SUGGESTION_ATTRIBUTIONS_URL = `${LIGHTSPEED_API_VERSION}/ai/attributions/`;
+export const LIGHTSPEED_ME_AUTH_URL = `/api/${LIGHTSPEED_API_VERSION}/me/`;
 
-export interface AnsibleContentEvent {
-  content: string;
-  documentUri: string;
-  trigger: AnsibleContentUploadTrigger;
-  activityId: string | undefined;
-}
-export interface SentimentEvent {
-  value: number;
-  feedback: string;
-}
+export const LIGHTSPEED_FEEDBACK_FORM_URL =
+  "https://red.ht/ansible-ai-feedback";
 
-export interface SuggestionQualityEvent {
-  prompt: string;
-  providedSuggestion: string;
-  expectedSuggestion: string;
-  additionalComment: string;
-}
-export interface IssueFeedbackEvent {
-  type: "bug-report" | "feature-request";
-  title: string;
-  description: string;
-}
+export const LIGHTSPEED_REPORT_EMAIL_ADDRESS = "ansible-content-ai@redhat.com";
+export const LIGHTSPEED_STATUS_BAR_CLICK_HANDLER =
+  "ansible.lightspeed.statusBar.clickHandler";
 
-export interface FeedbackRequestParams {
-  inlineSuggestion?: InlineSuggestionEvent;
-  ansibleContent?: AnsibleContentEvent;
-  sentimentFeedback?: SentimentEvent;
-  suggestionQualityFeedback?: SuggestionQualityEvent;
-  issueFeedback?: IssueFeedbackEvent;
-}
-
-export interface IDocumentTrackerFields {
-  activityId: string;
-  content: string;
-}
-
-export interface IDocumentTracker {
-  [key: string]: IDocumentTrackerFields;
-}
-
-export interface AttributionsRequestParams {
-  suggestion: string;
-  suggestionId: string;
-}
-
-export interface IAttributionsParams {
-  repo_name: string;
-  repo_url: string;
-  path: string;
-  license: string;
-  data_source: string;
-  ansible_type: string;
-  score: number;
-}
-
-export interface AttributionsResponseParams {
-  attributions: IAttributionsParams[];
-}
-
-export interface ISuggestionDetails {
-  suggestion: string;
-  suggestionId: string;
-}
+export const LIGHTSPEED_CLIENT_ID = "Vu2gClkeR5qUJTUGHoFAePmBznd6RZjDdy5FW2wy";
+export const LIGHTSPEED_SERVICE_LOGIN_TIMEOUT = 120000;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,7 +9,8 @@ import {
   workspace,
 } from "vscode";
 import { toggleEncrypt } from "./features/vault";
-import { AnsibleCommands, LightSpeedCommands } from "./definitions/constants";
+import { AnsibleCommands } from "./definitions/constants";
+import { LightSpeedCommands } from "./definitions/lightspeed";
 import {
   TelemetryErrorHandler,
   TelemetryOutputChannel,
@@ -60,9 +61,12 @@ import { AnsibleToxProvider } from "./features/ansibleTox/provider";
 import { findProjectDir } from "./features/ansibleTox/utils";
 import { LightspeedFeedbackWebviewViewProvider } from "./features/lightspeed/feedbackWebviewViewProvider";
 import { LightspeedFeedbackWebviewProvider } from "./features/lightspeed/feedbackWebviewProvider";
+import { IFileSystemWatchers } from "./interfaces/watchers";
 
 export let client: LanguageClient;
 export let lightSpeedManager: LightSpeedManager;
+export const globalFileSystemWatcher: IFileSystemWatchers = {};
+
 const lsName = "Ansible Support";
 
 export async function activate(context: ExtensionContext): Promise<void> {

--- a/src/features/lightspeed/api.ts
+++ b/src/features/lightspeed/api.ts
@@ -9,12 +9,12 @@ import {
   FeedbackResponseParams,
   AttributionsRequestParams,
   AttributionsResponseParams,
-} from "../../definitions/lightspeed";
+} from "../../interfaces/lightspeed";
 import {
   LIGHTSPEED_SUGGESTION_ATTRIBUTIONS_URL,
   LIGHTSPEED_SUGGESTION_COMPLETION_URL,
   LIGHTSPEED_SUGGESTION_FEEDBACK_URL,
-} from "../../definitions/constants";
+} from "../../definitions/lightspeed";
 import { LightSpeedAuthenticationProvider } from "./lightSpeedOAuthProvider";
 import { getBaseUri } from "./utils/webUtils";
 

--- a/src/features/lightspeed/attributionsWebview.ts
+++ b/src/features/lightspeed/attributionsWebview.ts
@@ -7,7 +7,7 @@ import {
   AttributionsResponseParams,
   IAttributionsParams,
   ISuggestionDetails,
-} from "../../definitions/lightspeed";
+} from "../../interfaces/lightspeed";
 import { getCurrentUTCDateTime } from "../utils/dateTime";
 
 export class AttributionsWebview implements vscode.WebviewViewProvider {

--- a/src/features/lightspeed/inlineSuggestions.ts
+++ b/src/features/lightspeed/inlineSuggestions.ts
@@ -1,7 +1,10 @@
+import * as pathUri from "path";
+import crypto from "crypto";
+import { URI } from "vscode-uri";
 import * as vscode from "vscode";
 import { v4 as uuidv4 } from "uuid";
 import _ from "lodash";
-
+import * as yaml from "yaml";
 import { adjustInlineSuggestionIndent } from "../utils/lightspeed";
 import { getCurrentUTCDateTime } from "../utils/dateTime";
 import { lightSpeedManager } from "../../extension";
@@ -9,10 +12,26 @@ import {
   CompletionResponseParams,
   InlineSuggestionEvent,
   CompletionRequestParams,
-  UserAction,
-} from "../../definitions/lightspeed";
-import { LightSpeedCommands } from "../../definitions/constants";
-import { shouldRequestInlineSuggestions } from "./utils/data";
+  IRolesContext,
+  IRoleContext,
+  IStandaloneTaskContext,
+} from "../../interfaces/lightspeed";
+import { UserAction } from "../../definitions/lightspeed";
+import { LightSpeedCommands } from "../../definitions/lightspeed";
+import {
+  getIncludeVarsContext,
+  getRelativePath,
+  getRolePathFromPathWithinRole,
+  shouldRequestInlineSuggestions,
+} from "./utils/data";
+import { getVarsFilesContext } from "./utils/data";
+import {
+  IAdditionalContext,
+  IAnsibleFileType,
+  IPlaybookContext,
+} from "../../interfaces/lightspeed";
+import { getAnsibleFileType, getCustomRolePaths } from "../utils/ansible";
+import { watchRolesDirectory } from "./utils/watchers";
 
 const TASK_REGEX_EP =
   /^(?<![\s-])(?<blank>\s*)(?<list>- \s*name\s*:\s*)(?<description>\S.*)(?<end>$)/;
@@ -70,6 +89,7 @@ export class LightSpeedInlineSuggestionProvider
       resetInlineSuggestionDisplayed();
       return [];
     }
+
     // If users continue to without pressing configured keys to
     // either accept or reject the suggestion, we will consider it as ignored.
     if (getInlineSuggestionDisplayed()) {
@@ -161,6 +181,7 @@ export async function getInlineSuggestionItems(
   inlineSuggestionData = {};
   inlineSuggestionDisplayTime = getCurrentUTCDateTime();
   const requestTime = getCurrentUTCDateTime();
+
   console.log(
     "[inline-suggestions] Inline suggestions triggered by user edits."
   );
@@ -188,13 +209,39 @@ export async function getInlineSuggestionItems(
       ? ""
       : document.getText(range).trimEnd();
 
-    if (!shouldRequestInlineSuggestions(documentContent)) {
+    let parsedAnsibleDocument = undefined;
+    try {
+      parsedAnsibleDocument = yaml.parse(documentContent, {
+        keepSourceTokens: true,
+      });
+      if (!parsedAnsibleDocument) {
+        return [];
+      }
+      // check if YAML is a list, if not it is not a valid Ansible document
+      if (
+        typeof parsedAnsibleDocument === "object" &&
+        !Array.isArray(parsedAnsibleDocument)
+      ) {
+        vscode.window.showErrorMessage(
+          "Ansible Lightspeed expects valid Ansible syntax. For playbook files it should be a list of plays and for tasks files it should be list of tasks."
+        );
+        return [];
+      }
+    } catch (err) {
+      vscode.window.showErrorMessage(
+        `Ansible Lightspeed expects valid YAML syntax to provide inline suggestions. Error: ${err}`
+      );
+      return [];
+    }
+
+    if (!shouldRequestInlineSuggestions(parsedAnsibleDocument)) {
       return [];
     }
     lightSpeedManager.statusBarProvider.statusBar.text =
       "$(loading~spin) Lightspeed";
     result = await requestInlineSuggest(
       documentContent,
+      parsedAnsibleDocument,
       documentUri,
       activityId,
       rhUserHasSeat
@@ -253,15 +300,26 @@ export async function getInlineSuggestionItems(
 
 async function requestInlineSuggest(
   content: string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  parsedAnsibleDocument: any,
   documentUri: string,
   activityId: string,
   rhUserHasSeat: boolean
 ): Promise<CompletionResponseParams> {
+  const documentDirPath = pathUri.dirname(URI.parse(documentUri).path);
+  const documentFilePath = URI.parse(documentUri).path;
+  const ansibleFileType: IAnsibleFileType = getAnsibleFileType(
+    documentFilePath,
+    parsedAnsibleDocument
+  );
+
+  const hash = crypto.createHash("sha256").update(documentUri).digest("hex");
   const completionData: CompletionRequestParams = {
     prompt: content,
     suggestionId: suggestionId,
     metadata: {
-      documentUri: documentUri,
+      documentUri: `document-${hash}`,
+      ansibleFileType: ansibleFileType,
       activityId: activityId,
     },
   };
@@ -271,6 +329,16 @@ async function requestInlineSuggest(
     if (modelId && modelId !== "") {
       completionData.modelId = modelId;
     }
+
+    const additionalContext = getAdditionalContext(
+      parsedAnsibleDocument,
+      documentDirPath,
+      documentFilePath,
+      ansibleFileType
+    );
+    if (completionData.metadata) {
+      completionData.metadata.additionalContext = additionalContext;
+    }
   }
   console.log(
     `[inline-suggestions] ${getCurrentUTCDateTime().toISOString()}: Completion request sent to Ansible Lightspeed.`
@@ -278,6 +346,9 @@ async function requestInlineSuggest(
 
   lightSpeedManager.statusBarProvider.statusBar.show();
   lightSpeedManager.statusBarProvider.statusBar.tooltip = "processing...";
+  console.log(
+    `[inline-suggestions] completionData: \n${yaml.stringify(completionData)}\n`
+  );
   const outputData: CompletionResponseParams =
     await lightSpeedManager.apiInstance.completionRequest(completionData);
   lightSpeedManager.statusBarProvider.statusBar.tooltip = "Done";
@@ -286,6 +357,92 @@ async function requestInlineSuggest(
     `[inline-suggestions] ${getCurrentUTCDateTime().toISOString()}: Completion response received from Ansible Lightspeed.`
   );
   return outputData;
+}
+
+export function getAdditionalContext(
+  parsedAnsibleDocument: yaml.YAMLMap[],
+  documentDirPath: string,
+  documentFilePath: string,
+  ansibleFileType: IAnsibleFileType
+): IAdditionalContext {
+  const workspaceFolders = vscode.workspace.workspaceFolders;
+  let workSpaceRoot = undefined;
+  const playbookContext: IPlaybookContext = {};
+  let roleContext: IRoleContext = {};
+  const standaloneTaskContext: IStandaloneTaskContext = {};
+  if (workspaceFolders) {
+    workSpaceRoot = workspaceFolders[0].uri.fsPath;
+  }
+  if (ansibleFileType === "playbook") {
+    const varsFilesContext = getVarsFilesContext(
+      lightSpeedManager,
+      parsedAnsibleDocument,
+      documentDirPath
+    );
+    playbookContext["varInfiles"] = varsFilesContext || {};
+    const rolesCache: IRolesContext = {};
+    if (workSpaceRoot) {
+      // check if roles are installed in the workspace
+      if (!(workSpaceRoot in lightSpeedManager.ansibleRolesCache)) {
+        const rolesPath = getCustomRolePaths(workSpaceRoot);
+        for (const rolePath of rolesPath) {
+          watchRolesDirectory(lightSpeedManager, rolePath, workSpaceRoot);
+        }
+      }
+      // if roles are installed in the workspace, then get the relative path w.r.t. the workspace root
+      if (workSpaceRoot in lightSpeedManager.ansibleRolesCache) {
+        const workspaceRolesCache =
+          lightSpeedManager.ansibleRolesCache[workSpaceRoot];
+        for (const absRolePath in workspaceRolesCache) {
+          const relativeRolePath = getRelativePath(
+            documentDirPath,
+            workSpaceRoot,
+            absRolePath
+          );
+          rolesCache[relativeRolePath] = workspaceRolesCache[absRolePath];
+        }
+      }
+    }
+    if ("common" in lightSpeedManager.ansibleRolesCache) {
+      for (const commonRolePath in lightSpeedManager.ansibleRolesCache) {
+        rolesCache[commonRolePath] =
+          lightSpeedManager.ansibleRolesCache["common"][commonRolePath];
+      }
+    }
+    playbookContext["roles"] = rolesCache;
+  } else if (ansibleFileType === "tasks_in_role") {
+    const roleCache = lightSpeedManager.ansibleRolesCache;
+    const absRolePath = getRolePathFromPathWithinRole(documentFilePath);
+    if (
+      workSpaceRoot &&
+      workSpaceRoot in roleCache &&
+      absRolePath in roleCache[workSpaceRoot]
+    ) {
+      roleContext = roleCache[workSpaceRoot][absRolePath];
+    }
+  }
+  const includeVarsContext =
+    getIncludeVarsContext(
+      lightSpeedManager,
+      parsedAnsibleDocument,
+      documentDirPath,
+      ansibleFileType
+    ) || {};
+
+  if (ansibleFileType === "playbook") {
+    playbookContext.includeVars = includeVarsContext;
+  } else if (ansibleFileType === "tasks_in_role") {
+    roleContext.includeVars = includeVarsContext;
+  } else if (ansibleFileType === "tasks") {
+    standaloneTaskContext.includeVars = includeVarsContext;
+  }
+
+  const additionalContext: IAdditionalContext = {
+    playbookContext: playbookContext,
+    roleContext: roleContext,
+    standaloneTaskContext: standaloneTaskContext,
+  };
+  return additionalContext;
 }
 
 // Handlers

--- a/src/features/lightspeed/lightSpeedOAuthProvider.ts
+++ b/src/features/lightspeed/lightSpeedOAuthProvider.ts
@@ -35,7 +35,7 @@ import {
   LIGHTSPEED_CLIENT_ID,
   LIGHTSPEED_SERVICE_LOGIN_TIMEOUT,
   LIGHTSPEED_ME_AUTH_URL,
-} from "../../definitions/constants";
+} from "../../definitions/lightspeed";
 import { LightspeedAuthSession } from "../../interfaces/lightspeed";
 
 const CODE_VERIFIER = generateCodeVerifier();

--- a/src/features/lightspeed/statusBar.ts
+++ b/src/features/lightspeed/statusBar.ts
@@ -2,7 +2,7 @@ import * as vscode from "vscode";
 import { LanguageClient } from "vscode-languageclient/node";
 import { LightSpeedAPI } from "./api";
 import { SettingsManager } from "../../settings";
-import { LightSpeedCommands } from "../../definitions/constants";
+import { LightSpeedCommands } from "../../definitions/lightspeed";
 
 export class LightspeedStatusBar {
   private apiInstance: LightSpeedAPI;

--- a/src/features/lightspeed/utils/data.ts
+++ b/src/features/lightspeed/utils/data.ts
@@ -1,36 +1,26 @@
 import * as vscode from "vscode";
 import * as yaml from "yaml";
+import * as path from "path";
+import * as fs from "fs";
+import { getExpandedPath } from "../../../utils/fileUtils";
+import { IParsedYaml } from "../../../interfaces/yaml";
+import {
+  IVarsFileContext,
+  IWorkSpaceRolesContext,
+  IVarsContext,
+  IIncludeVarsContext,
+} from "../../../interfaces/lightspeed";
+import { watchAnsibleFile } from "./watchers";
+import { LightSpeedManager } from "../base";
+import { VarType } from "../../../interfaces/lightspeed";
+import {
+  IncludeVarValidTaskName,
+  StandardRolePaths,
+} from "../../../definitions/constants";
 
 export function shouldRequestInlineSuggestions(
-  documentContent: string
+  parsedAnsibleDocument: yaml.YAMLMap[]
 ): boolean {
-  let parsedAnsibleDocument = undefined;
-  try {
-    parsedAnsibleDocument = yaml.parse(documentContent, {
-      keepSourceTokens: true,
-    });
-  } catch (err) {
-    vscode.window.showErrorMessage(
-      `Ansible Lightspeed expects valid YAML syntax to provide inline suggestions. Error: ${err}`
-    );
-    return false;
-  }
-  // if the file is empty, we don't want to request inline suggestions
-  if (parsedAnsibleDocument === undefined) {
-    return false;
-  }
-
-  // check if YAML is a list, if not it is not a valid Ansible document
-  if (
-    typeof parsedAnsibleDocument === "object" &&
-    !Array.isArray(parsedAnsibleDocument)
-  ) {
-    vscode.window.showErrorMessage(
-      "Ansible Lightspeed expects valid Ansible syntax. For playbook files it should be a list of plays and for tasks files it should be list of tasks."
-    );
-    return false;
-  }
-
   const lastObject = parsedAnsibleDocument[parsedAnsibleDocument.length - 1];
   if (typeof lastObject !== "object") {
     return false;
@@ -46,4 +36,335 @@ export function shouldRequestInlineSuggestions(
   }
 
   return true;
+}
+
+export function getVarsFilesContext(
+  lightSpeedManager: LightSpeedManager,
+  parsedAnsibleDocument: yaml.YAMLMap[],
+  basePath: string
+): IVarsFileContext | undefined {
+  const varFilesContext: IVarsFileContext = {};
+  // Check if the last play in parsedAnsibleDocument has a vars_files key
+  const lastObject = parsedAnsibleDocument[parsedAnsibleDocument.length - 1];
+  if (!("vars_files" in lastObject)) {
+    return undefined;
+  }
+  // Extract the contents of the files specified in the vars_files key
+  let varsFiles: string[] | string = <string[] | string>(
+    lastObject["vars_files"]
+  );
+  if (!Array.isArray(varsFiles)) {
+    varsFiles = [varsFiles];
+  }
+  for (const varFile of varsFiles) {
+    let expandedVarFilePath = varFile;
+    if (!path.isAbsolute(varFile)) {
+      expandedVarFilePath = path.join(basePath, varFile);
+    }
+    expandedVarFilePath = getExpandedPath(expandedVarFilePath);
+    if (!fs.existsSync(expandedVarFilePath)) {
+      console.debug(`File ${expandedVarFilePath} does not exist.`);
+      if (expandedVarFilePath in lightSpeedManager.ansibleVarFilesCache) {
+        delete lightSpeedManager.ansibleVarFilesCache[expandedVarFilePath];
+      }
+      continue;
+    }
+    if (expandedVarFilePath in lightSpeedManager.ansibleVarFilesCache) {
+      varFilesContext[varFile] =
+        lightSpeedManager.ansibleVarFilesCache[expandedVarFilePath];
+    } else {
+      try {
+        const updatedFileContents = readVarFiles(expandedVarFilePath);
+        if (!updatedFileContents) {
+          return;
+        }
+        lightSpeedManager.ansibleVarFilesCache[expandedVarFilePath] =
+          updatedFileContents;
+        varFilesContext[varFile] = updatedFileContents;
+        watchAnsibleFile(lightSpeedManager, expandedVarFilePath, "vars_files");
+      } catch (err) {
+        console.error(`Failed to parse ${varFile} with error ${err}`);
+      }
+    }
+  }
+  return varFilesContext;
+}
+
+export function getIncludeVarsContext(
+  lightSpeedManager: LightSpeedManager,
+  parsedAnsibleDocument: yaml.YAMLMap[],
+  basePath: string,
+  ansibleFileType: string
+): IIncludeVarsContext | undefined {
+  let tasksLists: [] = [];
+  const includeVarsContext: IIncludeVarsContext = {};
+  if (ansibleFileType === "playbook") {
+    // Check if the last play in parsedAnsibleDocument has a vars_files key
+    const lastObject = parsedAnsibleDocument[parsedAnsibleDocument.length - 1];
+    if (!("tasks" in lastObject)) {
+      return undefined;
+    }
+    // Extract the contents of the files specified in the vars_files key
+    tasksLists = <[]>lastObject["tasks"];
+  } else if (
+    ansibleFileType === "tasks_in_role" ||
+    ansibleFileType === "tasks"
+  ) {
+    tasksLists = <[]>parsedAnsibleDocument;
+  }
+  if (!Array.isArray(tasksLists)) {
+    return undefined;
+  }
+  for (const task of tasksLists) {
+    const matchingKey = Object.keys(task).find((key) =>
+      IncludeVarValidTaskName.includes(key)
+    );
+    if (!matchingKey) {
+      continue;
+    }
+    const includeVarsTask = task[matchingKey];
+    let includeVarsFiles = [];
+    if ("file" in includeVarsTask) {
+      if (Array.isArray(includeVarsTask["file"])) {
+        includeVarsFiles.push(...(<[]>includeVarsTask["file"]));
+      } else {
+        includeVarsFiles.push(includeVarsTask["file"]);
+      }
+    } else if ("dir" in includeVarsTask) {
+      const dirs = Array.isArray(includeVarsTask["dir"])
+        ? includeVarsTask["dir"]
+        : [includeVarsTask["dir"]];
+      for (const dir of dirs) {
+        let dirPath = <string>dir;
+        if (!fs.existsSync(dirPath) || !fs.lstatSync(dirPath).isDirectory()) {
+          continue;
+        }
+        if (!path.isAbsolute(dirPath)) {
+          if (ansibleFileType === "tasks_in_role") {
+            dirPath = path.join(basePath, "vars", dir);
+          } else {
+            dirPath = path.join(basePath, dir);
+          }
+        }
+        const files = fs
+          .readdirSync(dirPath)
+          .filter((file) => {
+            return file.endsWith(".yml") || file.endsWith(".yaml");
+          })
+          .slice(0, 10);
+
+        if ("files_matching" in task) {
+          const matchingFiles = files.filter((file) => {
+            return path.basename(file) === task["files_matching"];
+          });
+          includeVarsFiles.push(
+            ...matchingFiles.map((file) => path.join(dirPath, file))
+          );
+        } else {
+          includeVarsFiles.push(
+            ...files.map((file) => path.join(dirPath, file))
+          );
+        }
+      }
+    }
+    if ("ignore_files" in task) {
+      const ignoreFiles = Array.isArray(task["ignore_files"])
+        ? task["ignore_files"]
+        : [task["ignore_files"]];
+      includeVarsFiles = includeVarsFiles.filter((file) => {
+        const fileName = path.basename(file);
+        return !ignoreFiles.includes(<never>fileName);
+      });
+    }
+    for (const includeVarsFile of includeVarsFiles) {
+      let absVarsFilePath = includeVarsFile;
+      if (!path.isAbsolute(includeVarsFile)) {
+        absVarsFilePath = path.join(basePath, includeVarsFile);
+      }
+
+      if (absVarsFilePath in includeVarsContext) {
+        continue;
+      }
+      let varData = readVarFiles(absVarsFilePath);
+      if (varData) {
+        if ("name" in includeVarsTask) {
+          const varTopLevel = includeVarsTask["name"];
+          try {
+            const parsedVarData = yaml.parse(varData, {
+              keepSourceTokens: true,
+            });
+            varData = <string>yaml.stringify({ [varTopLevel]: parsedVarData });
+          } catch (err) {
+            console.error(
+              `Failed to add ${varTopLevel} to ${varData} with error ${err}`
+            );
+          }
+        }
+        includeVarsContext[absVarsFilePath] = varData;
+      }
+    }
+  }
+
+  return includeVarsContext;
+}
+
+export function readVarFiles(varFile: string): string | undefined {
+  try {
+    if (!fs.existsSync(varFile)) {
+      return undefined;
+    }
+    const contents = fs.readFileSync(varFile, "utf8");
+    const parsedAnsibleVars = yaml.parse(contents, {
+      keepSourceTokens: true,
+    });
+    removeVarsValues(parsedAnsibleVars);
+    const updatedFileContents = yaml.stringify(parsedAnsibleVars);
+    return updatedFileContents;
+  } catch (err) {
+    console.error(`Failed to read ${varFile} with error ${err}`);
+    return undefined;
+  }
+}
+function removeVarsValues(parsedYaml: IParsedYaml[] | IParsedYaml | "") {
+  if (Array.isArray(parsedYaml)) {
+    for (const item of parsedYaml) {
+      removeVarsValues(item);
+    }
+  } else if (typeof parsedYaml === "object" && parsedYaml !== null) {
+    for (const key in parsedYaml) {
+      if (Object.prototype.hasOwnProperty.call(parsedYaml, key)) {
+        parsedYaml[key] = removeVarsValues(parsedYaml[key]);
+      }
+    }
+  } else {
+    parsedYaml = "";
+  }
+
+  return parsedYaml;
+}
+
+export function updateRolesCache(
+  uri: vscode.Uri,
+  lightSpeedManager: LightSpeedManager
+) {
+  let dirPath = uri.fsPath;
+  const stats = fs.statSync(dirPath);
+  if (stats.isFile()) {
+    dirPath = path.dirname(dirPath);
+  }
+  if (dirPath in StandardRolePaths) {
+    updateRolesContext(lightSpeedManager, dirPath, "common");
+  } else {
+    const workspaceFolders = vscode.workspace.workspaceFolders;
+    if (workspaceFolders) {
+      const workspaceFolder = workspaceFolders[0].uri.fsPath;
+      updateRolesContext(lightSpeedManager, dirPath, workspaceFolder);
+    }
+  }
+}
+
+export function updateRolesContext(
+  lightSpeedManager: LightSpeedManager,
+  rolesRootPath: string,
+  workSpaceRoot: string
+): IWorkSpaceRolesContext | undefined {
+  if (!fs.existsSync(rolesRootPath) || !rolesRootPath.endsWith("roles")) {
+    return;
+  }
+  const roleNames = fs
+    .readdirSync(rolesRootPath)
+    .filter((name) =>
+      fs.statSync(path.join(rolesRootPath, name)).isDirectory()
+    );
+  for (const roleName of roleNames) {
+    const rolePath = path.join(rolesRootPath, roleName);
+    updateRoleContext(lightSpeedManager, rolePath, workSpaceRoot);
+  }
+}
+export function updateRoleContext(
+  lightSpeedManager: LightSpeedManager,
+  rolePath: string,
+  workSpaceRoot: string
+) {
+  if (!lightSpeedManager.ansibleRolesCache[workSpaceRoot]) {
+    lightSpeedManager.ansibleRolesCache[workSpaceRoot] = {};
+  }
+  const rolesContext = lightSpeedManager.ansibleRolesCache[workSpaceRoot];
+  rolesContext[rolePath] = {
+    name: rolePath.split(path.sep).pop(),
+  };
+
+  // Get all the task files in the tasks directory
+  const tasksPath = path.join(rolePath, "tasks");
+  if (fs.existsSync(tasksPath)) {
+    const taskNames = fs
+      .readdirSync(tasksPath)
+      .filter((name) => [".yml", ".yaml"].includes(path.extname(name)))
+      .map((name) => path.basename(name, path.extname(name)));
+    rolesContext[rolePath]["tasks"] = taskNames;
+  }
+
+  rolesContext[rolePath]["roleVars"] = {
+    defaults: getVarsFromRoles(rolePath, "defaults") || {},
+    vars: getVarsFromRoles(rolePath, "vars") || {},
+  };
+}
+
+export function getRelativePath(
+  documentDir: string,
+  workSpaceRoot: string,
+  absPath: string
+): string {
+  let relativePath = documentDir;
+  if (documentDir && documentDir.startsWith(workSpaceRoot)) {
+    relativePath = path.relative(documentDir, absPath);
+  }
+  return relativePath;
+}
+
+function getVarsFromRoles(
+  rolePath: string,
+  varType: VarType
+): IVarsContext | undefined {
+  const varsRootPath = path.join(rolePath, varType);
+  if (!fs.existsSync(varsRootPath)) {
+    return;
+  }
+  const varsFiles =
+    fs
+      .readdirSync(varsRootPath)
+      .filter((name) => [".yml", ".yaml"].includes(path.extname(name)))
+      .map((name) => name)
+      .map((name) => path.join(varsRootPath, name)) || [];
+  for (const varsFile of varsFiles) {
+    if (!fs.existsSync(varsFile)) {
+      continue;
+    }
+
+    try {
+      const varsContext: IVarsContext = {};
+      const varsFileName = path.basename(varsFile);
+      const varsFileContent = readVarFiles(varsFile);
+      if (varsFileContent) {
+        varsContext[varsFileName] = varsFileContent;
+        return varsContext;
+      }
+    } catch (err) {
+      console.error(`Failed to read ${varsFile} with error ${err}`);
+    }
+  }
+
+  return;
+}
+
+export function getRolePathFromPathWithinRole(roleFilePath: string): string {
+  const pathSep = path.sep;
+  const rolesIndex =
+    roleFilePath.indexOf(`${pathSep}roles${pathSep}`) +
+    `${path.sep}roles${path.sep}`.length;
+  const roleNamePath = roleFilePath.substring(
+    0,
+    roleFilePath.indexOf(path.sep, rolesIndex)
+  );
+  return roleNamePath;
 }

--- a/src/features/lightspeed/utils/feedbackView.ts
+++ b/src/features/lightspeed/utils/feedbackView.ts
@@ -2,7 +2,7 @@ import { Disposable, Webview, window, Uri } from "vscode";
 import { getUri } from "../../utils/getUri";
 import { getNonce } from "../../utils/getNonce";
 import { lightSpeedManager } from "../../../extension";
-import { FeedbackRequestParams } from "../../../definitions/lightspeed";
+import { FeedbackRequestParams } from "../../../interfaces/lightspeed";
 
 export function getWebviewContent(webview: Webview, extensionUri: Uri) {
   const webviewUri = getUri(webview, extensionUri, [

--- a/src/features/lightspeed/utils/watchers.ts
+++ b/src/features/lightspeed/utils/watchers.ts
@@ -1,0 +1,130 @@
+import * as vscode from "vscode";
+import * as path from "path";
+import * as fs from "fs";
+import { globalFileSystemWatcher } from "../../../extension";
+import { LightSpeedManager } from "../base";
+import { IAnsibleType } from "../../../interfaces/watchers";
+import {
+  getRolePathFromPathWithinRole,
+  readVarFiles,
+  updateRoleContext,
+} from "./data";
+import { isFile } from "../../../utils/fileUtils";
+import { updateRolesContext } from "./data";
+import { StandardRolePaths } from "../../../definitions/constants";
+
+export async function watchAnsibleFile(
+  lightSpeedManager: LightSpeedManager,
+  filePath: string,
+  ansibleType: IAnsibleType
+) {
+  try {
+    if (!isFile(filePath)) {
+      console.error(`${filePath} is not a file`);
+      return;
+    }
+    if (globalFileSystemWatcher[filePath] !== undefined) {
+      console.log(`File ${filePath} is already being watched`);
+      return;
+    }
+
+    const fileWatcher = vscode.workspace.createFileSystemWatcher(filePath);
+
+    fileWatcher.onDidChange(() => {
+      console.log(`File ${filePath} watcher has been changed`);
+      if (ansibleType === "vars_files") {
+        console.log(`File ${filePath} is a vars_file`);
+        const updatedFileContents = readVarFiles(filePath);
+        if (!updatedFileContents) {
+          return;
+        }
+        lightSpeedManager.ansibleVarFilesCache[filePath] = updatedFileContents;
+      }
+    });
+
+    fileWatcher.onDidDelete(() => {
+      console.log(`File ${filePath} watcher has been deleted`);
+      if (filePath in lightSpeedManager.ansibleVarFilesCache) {
+        delete lightSpeedManager.ansibleVarFilesCache[filePath];
+      }
+    });
+
+    fileWatcher.onDidCreate(() => {
+      console.log(`File ${filePath} watcher has been created`);
+    });
+
+    globalFileSystemWatcher.filePath.watcher = fileWatcher;
+    globalFileSystemWatcher.filePath.type = ansibleType;
+
+    console.log(`Watching file ${filePath}`);
+  } catch (err) {
+    console.error(`Failed to watch file ${filePath} with error ${err}`);
+    return;
+  }
+}
+
+export function watchRolesDirectory(
+  lightSpeedManager: LightSpeedManager,
+  rolesPath: string,
+  workspaceRoot?: string
+) {
+  if (!workspaceRoot) {
+    workspaceRoot = "common";
+  }
+  const ansibleRolesCache = lightSpeedManager.ansibleRolesCache;
+  if (
+    ansibleRolesCache[workspaceRoot] &&
+    rolesPath in ansibleRolesCache[workspaceRoot]
+  ) {
+    console.log(`Directory ${rolesPath} is already being watched`);
+    updateRolesContext(lightSpeedManager, rolesPath, workspaceRoot);
+    return;
+  } else {
+    updateRolesContext(lightSpeedManager, rolesPath, workspaceRoot);
+    console.log(`Created roles cache for ${rolesPath}`);
+  }
+
+  const watcher = vscode.workspace.createFileSystemWatcher(
+    path.join(rolesPath, "**/*")
+  );
+
+  watcher.onDidChange((uri) => {
+    const currentWorkspaceRoot = vscode.workspace.workspaceFolders;
+    if (currentWorkspaceRoot) {
+      const workspaceRoot = currentWorkspaceRoot[0].uri.fsPath;
+      const rolePath = getRolePathFromPathWithinRole(uri.fsPath);
+      updateRoleContext(lightSpeedManager, rolePath, workspaceRoot);
+      console.log(`Directory ${uri.fsPath} has been changed`);
+    }
+  });
+
+  watcher.onDidDelete((uri) => {
+    let dirPath = uri.fsPath;
+    const stats = fs.statSync(dirPath);
+    if (stats.isFile()) {
+      dirPath = path.dirname(dirPath);
+    }
+    if (dirPath in StandardRolePaths) {
+      delete ansibleRolesCache["common"][dirPath];
+    } else {
+      const workspaceFolders = vscode.workspace.workspaceFolders;
+      if (workspaceFolders) {
+        const workspaceFolder = workspaceFolders[0].uri.fsPath;
+        if (dirPath in ansibleRolesCache[workspaceFolder]) {
+          delete ansibleRolesCache[workspaceFolder][dirPath];
+        }
+      }
+    }
+    console.log(`Directory ${dirPath} has been deleted`);
+  });
+
+  watcher.onDidCreate((uri) => {
+    const currentWorkspaceRoot = vscode.workspace.workspaceFolders;
+    if (currentWorkspaceRoot) {
+      const workspaceRoot = currentWorkspaceRoot[0].uri.fsPath;
+      const rolePath = getRolePathFromPathWithinRole(uri.fsPath);
+      updateRoleContext(lightSpeedManager, rolePath, workspaceRoot);
+      console.log(`Directory ${uri.fsPath} has been changed`);
+    }
+  });
+}

--- a/src/features/utils/ansible.ts
+++ b/src/features/utils/ansible.ts
@@ -1,0 +1,70 @@
+import * as glob from "glob";
+import * as path from "path";
+import * as fs from "fs";
+import { minimatch } from "minimatch";
+import {
+  AnsibleFileTypes,
+  PlaybookKeywords,
+  StandardRolePaths,
+} from "../../definitions/constants";
+
+import { IAnsibleFileType } from "../../interfaces/lightspeed";
+import { parseYamlFile } from "./data";
+
+export function getAnsibleFileType(
+  filePath: string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  parsedAnsibleDocument?: any
+): IAnsibleFileType {
+  if (!parsedAnsibleDocument) {
+    parsedAnsibleDocument = parseYamlFile(filePath);
+  }
+  const lastObject = parsedAnsibleDocument[parsedAnsibleDocument.length - 1];
+  if (typeof lastObject !== "object") {
+    return "other";
+  }
+  const objectKeys = Object.keys(lastObject);
+  for (const keyword of objectKeys) {
+    if (keyword in PlaybookKeywords) {
+      return "playbook";
+    }
+  }
+  for (const pattern in AnsibleFileTypes) {
+    if (AnsibleFileTypes.hasOwnProperty(pattern)) {
+      if (minimatch(filePath, pattern as string)) {
+        return AnsibleFileTypes[pattern];
+      }
+    }
+  }
+
+  return "other";
+}
+
+export function getCustomRolePaths(workspacePath?: string): string[] {
+  const rolePaths: string[] = [];
+
+  if (workspacePath) {
+    const pattern = path.join(workspacePath, "**/roles");
+    const options = {
+      ignore: ["**/node_modules/**", "**/.git/**"],
+      absolute: true,
+    };
+    const workspaceRolePaths = glob.sync(pattern, options);
+    rolePaths.push(...workspaceRolePaths);
+  }
+
+  return rolePaths;
+}
+
+export function getCommonRoles(): string[] {
+  const rolePaths: string[] = [];
+  const expandedPaths = StandardRolePaths.map((p) =>
+    path.join(path.parse(p).root, path.normalize(p).slice(1))
+  );
+  const standardRolePaths = expandedPaths.filter(
+    (p) => fs.existsSync(p) && fs.statSync(p).isDirectory()
+  );
+  rolePaths.push(...standardRolePaths);
+
+  return rolePaths;
+}

--- a/src/features/utils/data.ts
+++ b/src/features/utils/data.ts
@@ -1,3 +1,6 @@
+import * as fs from "fs";
+import * as yaml from "yaml";
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function compareObjects(baseObject: any, newObject: any): boolean {
   // compare the number of keys
@@ -17,4 +20,22 @@ export function compareObjects(baseObject: any, newObject: any): boolean {
 
   // all keys and values are equal
   return true;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function parseYamlFile(filePath: string): any {
+  const stats = fs.statSync(filePath);
+  if (!stats.isFile()) {
+    return undefined;
+  }
+  try {
+    const fileContents = fs.readFileSync(filePath, "utf8");
+    const parsedAnsibleDocument = yaml.parse(fileContents, {
+      keepSourceTokens: true,
+    });
+    return parsedAnsibleDocument;
+  } catch (error) {
+    console.error(`Error parsing YAML file ${filePath}: ${error}`);
+    return undefined;
+  }
 }

--- a/src/interfaces/lightspeed.ts
+++ b/src/interfaces/lightspeed.ts
@@ -1,5 +1,159 @@
 import { AuthenticationSession } from "vscode";
+import {
+  AnsibleContentUploadTrigger,
+  UserAction,
+} from "../definitions/lightspeed";
 
 export interface LightspeedAuthSession extends AuthenticationSession {
   rhUserHasSeat: boolean;
+}
+
+export interface CompletionResponseParams {
+  predictions: string[];
+}
+
+export interface MetadataParams {
+  documentUri: string;
+  ansibleFileType: IAnsibleFileType;
+  activityId: string;
+  additionalContext?: IAdditionalContext;
+}
+
+export interface CompletionRequestParams {
+  prompt: string;
+  suggestionId?: string;
+  metadata?: MetadataParams;
+  modelId?: string;
+}
+
+export interface FeedbackResponseParams {
+  message: string;
+}
+
+export interface InlineSuggestionEvent {
+  latency?: number;
+  userActionTime?: number;
+  documentUri?: string;
+  action?: UserAction;
+  error?: string;
+  suggestionId?: string;
+  activityId?: string;
+}
+
+export interface AnsibleContentEvent {
+  content: string;
+  documentUri: string;
+  trigger: AnsibleContentUploadTrigger;
+  activityId: string | undefined;
+}
+export interface SentimentEvent {
+  value: number;
+  feedback: string;
+}
+
+export interface SuggestionQualityEvent {
+  prompt: string;
+  providedSuggestion: string;
+  expectedSuggestion: string;
+  additionalComment: string;
+}
+export interface IssueFeedbackEvent {
+  type: "bug-report" | "feature-request";
+  title: string;
+  description: string;
+}
+
+export interface FeedbackRequestParams {
+  inlineSuggestion?: InlineSuggestionEvent;
+  ansibleContent?: AnsibleContentEvent;
+  sentimentFeedback?: SentimentEvent;
+  suggestionQualityFeedback?: SuggestionQualityEvent;
+  issueFeedback?: IssueFeedbackEvent;
+}
+
+export interface IDocumentTrackerFields {
+  activityId: string;
+  content: string;
+}
+
+export interface IDocumentTracker {
+  [key: string]: IDocumentTrackerFields;
+}
+
+export interface AttributionsRequestParams {
+  suggestion: string;
+  suggestionId: string;
+}
+
+export interface IAttributionsParams {
+  repo_name: string;
+  repo_url: string;
+  path: string;
+  license: string;
+  data_source: string;
+  ansible_type: string;
+  score: number;
+}
+
+export interface AttributionsResponseParams {
+  attributions: IAttributionsParams[];
+}
+
+export interface ISuggestionDetails {
+  suggestion: string;
+  suggestionId: string;
+}
+
+export type IAnsibleFileType = "playbook" | "tasks_in_role" | "tasks" | "other";
+
+export type VarType = "defaults" | "vars";
+
+export interface IAnsibleFileTypes {
+  [key: string]: IAnsibleFileType;
+}
+
+export interface IVarsContext {
+  [key: string]: string;
+}
+
+export interface IIncludeVarsContext {
+  [key: string]: string;
+}
+
+export interface IVarsFileContext {
+  [key: string]: string;
+}
+
+export interface IRoleVarsContext {
+  defaults: IVarsFileContext;
+  vars: IVarsFileContext;
+}
+export interface IRoleContext {
+  name?: string;
+  tasks?: string[];
+  roleVars?: IRoleVarsContext;
+  includeVars?: IIncludeVarsContext;
+}
+export interface IRolesContext {
+  [rolePath: string]: IRoleContext;
+}
+
+export interface IStandaloneTaskContext {
+  includeVars?: IIncludeVarsContext;
+}
+
+export interface IWorkSpaceRolesContext {
+  [workSpaceRoot: string]: IRolesContext;
+}
+
+export interface IPlaybookContext {
+  varInfiles?: IVarsFileContext;
+  roles?: IRolesContext;
+  taskFileNames?: string[];
+  includeVars?: IIncludeVarsContext;
+}
+export interface IAdditionalContext {
+  playbookContext?: IPlaybookContext;
+  roleContext?: IRoleContext;
+  standaloneTaskContext?: IStandaloneTaskContext;
 }

--- a/src/interfaces/watchers.ts
+++ b/src/interfaces/watchers.ts
@@ -1,0 +1,12 @@
+import * as vscode from "vscode";
+
+export type IAnsibleType = "vars_files";
+
+export interface IWatchersType {
+  watcher: vscode.FileSystemWatcher;
+  type: IAnsibleType;
+}
+
+export interface IFileSystemWatchers {
+  [key: string]: IWatchersType;
+}

--- a/src/interfaces/yaml.ts
+++ b/src/interfaces/yaml.ts
@@ -1,0 +1,4 @@
+export interface IParsedYaml {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [key: string]: any;
+}

--- a/src/utils/fileUtils.ts
+++ b/src/utils/fileUtils.ts
@@ -1,0 +1,23 @@
+import * as path from "path";
+import * as os from "os";
+import * as fs from "fs";
+
+export function getExpandedPath(filePath: string, basePath?: string): string {
+  if (basePath && !path.isAbsolute(filePath)) {
+    filePath = path.join(basePath, filePath);
+  }
+
+  filePath = filePath.replace(/^~(?=$|\/|\\)/, os.homedir());
+  filePath = path.resolve(filePath);
+  return filePath;
+}
+
+export function isFile(filePath: string): boolean {
+  try {
+    const stat = fs.statSync(filePath);
+    return stat.isFile();
+  } catch (error) {
+    console.error(`Error checking if ${filePath} is a file: ${error}`);
+    return false;
+  }
+}

--- a/test/helper.ts
+++ b/test/helper.ts
@@ -2,10 +2,10 @@ import * as vscode from "vscode";
 import * as path from "path";
 import sinon from "sinon";
 import { assert } from "chai";
-import { LightSpeedCommands } from "../src/definitions/constants";
+import { LightSpeedCommands } from "../src/definitions/lightspeed";
 import { integer } from "vscode-languageclient";
 import axios from "axios";
-import { LIGHTSPEED_ME_AUTH_URL } from "../src/definitions/constants";
+import { LIGHTSPEED_ME_AUTH_URL } from "../src/definitions/lightspeed";
 import { getInlineSuggestionItems } from "../src/features/lightspeed/inlineSuggestions";
 
 export let doc: vscode.TextDocument;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1426,6 +1426,7 @@ __metadata:
     "@types/chai": ^4.3.5
     "@types/glob": ^8.1.0
     "@types/ini": ^1.3.31
+    "@types/minimatch": ^5.1.2
     "@types/mocha": ^10.0.1
     "@types/node": ^18.16.3
     "@types/sinon": ^10.0.14
@@ -1447,6 +1448,7 @@ __metadata:
     eslint-plugin-tsdoc: ^0.2.17
     glob: ^9.3.5
     ini: ^4.0.0
+    minimatch: ^9.0.3
     mocha: ^10.2.0
     mochawesome: ^7.1.3
     mochawesome-report-generator: ^6.2.0
@@ -1461,6 +1463,7 @@ __metadata:
     uuid: ^9.0.0
     vscode-extension-tester: ^5.5.3
     vscode-languageclient: ^8.1.0
+    vscode-uri: ^3.0.7
     warnings-to-errors-webpack-plugin: ^2.3.0
     webpack: ^5.81.0
     webpack-cli: ^5.0.2
@@ -4716,7 +4719,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^9.0.1":
+"minimatch@npm:^9.0.1, minimatch@npm:^9.0.3":
   version: 9.0.3
   resolution: "minimatch@npm:9.0.3"
   dependencies:


### PR DESCRIPTION
For each of the completion request send addtional context as below
*  The variables referred in the list of `vars_files` keyword if present and can be resolved to a path of the file system.
*  The variables referred in the `include_vars` task if present and can be resolved to a path of the file system.
*  The list of roles and it's data
   - The relative path of role with respect to the playbook path
   - The name of the role
   - List of tasks within the role
   - The default variables under the default folder
   - The vars varaibles under the vars folder

Note: Only the variable structure and key value is preserved and all the
      values are removed.