### PR TITLE
lightspeed/inlineSuggestions: refactoring to simplify the testing

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -68,6 +68,7 @@ hbenl
 hostvars
 hotfixes
 icontent
+inlinesuggestion
 jeinwag
 johndoe
 keyfile
@@ -125,6 +126,7 @@ tsdoc
 ttakamiy
 unstash
 untildify
+useractionhandler
 userdata
 usermod
 uuidv4

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -45,8 +45,7 @@ import {
   inlineSuggestionTriggerHandler,
   inlineSuggestionCommitHandler,
   inlineSuggestionHideHandler,
-  getInlineSuggestionDisplayed,
-  resetInlineSuggestionDisplayed,
+  suggestionDisplayed,
 } from "./features/lightspeed/inlineSuggestions";
 import { AnsibleContentUploadTrigger } from "./definitions/lightspeed";
 import { ContentMatchesWebview } from "./features/lightspeed/contentMatchesWebview";
@@ -226,11 +225,11 @@ export async function activate(context: ExtensionContext): Promise<void> {
       const lightSpeedSettings =
         lightSpeedManager.settingsManager.settings.lightSpeedService;
       if (
-        getInlineSuggestionDisplayed() &&
+        suggestionDisplayed.get() &&
         lightSpeedSettings.enabled &&
         lightSpeedSettings.suggestions.enabled
       ) {
-        resetInlineSuggestionDisplayed();
+        suggestionDisplayed.reset();
       }
     })
   );

--- a/src/features/lightspeed/inlineSuggestions.ts
+++ b/src/features/lightspeed/inlineSuggestions.ts
@@ -12,40 +12,194 @@ import {
   CompletionResponseParams,
   InlineSuggestionEvent,
   CompletionRequestParams,
-  IRolesContext,
-  IRoleContext,
-  IStandaloneTaskContext,
 } from "../../interfaces/lightspeed";
 import {
+  LightSpeedCommands,
   LIGHTSPEED_SUGGESTION_TYPE,
   MULTI_TASK_REGEX_EP,
   SINGLE_TASK_REGEX_EP,
   UserAction,
 } from "../../definitions/lightspeed";
-import { LightSpeedCommands } from "../../definitions/lightspeed";
 import {
-  getIncludeVarsContext,
-  getRelativePath,
-  getRolePathFromPathWithinRole,
   shouldRequestInlineSuggestions,
   shouldTriggerMultiTaskSuggestion,
 } from "./utils/data";
-import { getVarsFilesContext } from "./utils/data";
-import {
-  IAdditionalContext,
-  IAnsibleFileType,
-  IPlaybookContext,
-} from "../../interfaces/lightspeed";
-import { getAnsibleFileType, getCustomRolePaths } from "../utils/ansible";
-import { watchRolesDirectory } from "./utils/watchers";
+import { IAnsibleFileType } from "../../interfaces/lightspeed";
+import { getAnsibleFileType } from "../utils/ansible";
+import { SuggestionDisplayed } from "./inlinesuggestion/suggestionDisplayed";
+import { LightSpeedServiceSettings } from "../../interfaces/extensionSettings";
+import { getAdditionalContext } from "./inlinesuggestion/additionalContext";
 
-let suggestionId = "";
-let currentSuggestion = "";
 let inlineSuggestionData: InlineSuggestionEvent = {};
 let inlineSuggestionDisplayTime: Date;
-let _inlineSuggestionDisplayed = false;
 let previousTriggerPosition: vscode.Position;
-let _cachedCompletionItem: vscode.InlineCompletionItem[];
+export const suggestionDisplayed = new SuggestionDisplayed();
+
+interface DocumentInfo {
+  ansibleFileType: IAnsibleFileType;
+  documentContent: string;
+  documentDirPath: string;
+  documentFilePath: string;
+  documentUri: string;
+  parsedAnsibleDocument: yaml.YAMLMap[];
+}
+
+interface SuggestionMatchInfo {
+  currentLineText: vscode.TextLine;
+  lineToExtractPrompt: vscode.TextLine;
+  taskMatchedPattern: RegExpMatchArray | null;
+  spacesBeforeCursor: number;
+  spacesBeforePromptStart: number;
+  suggestionMatchType: LIGHTSPEED_SUGGESTION_TYPE | undefined;
+}
+
+interface InlinePosition {
+  document: vscode.TextDocument;
+  position: vscode.Position;
+  context: vscode.InlineCompletionContext;
+}
+
+export interface CallbackEntry {
+  (
+    suggestionDisplayed: SuggestionDisplayed,
+    inlinePosition: InlinePosition
+  ): Promise<vscode.InlineCompletionItem[]>;
+}
+
+export const onTextEditorNotActive: CallbackEntry = async function (
+  suggestionDisplayed: SuggestionDisplayed
+) {
+  suggestionDisplayed.reset();
+  return [];
+};
+
+const onNotForMe: CallbackEntry = async function (
+  suggestionDisplayed: SuggestionDisplayed
+) {
+  lightSpeedManager.statusBarProvider.statusBar.hide();
+  suggestionDisplayed.reset();
+  return [];
+};
+
+const onCancellationRequested: CallbackEntry = async function (
+  suggestionDisplayed: SuggestionDisplayed
+) {
+  suggestionDisplayed.reset();
+  return [];
+};
+
+const onLightspeedIsDisabled: CallbackEntry = async function (
+  suggestionDisplayed: SuggestionDisplayed
+) {
+  console.debug("[ansible-lightspeed] Ansible Lightspeed is disabled.");
+  lightSpeedManager.statusBarProvider.updateLightSpeedStatusbar();
+  suggestionDisplayed.reset();
+  return [];
+};
+
+const onLightspeedURLMisconfigured: CallbackEntry = async function (
+  suggestionDisplayed: SuggestionDisplayed
+) {
+  vscode.window.showErrorMessage(
+    "Ansible Lightspeed URL is empty. Please provide a URL."
+  );
+  suggestionDisplayed.reset();
+  return [];
+};
+
+const onRetrySuggestion: CallbackEntry = async function (
+  suggestionDisplayed: SuggestionDisplayed
+) {
+  return suggestionDisplayed.cachedCompletionItem;
+};
+
+const onRefusedSuggestion: CallbackEntry = async function () {
+  vscode.commands.executeCommand(LightSpeedCommands.LIGHTSPEED_SUGGESTION_HIDE);
+  return [];
+};
+
+const onRequestInProgress: CallbackEntry = async function () {
+  lightSpeedManager.apiInstance.inlineSuggestionFeedbackSent = true;
+  vscode.commands.executeCommand(
+    LightSpeedCommands.LIGHTSPEED_SUGGESTION_HIDE,
+    UserAction.IGNORED
+  );
+  return [];
+};
+
+const onDefault: CallbackEntry = function (
+  suggestionDisplayed: SuggestionDisplayed,
+  inlinePosition: InlinePosition
+) {
+  const suggestionItems = getInlineSuggestionItems(inlinePosition);
+  return suggestionItems;
+};
+
+const CompletionState = {
+  TextEditorNotActive: onTextEditorNotActive,
+  NotForMe: onNotForMe,
+  CancellationRequested: onCancellationRequested,
+  LightspeedIsDisabled: onLightspeedIsDisabled,
+  LightspeedURLMisconfigured: onLightspeedURLMisconfigured,
+  RetrySuggestion: onRetrySuggestion,
+  RefusedSuggestion: onRefusedSuggestion,
+  RequestInProgress: onRequestInProgress,
+  Default: onDefault,
+} as const;
+type CompletionState = (typeof CompletionState)[keyof typeof CompletionState];
+
+function getCompletionState(
+  suggestionDisplayed: SuggestionDisplayed,
+  completionRequestInProgress: boolean,
+  languageId: string,
+  isCancellationRequested: boolean,
+  lightSpeedSetting: LightSpeedServiceSettings,
+  positionHasChanged?: boolean
+): CompletionState {
+  if (completionRequestInProgress) {
+    return CompletionState.RequestInProgress;
+  }
+  if (languageId !== "ansible") {
+    return CompletionState.NotForMe;
+  }
+  if (isCancellationRequested) {
+    return CompletionState.CancellationRequested;
+  }
+  if (!lightSpeedSetting.enabled || !lightSpeedSetting.suggestions.enabled) {
+    return CompletionState.LightspeedIsDisabled;
+  }
+
+  if (!lightSpeedSetting.URL.trim()) {
+    return CompletionState.LightspeedURLMisconfigured;
+  }
+
+  // If users continue to without pressing configured keys to
+  // either accept or reject the suggestion, we will consider it as ignored.
+  if (suggestionDisplayed.get() && !positionHasChanged) {
+    /* The following approach is implemented to address a specific issue related to the
+     * behavior of inline suggestion in the 'automated' trigger scenario:
+     *
+     * Whenever the toolbar appears on the suggestion, the method provideInlineCompletionItems
+     * is called again with trigger kind as 'invoke'. This results in a new request for inline
+     * suggestion, causing the current suggestion to disappear.
+     *
+     * To resolve this issue, we have implemented a mechanism to keep track of the previous and current
+     * cursor position of the trigger. We cache and return the same completion item when the cursor
+     * position remains unchanged, thus avoiding the disappearance of the current suggestion.
+     *
+     * It is important to note that the entire flow is triggered whenever the user makes any changes.
+     * As a result, we always make a new request for inline suggestion whenever any changes are made
+     * in the editor.
+     */
+    return CompletionState.RetrySuggestion;
+  }
+
+  if (suggestionDisplayed.get()) {
+    return CompletionState.RefusedSuggestion;
+  }
+
+  return CompletionState.Default;
+}
 
 export class LightSpeedInlineSuggestionProvider
   implements vscode.InlineCompletionItemProvider
@@ -55,268 +209,245 @@ export class LightSpeedInlineSuggestionProvider
     position: vscode.Position,
     context: vscode.InlineCompletionContext,
     token: vscode.CancellationToken
-  ): vscode.ProviderResult<vscode.InlineCompletionItem[]> {
-    const apiInstance = lightSpeedManager.apiInstance;
-    if (
-      apiInstance.completionRequestInProgress &&
-      !apiInstance.inlineSuggestionFeedbackSent
-    ) {
-      apiInstance.inlineSuggestionFeedbackSent = true;
-      vscode.commands.executeCommand(
-        LightSpeedCommands.LIGHTSPEED_SUGGESTION_HIDE,
-        UserAction.IGNORED
-      );
-    }
+  ):
+    | vscode.ProviderResult<vscode.InlineCompletionItem[]>
+    | Promise<vscode.InlineCompletionItem[]> {
     const activeTextEditor = vscode.window.activeTextEditor;
-    if (!activeTextEditor) {
-      resetInlineSuggestionDisplayed();
-      return [];
-    }
-    if (activeTextEditor.document.languageId !== "ansible") {
-      lightSpeedManager.statusBarProvider.statusBar.hide();
-      resetInlineSuggestionDisplayed();
-      return [];
-    }
-
-    if (token.isCancellationRequested) {
-      resetInlineSuggestionDisplayed();
-      return [];
-    }
-    if (document.languageId !== "ansible") {
-      lightSpeedManager.statusBarProvider.statusBar.hide();
-      resetInlineSuggestionDisplayed();
-      return [];
-    }
     const lightSpeedSetting =
       lightSpeedManager.settingsManager.settings.lightSpeedService;
-    if (!lightSpeedSetting.enabled || !lightSpeedSetting.suggestions.enabled) {
-      console.debug("[ansible-lightspeed] Ansible Lightspeed is disabled.");
-      lightSpeedManager.statusBarProvider.updateLightSpeedStatusbar();
-      resetInlineSuggestionDisplayed();
-      return [];
-    }
 
-    if (!lightSpeedSetting.URL.trim()) {
-      vscode.window.showErrorMessage(
-        "Ansible Lightspeed URL is empty. Please provide a URL."
-      );
-      resetInlineSuggestionDisplayed();
-      return [];
-    }
-
-    // If users continue to without pressing configured keys to
-    // either accept or reject the suggestion, we will consider it as ignored.
-    if (getInlineSuggestionDisplayed()) {
-      /* The following approach is implemented to address a specific issue related to the
-       * behavior of inline suggestion in the 'automated' trigger scenario:
-       *
-       * Whenever the toolbar appears on the suggestion, the method provideInlineCompletionItems
-       * is called again with trigger kind as 'invoke'. This results in a new request for inline
-       * suggestion, causing the current suggestion to disappear.
-       *
-       * To resolve this issue, we have implemented a mechanism to keep track of the previous and current
-       * cursor position of the trigger. We cache and return the same completion item when the cursor
-       * position remains unchanged, thus avoiding the disappearance of the current suggestion.
-       *
-       * It is important to note that the entire flow is triggered whenever the user makes any changes.
-       * As a result, we always make a new request for inline suggestion whenever any changes are made
-       * in the editor.
-       */
-      if (_.isEqual(position, previousTriggerPosition)) {
-        return _cachedCompletionItem;
-      }
-
-      vscode.commands.executeCommand(
-        LightSpeedCommands.LIGHTSPEED_SUGGESTION_HIDE
-      );
-      return [];
-    }
-    const suggestionItems = getInlineSuggestionItems(
-      context,
-      document,
-      position
+    const state = getCompletionState(
+      suggestionDisplayed,
+      lightSpeedManager.apiInstance.completionRequestInProgress &&
+        !lightSpeedManager.apiInstance.inlineSuggestionFeedbackSent,
+      (activeTextEditor && activeTextEditor.document.languageId) ||
+        document.languageId,
+      token.isCancellationRequested,
+      lightSpeedSetting,
+      !_.isEqual(position, previousTriggerPosition)
     );
-    return suggestionItems;
+    return state(suggestionDisplayed, {
+      document: document,
+      position: position,
+      context: context,
+    });
   }
 }
 
-export async function getInlineSuggestionItems(
-  context: vscode.InlineCompletionContext,
-  document: vscode.TextDocument,
-  currentPosition: vscode.Position
-): Promise<vscode.InlineCompletionItem[]> {
-  let result: CompletionResponseParams = {
-    predictions: [],
-  };
-  const range = new vscode.Range(new vscode.Position(0, 0), currentPosition);
-  const documentContent = range.isEmpty
-    ? ""
-    : document.getText(range).trimEnd();
+const onUnexpectedPromptWithNoSeat: CallbackEntry = async function (
+  suggestionDisplayed: SuggestionDisplayed,
+  inlinePosition: InlinePosition
+) {
+  suggestionDisplayed.reset();
+  // If the user has triggered the inline suggestion by pressing the configured keys,
+  // we will show an information message to the user to help them understand the
+  // correct cursor position to trigger the inline suggestion.
+  if (
+    inlinePosition.context.triggerKind ===
+    vscode.InlineCompletionTriggerKind.Invoke
+  ) {
+    const suggestionMatchInfo = getSuggestionMatchType(inlinePosition);
+    if (
+      !suggestionMatchInfo.taskMatchedPattern ||
+      !suggestionMatchInfo.currentLineText.isEmptyOrWhitespace
+    ) {
+      vscode.window.showInformationMessage(
+        "Cursor should be positioned on the line after the task name with the same indent as that of the task name line to trigger an inline suggestion."
+      );
+    } else if (
+      suggestionMatchInfo.taskMatchedPattern &&
+      suggestionMatchInfo.currentLineText.isEmptyOrWhitespace &&
+      suggestionMatchInfo.spacesBeforePromptStart !==
+        suggestionMatchInfo.spacesBeforeCursor
+    ) {
+      vscode.window.showInformationMessage(
+        `Cursor must be in column ${suggestionMatchInfo.spacesBeforePromptStart} to trigger an inline suggestion.`
+      );
+    }
+  }
+  return [];
+};
 
-  let suggestionMatchType: LIGHTSPEED_SUGGESTION_TYPE | undefined = undefined;
+const onUnexpectedPromptWithSeat: CallbackEntry = async function (
+  suggestionDisplayed: SuggestionDisplayed,
+  inlinePosition: InlinePosition
+) {
+  suggestionDisplayed.reset();
+  // If the user has triggered the inline suggestion by pressing the configured keys,
+  // we will show an information message to the user to help them understand the
+  // correct cursor position to trigger the inline suggestion.
+  if (
+    inlinePosition.context.triggerKind ===
+    vscode.InlineCompletionTriggerKind.Invoke
+  ) {
+    const suggestionMatchInfo = getSuggestionMatchType(inlinePosition);
+    if (
+      !suggestionMatchInfo.suggestionMatchType ||
+      !suggestionMatchInfo.currentLineText.isEmptyOrWhitespace
+    ) {
+      vscode.window.showInformationMessage(
+        "Cursor should be positioned on the line after the task name " +
+          "or a comment line within task context to trigger an inline suggestion."
+      );
+    } else if (
+      suggestionMatchInfo.suggestionMatchType &&
+      suggestionMatchInfo.currentLineText.isEmptyOrWhitespace &&
+      suggestionMatchInfo.spacesBeforePromptStart !==
+        suggestionMatchInfo.spacesBeforeCursor
+    ) {
+      vscode.window.showInformationMessage(
+        `Cursor must be in column ${suggestionMatchInfo.spacesBeforePromptStart} ` +
+          `to trigger an inline suggestion.`
+      );
+    }
+  }
+  return [];
+};
 
+const onMultiTaskWithNoSeat: CallbackEntry = async function () {
+  console.debug(
+    "[inline-suggestions] Multitask suggestions not supported for a non seat user."
+  );
+  return [];
+};
+
+const onShouldNotTriggerSuggestion: CallbackEntry = async function () {
+  return [];
+};
+
+function retrieveActivityIdFromTracker(
+  documentInfo: DocumentInfo,
+  inlinePosition: InlinePosition
+): string {
+  if (
+    !(documentInfo.documentUri in lightSpeedManager.lightSpeedActivityTracker)
+  ) {
+    lightSpeedManager.lightSpeedActivityTracker[documentInfo.documentUri] = {
+      activityId: uuidv4(),
+      content: inlinePosition.document.getText(),
+    };
+  }
+  return lightSpeedManager.lightSpeedActivityTracker[documentInfo.documentUri]
+    .activityId;
+}
+
+async function requestSuggestion(
+  documentInfo: DocumentInfo,
+  inlinePosition: InlinePosition
+): Promise<CompletionResponseParams> {
   const rhUserHasSeat =
     await lightSpeedManager.lightSpeedAuthenticationProvider.rhUserHasSeat();
-
-  const lineToExtractPrompt = document.lineAt(currentPosition.line - 1);
-  const taskMatchedPattern =
-    lineToExtractPrompt.text.match(SINGLE_TASK_REGEX_EP);
-  const currentLineText = document.lineAt(currentPosition);
-  const spacesBeforeCursor =
-    currentLineText?.text.slice(0, currentPosition.character).match(/^ +/)?.[0]
-      .length || 0;
-
-  if (taskMatchedPattern) {
-    suggestionMatchType = "SINGLE-TASK";
-  } else {
-    const commentMatchedPattern =
-      lineToExtractPrompt.text.match(MULTI_TASK_REGEX_EP);
-    if (commentMatchedPattern) {
-      suggestionMatchType = "MULTI-TASK";
-    }
-  }
-
-  const spacesBeforePromptStart =
-    lineToExtractPrompt?.text.match(/^ +/)?.[0].length || 0;
-
-  if (
-    !suggestionMatchType ||
-    !currentLineText.isEmptyOrWhitespace ||
-    spacesBeforePromptStart !== spacesBeforeCursor
-  ) {
-    resetInlineSuggestionDisplayed();
-    // If the user has triggered the inline suggestion by pressing the configured keys,
-    // we will show an information message to the user to help them understand the
-    // correct cursor position to trigger the inline suggestion.
-    if (context.triggerKind === vscode.InlineCompletionTriggerKind.Invoke) {
-      if (rhUserHasSeat) {
-        if (!suggestionMatchType || !currentLineText.isEmptyOrWhitespace) {
-          vscode.window.showInformationMessage(
-            "Cursor should be positioned on the line after the task name or a comment line within task context to trigger an inline suggestion."
-          );
-        } else if (
-          suggestionMatchType &&
-          currentLineText.isEmptyOrWhitespace &&
-          spacesBeforePromptStart !== spacesBeforeCursor
-        ) {
-          vscode.window.showInformationMessage(
-            `Cursor must be in column ${spacesBeforePromptStart} to trigger an inline suggestion.`
-          );
-        }
-      } else {
-        if (!taskMatchedPattern || !currentLineText.isEmptyOrWhitespace) {
-          vscode.window.showInformationMessage(
-            "Cursor should be positioned on the line after the task name with the same indent as that of the task name line to trigger an inline suggestion."
-          );
-        } else if (
-          taskMatchedPattern &&
-          currentLineText.isEmptyOrWhitespace &&
-          spacesBeforePromptStart !== spacesBeforeCursor
-        ) {
-          vscode.window.showInformationMessage(
-            `Cursor must be in column ${spacesBeforePromptStart} to trigger an inline suggestion.`
-          );
-        }
-      }
-    }
-    return [];
-  }
-
-  let parsedAnsibleDocument = undefined;
-  const documentUri = document.uri.toString();
-  const documentDirPath = pathUri.dirname(URI.parse(documentUri).path);
-  const documentFilePath = URI.parse(documentUri).path;
-  const ansibleFileType: IAnsibleFileType = getAnsibleFileType(
-    documentFilePath,
-    documentContent
-  );
-
-  if (suggestionMatchType === "MULTI-TASK") {
-    if (rhUserHasSeat === false) {
-      console.debug(
-        "[inline-suggestions] Multitask suggestions not supported for a non seat user."
-      );
-      return [];
-    } else {
-      if (
-        !shouldTriggerMultiTaskSuggestion(
-          documentContent,
-          spacesBeforePromptStart,
-          ansibleFileType
-        )
-      ) {
-        return [];
-      }
-    }
-  }
-
-  try {
-    parsedAnsibleDocument = yaml.parse(documentContent, {
-      keepSourceTokens: true,
-    });
-  } catch (err) {
-    vscode.window.showErrorMessage(
-      `Ansible Lightspeed expects valid YAML syntax to provide inline suggestions. Error: ${err}`
+  const lightSpeedStatusbarText =
+    await lightSpeedManager.statusBarProvider.getLightSpeedStatusBarText(
+      rhUserHasSeat
     );
-    return [];
-  }
-  if (
-    suggestionMatchType === "SINGLE-TASK" &&
-    !shouldRequestInlineSuggestions(parsedAnsibleDocument, ansibleFileType)
-  ) {
-    return [];
-  }
+  const suggestionId = uuidv4();
+  try {
+    const activityId = retrieveActivityIdFromTracker(
+      documentInfo,
+      inlinePosition
+    );
+    inlineSuggestionData["suggestionId"] = suggestionId;
+    inlineSuggestionData["documentUri"] = documentInfo.documentUri;
+    inlineSuggestionData["activityId"] = activityId;
 
+    lightSpeedManager.statusBarProvider.statusBar.text = `$(loading~spin) ${lightSpeedStatusbarText}`;
+    return await requestInlineSuggest(
+      documentInfo.documentContent,
+      documentInfo.parsedAnsibleDocument,
+      documentInfo.documentUri,
+      activityId,
+      rhUserHasSeat,
+      documentInfo.documentDirPath,
+      documentInfo.documentFilePath,
+      documentInfo.ansibleFileType,
+      suggestionId
+    );
+  } catch (error) {
+    inlineSuggestionData["error"] = `${error}`;
+    vscode.window.showErrorMessage(`Error in inline suggestions: ${error}`);
+    return { predictions: [], suggestionId: suggestionId };
+  } finally {
+    lightSpeedManager.statusBarProvider.statusBar.text =
+      lightSpeedStatusbarText;
+  }
+}
+
+const onDoSingleTasksSuggestion: CallbackEntry = async function (
+  suggestionDisplayed: SuggestionDisplayed,
+  inlinePosition: InlinePosition
+) {
   inlineSuggestionData = {};
-  suggestionId = "";
   inlineSuggestionDisplayTime = getCurrentUTCDateTime();
   const requestTime = getCurrentUTCDateTime();
   console.log(
     "[inline-suggestions] Inline suggestions triggered by user edits."
   );
-  const lightSpeedStatusbarText =
-    await lightSpeedManager.statusBarProvider.getLightSpeedStatusBarText(
-      rhUserHasSeat
-    );
-  try {
-    suggestionId = uuidv4();
-    let activityId: string | undefined = undefined;
-    inlineSuggestionData["suggestionId"] = suggestionId;
-    inlineSuggestionData["documentUri"] = documentUri;
+  const documentInfo = loadFile(inlinePosition);
+  const suggestionMatchInfo = getSuggestionMatchType(inlinePosition);
 
-    if (!(documentUri in lightSpeedManager.lightSpeedActivityTracker)) {
-      activityId = uuidv4();
-      lightSpeedManager.lightSpeedActivityTracker[documentUri] = {
-        activityId: activityId,
-        content: document.getText(),
-      };
-    } else {
-      activityId =
-        lightSpeedManager.lightSpeedActivityTracker[documentUri].activityId;
-    }
-    inlineSuggestionData["activityId"] = activityId;
-
-    lightSpeedManager.statusBarProvider.statusBar.text = `$(loading~spin) ${lightSpeedStatusbarText}`;
-    result = await requestInlineSuggest(
-      documentContent,
-      parsedAnsibleDocument,
-      documentUri,
-      activityId,
-      rhUserHasSeat,
-      documentDirPath,
-      documentFilePath,
-      ansibleFileType
-    );
-    lightSpeedManager.statusBarProvider.statusBar.text =
-      lightSpeedStatusbarText;
-  } catch (error) {
-    inlineSuggestionData["error"] = `${error}`;
-    vscode.window.showErrorMessage(`Error in inline suggestions: ${error}`);
+  const result = await requestSuggestion(documentInfo, inlinePosition);
+  if (!result || !result.predictions || result.predictions.length === 0) {
+    console.error("[inline-suggestions] Inline suggestions not found.");
     return [];
-  } finally {
-    lightSpeedManager.statusBarProvider.statusBar.text =
-      lightSpeedStatusbarText;
   }
+  const responseTime = getCurrentUTCDateTime();
+  inlineSuggestionData["latency"] =
+    responseTime.getTime() - requestTime.getTime();
+
+  const inlineSuggestionUserActionItems: vscode.InlineCompletionItem[] = [];
+  const insertTexts: string[] = [];
+  result.predictions.forEach((prediction) => {
+    let insertText = prediction;
+    insertText = adjustInlineSuggestionIndent(
+      prediction,
+      inlinePosition.position
+    );
+    insertText = insertText.replace(/^[ \t]+(?=\r?\n)/gm, "");
+    insertTexts.push(insertText);
+
+    const inlineSuggestionItem = new vscode.InlineCompletionItem(insertText);
+    inlineSuggestionUserActionItems.push(inlineSuggestionItem);
+  });
+  // currentSuggestion is used in user action handlers
+  // to track the suggestion that user is currently working on
+  const currentSuggestion: string = result.predictions[0];
+
+  // previousTriggerPosition is used to track the cursor position
+  // on hover when the suggestion is displayed
+  previousTriggerPosition = inlinePosition.position;
+
+  console.log(
+    `[inline-suggestions] Received Inline Suggestion\n:${currentSuggestion}`
+  );
+  const contentMatchesForSuggestion = `${suggestionMatchInfo.lineToExtractPrompt.text.trimEnd()}\n${currentSuggestion}`;
+  lightSpeedManager.contentMatchesProvider.suggestionDetails = [
+    {
+      suggestionId: result.suggestionId,
+      suggestion: contentMatchesForSuggestion,
+    },
+  ];
+  // if the suggestion is not empty then we set the flag to true
+  // indicating that the suggestion is displayed and will be used
+  // to track the user action on the suggestion in scenario where
+  // the user continued to type without accepting or rejecting the suggestion
+  suggestionDisplayed.set(inlineSuggestionUserActionItems);
+  return inlineSuggestionUserActionItems;
+};
+
+const onDoMultiTasksSuggestion: CallbackEntry = async function (
+  suggestionDisplayed: SuggestionDisplayed,
+  inlinePosition: InlinePosition
+) {
+  inlineSuggestionData = {};
+  inlineSuggestionDisplayTime = getCurrentUTCDateTime();
+  const requestTime = getCurrentUTCDateTime();
+  console.log(
+    "[inline-suggestions] Inline suggestions triggered by user edits."
+  );
+  const documentInfo = loadFile(inlinePosition);
+
+  const result = await requestSuggestion(documentInfo, inlinePosition);
   if (!result || !result.predictions || result.predictions.length === 0) {
     console.error("[inline-suggestions] Inline suggestions not found.");
     return [];
@@ -330,7 +461,10 @@ export async function getInlineSuggestionItems(
   const insertTexts: string[] = [];
   result.predictions.forEach((prediction) => {
     let insertText = prediction;
-    insertText = adjustInlineSuggestionIndent(prediction, currentPosition);
+    insertText = adjustInlineSuggestionIndent(
+      prediction,
+      inlinePosition.position
+    );
     insertText = insertText.replace(/^[ \t]+(?=\r?\n)/gm, "");
     insertTexts.push(insertText);
 
@@ -339,22 +473,19 @@ export async function getInlineSuggestionItems(
   });
   // currentSuggestion is used in user action handlers
   // to track the suggestion that user is currently working on
-  currentSuggestion = result.predictions[0];
+  const currentSuggestion: string = result.predictions[0];
 
   // previousTriggerPosition is used to track the cursor position
   // on hover when the suggestion is displayed
-  previousTriggerPosition = currentPosition;
+  previousTriggerPosition = inlinePosition.position;
 
   console.log(
     `[inline-suggestions] Received Inline Suggestion\n:${currentSuggestion}`
   );
-  let contentMatchesForSuggestion = currentSuggestion;
-  if (suggestionMatchType === "SINGLE-TASK") {
-    contentMatchesForSuggestion = `${lineToExtractPrompt.text.trimEnd()}\n${currentSuggestion}`;
-  }
+  const contentMatchesForSuggestion = currentSuggestion;
   lightSpeedManager.contentMatchesProvider.suggestionDetails = [
     {
-      suggestionId: suggestionId,
+      suggestionId: result.suggestionId,
       suggestion: contentMatchesForSuggestion,
     },
   ];
@@ -362,8 +493,173 @@ export async function getInlineSuggestionItems(
   // indicating that the suggestion is displayed and will be used
   // to track the user action on the suggestion in scenario where
   // the user continued to type without accepting or rejecting the suggestion
-  setInlineSuggestionDisplayed(inlineSuggestionUserActionItems);
+  suggestionDisplayed.set(inlineSuggestionUserActionItems);
   return inlineSuggestionUserActionItems;
+};
+
+function getSuggestionMatchType(
+  inlinePosition: InlinePosition
+): SuggestionMatchInfo {
+  let suggestionMatchType: LIGHTSPEED_SUGGESTION_TYPE | undefined = undefined;
+
+  const lineToExtractPrompt = inlinePosition.document.lineAt(
+    inlinePosition.position.line - 1
+  );
+  const spacesBeforePromptStart =
+    lineToExtractPrompt?.text.match(/^ +/)?.[0].length || 0;
+
+  const taskMatchedPattern =
+    lineToExtractPrompt.text.match(SINGLE_TASK_REGEX_EP);
+  const currentLineText = inlinePosition.document.lineAt(
+    inlinePosition.position
+  );
+  const spacesBeforeCursor =
+    currentLineText?.text
+      .slice(0, inlinePosition.position.character)
+      .match(/^ +/)?.[0].length || 0;
+
+  if (taskMatchedPattern) {
+    suggestionMatchType = "SINGLE-TASK";
+  } else {
+    const commentMatchedPattern =
+      lineToExtractPrompt.text.match(MULTI_TASK_REGEX_EP);
+    if (commentMatchedPattern) {
+      suggestionMatchType = "MULTI-TASK";
+    }
+  }
+
+  return {
+    currentLineText: currentLineText,
+    lineToExtractPrompt: lineToExtractPrompt,
+    taskMatchedPattern: taskMatchedPattern,
+    spacesBeforeCursor: spacesBeforeCursor,
+    spacesBeforePromptStart: spacesBeforePromptStart,
+    suggestionMatchType: suggestionMatchType,
+  };
+}
+
+function loadFile(inlinePosition: InlinePosition): DocumentInfo {
+  const range = new vscode.Range(
+    new vscode.Position(0, 0),
+    inlinePosition.position
+  );
+  const documentContent = range.isEmpty
+    ? ""
+    : inlinePosition.document.getText(range).trimEnd();
+
+  let parsedAnsibleDocument = undefined;
+  const documentUri = inlinePosition.document.uri.toString();
+  const documentDirPath = pathUri.dirname(URI.parse(documentUri).path);
+  const documentFilePath = URI.parse(documentUri).path;
+  const ansibleFileType: IAnsibleFileType = getAnsibleFileType(
+    documentFilePath,
+    documentContent
+  );
+
+  try {
+    parsedAnsibleDocument = yaml.parse(documentContent, {
+      keepSourceTokens: true,
+    });
+  } catch (err) {
+    vscode.window.showErrorMessage(
+      `Ansible Lightspeed expects valid YAML syntax to provide inline suggestions. Error: ${err}`
+    );
+    throw err;
+  }
+
+  return {
+    ansibleFileType: ansibleFileType,
+    documentContent: documentContent,
+    documentDirPath: documentDirPath,
+    documentFilePath: documentFilePath,
+    documentUri: documentUri,
+    parsedAnsibleDocument: parsedAnsibleDocument,
+  };
+}
+
+const InlineSuggestionState = {
+  UnexpectedPromptWithNoSeat: onUnexpectedPromptWithNoSeat,
+  UnexpectedPromptWithSeat: onUnexpectedPromptWithSeat,
+  CancellationRequested: onCancellationRequested,
+  MultiTaskWithNoSeat: onMultiTaskWithNoSeat,
+  ShouldNotTriggerSuggestion: onShouldNotTriggerSuggestion,
+  DoMultiTasksSuggestion: onDoMultiTasksSuggestion,
+  DoSingleTaskSuggestion: onDoSingleTasksSuggestion,
+} as const;
+type InlineSuggestionState =
+  (typeof InlineSuggestionState)[keyof typeof InlineSuggestionState];
+
+async function getInlineSuggestionState(
+  inlinePosition: InlinePosition
+): Promise<CallbackEntry> {
+  const suggestionMatchInfo = getSuggestionMatchType(inlinePosition);
+  const rhUserHasSeat =
+    await lightSpeedManager.lightSpeedAuthenticationProvider.rhUserHasSeat();
+
+  if (
+    !suggestionMatchInfo.suggestionMatchType ||
+    !suggestionMatchInfo.currentLineText.isEmptyOrWhitespace ||
+    suggestionMatchInfo.spacesBeforePromptStart !==
+      suggestionMatchInfo.spacesBeforeCursor
+  ) {
+    // If the user has triggered the inline suggestion by pressing the configured keys,
+    // we will show an information message to the user to help them understand the
+    // correct cursor position to trigger the inline suggestion.
+    if (
+      inlinePosition.context.triggerKind ===
+      vscode.InlineCompletionTriggerKind.Invoke
+    ) {
+      return rhUserHasSeat
+        ? InlineSuggestionState.UnexpectedPromptWithSeat
+        : InlineSuggestionState.UnexpectedPromptWithNoSeat;
+    }
+    return InlineSuggestionState.CancellationRequested;
+  }
+
+  const documentInfo = loadFile(inlinePosition);
+  const hasValidPrompt: boolean =
+    shouldTriggerMultiTaskSuggestion(
+      documentInfo.documentContent,
+      suggestionMatchInfo.spacesBeforePromptStart,
+      documentInfo.ansibleFileType
+    ) ||
+    shouldRequestInlineSuggestions(
+      documentInfo.parsedAnsibleDocument,
+      documentInfo.ansibleFileType
+    );
+
+  if (!hasValidPrompt) {
+    return InlineSuggestionState.ShouldNotTriggerSuggestion;
+  }
+
+  switch (
+    `${suggestionMatchInfo.suggestionMatchType}-${
+      rhUserHasSeat ? "has-seat" : "no-seat"
+    }`
+  ) {
+    case "MULTI-TASK-no-seat": {
+      return InlineSuggestionState.MultiTaskWithNoSeat;
+    }
+    case "MULTI-TASK-has-seat": {
+      return InlineSuggestionState.DoMultiTasksSuggestion;
+    }
+    case "SINGLE-TASK-no-seat": {
+      return InlineSuggestionState.DoSingleTaskSuggestion;
+    }
+    case "SINGLE-TASK-has-seat": {
+      return InlineSuggestionState.DoSingleTaskSuggestion;
+    }
+  }
+
+  return InlineSuggestionState.ShouldNotTriggerSuggestion;
+}
+
+export async function getInlineSuggestionItems(
+  inlinePosition: InlinePosition
+): Promise<vscode.InlineCompletionItem[]> {
+  const state = await getInlineSuggestionState(inlinePosition);
+
+  return state(suggestionDisplayed, inlinePosition);
 }
 
 async function requestInlineSuggest(
@@ -375,7 +671,8 @@ async function requestInlineSuggest(
   rhUserHasSeat: boolean | undefined,
   documentDirPath: string,
   documentFilePath: string,
-  ansibleFileType: IAnsibleFileType
+  ansibleFileType: IAnsibleFileType,
+  suggestionId: string
 ): Promise<CompletionResponseParams> {
   const hash = crypto.createHash("sha256").update(documentUri).digest("hex");
   const completionData: CompletionRequestParams = {
@@ -399,7 +696,8 @@ async function requestInlineSuggest(
       parsedAnsibleDocument,
       documentDirPath,
       documentFilePath,
-      ansibleFileType
+      ansibleFileType,
+      vscode.workspace.workspaceFolders
     );
     if (completionData.metadata) {
       completionData.metadata.additionalContext = additionalContext;
@@ -433,98 +731,14 @@ async function requestInlineSuggest(
     if (userProvidedModel && userProvidedModel !== "") {
       if (outputData.model !== userProvidedModel) {
         vscode.window.showWarningMessage(
-          `Ansible Lightspeed is using the model ${outputData.model} for suggestions instead of ${userProvidedModel}. Please contact your administrator.`
+          `Ansible Lightspeed is using the model ${outputData.model} ` +
+            `for suggestions instead of ${userProvidedModel}. ` +
+            `Please contact your administrator.`
         );
       }
     }
   }
   return outputData;
-}
-
-export function getAdditionalContext(
-  parsedAnsibleDocument: yaml.YAMLMap[],
-  documentDirPath: string,
-  documentFilePath: string,
-  ansibleFileType: IAnsibleFileType
-): IAdditionalContext {
-  const workspaceFolders = vscode.workspace.workspaceFolders;
-  let workSpaceRoot = undefined;
-  const playbookContext: IPlaybookContext = {};
-  let roleContext: IRoleContext = {};
-  const standaloneTaskContext: IStandaloneTaskContext = {};
-  if (workspaceFolders) {
-    workSpaceRoot = workspaceFolders[0].uri.fsPath;
-  }
-  if (ansibleFileType === "playbook") {
-    const varsFilesContext = getVarsFilesContext(
-      lightSpeedManager,
-      parsedAnsibleDocument,
-      documentDirPath
-    );
-    playbookContext["varInfiles"] = varsFilesContext || {};
-    const rolesCache: IRolesContext = {};
-    if (workSpaceRoot) {
-      // check if roles are installed in the workspace
-      if (!(workSpaceRoot in lightSpeedManager.ansibleRolesCache)) {
-        const rolesPath = getCustomRolePaths(workSpaceRoot);
-        for (const rolePath of rolesPath) {
-          watchRolesDirectory(lightSpeedManager, rolePath, workSpaceRoot);
-        }
-      }
-      // if roles are installed in the workspace, then get the relative path w.r.t. the workspace root
-      if (workSpaceRoot in lightSpeedManager.ansibleRolesCache) {
-        const workspaceRolesCache =
-          lightSpeedManager.ansibleRolesCache[workSpaceRoot];
-        for (const absRolePath in workspaceRolesCache) {
-          const relativeRolePath = getRelativePath(
-            documentDirPath,
-            workSpaceRoot,
-            absRolePath
-          );
-          rolesCache[relativeRolePath] = workspaceRolesCache[absRolePath];
-        }
-      }
-    }
-    if ("common" in lightSpeedManager.ansibleRolesCache) {
-      for (const commonRolePath in lightSpeedManager.ansibleRolesCache) {
-        rolesCache[commonRolePath] =
-          lightSpeedManager.ansibleRolesCache["common"][commonRolePath];
-      }
-    }
-    playbookContext["roles"] = rolesCache;
-  } else if (ansibleFileType === "tasks_in_role") {
-    const roleCache = lightSpeedManager.ansibleRolesCache;
-    const absRolePath = getRolePathFromPathWithinRole(documentFilePath);
-    if (
-      workSpaceRoot &&
-      workSpaceRoot in roleCache &&
-      absRolePath in roleCache[workSpaceRoot]
-    ) {
-      roleContext = roleCache[workSpaceRoot][absRolePath];
-    }
-  }
-  const includeVarsContext =
-    getIncludeVarsContext(
-      lightSpeedManager,
-      parsedAnsibleDocument,
-      documentDirPath,
-      ansibleFileType
-    ) || {};
-
-  if (ansibleFileType === "playbook") {
-    playbookContext.includeVars = includeVarsContext;
-  } else if (ansibleFileType === "tasks_in_role") {
-    roleContext.includeVars = includeVarsContext;
-  } else if (ansibleFileType === "tasks") {
-    standaloneTaskContext.includeVars = includeVarsContext;
-  }
-
-  const additionalContext: IAdditionalContext = {
-    playbookContext: playbookContext,
-    roleContext: roleContext,
-    standaloneTaskContext: standaloneTaskContext,
-  };
-  return additionalContext;
 }
 
 // Handlers
@@ -562,6 +776,8 @@ export async function inlineSuggestionCommitHandler() {
     LightSpeedCommands.LIGHTSPEED_FETCH_TRAINING_MATCHES
   );
 
+  const suggestionId =
+    lightSpeedManager.contentMatchesProvider.suggestionDetails[0].suggestionId;
   // Send feedback for accepted suggestion
   await inlineSuggestionUserActionHandler(suggestionId, UserAction.ACCEPTED);
 }
@@ -571,20 +787,27 @@ export async function inlineSuggestionHideHandler(userAction?: UserAction) {
     return;
   }
   const action = userAction || UserAction.REJECTED;
-  if (action === UserAction.REJECTED) {
-    console.log("[inline-suggestions] User rejected the inline suggestion.");
-  } else if (action === UserAction.IGNORED) {
-    console.log("[inline-suggestions] User ignored the inline suggestion.");
-  } else {
-    console.log(
-      "[inline-suggestions] User didn't accept the inline suggestion."
-    );
+  switch (action) {
+    case UserAction.REJECTED: {
+      console.log("[inline-suggestions] User rejected the inline suggestion.");
+    }
+    case UserAction.IGNORED: {
+      console.log("[inline-suggestions] User ignored the inline suggestion.");
+    }
+    default: {
+      console.log(
+        "[inline-suggestions] User didn't accept the inline suggestion."
+      );
+    }
   }
+
   // Hide the suggestion
   console.log("[inline-suggestions] User ignored the inline suggestion.");
   vscode.commands.executeCommand("editor.action.inlineSuggest.hide");
 
-  // Send feedback for accepted suggestion
+  const suggestionId =
+    lightSpeedManager.contentMatchesProvider.suggestionDetails[0].suggestionId;
+  // Send feedback for refused suggestion
   await inlineSuggestionUserActionHandler(suggestionId, action);
 }
 
@@ -598,7 +821,7 @@ export async function inlineSuggestionUserActionHandler(
   // since user has either accepted or ignored the suggestion
   // inline suggestion is no longer displayed and we can reset the
   // the flag here
-  resetInlineSuggestionDisplayed();
+  suggestionDisplayed.reset();
   inlineSuggestionData["action"] = isSuggestionAccepted;
   inlineSuggestionData["suggestionId"] = suggestionId;
   const inlineSuggestionFeedbackPayload = {
@@ -608,20 +831,4 @@ export async function inlineSuggestionUserActionHandler(
     inlineSuggestionFeedbackPayload
   );
   inlineSuggestionData = {};
-}
-
-export function resetInlineSuggestionDisplayed() {
-  _inlineSuggestionDisplayed = false;
-  _cachedCompletionItem = [];
-}
-
-function setInlineSuggestionDisplayed(
-  inlineCompletionItem: vscode.InlineCompletionItem[]
-) {
-  _inlineSuggestionDisplayed = true;
-  _cachedCompletionItem = inlineCompletionItem;
-}
-
-export function getInlineSuggestionDisplayed() {
-  return _inlineSuggestionDisplayed;
 }

--- a/src/features/lightspeed/inlinesuggestion/additionalContext.ts
+++ b/src/features/lightspeed/inlinesuggestion/additionalContext.ts
@@ -1,0 +1,105 @@
+import { WorkspaceFolder } from "vscode";
+import * as yaml from "yaml";
+import {
+  IAdditionalContext,
+  IAnsibleFileType,
+  IPlaybookContext,
+  IRoleContext,
+  IRolesContext,
+  IStandaloneTaskContext,
+} from "../../../interfaces/lightspeed";
+import {
+  getVarsFilesContext,
+  getRelativePath,
+  getRolePathFromPathWithinRole,
+  getIncludeVarsContext,
+} from "../utils/data";
+import { lightSpeedManager } from "../../../extension";
+import { getCustomRolePaths } from "../../utils/ansible";
+import { watchRolesDirectory } from "../utils/watchers";
+
+export function getAdditionalContext(
+  parsedAnsibleDocument: yaml.YAMLMap[],
+  documentDirPath: string,
+  documentFilePath: string,
+  ansibleFileType: IAnsibleFileType,
+  workspaceFolders: readonly WorkspaceFolder[] | undefined
+): IAdditionalContext {
+  let workSpaceRoot = undefined;
+  const playbookContext: IPlaybookContext = {};
+  let roleContext: IRoleContext = {};
+  const standaloneTaskContext: IStandaloneTaskContext = {};
+  if (workspaceFolders) {
+    workSpaceRoot = workspaceFolders[0].uri.fsPath;
+  }
+  if (ansibleFileType === "playbook") {
+    const varsFilesContext = getVarsFilesContext(
+      lightSpeedManager,
+      parsedAnsibleDocument,
+      documentDirPath
+    );
+    playbookContext["varInfiles"] = varsFilesContext || {};
+    const rolesCache: IRolesContext = {};
+    if (workSpaceRoot) {
+      // check if roles are installed in the workspace
+      if (!(workSpaceRoot in lightSpeedManager.ansibleRolesCache)) {
+        const rolesPath = getCustomRolePaths(workSpaceRoot);
+        for (const rolePath of rolesPath) {
+          watchRolesDirectory(lightSpeedManager, rolePath, workSpaceRoot);
+        }
+      }
+      // if roles are installed in the workspace, then get the relative path w.r.t. the workspace root
+      if (workSpaceRoot in lightSpeedManager.ansibleRolesCache) {
+        const workspaceRolesCache =
+          lightSpeedManager.ansibleRolesCache[workSpaceRoot];
+        for (const absRolePath in workspaceRolesCache) {
+          const relativeRolePath = getRelativePath(
+            documentDirPath,
+            workSpaceRoot,
+            absRolePath
+          );
+          rolesCache[relativeRolePath] = workspaceRolesCache[absRolePath];
+        }
+      }
+    }
+    if ("common" in lightSpeedManager.ansibleRolesCache) {
+      for (const commonRolePath in lightSpeedManager.ansibleRolesCache) {
+        rolesCache[commonRolePath] =
+          lightSpeedManager.ansibleRolesCache["common"][commonRolePath];
+      }
+    }
+    playbookContext["roles"] = rolesCache;
+  } else if (ansibleFileType === "tasks_in_role") {
+    const roleCache = lightSpeedManager.ansibleRolesCache;
+    const absRolePath = getRolePathFromPathWithinRole(documentFilePath);
+    if (
+      workSpaceRoot &&
+      workSpaceRoot in roleCache &&
+      absRolePath in roleCache[workSpaceRoot]
+    ) {
+      roleContext = roleCache[workSpaceRoot][absRolePath];
+    }
+  }
+  const includeVarsContext =
+    getIncludeVarsContext(
+      lightSpeedManager,
+      parsedAnsibleDocument,
+      documentDirPath,
+      ansibleFileType
+    ) || {};
+
+  if (ansibleFileType === "playbook") {
+    playbookContext.includeVars = includeVarsContext;
+  } else if (ansibleFileType === "tasks_in_role") {
+    roleContext.includeVars = includeVarsContext;
+  } else if (ansibleFileType === "tasks") {
+    standaloneTaskContext.includeVars = includeVarsContext;
+  }
+
+  const additionalContext: IAdditionalContext = {
+    playbookContext: playbookContext,
+    roleContext: roleContext,
+    standaloneTaskContext: standaloneTaskContext,
+  };
+  return additionalContext;
+}

--- a/src/features/lightspeed/inlinesuggestion/suggestionDisplayed.ts
+++ b/src/features/lightspeed/inlinesuggestion/suggestionDisplayed.ts
@@ -1,0 +1,25 @@
+import { InlineCompletionItem } from "vscode";
+
+export class SuggestionDisplayed {
+  inlineSuggestionDisplayed: boolean;
+  cachedCompletionItem: InlineCompletionItem[];
+
+  constructor() {
+    this.inlineSuggestionDisplayed = false;
+    this.cachedCompletionItem = [];
+  }
+
+  reset() {
+    this.inlineSuggestionDisplayed = false;
+    this.cachedCompletionItem = [];
+  }
+
+  set(inlineCompletionItem: InlineCompletionItem[]) {
+    this.inlineSuggestionDisplayed = true;
+    this.cachedCompletionItem = inlineCompletionItem;
+  }
+
+  get() {
+    return this.inlineSuggestionDisplayed;
+  }
+}

--- a/src/interfaces/lightspeed.ts
+++ b/src/interfaces/lightspeed.ts
@@ -13,6 +13,7 @@ export interface LightspeedAuthSession extends AuthenticationSession {
 export interface CompletionResponseParams {
   predictions: string[];
   model?: string;
+  suggestionId: string;
 }
 
 export interface MetadataParams {


### PR DESCRIPTION
The goal is to break up the logic in two parts:
1. The code that we use parse the prompt is now isolated in:
  - `getCompletionState()` and
  - `InlineSuggestionState()`.
  It will only return a state that trigger a callback function.
2. Is the second part, where our `on*` callbacks are finally called
  to trigger potentially a change.

The benefits of this approach:

- Since we parsing of the content and prompt only creates a state without
  any side-effect, it becomes easier to properly test it.
- Also the callbacks are much smaller and simpler. They become more suitable
  for future unit-test integration.

Also, this PR reduces the number of global variables.
