### PR TITLE
Ignore a webpack warning from vscode-languageserver-textdocument

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,7 @@ concurrency:
 
 env:
   FORCE_COLOR: "1" # make mocha output colorful
+  PRETTIER_LEGACY_CLI: "1" # https://github.com/prettier/prettier/issues/15832
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/package.json
+++ b/package.json
@@ -766,7 +766,7 @@
     "//": "node version affects only development, it does not affect VS Code runtime",
     "node": ">=16.0",
     "npm": "\n\nERROR: Please use yarn instead of npm for this repository.!!!\n\n",
-    "vscode": "^1.71.0",
+    "vscode": "^1.85.0",
     "yarn": ">=3.2.1"
   },
   "extensionDependencies": [

--- a/src/utils/telemetryUtils.ts
+++ b/src/utils/telemetryUtils.ts
@@ -2,8 +2,7 @@ import {
   getRedHatService,
   TelemetryService,
 } from "@redhat-developer/vscode-redhat-telemetry/lib";
-import { RedHatService } from '@redhat-developer/vscode-redhat-telemetry';
-
+import { RedHatService } from "@redhat-developer/vscode-redhat-telemetry";
 
 import { ExtensionContext } from "vscode";
 import {

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -39,6 +39,13 @@ const config = {
     __dirname: false, // leave the __dirname-behavior intact
   },
   plugins: [new WarningsToErrorsPlugin()],
+  ignoreWarnings: [
+    {
+      // https://github.com/microsoft/vscode-languageserver-node/issues/1355
+      message:
+        /require function is used in a way in which dependencies cannot be statically extracted/,
+    },
+  ],
   output: {
     filename: (pathData: { chunk: { name: string } }) => {
       return pathData.chunk.name === "client"


### PR DESCRIPTION
We started seeing the following error when we run `yarn run webpack`:

```
ERROR in ./node_modules/vscode-languageserver-textdocument/lib/umd/main.js 12:24-31
Critical dependency: require function is used in a way in which dependencies cannot be statically extracted
    at CommonJsRequireContextDependency.getWarnings (/home/ttakamiy/git/TamiTakamiya/vscode-ansible/node_modules/webpack/lib/dependencies/ContextDependency.js:109:18)
    at Compilation.reportDependencyErrorsAndWarnings (/home/ttakamiy/git/TamiTakamiya/vscode-ansible/node_modules/webpack/lib/Compilation.js:3140:24)
    at /home/ttakamiy/git/TamiTakamiya/vscode-ansible/node_modules/webpack/lib/Compilation.js:2737:28
    at _next2 (eval at create (/home/ttakamiy/git/TamiTakamiya/vscode-ansible/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:34:1)
    at eval (eval at create (/home/ttakamiy/git/TamiTakamiya/vscode-ansible/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:62:1)
    at /home/ttakamiy/git/TamiTakamiya/vscode-ansible/node_modules/webpack/lib/FlagDependencyExportsPlugin.js:380:10
    at /home/ttakamiy/git/TamiTakamiya/vscode-ansible/node_modules/neo-async/async.js:2830:7
    at Object.each (/home/ttakamiy/git/TamiTakamiya/vscode-ansible/node_modules/neo-async/async.js:2850:39)
    at /home/ttakamiy/git/TamiTakamiya/vscode-ansible/node_modules/webpack/lib/FlagDependencyExportsPlugin.js:356:17
    at /home/ttakamiy/git/TamiTakamiya/vscode-ansible/node_modules/neo-async/async.js:2830:7
 @ ./node_modules/@ansible/ansible-language-server/out/server/src/server.js 3:45-90

webpack 5.89.0 compiled with 1 error in 74784 ms
```

It is considered as the same error as the one described in [this issue](https://github.com/microsoft/vscode-languageserver-node/issues/1355), which suggests two changes in webpack config (`webpack.config.ts`) to deal with the problem:

First one (for a "web extension")
```
resolve: {
			mainFields: ['browser', 'module', 'main'],
```
Second one (for a "desktop extension")
```
resolve: {
			conditionNames: ['import', 'require'],
			mainFields: ['module', 'main'],
```

I found the second one fix the build issue, but the generated extension showed the following error at runtime:
```
crypto.getRandomValues() not supported. See https://github.com/uuidjs/uuid#getrandomvalues-not-supported
```

I think it would be less risky to ignore the warning (note: we are using `WarningsToErrorsPlugin`)  instead of adding some parameters to webpack config. This PR contains the change in `webpack.config.ts` to ignore the warning.

----

This PR also includes:

- Fix the mismatch between  `@types/vscode` and `vscode` dependences
- Fix for a lint error (`src/utils/telemetryUtils.ts`)
- Fix for misterious lint errors on `tsconfig.json` and `.devcontainer/devcontainer.json` ([Ref](https://github.com/prettier/prettier/issues/15832#issuecomment-1864886123))
```
prettier.................................................................Failed
- hook id: prettier
- files were modified by this hook

25htsconfig.json
25h25h.devcontainer/devcontainer.json
25h
```
Note: I have no idea what those `25h` are...