### PR TITLE
Add check to not sent feedback events for subscribed lightspeed users…

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ the extension:
 - yaml files having playbook in their filename: `*playbook*.yml` or
   `*playbook*.yaml`
 
-Additionally, in vscode, you can add persistent file association for language to
-`settings.json` file like this:
+Additionally, in VS Code, you can add persistent file association for language
+to `settings.json` file like this:
 
 ```json
 {
@@ -174,7 +174,7 @@ any level (User, Remote, Workspace and/or Folder).
 
 - `ansible.ansible.path`: Path to the `ansible` executable.
 - `ansible.ansible.reuseTerminal`: Enabling this will cause ansible commands run
-  through VSCode to reuse the same Ansible Terminal.
+  through VS Code to reuse the same Ansible Terminal.
 - `ansible.ansible.useFullyQualifiedCollectionNames`: Toggles use of fully
   qualified collection names (FQCN) when inserting a module name. Disabling it
   will only use FQCNs when necessary, that is when the collection isn't
@@ -219,7 +219,7 @@ any level (User, Remote, Workspace and/or Folder).
   when completing modules.
 - `ansible.completion.provideModuleOptionAliases`: Toggle alias provider when
   completing module options.
-- `ansibleServer.trace.server`: Traces the communication between VSCode and the
+- `ansibleServer.trace.server`: Traces the communication between VS Code and the
   ansible language server.
 - `ansible.lightspeed.enabled`: Enable Ansible Lightspeed.
 - `ansible.lightspeed.URL`: URL for Ansible Lightspeed.

--- a/package.json
+++ b/package.json
@@ -243,7 +243,7 @@
             "scope": "machine-overridable",
             "type": "boolean",
             "default": false,
-            "markdownDescription": "Enabling this will cause ansible commands run through VSCode to reuse the same Ansible Terminal.",
+            "markdownDescription": "Enabling this will cause ansible commands run through VS Code to reuse the same Ansible Terminal.",
             "order": 2
           }
         }
@@ -729,7 +729,7 @@
   "displayName": "Ansible",
   "engineStrict": true,
   "engines": {
-    "//": "node version affects only development, it does not affect vscode runtime",
+    "//": "node version affects only development, it does not affect VS Code runtime",
     "node": ">=16.0",
     "npm": "\n\nERROR: Please use yarn instead of npm for this repository.!!!\n\n",
     "vscode": "^1.71.0",

--- a/src/features/lightspeed/api.ts
+++ b/src/features/lightspeed/api.ts
@@ -151,6 +151,20 @@ export class LightSpeedAPI {
       console.error("Ansible Lightspeed instance is not initialized.");
       return {} as FeedbackResponseParams;
     }
+    const rhUserHasSeat = await this.lightSpeedAuthProvider.rhUserHasSeat();
+    if (rhUserHasSeat) {
+      if (inputData.inlineSuggestion) {
+        delete inputData.inlineSuggestion;
+      }
+      if (inputData.ansibleContent) {
+        delete inputData.ansibleContent;
+      }
+    }
+
+    if (Object.keys(inputData).length === 0) {
+      return {} as FeedbackResponseParams;
+    }
+
     try {
       const response = await axiosInstance.post(
         LIGHTSPEED_SUGGESTION_FEEDBACK_URL,

--- a/src/features/lightspeed/inlineSuggestions.ts
+++ b/src/features/lightspeed/inlineSuggestions.ts
@@ -221,7 +221,7 @@ export async function getInlineSuggestionItems(
   const documentFilePath = URI.parse(documentUri).path;
   const ansibleFileType: IAnsibleFileType = getAnsibleFileType(
     documentFilePath,
-    parsedAnsibleDocument
+    documentContent
   );
 
   if (suggestionMatchType === "MULTI-TASK") {
@@ -569,9 +569,6 @@ export async function inlineSuggestionUserActionHandler(
   };
   lightSpeedManager.apiInstance.feedbackRequest(
     inlineSuggestionFeedbackPayload
-  );
-  console.debug(
-    `[ansible-lightspeed-feedback] User action event lightSpeedInlineSuggestionFeedbackEvent sent.`
   );
   inlineSuggestionData = {};
 }

--- a/src/features/utils/ansible.ts
+++ b/src/features/utils/ansible.ts
@@ -1,6 +1,7 @@
 import * as glob from "glob";
 import * as path from "path";
 import * as fs from "fs";
+import * as yaml from "yaml";
 import { minimatch } from "minimatch";
 import {
   AnsibleFileTypes,
@@ -9,15 +10,22 @@ import {
 } from "../../definitions/constants";
 
 import { IAnsibleFileType } from "../../interfaces/lightspeed";
-import { parseYamlFile } from "./data";
 
 export function getAnsibleFileType(
   filePath: string,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  parsedAnsibleDocument?: any
+  documentContent: string
 ): IAnsibleFileType {
-  if (!parsedAnsibleDocument) {
-    parsedAnsibleDocument = parseYamlFile(filePath);
+  let parsedAnsibleDocument;
+  try {
+    parsedAnsibleDocument = yaml.parse(documentContent, {
+      keepSourceTokens: true,
+    });
+  } catch (err) {
+    console.log(err);
+    return "other";
+  }
+  if (!parsedAnsibleDocument || parsedAnsibleDocument.length === 0) {
+    return "other";
   }
   const lastObject = parsedAnsibleDocument[parsedAnsibleDocument.length - 1];
   if (typeof lastObject !== "object") {


### PR DESCRIPTION
… and other updates

*  If a logged in user is a Lightspeed subscriber do not send `inlineSuggestion` and `ansibleContent` events
*  Change `VSCode` to `VS Code` in docs
*  For the suggestion trigger check parse the file content before cursor position  to identify the Ansible file type