### PR TITLE
GHA: don't assume go-task spawn a subshell to run the commands

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -149,21 +149,24 @@ tasks:
     deps:
       - package
     cmds:
-      - source "${VIRTUAL_ENV}/bin/activate" && yarn run test-e2e
+      - $VIRTUAL_ENV/bin/python3 --version
+      - bash -c 'source "${VIRTUAL_ENV}/bin/activate" && yarn run test-e2e'
     interactive: true
   test-ui:
     desc: Run UI tests
     deps:
       - package
     cmds:
-      - source "${VIRTUAL_ENV}/bin/activate" && yarn run test-ui-current
+      - $VIRTUAL_ENV/bin/python3 --version
+      - bash -c 'source "${VIRTUAL_ENV}/bin/activate" && yarn run test-ui-current'
     interactive: true
   test-ui-old:
     desc: Run UI tests (oldest vscode)
     deps:
       - package
     cmds:
-      - source "${VIRTUAL_ENV}/bin/activate" && yarn run test-ui-oldest
+      - $VIRTUAL_ENV/bin/python3 --version
+      - bash -c 'source "${VIRTUAL_ENV}/bin/activate" && yarn run test-ui-oldest'
     interactive: true
   package:
     vars:


### PR DESCRIPTION
Time to time, `go-task` fails to run the following command and returns an err 127 (command not found). It seems it doesn't spawn a sub-shell to run the 2 commands and consequently file to find a command with the same name.
By explicitly requesting a sub-shell with `bash -c 'command'`, we avoid the error.

```
cmds:
      - source "${VIRTUAL_ENV}/bin/activate" && yarn run test-e2e
```

We also now print the Python version from the venv. It's a good way to double-check the venv is actually created during the `setup`.
    