### PR TITLE
Add a checkbox while sharing Lightspeed sentiment/issue feedback

### DIFF
--- a/src/features/lightspeed/utils/feedbackView.ts
+++ b/src/features/lightspeed/utils/feedbackView.ts
@@ -17,56 +17,60 @@ export function getWebviewContent(webview: Webview, extensionUri: Uri) {
   const nonce = getNonce();
 
   return /*html*/ `
-        <!DOCTYPE html>
-        <html lang="en">
-          <head>
-            <meta charset="UTF-8">
-            <meta name="viewport" content="width=device-width, initial-scale=1.0">
-            <link rel="stylesheet" href="${styleUri}">
-            <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${webview.cspSource}; script-src 'nonce-${nonce}';">
-            <title>Ansible Lightspeed Feedback!</title>
-          </head>
-          <body>
-            <form id="feedback-form">
-              <section class="component-container">
-                <h3>How was your experience?</h3>
-                <section class="sentiment-button">
-                  <div class="sentiment-selector">
-                      <input id="very-negative" value=1 type="radio" name="sentiment" />
-                      <label class="sentiment very-negative" for="very-negative"></label>
-                      <input id="negative" value=2 type="radio" name="sentiment" />
-                      <label class="sentiment negative"for="negative"></label>
-                      <input id="neutral" value=3 type="radio" name="sentiment" />
-                      <label class="sentiment neutral"for="neutral"></label>
-                      <input id="positive" value=4 type="radio" name="sentiment" />
-                      <label class="sentiment positive"for="positive"></label>
-                      <input id="very-positive" value=5 type="radio" name="sentiment" />
-                      <label class="sentiment very-positive"for="very-positive"></label>
-                  </div>
-                </section>
-              </section>
+  <!DOCTYPE html>
+  <html lang="en">
+    <head>
+      <meta charset="UTF-8">
+      <meta name="viewport" content="width=device-width, initial-scale=1.0">
+      <link rel="stylesheet" href="${styleUri}">
+      <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${webview.cspSource}; script-src 'nonce-${nonce}';">
+      <title>Ansible Lightspeed Feedback!</title>
+    </head>
+    <body>
+      <form id="feedback-form">
+        <section class="component-container">
+          <h3>How was your experience?</h3>
+          <section class="sentiment-button">
+            <div class="sentiment-selector">
+                <input id="very-negative" value=1 type="radio" name="sentiment" />
+                <label class="sentiment very-negative" for="very-negative"></label>
+                <input id="negative" value=2 type="radio" name="sentiment" />
+                <label class="sentiment negative"for="negative"></label>
+                <input id="neutral" value=3 type="radio" name="sentiment" />
+                <label class="sentiment neutral"for="neutral"></label>
+                <input id="positive" value=4 type="radio" name="sentiment" />
+                <label class="sentiment positive"for="positive"></label>
+                <input id="very-positive" value=5 type="radio" name="sentiment" />
+                <label class="sentiment very-positive"for="very-positive"></label>
+            </div>
+          </section>
+        </section>
+        <section class="component-section">
+            <p class="required">Tell us why?</p>
+            <vscode-text-area maxlength="512" cols="29" resize="both" id="sentiment-comment"></vscode-text-area>
+        </section>
+        <section class="component-section">
+            <input type="checkbox" id="sentiment-data-sharing-checkbox">
+            <label for="sentiment-data-sharing-checkbox">I understand that feedback is shared with Red Hat and IBM.</label>
+        </section>
+        <section class="component-section">
+            <vscode-button id="sentiment-submit" disabled>Send</vscode-button>
+        </section>
+        <vscode-divider></vscode-divider>
+        <section class="component-container">
+            <h3>Tell us more</h3>
               <section class="component-section">
-                  <p class="required">Tell us why?</p>
-                  <vscode-text-area maxlength="512" cols="29" resize="both" id="sentiment-comment"></vscode-text-area>
+                <vscode-dropdown id="issue-type-dropdown" class="issue-dropdown">
+                  <vscode-option selected value="select-issue-type">Select Issue type</vscode-option>
+                  <vscode-option value="bug-report">Bug report</vscode-option>
+                  <vscode-option value="feature-request">Feature request</vscode-option>
+                  <vscode-option value="suggestion-feedback">Suggestion feedback</vscode-option>
+                </vscode-dropdown>
               </section>
-              <section class="component-section">
-                  <vscode-button id="sentiment-submit">Send</vscode-button>
-              </section>
-          <vscode-divider></vscode-divider>
-          <section class="component-container">
-              <h3>Tell us more</h3>
-                <section class="component-section">
-                  <vscode-dropdown id="issue-type-dropdown" class="issue-dropdown">
-                    <vscode-option selected value="select-issue-type">Select Issue type</vscode-option>
-                    <vscode-option value="bug-report">Bug report</vscode-option>
-                    <vscode-option value="feature-request">Feature request</vscode-option>
-                    <vscode-option value="suggestion-feedback">Suggestion feedback</vscode-option>
-                  </vscode-dropdown>
-                </section>
-                  <script type="module" nonce="${nonce}" src="${webviewUri}"></script>
-            </form>
-          </body>
-        </html>
+                <script type="module" nonce="${nonce}" src="${webviewUri}"></script>
+          </form>
+    </body>
+  </html>
         `;
 }
 

--- a/src/webview/apps/lightspeed/main.ts
+++ b/src/webview/apps/lightspeed/main.ts
@@ -5,6 +5,7 @@ import {
   Dropdown,
   TextArea,
   TextField,
+  Checkbox,
 } from "@vscode/webview-ui-toolkit";
 
 provideVSCodeDesignSystem().register(allComponents);
@@ -52,7 +53,11 @@ function main() {
             <vscode-text-area id="issue-description" cols="29" maxlength="4096" placeholder="Enter details." resize="both"/>
           </section>
           <section class="component-section">
-            <vscode-button id="issue-submit-button">Submit</vscode-button>
+            <input type="checkbox" id="feedback-data-sharing-checkbox">
+            <label for="feedback-data-sharing-checkbox">I understand that feedback is shared with Red Hat and IBM.</label>
+          </section>
+          <section class="component-section">
+            <vscode-button id="issue-submit-button" disabled>Submit</vscode-button>
         </section>
       `;
       feedbackForm.append(bugReportSection);
@@ -67,7 +72,11 @@ function main() {
           <vscode-text-area id="issue-description" cols="29" maxlength="4096" placeholder="Enter details." resize="both" />
         </section>
         <section class="component-section">
-          <vscode-button id="issue-submit-button">Submit</vscode-button>
+          <input type="checkbox" id="feedback-data-sharing-checkbox">
+          <label for="feedback-data-sharing-checkbox">I understand that feedback is shared with Red Hat and IBM.</label>
+        </section>
+        <section class="component-section">
+          <vscode-button id="issue-submit-button" disabled>Submit</vscode-button>
         </section>
       `;
       feedbackForm.appendChild(featureRequestSection);
@@ -90,7 +99,11 @@ function main() {
           <vscode-text-area id="suggestion-additional-comment" cols="29" class="m-b-10" placeholder="Enter details." resize="both" />
         </section>
         <section class="component-section">
-            <vscode-button id="issue-submit-button">Submit</vscode-button>
+          <input type="checkbox" id="feedback-data-sharing-checkbox">
+          <label for="feedback-data-sharing-checkbox">I understand that feedback is shared with Red Hat and IBM.</label>
+        </section>
+        <section class="component-section">
+            <vscode-button id="issue-submit-button" disabled>Submit</vscode-button>
         </section>
       `;
 
@@ -115,6 +128,14 @@ function handleSentimentFeedback() {
   const sentimentSendButton = document.getElementById(
     "sentiment-submit"
   ) as Button;
+
+  const sentimentDataSharingCheckbox = document.getElementById(
+    "sentiment-data-sharing-checkbox"
+  ) as Checkbox;
+
+  sentimentDataSharingCheckbox.addEventListener("change", () => {
+    sentimentSendButton.disabled = !sentimentDataSharingCheckbox.checked;
+  });
 
   sentimentSendButton.addEventListener("click", () => {
     const sentimentSelector = document.querySelector(
@@ -167,6 +188,14 @@ function handleIssueFeedback() {
   const issueDescriptionTextArea = document.getElementById(
     "issue-description"
   ) as TextArea;
+
+  const feedbackDataSharingCheckbox = document.getElementById(
+    "feedback-data-sharing-checkbox"
+  ) as Checkbox;
+
+  feedbackDataSharingCheckbox.addEventListener("change", () => {
+    issueSubmitButton.disabled = !feedbackDataSharingCheckbox.checked;
+  });
 
   issueSubmitButton.addEventListener("click", () => {
     console.log(`Issue type: ${issueTypeDropdown.value}`);


### PR DESCRIPTION
* Add a checkbox which ensure user selects and agree to sharing the feedback data with Red Hat and IBM for sentiment and issue feedback