### PR TITLE
Lightspeed VSCode extension: Analytics telemetry opting-out support

### DIFF
--- a/src/features/lightspeed/api.ts
+++ b/src/features/lightspeed/api.ts
@@ -136,6 +136,7 @@ export class LightSpeedAPI {
 
   public async feedbackRequest(
     inputData: FeedbackRequestParams,
+    orgOptOutTelemetry = false,
     showAuthErrorMessage = false,
     showInfoMessage = false
   ): Promise<FeedbackResponseParams> {
@@ -154,7 +155,7 @@ export class LightSpeedAPI {
     }
     const rhUserHasSeat = await this.lightSpeedAuthProvider.rhUserHasSeat();
 
-    if (rhUserHasSeat && this.lightSpeedAuthProvider.optOutTelemetry) {
+    if (rhUserHasSeat && orgOptOutTelemetry) {
       if (inputData.inlineSuggestion) {
         delete inputData.inlineSuggestion;
       }

--- a/src/features/lightspeed/api.ts
+++ b/src/features/lightspeed/api.ts
@@ -153,10 +153,10 @@ export class LightSpeedAPI {
       return {} as FeedbackResponseParams;
     }
     const rhUserHasSeat = await this.lightSpeedAuthProvider.rhUserHasSeat();
-    const orgTelementryOptOut =
+    const orgTelemetryOptOut =
       this.settingsManager.settings.lightSpeedService.orgTelemetryOptOut;
 
-    if (rhUserHasSeat && orgTelementryOptOut) {
+    if (rhUserHasSeat && orgTelemetryOptOut) {
       if (inputData.inlineSuggestion) {
         delete inputData.inlineSuggestion;
       }

--- a/src/features/lightspeed/api.ts
+++ b/src/features/lightspeed/api.ts
@@ -153,10 +153,8 @@ export class LightSpeedAPI {
       return {} as FeedbackResponseParams;
     }
     const rhUserHasSeat = await this.lightSpeedAuthProvider.rhUserHasSeat();
-    const orgTelemetryOptOut =
-      this.settingsManager.settings.lightSpeedService.orgTelemetryOptOut;
 
-    if (rhUserHasSeat && orgTelemetryOptOut) {
+    if (rhUserHasSeat && this.lightSpeedAuthProvider.optOutTelemetry) {
       if (inputData.inlineSuggestion) {
         delete inputData.inlineSuggestion;
       }

--- a/src/features/lightspeed/api.ts
+++ b/src/features/lightspeed/api.ts
@@ -153,7 +153,10 @@ export class LightSpeedAPI {
       return {} as FeedbackResponseParams;
     }
     const rhUserHasSeat = await this.lightSpeedAuthProvider.rhUserHasSeat();
-    if (rhUserHasSeat) {
+    const orgTelementryOptOut =
+      this.settingsManager.settings.lightSpeedService.orgTelemetryOptOut;
+
+    if (rhUserHasSeat && orgTelementryOptOut) {
       if (inputData.inlineSuggestion) {
         delete inputData.inlineSuggestion;
       }

--- a/src/features/lightspeed/base.ts
+++ b/src/features/lightspeed/base.ts
@@ -76,8 +76,7 @@ export class LightSpeedManager {
     this.apiInstance
       .getData(`${getBaseUri(this.settingsManager)}${LIGHTSPEED_ME_AUTH_URL}`)
       .then((userResponse: UserResponse) => {
-        this.lightSpeedAuthenticationProvider.optOutTelemetry =
-          userResponse.org_telemetry_opt_out;
+        this.orgTelemetryOptOut = userResponse.org_telemetry_opt_out;
       })
       .catch((error) => {
         console.error(error);
@@ -226,6 +225,6 @@ export class LightSpeedManager {
       },
     };
     console.log("[ansible-lightspeed-feedback] Event ansibleContent sent.");
-    this.apiInstance.feedbackRequest(inputData);
+    this.apiInstance.feedbackRequest(inputData, this.orgTelemetryOptOut);
   }
 }

--- a/src/features/lightspeed/base.ts
+++ b/src/features/lightspeed/base.ts
@@ -76,7 +76,7 @@ export class LightSpeedManager {
     this.apiInstance
       .getData(`${getBaseUri(this.settingsManager)}${LIGHTSPEED_ME_AUTH_URL}`)
       .then((userResponse: UserResponse) => {
-        this.settingsManager.settings.lightSpeedService.orgTelemetryOptOut =
+        this.lightSpeedAuthenticationProvider.optOutTelemetry =
           userResponse.org_telemetry_opt_out;
       })
       .catch((error) => {
@@ -169,10 +169,8 @@ export class LightSpeedManager {
 
     const rhUserHasSeat =
       await this.lightSpeedAuthenticationProvider.rhUserHasSeat();
-    const orgTelemetryOptOut =
-      this.settingsManager.settings.lightSpeedService.orgTelemetryOptOut;
 
-    if (rhUserHasSeat && orgTelemetryOptOut) {
+    if (rhUserHasSeat && this.orgTelemetryOptOut) {
       return;
     }
 

--- a/src/features/lightspeed/base.ts
+++ b/src/features/lightspeed/base.ts
@@ -11,17 +11,24 @@ import {
   IIncludeVarsContext,
   IWorkSpaceRolesContext,
 } from "../../interfaces/lightspeed";
-import { AnsibleContentUploadTrigger } from "../../definitions/lightspeed";
+import {
+  LIGHTSPEED_ME_AUTH_URL,
+  AnsibleContentUploadTrigger,
+} from "../../definitions/lightspeed";
 import { ContentMatchesWebview } from "./contentMatchesWebview";
 import {
   ANSIBLE_LIGHTSPEED_AUTH_ID,
   ANSIBLE_LIGHTSPEED_AUTH_NAME,
+  getBaseUri,
 } from "./utils/webUtils";
 import { LightspeedStatusBar } from "./statusBar";
 import { IVarsFileContext } from "../../interfaces/lightspeed";
 import { getCustomRolePaths, getCommonRoles } from "../utils/ansible";
 import { watchRolesDirectory } from "./utils/watchers";
-import { LightSpeedServiceSettings } from "../../interfaces/extensionSettings";
+import {
+  LightSpeedServiceSettings,
+  UserResponse,
+} from "../../interfaces/extensionSettings";
 
 export class LightSpeedManager {
   private context;
@@ -37,6 +44,7 @@ export class LightSpeedManager {
   public ansibleRolesCache: IWorkSpaceRolesContext = {};
   public ansibleIncludeVarsCache: IIncludeVarsContext = {};
   public currentModelValue: string | undefined = undefined;
+  public orgTelemetryOptOut = false;
 
   constructor(
     context: vscode.ExtensionContext,
@@ -65,6 +73,15 @@ export class LightSpeedManager {
       this.settingsManager,
       this.lightSpeedAuthenticationProvider
     );
+    this.apiInstance
+      .getData(`${getBaseUri(this.settingsManager)}${LIGHTSPEED_ME_AUTH_URL}`)
+      .then((userResponse: UserResponse) => {
+        this.settingsManager.settings.lightSpeedService.orgTelemetryOptOut =
+          userResponse.org_telemetry_opt_out;
+      })
+      .catch((error) => {
+        console.error(error);
+      });
     this.contentMatchesProvider = new ContentMatchesWebview(
       this.context,
       this.client,
@@ -150,7 +167,12 @@ export class LightSpeedManager {
       return;
     }
 
-    if (await this.lightSpeedAuthenticationProvider.rhUserHasSeat()) {
+    const rhUserHasSeat =
+      await this.lightSpeedAuthenticationProvider.rhUserHasSeat();
+    const orgTelementryOptOut =
+      this.settingsManager.settings.lightSpeedService.orgTelemetryOptOut;
+
+    if (rhUserHasSeat && orgTelementryOptOut) {
       return;
     }
 

--- a/src/features/lightspeed/base.ts
+++ b/src/features/lightspeed/base.ts
@@ -169,10 +169,10 @@ export class LightSpeedManager {
 
     const rhUserHasSeat =
       await this.lightSpeedAuthenticationProvider.rhUserHasSeat();
-    const orgTelementryOptOut =
+    const orgTelemetryOptOut =
       this.settingsManager.settings.lightSpeedService.orgTelemetryOptOut;
 
-    if (rhUserHasSeat && orgTelementryOptOut) {
+    if (rhUserHasSeat && orgTelemetryOptOut) {
       return;
     }
 

--- a/src/features/lightspeed/inlineSuggestions.ts
+++ b/src/features/lightspeed/inlineSuggestions.ts
@@ -828,7 +828,8 @@ export async function inlineSuggestionUserActionHandler(
     inlineSuggestion: inlineSuggestionData,
   };
   lightSpeedManager.apiInstance.feedbackRequest(
-    inlineSuggestionFeedbackPayload
+    inlineSuggestionFeedbackPayload,
+    lightSpeedManager.orgTelemetryOptOut
   );
   inlineSuggestionData = {};
 }

--- a/src/features/lightspeed/lightSpeedOAuthProvider.ts
+++ b/src/features/lightspeed/lightSpeedOAuthProvider.ts
@@ -57,7 +57,6 @@ export class LightSpeedAuthenticationProvider
   private _authId: string;
   private _authName: string;
   private _externalRedirectUri: string;
-  private _optOutTelemetry: boolean;
 
   constructor(
     private readonly context: ExtensionContext,
@@ -70,8 +69,6 @@ export class LightSpeedAuthenticationProvider
     this._authId = authId;
     this._authName = authName;
     this._externalRedirectUri = externalRedirectUri;
-    // Should be initialized by promise in async
-    this._optOutTelemetry = false;
   }
 
   public initialize() {
@@ -91,14 +88,6 @@ export class LightSpeedAuthenticationProvider
       ),
       window.registerUriHandler(this._uriHandler)
     );
-  }
-
-  get optOutTelemetry() {
-    return this._optOutTelemetry;
-  }
-
-  set optOutTelemetry(value: boolean) {
-    this._optOutTelemetry = value;
   }
 
   async setExternalRedirectUri() {

--- a/src/features/lightspeed/lightSpeedOAuthProvider.ts
+++ b/src/features/lightspeed/lightSpeedOAuthProvider.ts
@@ -57,6 +57,7 @@ export class LightSpeedAuthenticationProvider
   private _authId: string;
   private _authName: string;
   private _externalRedirectUri: string;
+  private _optOutTelemetry: boolean;
 
   constructor(
     private readonly context: ExtensionContext,
@@ -69,6 +70,8 @@ export class LightSpeedAuthenticationProvider
     this._authId = authId;
     this._authName = authName;
     this._externalRedirectUri = externalRedirectUri;
+    // Should be initialized by promise in async
+    this._optOutTelemetry = false;
   }
 
   public initialize() {
@@ -88,6 +91,14 @@ export class LightSpeedAuthenticationProvider
       ),
       window.registerUriHandler(this._uriHandler)
     );
+  }
+
+  get optOutTelemetry() {
+    return this._optOutTelemetry;
+  }
+
+  set optOutTelemetry(value: boolean) {
+    this._optOutTelemetry = value;
   }
 
   async setExternalRedirectUri() {

--- a/src/features/lightspeed/utils/feedbackView.ts
+++ b/src/features/lightspeed/utils/feedbackView.ts
@@ -132,7 +132,12 @@ export function setWebviewMessageListener(
         }
       }
       if (userFeedback && lightSpeedManager) {
-        lightSpeedManager.apiInstance.feedbackRequest(userFeedback, true, true);
+        lightSpeedManager.apiInstance.feedbackRequest(
+          userFeedback,
+          lightSpeedManager.orgTelemetryOptOut,
+          true,
+          true
+        );
       }
     },
     undefined,

--- a/src/interfaces/extensionSettings.ts
+++ b/src/interfaces/extensionSettings.ts
@@ -33,10 +33,10 @@ export interface UserResponse {
   org_telemetry_opt_out: boolean;
 }
 
+// Settings appear on VS Code Settings UI
 export interface LightSpeedServiceSettings {
   enabled: boolean;
   URL: string;
   suggestions: { enabled: boolean };
   model: string | undefined;
-  orgTelemetryOptOut?: boolean;
 }

--- a/src/interfaces/extensionSettings.ts
+++ b/src/interfaces/extensionSettings.ts
@@ -24,9 +24,19 @@ export interface ExecutionEnvironmentSettings {
   volumeMounts: Array<IVolumeMounts>;
 }
 
+export interface UserResponse {
+  rh_org_has_subscription: boolean;
+  rh_user_has_seat: boolean;
+  rh_user_is_org_admin: boolean;
+  external_username: string;
+  username: string;
+  org_telemetry_opt_out: boolean;
+}
+
 export interface LightSpeedServiceSettings {
   enabled: boolean;
   URL: string;
   suggestions: { enabled: boolean };
   model: string | undefined;
+  orgTelemetryOptOut?: boolean;
 }


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: <https://issues.redhat.com/browse/AAP-18663>
<!-- This PR does not need a corresponding Jira item. -->

## Description
<!-- Describe the changes introduced in the PR below, including any relevant motivation, context, and technical/design decisions -->
Since the addition of the opt-out flag for the analytics telemetry, the VSCode extension should send data to the wisdom service if user is not Opt Out from sending telemetry (this PR). Also Wisdom service ([wisdom-service PR](https://github.com/ansible/ansible-wisdom-service/pull/808)) should send an event to the segment if user is not opt out from the telemetry.

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR and [wisdom-service](https://github.com/ansible/ansible-wisdom-service/pull/808)
2. Create a user without org and/or user with opt out from telemetry org
3. Do a completion in VS Code plugin. Now one events will be send to the wisdom service (and to the segment).
4. Add user with org with not opt out from telemetry
5. Do a completion in VS Code plugin. Now two events will be send to the wisdom service (and to the segment after) Recommendation Action event is sent to the wisdom service and further to the segment.

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->
Described above.