### PR TITLE
Show the license section of content matches only for licensed users

### DIFF
--- a/src/features/lightspeed/base.ts
+++ b/src/features/lightspeed/base.ts
@@ -69,7 +69,8 @@ export class LightSpeedManager {
       this.context,
       this.client,
       this.settingsManager,
-      this.apiInstance
+      this.apiInstance,
+      this.lightSpeedAuthenticationProvider
     );
 
     // create a new project lightspeed status bar item that we can manage


### PR DESCRIPTION
This is for hiding the license section in the content match data on the ContentMatchesWebview when the current user is not a licensed user.

I am aware that there is no unit test for this. As there is no existing unit test for ContentMatchesWebview, it would require considerable amount of work. I would like to write those test cases in a separate PR.