### PR TITLE
Fix for multi-task and single-task lightspeed suggestions

### DIFF
--- a/src/features/lightspeed/api.ts
+++ b/src/features/lightspeed/api.ts
@@ -77,7 +77,9 @@ export class LightSpeedAPI {
       return {} as CompletionResponseParams;
     }
     console.log(
-      `Completion request sent to lightspeed: ${JSON.stringify(inputData)}`
+      `[ansible-lightspeed] Completion request sent to lightspeed: ${JSON.stringify(
+        inputData
+      )}`
     );
     try {
       const response = await axiosInstance.post(
@@ -186,7 +188,9 @@ export class LightSpeedAPI {
       return {} as FeedbackResponseParams;
     }
     console.log(
-      `Feedback request sent to lightspeed: ${JSON.stringify(inputData)}`
+      `[ansible-lightspeed] Feedback request sent to lightspeed: ${JSON.stringify(
+        inputData
+      )}`
     );
     try {
       const response = await axiosInstance.post(
@@ -239,7 +243,9 @@ export class LightSpeedAPI {
     }
     try {
       console.log(
-        `Content Match request sent to lightspeed: ${JSON.stringify(inputData)}`
+        `[ansible-lightspeed] Content Match request sent to lightspeed: ${JSON.stringify(
+          inputData
+        )}`
       );
       const response = await axiosInstance.post(
         LIGHTSPEED_SUGGESTION_CONTENT_MATCHES_URL,

--- a/src/features/lightspeed/api.ts
+++ b/src/features/lightspeed/api.ts
@@ -76,6 +76,9 @@ export class LightSpeedAPI {
       console.error("Ansible Lightspeed instance is not initialized.");
       return {} as CompletionResponseParams;
     }
+    console.log(
+      `Completion request sent to lightspeed: ${JSON.stringify(inputData)}`
+    );
     try {
       const response = await axiosInstance.post(
         LIGHTSPEED_SUGGESTION_COMPLETION_URL,
@@ -112,6 +115,23 @@ export class LightSpeedAPI {
           vscode.window.showErrorMessage(
             "Bad Request response. Please try again."
           );
+        } else if (err?.response?.status === 403) {
+          const responseErrorData = <AxiosError<{ message?: string }>>(
+            err?.response?.data
+          );
+          if (
+            responseErrorData &&
+            responseErrorData.hasOwnProperty("message") &&
+            responseErrorData.message?.includes("WCA Model ID is invalid")
+          ) {
+            vscode.window.showErrorMessage(
+              `Model ID "${this.settingsManager.settings.lightSpeedService.model}" is invalid. Please contact your administrator.`
+            );
+          } else {
+            vscode.window.showErrorMessage(
+              `User not authorized to access Ansible Lightspeed.`
+            );
+          }
         } else if (err?.response?.status.toString().startsWith("5")) {
           vscode.window.showErrorMessage(
             "Ansible Lightspeed encountered an error. Try again after some time."
@@ -165,7 +185,9 @@ export class LightSpeedAPI {
     if (Object.keys(inputData).length === 0) {
       return {} as FeedbackResponseParams;
     }
-
+    console.log(
+      `Feedback request sent to lightspeed: ${JSON.stringify(inputData)}`
+    );
     try {
       const response = await axiosInstance.post(
         LIGHTSPEED_SUGGESTION_FEEDBACK_URL,
@@ -177,7 +199,6 @@ export class LightSpeedAPI {
       if (showInfoMessage) {
         vscode.window.showInformationMessage("Thanks for your feedback!");
       }
-      console.log(`Event sent to lightspeed: ${JSON.stringify(inputData)}}`);
       return response.data;
     } catch (error) {
       const err = error as AxiosError;
@@ -217,6 +238,9 @@ export class LightSpeedAPI {
       return {} as ContentMatchesResponseParams;
     }
     try {
+      console.log(
+        `Content Match request sent to lightspeed: ${JSON.stringify(inputData)}`
+      );
       const response = await axiosInstance.post(
         LIGHTSPEED_SUGGESTION_CONTENT_MATCHES_URL,
         inputData,

--- a/src/features/lightspeed/base.ts
+++ b/src/features/lightspeed/base.ts
@@ -21,6 +21,7 @@ import { LightspeedStatusBar } from "./statusBar";
 import { IVarsFileContext } from "../../interfaces/lightspeed";
 import { getCustomRolePaths, getCommonRoles } from "../utils/ansible";
 import { watchRolesDirectory } from "./utils/watchers";
+import { LightSpeedServiceSettings } from "../../interfaces/extensionSettings";
 
 export class LightSpeedManager {
   private context;
@@ -82,9 +83,10 @@ export class LightSpeedManager {
   }
 
   public async reInitialize(): Promise<void> {
-    const lightspeedEnabled = await vscode.workspace
-      .getConfiguration("ansible")
-      .get("lightspeed.enabled");
+    const lightspeedSettings = <LightSpeedServiceSettings>(
+      vscode.workspace.getConfiguration("ansible").get("lightspeed")
+    );
+    const lightspeedEnabled = lightspeedSettings.enabled;
 
     if (!lightspeedEnabled) {
       await this.resetContext();
@@ -94,6 +96,19 @@ export class LightSpeedManager {
     } else {
       this.lightSpeedAuthenticationProvider.initialize();
       this.setContext();
+      if (lightspeedSettings.suggestions.enabled) {
+        const githubConfig = (<unknown>(
+          vscode.workspace.getConfiguration("github")
+        )) as {
+          copilot: { enable?: { ansible?: boolean } };
+        };
+        const copilotEnableForAnsible = githubConfig.copilot.enable?.ansible;
+        if (copilotEnableForAnsible) {
+          vscode.window.showInformationMessage(
+            "Please disable GitHub Copilot for Ansible Lightspeed file types to use Ansible Lightspeed."
+          );
+        }
+      }
     }
   }
 

--- a/src/features/lightspeed/contentMatchesWebview.ts
+++ b/src/features/lightspeed/contentMatchesWebview.ts
@@ -182,7 +182,6 @@ export class ContentMatchesWebview implements vscode.WebviewViewProvider {
           <li>Path: ${contentMatchResponse.path}</li>
           <li>Data Source: ${contentMatchResponse.data_source}</li>
           <li>License: ${contentMatchResponse.license}</li>
-          <li>Ansible type: ${contentMatchResponse.ansible_type}</li>
           <li>Score: ${contentMatchResponse.score}</li>
         </ul>
       </details>

--- a/src/features/lightspeed/lightSpeedOAuthProvider.ts
+++ b/src/features/lightspeed/lightSpeedOAuthProvider.ts
@@ -584,11 +584,14 @@ export class LightSpeedAuthenticationProvider
     return userAuth;
   }
 
-  public async rhUserHasSeat(): Promise<boolean> {
+  public async rhUserHasSeat(): Promise<boolean | undefined> {
     const authSession = await this.getLightSpeedAuthSession();
-    if (authSession?.rhUserHasSeat) {
+    if (authSession === undefined) {
+      return undefined;
+    } else if (authSession?.rhUserHasSeat) {
       return true;
+    } else {
+      return false;
     }
-    return false;
   }
 }

--- a/src/features/lightspeed/utils/data.ts
+++ b/src/features/lightspeed/utils/data.ts
@@ -24,22 +24,36 @@ import {
 } from "../../../definitions/lightspeed";
 
 export function shouldRequestInlineSuggestions(
-  parsedAnsibleDocument: yaml.YAMLMap[]
+  parsedAnsibleDocument: yaml.YAMLMap[],
+  ansibleFileType: IAnsibleFileType
 ): boolean {
   const lastObject = parsedAnsibleDocument[parsedAnsibleDocument.length - 1];
   if (typeof lastObject !== "object") {
     return false;
   }
-  // for the last entry in list check if the inline suggestion
-  // triggered is in Ansible play context by checking for "hosts" keyword.
+
   const objectKeys = Object.keys(lastObject);
-  if (
-    objectKeys[objectKeys.length - 1] === "name" &&
-    objectKeys.includes("hosts")
-  ) {
+  const lastParentKey = objectKeys[objectKeys.length - 1];
+
+  // check if single-task trigger is in play context or not
+  if (lastParentKey === "name" && objectKeys.includes("hosts")) {
     return false;
   }
 
+  // check if single-task trigger is in vars context or not
+  if (lastParentKey === "vars" || lastParentKey === "vars_files") {
+    return false;
+  }
+
+  // for file identified as playbook, check single task trigger in task context
+  if (
+    ansibleFileType === "playbook" &&
+    !["tasks", "pre_tasks", "post_tasks", "handlers"].some((key) =>
+      objectKeys.includes(key)
+    )
+  ) {
+    return false;
+  }
   return true;
 }
 

--- a/src/interfaces/lightspeed.ts
+++ b/src/interfaces/lightspeed.ts
@@ -92,7 +92,6 @@ export interface IContentMatchParams {
   path: string;
   license: string;
   data_source: string;
-  ansible_type: string;
   score: number;
 }
 


### PR DESCRIPTION
*  Remove whitespaces from blank lines in between multi-task suggestion
*  Show user information message is model Id is invalid.
*  If file is under playbook folder don't trigger single-task suggestion in play context.
*  Add information message for user if both Github copilot for Ansible and Lightspeed setting in enabled.
*  Don't trigger single-task suggestion if `- name: <descrption>` pattern if found under `vars` context.
*  Remove `ansible_type` field from content matches display as it is no longer used.
*  If user is not logged in and lightspeed setting is enabled show login message for mulit-task suggestion trigger request.