### PR TITLE
enable lightspeed connect when ready

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,8 @@
       },
       {
         "view": "lightspeed-explorer-treeview",
-        "contents": "Welcome to Ansible Lightspeed for Visual Studio Code.\nExperience smarter automation using Ansible Lightspeed with watsonx Code Assistant solutions for your playbook. [Learn more](https://www.redhat.com/en/engage/project-wisdom)\nLet's simplify your workflow by connecting VS Code with Ansible Lightspeed.\n[Connect](command:ansible.lightspeed.oauth)"
+        "contents": "Welcome to Ansible Lightspeed for Visual Studio Code.\nExperience smarter automation using Ansible Lightspeed with watsonx Code Assistant solutions for your playbook. [Learn more](https://www.redhat.com/en/engage/project-wisdom)\nLet's simplify your workflow by connecting VS Code with Ansible Lightspeed.\n[Connect](command:ansible.lightspeed.oauth)",
+        "enablement": "lightspeedConnectReady"
       }
     ],
     "jsonValidation": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -151,7 +151,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
     telemetry
   );
 
-  vscode.commands.executeCommand('setContext', 'lightspeedConnectReady', true)
+  vscode.commands.executeCommand("setContext", "lightspeedConnectReady", true);
 
   context.subscriptions.push(
     vscode.commands.registerCommand(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -151,6 +151,8 @@ export async function activate(context: ExtensionContext): Promise<void> {
     telemetry
   );
 
+  vscode.commands.executeCommand('setContext', 'lightspeedConnectReady', true)
+
   context.subscriptions.push(
     vscode.commands.registerCommand(
       LightSpeedCommands.LIGHTSPEED_STATUS_BAR_CLICK,


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-19148

Fixes issue of `Cannot set properties of undefined (setting 'currentModelValue')` when Connect button is pressed before LightSpeedManager is initialized. 

I considered instead just checking if `lightSpeedManager` is defined before trying to set `currentModelValue`, but this fix feels safer to me given the seemingly delicate nature of the interdependencies and potential timing issues in the code. We could consider moving the initialization of the LightSpeedManager up higher in the `actvate` function too, to decrease the amount of time the `Connect` button is disabled. I think it's ok it's disabled though because the user has the visual indicator of the Sentiment panel trying to load while they wait.

Fix tested on RHEL 9.