### PR TITLE
handle command in python interpreter path

### DIFF
--- a/src/features/pythonMetadata.ts
+++ b/src/features/pythonMetadata.ts
@@ -109,7 +109,9 @@ export class PythonInterpreterManager {
     try {
       version = execSync(`${interpreterPath} -V`).toString().trim();
     } catch (error) {
-      console.error(`Error gathering python version from ${interpreterPath}: ${error}`);
+      console.error(
+        `Error gathering python version from ${interpreterPath}: ${error}`
+      );
       return;
     }
     let envLabel: string = version;


### PR DESCRIPTION
Follow-up to https://github.com/ansible/vscode-ansible/pull/1077
Thanks @TamiTakamiya for discovering my previous fix doesn't work if the python interpreter path just contains the command e.g. "python" or "python3". This new approach handles that and saves us an extra sync call.

Tested with valid absolute path, valid command, invalid values, and no value.