### PR TITLE
lightspeed: show a proper message when the user has no seat

### DIFF
--- a/src/features/lightspeed/handleApiError.ts
+++ b/src/features/lightspeed/handleApiError.ts
@@ -29,28 +29,29 @@ export function retrieveError(err: AxiosError): string {
         responseErrorData.message?.includes("WCA Model ID is invalid")
       ) {
         return `Model ID is invalid. Please contact your administrator.`;
-      } else if (
-        responseErrorData &&
-        responseErrorData.hasOwnProperty("code") &&
-        responseErrorData.code ===
-          "permission_denied__org_ready_user_has_no_seat"
-      ) {
-        return `You do not have a licensed seat for Ansible Lightspeed and your organization is using the paid commercial service. Contact your Red Hat Organization's administrator for more information on how to get a licensed seat.`;
-      } else if (
-        responseErrorData &&
-        responseErrorData.hasOwnProperty("code") &&
-        responseErrorData.code ===
-          "permission_denied__org_not_ready_because_wca_not_configured"
-      ) {
-        return `Contact your administrator to configure IBM watsonx Code Assistant model settings for your organization.`;
-      } else if (
-        responseErrorData &&
-        responseErrorData.hasOwnProperty("code") &&
-        responseErrorData.code === "permission_denied__user_trial_expired"
-      ) {
-        return `Your trial to the generative AI model has expired. Refer to your IBM Cloud Account to re-enable access to the IBM watsonx Code Assistant.`;
+      } else if (responseErrorData) {
+        switch (
+          responseErrorData.hasOwnProperty("code") &&
+          responseErrorData.code
+        ) {
+          case "permission_denied__org_ready_user_has_no_seat": {
+            return "You do not have a licensed seat for Ansible Lightspeed and your organization is using the paid commercial service. Contact your Red Hat Organization's administrator for more information on how to get a licensed seat.";
+          }
+          case "permission_denied__org_not_ready_because_wca_not_configured": {
+            return "Contact your administrator to configure IBM watsonx Code Assistant model settings for your organization.";
+          }
+          case "permission_denied__user_trial_expired": {
+            return "Your trial to the generative AI model has expired. Refer to your IBM Cloud Account to re-enable access to the IBM watsonx Code Assistant.";
+          }
+          case "permission_denied__user_with_no_seat": {
+            return "You don't have access to IBM watsonx Code Assistant. Contact your administrator.";
+          }
+          default: {
+            return "User not authorized to access Ansible Lightspeed.";
+          }
+        }
       } else {
-        return `User not authorized to access Ansible Lightspeed.`;
+        return "User not authorized to access Ansible Lightspeed.";
       }
     } else if (err?.response?.status.toString().startsWith("5")) {
       return "Ansible Lightspeed encountered an error. Try again after some time.";

--- a/test/units/lightspeed/handleApiError.test.ts
+++ b/test/units/lightspeed/handleApiError.test.ts
@@ -105,6 +105,18 @@ describe("testing the error handling", () => {
       `Contact your administrator to configure IBM watsonx Code Assistant model settings for your organization.`
     );
   });
+  it("err Forbidden - No Seat", () => {
+    const msg = retrieveError(
+      createError(403, {
+        code: "permission_denied__user_with_no_seat",
+      })
+    );
+    assert.equal(
+      msg,
+      "You don't have access to IBM watsonx Code Assistant. Contact your administrator."
+    );
+  });
+
   it("err Forbidden", () => {
     const msg = retrieveError(createError(403));
     assert.equal(msg, `User not authorized to access Ansible Lightspeed.`);


### PR DESCRIPTION
Return the following message when the users cannot reach the service because
they have no seat:

`You don't have access to IBM watsonx Code Assistant. Contact your administrator.`
