### PR TITLE
Enable code coverage on e2e tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ CHANGELOG.html
 .direnv
 .tool-versions
 coverage
+.nyc_output
+.idea
+*.pyc

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -11,5 +11,9 @@ overrides:
     options:
       proseWrap: always
       printWidth: 80
+  - files:
+      - "**/*.json"
+    options:
+      trailingComma: none
 semi: true
 trailingComma: es5 # needed to force prettier 3.x to use 2.x settings and avoid conflict with eslint

--- a/package.json
+++ b/package.json
@@ -805,11 +805,13 @@
     "webpack": "yarn run clean && yarn run compile && webpack --mode production --config ./webpack.config.ts",
     "webpack-dev": "yarn run clean && webpack --mode development --config ./webpack.config.ts",
     "webpack:watch": "webpack --mode development --config ./webpack.config.ts --watch",
-    "clean": "rimraf out/client out/server out/tsconfig.tsbuildinfo",
+    "clean": "rimraf out/client out/server out/tsconfig.tsbuildinfo coverage .nyc_output",
     "test-compile": "yarn run clean && yarn run compile && tsc -p ./",
     "test-compile-withserver": "yarn run clean && yarn run compile-withserver && tsc -p ./",
     "test-e2e": "yarn run test-compile && node ./out/client/test/testRunner",
-    "test-e2e-withserver": "yarn run test-compile-withserver && node ./out/client/test/testRunner"
+    "coverage-e2e": "COVERAGE=1 yarn run test-e2e",
+    "test-e2e-withserver": "yarn run test-compile-withserver && node ./out/client/test/testRunner",
+    "coverage-e2e-withserver": "COVERAGE=1 yarn run test-e2e-withserver"
   },
   "version": "2.9.0",
   "packageManager": "yarn@4.0.2",

--- a/test/index.ts
+++ b/test/index.ts
@@ -2,7 +2,36 @@ import * as path from "path";
 import Mocha from "mocha";
 import glob from "glob";
 
+function setupCoverage() {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const NYC = require("nyc");
+  const nyc = new NYC({
+    cwd: path.join(__dirname, "..", "..", ".."),
+    reporter: ["text", "html"],
+    all: true,
+    silent: false,
+    instrument: true,
+    hookRequire: true,
+    hookRunInContext: true,
+    hookRunInThisContext: true,
+    include: ["out/client/**/*.js", "out/server/**/*.js"],
+    exclude: ["**/test/**"],
+  });
+
+  nyc.reset();
+  nyc.wrap();
+
+  return nyc;
+}
+
 export async function run(): Promise<void> {
+  // Setup NYC for code coverage
+  const nyc = process.env.COVERAGE ? setupCoverage() : null;
+
+  // if (nyc) { // For debugging
+  //   console.log("Glob verification", await nyc.exclude.glob(nyc.cwd));
+  // }
+
   // Create the mocha test
   const mocha = new Mocha({
     color: true,
@@ -26,8 +55,8 @@ export async function run(): Promise<void> {
   // Add files to the test suite
   files.forEach((file) => mocha.addFile(path.resolve(testsRoot, file)));
 
-  return new Promise((c, e) => {
-    try {
+  try {
+    await new Promise<void>((c, e) => {
       // Run the mocha test
       mocha.run((failures: number) => {
         if (failures > 0) {
@@ -36,9 +65,13 @@ export async function run(): Promise<void> {
           c();
         }
       });
-    } catch (err) {
-      console.error(err);
-      e(err);
+    });
+  } catch (err) {
+    console.error(err);
+  } finally {
+    if (nyc) {
+      nyc.writeCoverageFile();
+      await nyc.report();
     }
-  });
+  }
 }

--- a/test/testRunner.ts
+++ b/test/testRunner.ts
@@ -79,17 +79,6 @@ async function main(): Promise<void> {
     fs.mkdirSync(path.dirname(settings_dst), { recursive: true });
     fs.copyFileSync(settings_src, settings_dst);
 
-    // Install the ansible extension from generated .vsix
-    const installLog = cp.execSync(
-      `"${cliPath}" ${cliArgs.join(
-        " "
-      )} --install-extension ansible-*.vsix --force`,
-      {
-        env: env,
-      }
-    );
-    console.log(installLog.toString());
-
     // Install the dependent extensions
     const dependencies = ["ms-python.python", "redhat.vscode-yaml"];
     for (const dep of dependencies) {
@@ -109,7 +98,7 @@ async function main(): Promise<void> {
 
     // The folder containing the Extension Manifest package.json
     // Passed to `--extensionDevelopmentPath`
-    const extensionDevelopmentPath = path.resolve(__dirname, "../../");
+    const extensionDevelopmentPath = path.resolve(__dirname, "../../../");
 
     // The path to test runner
     // Passed to --extensionTestsPath


### PR DESCRIPTION
Moved from #1053 (moved the code changes from a forked branch to a branch of the upstream repo)
----
Enable code coverage on End-to-End tests. HTML report is generated in the `coverage/index.html`.

(Reference)
- https://frenya.net/blog/vscode-extension-code-coverage-nyc

![Screenshot from 2024-01-20 09-19-58](https://github.com/ansible/vscode-ansible/assets/27698807/a2fd4229-7ffc-4408-b374-f404368112c5)