### PR TITLE
handle invalid python interpreter path

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -139,7 +139,11 @@ export async function activate(context: ExtensionContext): Promise<void> {
     telemetry,
     extSettings
   );
-  await pythonInterpreterManager.updatePythonInfoInStatusbar();
+  try {
+    await pythonInterpreterManager.updatePythonInfoInStatusbar();
+  } catch (error) {
+    console.error(`Error updating python status bar: ${error}`);
+  }
 
   /**
    * Handle "Ansible Lightspeed" in the extension

--- a/src/features/pythonMetadata.ts
+++ b/src/features/pythonMetadata.ts
@@ -86,8 +86,10 @@ export class PythonInterpreterManager {
     } else {
       if (!interpreterPath)
         this.pythonInterpreterStatusBarItem.text = "Select python environment";
-      else
+      else {
         this.pythonInterpreterStatusBarItem.text = "Invalid python environment";
+        console.error(`The specified python interpreter path in settings does not exist: ${interpreterPath} `)
+      }
       this.pythonInterpreterStatusBarItem.backgroundColor = new ThemeColor(
         "statusBarItem.warningBackground"
       );

--- a/src/features/pythonMetadata.ts
+++ b/src/features/pythonMetadata.ts
@@ -88,7 +88,9 @@ export class PythonInterpreterManager {
         this.pythonInterpreterStatusBarItem.text = "Select python environment";
       else {
         this.pythonInterpreterStatusBarItem.text = "Invalid python environment";
-        console.error(`The specified python interpreter path in settings does not exist: ${interpreterPath} `)
+        console.error(
+          `The specified python interpreter path in settings does not exist: ${interpreterPath} `
+        );
       }
       this.pythonInterpreterStatusBarItem.backgroundColor = new ThemeColor(
         "statusBarItem.warningBackground"

--- a/src/features/pythonMetadata.ts
+++ b/src/features/pythonMetadata.ts
@@ -12,7 +12,7 @@ import { TelemetryManager } from "../utils/telemetryUtils";
 import { SettingsManager } from "../settings";
 import { AnsibleCommands } from "../definitions/constants";
 import { execSync } from "child_process";
-import fs from 'fs';
+import fs from "fs";
 
 export class PythonInterpreterManager {
   private context;

--- a/src/features/pythonMetadata.ts
+++ b/src/features/pythonMetadata.ts
@@ -12,6 +12,7 @@ import { TelemetryManager } from "../utils/telemetryUtils";
 import { SettingsManager } from "../settings";
 import { AnsibleCommands } from "../definitions/constants";
 import { execSync } from "child_process";
+import fs from 'fs';
 
 export class PythonInterpreterManager {
   private context;
@@ -71,9 +72,9 @@ export class PythonInterpreterManager {
     );
     this.pythonInterpreterStatusBarItem.show();
 
-    if (this.extensionSettings.settings.interpreterPath) {
-      const interpreterPath = this.extensionSettings.settings.interpreterPath;
-      const label = this.makeLabelFromPath(interpreterPath);
+    const interpreterPath = this.extensionSettings.settings.interpreterPath;
+    if (interpreterPath && fs.existsSync(interpreterPath)) {
+      const label = this.makeLabelFromPath(interpreterPath!);
       if (label) {
         this.pythonInterpreterStatusBarItem.text = label;
         this.pythonInterpreterStatusBarItem.tooltip = new MarkdownString(
@@ -83,7 +84,10 @@ export class PythonInterpreterManager {
         this.pythonInterpreterStatusBarItem.backgroundColor = "";
       }
     } else {
-      this.pythonInterpreterStatusBarItem.text = "Select python environment";
+      if (!interpreterPath)
+        this.pythonInterpreterStatusBarItem.text = "Select python environment";
+      else
+        this.pythonInterpreterStatusBarItem.text = "Invalid python environment";
       this.pythonInterpreterStatusBarItem.backgroundColor = new ThemeColor(
         "statusBarItem.warningBackground"
       );


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-19148

When you have a path in your settings for python interpreter that does not exist, makeLabelFromPath throws an error that causes the `activate` function in extension.ts to fail part way through. As a result, the Lightspeed sentiment panel never loads properly and you can't successfully log in to Lightspeed. This change adds better handling for the scenario of an interpreter path that doesn't exist, and also catches any errors coming from `updatePythonInfoInStatusbar` to avoid disruption of Lightspeed capabilities initializing.