### PR TITLE
lightspeed: use the code value from the 403

### DIFF
--- a/src/features/lightspeed/api.ts
+++ b/src/features/lightspeed/api.ts
@@ -150,6 +150,15 @@ export class LightSpeedAPI {
             vscode.window.showErrorMessage(
               `Model ID "${this.settingsManager.settings.lightSpeedService.model}" is invalid. Please contact your administrator.`
             );
+          } else if (
+            responseErrorData &&
+            responseErrorData.hasOwnProperty("code") &&
+            responseErrorData.code ===
+              "permission_denied__org_ready_user_has_no_seat"
+          ) {
+            vscode.window.showErrorMessage(
+              `You do not have a licensed seat for Ansible Lightspeed and your organization is using the paid commercial service. Contact your Red Hat Organization's administrator for more information on how to get a licensed seat.`
+            );
           } else {
             vscode.window.showErrorMessage(
               `User not authorized to access Ansible Lightspeed.`

--- a/src/features/lightspeed/api.ts
+++ b/src/features/lightspeed/api.ts
@@ -159,6 +159,15 @@ export class LightSpeedAPI {
             vscode.window.showErrorMessage(
               `You do not have a licensed seat for Ansible Lightspeed and your organization is using the paid commercial service. Contact your Red Hat Organization's administrator for more information on how to get a licensed seat.`
             );
+          } else if (
+            responseErrorData &&
+            responseErrorData.hasOwnProperty("code") &&
+            responseErrorData.code ===
+              "permission_denied__org_not_ready_because_wca_not_configured"
+          ) {
+            vscode.window.showErrorMessage(
+              `Contact your administrator to configure IBM watsonx Code Assistant model settings for your organization.`
+            );
           } else {
             vscode.window.showErrorMessage(
               `User not authorized to access Ansible Lightspeed.`

--- a/src/features/lightspeed/lightSpeedOAuthProvider.ts
+++ b/src/features/lightspeed/lightSpeedOAuthProvider.ts
@@ -132,6 +132,9 @@ export class LightSpeedAuthenticationProvider
 
       const identifier = uuid();
       const userName = userinfo.external_username || userinfo.username || "";
+      const rhOrgHasSubscription = userinfo.rh_org_has_subscription
+        ? userinfo.rh_org_has_subscription
+        : false;
       const rhUserHasSeat = userinfo.rh_user_has_seat
         ? userinfo.rh_user_has_seat
         : false;
@@ -139,6 +142,8 @@ export class LightSpeedAuthenticationProvider
       let label = userName;
       if (rhUserHasSeat) {
         label += " (licensed)";
+      } else if (rhOrgHasSubscription) {
+        label += " (no seat assigned)";
       } else {
         label += " (Tech Preview)";
       }
@@ -172,7 +177,8 @@ export class LightSpeedAuthenticationProvider
 
       lightSpeedManager.statusBarProvider.statusBar.text =
         await lightSpeedManager.statusBarProvider.getLightSpeedStatusBarText(
-          rhUserHasSeat
+          rhUserHasSeat,
+          rhOrgHasSubscription
         );
 
       lightSpeedManager.statusBarProvider.setLightSpeedStatusBarTooltip(
@@ -626,6 +632,26 @@ export class LightSpeedAuthenticationProvider
     } else {
       console.log(
         `[ansible-lightspeed-oauth] User "${authSession?.account?.label}" does not have a seat.`
+      );
+      return false;
+    }
+  }
+
+  public async rhOrgHasSubscription(): Promise<boolean | undefined> {
+    const authSession = await this.getLightSpeedAuthSession();
+    if (authSession === undefined) {
+      console.log(
+        "[ansible-lightspeed-oauth] User authentication session not found."
+      );
+      return undefined;
+    } else if (authSession?.rhOrgHasSubscription) {
+      console.log(
+        `[ansible-lightspeed-oauth] User "${authSession?.account?.label}" has an Org with a subscription.`
+      );
+      return true;
+    } else {
+      console.log(
+        `[ansible-lightspeed-oauth] User "${authSession?.account?.label}" does not have an Org with a subscription.`
       );
       return false;
     }

--- a/src/features/lightspeed/statusBar.ts
+++ b/src/features/lightspeed/statusBar.ts
@@ -52,14 +52,21 @@ export class LightspeedStatusBar {
   }
 
   public async getLightSpeedStatusBarText(
-    rhUserHasSeat?: boolean
+    rhUserHasSeat?: boolean,
+    rhOrgHasSubscription?: boolean
   ): Promise<string> {
     let lightSpeedStatusbarText;
     if (rhUserHasSeat === undefined) {
       rhUserHasSeat = await this.lightSpeedAuthProvider.rhUserHasSeat();
     }
+    if (rhOrgHasSubscription === undefined) {
+      rhOrgHasSubscription =
+        await this.lightSpeedAuthProvider.rhOrgHasSubscription();
+    }
     if (rhUserHasSeat === true) {
       lightSpeedStatusbarText = "Lightspeed (licensed)";
+    } else if (rhOrgHasSubscription === true && rhUserHasSeat === false) {
+      lightSpeedStatusbarText = "Lightspeed (no seat assigned)";
     } else if (rhUserHasSeat === false) {
       lightSpeedStatusbarText = "Lightspeed (Tech Preview)";
     } else {

--- a/src/features/lightspeed/utils/webUtils.ts
+++ b/src/features/lightspeed/utils/webUtils.ts
@@ -77,6 +77,8 @@ export function getLoggedInSessionDetails(
   const modelInfo: LightspeedSessionModelInfo = {};
   if (sessionData.rhUserHasSeat) {
     userInfo.userType = "Licensed";
+  } else if (sessionData.rhOrgHasSubscription && sessionData.rhUserHasSeat) {
+    userInfo.userType = "No seat assigned";
   } else {
     userInfo.userType = "Tech Preview";
   }

--- a/src/interfaces/lightspeed.ts
+++ b/src/interfaces/lightspeed.ts
@@ -166,7 +166,7 @@ export interface IAdditionalContext {
 }
 
 export interface LightspeedSessionUserInfo {
-  userType?: "Licensed" | "Tech Preview";
+  userType?: "Licensed" | "No seat assigned" | "Tech Preview";
   role?: string;
   subscribed?: boolean;
 }


### PR DESCRIPTION
The 403 error can now return a `code` value to specify the nature of the
error.
`permission_denied_wca_api_key_is_missing` is the first case we can get.
The error happens when the access is denied because the user has a seat
but the organization has not been fully configured yet.

Depends-On: https://github.com/ansible/vscode-ansible/pull/1026
Depends-On: https://github.com/ansible/vscode-ansible/pull/1029