### PR TITLE
avoid an exception during init if 'roles' is not a directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -729,6 +729,7 @@
     "@types/mocha": "^10.0.6",
     "@types/node": "^20.11.7",
     "@types/sinon": "^17.0.3",
+    "@types/tmp": "^0.2.6",
     "@types/uuid": "^9.0.8",
     "@types/vscode": "^1.85.0",
     "@types/vscode-webview": "^1.57.4",

--- a/src/features/lightspeed/base.ts
+++ b/src/features/lightspeed/base.ts
@@ -93,7 +93,7 @@ export class LightSpeedManager {
     const lightspeedEnabled = lightspeedSettings.enabled;
 
     if (!lightspeedEnabled) {
-      await this.resetContext();
+      this.resetContext();
       await this.lightSpeedAuthenticationProvider.dispose();
       this.statusBarProvider.statusBar.hide();
       return;
@@ -117,7 +117,7 @@ export class LightSpeedManager {
     }
   }
 
-  private async resetContext(): Promise<void> {
+  private resetContext(): void {
     this.ansibleVarFilesCache = {};
     this.ansibleRolesCache = {};
   }

--- a/src/features/lightspeed/utils/readVarFiles.ts
+++ b/src/features/lightspeed/utils/readVarFiles.ts
@@ -1,0 +1,40 @@
+import * as fs from "fs";
+import * as yaml from "yaml";
+
+import { IParsedYaml } from "../../../interfaces/yaml";
+
+function removeVarsValues(parsedYaml: IParsedYaml[] | IParsedYaml | "") {
+  if (Array.isArray(parsedYaml)) {
+    for (const item of parsedYaml) {
+      removeVarsValues(item);
+    }
+  } else if (typeof parsedYaml === "object" && parsedYaml !== null) {
+    for (const key in parsedYaml) {
+      if (Object.prototype.hasOwnProperty.call(parsedYaml, key)) {
+        parsedYaml[key] = removeVarsValues(parsedYaml[key]);
+      }
+    }
+  } else {
+    parsedYaml = "";
+  }
+
+  return parsedYaml;
+}
+
+export function readVarFiles(varFile: string): string | undefined {
+  try {
+    if (!fs.existsSync(varFile)) {
+      return undefined;
+    }
+    const contents = fs.readFileSync(varFile, "utf8");
+    const parsedAnsibleVars = yaml.parse(contents, {
+      keepSourceTokens: true,
+    });
+    removeVarsValues(parsedAnsibleVars);
+    const updatedFileContents = yaml.stringify(parsedAnsibleVars);
+    return updatedFileContents;
+  } catch (err) {
+    console.error(`Failed to read ${varFile} with error ${err}`);
+    return undefined;
+  }
+}

--- a/src/features/lightspeed/utils/updateRolesContext.ts
+++ b/src/features/lightspeed/utils/updateRolesContext.ts
@@ -1,0 +1,109 @@
+import * as path from "path";
+import * as fs from "fs";
+
+import {
+  IVarsContext,
+  IWorkSpaceRolesContext,
+} from "../../../interfaces/lightspeed";
+import { readVarFiles } from "./readVarFiles";
+import { VarType } from "../../../interfaces/lightspeed";
+
+function getVarsFromRoles(
+  rolePath: string,
+  varType: VarType
+): IVarsContext | undefined {
+  const varsRootPath = path.join(rolePath, varType);
+  if (!fs.existsSync(varsRootPath)) {
+    return;
+  }
+  let dirContent;
+  try {
+    dirContent = fs.readdirSync(varsRootPath);
+  } catch (err) {
+    console.error(`Failed to read a var directory with error ${err}`);
+    return;
+  }
+
+  const varsFiles =
+    dirContent
+      .filter((name) => [".yml", ".yaml"].includes(path.extname(name)))
+      .map((name) => name)
+      .map((name) => path.join(varsRootPath, name)) || [];
+  for (const varsFile of varsFiles) {
+    if (!fs.existsSync(varsFile)) {
+      continue;
+    }
+
+    try {
+      const varsContext: IVarsContext = {};
+      const varsFileName = path.basename(varsFile);
+      const varsFileContent = readVarFiles(varsFile);
+      if (varsFileContent) {
+        varsContext[varsFileName] = varsFileContent;
+        return varsContext;
+      }
+    } catch (err) {
+      console.error(`Failed to read ${varsFile} with error ${err}`);
+    }
+  }
+
+  return;
+}
+
+export function updateRolesContext(
+  ansibleRolesCache: IWorkSpaceRolesContext,
+  rolesRootPath: string,
+  workSpaceRoot: string
+): IWorkSpaceRolesContext | undefined {
+  if (!fs.existsSync(rolesRootPath) || !rolesRootPath.endsWith("roles")) {
+    return;
+  }
+  let dirContent;
+  try {
+    dirContent = fs.readdirSync(rolesRootPath);
+  } catch (error) {
+    console.error(`Cannot read the directory: ${error}`);
+    return;
+  }
+
+  const roleNames = dirContent.filter((name) =>
+    fs.statSync(path.join(rolesRootPath, name)).isDirectory()
+  );
+  for (const roleName of roleNames) {
+    const rolePath = path.join(rolesRootPath, roleName);
+    updateRoleContext(ansibleRolesCache, rolePath, workSpaceRoot);
+  }
+}
+export function updateRoleContext(
+  ansibleRolesCache: IWorkSpaceRolesContext,
+  rolePath: string,
+  workSpaceRoot: string
+) {
+  if (!ansibleRolesCache[workSpaceRoot]) {
+    ansibleRolesCache[workSpaceRoot] = {};
+  }
+  const rolesContext = ansibleRolesCache[workSpaceRoot];
+  rolesContext[rolePath] = {
+    name: rolePath.split(path.sep).pop(),
+  };
+
+  // Get all the task files in the tasks directory
+  const tasksPath = path.join(rolePath, "tasks");
+  if (fs.existsSync(tasksPath)) {
+    try {
+      const dirContent = fs.readdirSync(tasksPath);
+
+      const taskNames = dirContent
+        .filter((name) => [".yml", ".yaml"].includes(path.extname(name)))
+        .map((name) => path.basename(name, path.extname(name)));
+      rolesContext[rolePath]["tasks"] = taskNames;
+    } catch (err) {
+      console.error(`Failed to read "tasks" directory with error ${err}`);
+    }
+  }
+
+  rolesContext[rolePath]["roleVars"] = {
+    defaults: getVarsFromRoles(rolePath, "defaults") || {},
+    vars: getVarsFromRoles(rolePath, "vars") || {},
+  };
+}

--- a/src/features/lightspeed/utils/watchers.ts
+++ b/src/features/lightspeed/utils/watchers.ts
@@ -4,13 +4,11 @@ import * as fs from "fs";
 import { globalFileSystemWatcher } from "../../../extension";
 import { LightSpeedManager } from "../base";
 import { IAnsibleType } from "../../../interfaces/watchers";
-import {
-  getRolePathFromPathWithinRole,
-  readVarFiles,
-  updateRoleContext,
-} from "./data";
+import { getRolePathFromPathWithinRole } from "./data";
+import { readVarFiles } from "./readVarFiles";
+import { updateRoleContext, updateRolesContext } from "./updateRolesContext";
+
 import { isFile } from "../../../utils/fileUtils";
-import { updateRolesContext } from "./data";
 import { StandardRolePaths } from "../../../definitions/constants";
 
 export async function watchAnsibleFile(
@@ -77,10 +75,18 @@ export function watchRolesDirectory(
     rolesPath in ansibleRolesCache[workspaceRoot]
   ) {
     console.log(`Directory ${rolesPath} is already being watched`);
-    updateRolesContext(lightSpeedManager, rolesPath, workspaceRoot);
+    updateRolesContext(
+      lightSpeedManager.ansibleRolesCache,
+      rolesPath,
+      workspaceRoot
+    );
     return;
   } else {
-    updateRolesContext(lightSpeedManager, rolesPath, workspaceRoot);
+    updateRolesContext(
+      lightSpeedManager.ansibleRolesCache,
+      rolesPath,
+      workspaceRoot
+    );
     console.log(`Created roles cache for ${rolesPath}`);
   }
 
@@ -93,7 +99,11 @@ export function watchRolesDirectory(
     if (currentWorkspaceRoot) {
       const workspaceRoot = currentWorkspaceRoot[0].uri.fsPath;
       const rolePath = getRolePathFromPathWithinRole(uri.fsPath);
-      updateRoleContext(lightSpeedManager, rolePath, workspaceRoot);
+      updateRoleContext(
+        lightSpeedManager.ansibleRolesCache,
+        rolePath,
+        workspaceRoot
+      );
       console.log(`Directory ${uri.fsPath} has been changed`);
     }
   });
@@ -123,7 +133,11 @@ export function watchRolesDirectory(
     if (currentWorkspaceRoot) {
       const workspaceRoot = currentWorkspaceRoot[0].uri.fsPath;
       const rolePath = getRolePathFromPathWithinRole(uri.fsPath);
-      updateRoleContext(lightSpeedManager, rolePath, workspaceRoot);
+      updateRoleContext(
+        lightSpeedManager.ansibleRolesCache,
+        rolePath,
+        workspaceRoot
+      );
       console.log(`Directory ${uri.fsPath} has been changed`);
     }
   });

--- a/test/units/lightspeed/utils/updateRolesContext.ts
+++ b/test/units/lightspeed/utils/updateRolesContext.ts
@@ -1,0 +1,201 @@
+require("assert");
+
+import { updateRolesContext } from "../../../../src/features/lightspeed/utils/updateRolesContext";
+import assert from "assert";
+import sinon from "sinon";
+import tmp from "tmp";
+import fs from "fs";
+
+import { IWorkSpaceRolesContext } from "../../../../src/interfaces/lightspeed";
+
+describe("testing updateRolesContext", () => {
+  const tmpDir = tmp.dirSync();
+  after(function () {
+    fs.rmSync(tmpDir.name, { recursive: true, force: true });
+  });
+
+  it("with no root directory", () => {
+    const ansibleRolesCache: IWorkSpaceRolesContext = {};
+    const result = updateRolesContext(ansibleRolesCache, "", "workSpace");
+
+    assert.strictEqual(result, undefined);
+    assert.equal(Object.keys(ansibleRolesCache).length, 0);
+  });
+
+  it("with an empty roles directory", () => {
+    const ansibleRolesCache: IWorkSpaceRolesContext = {};
+
+    const root_dir = `${tmpDir.name}/empty`;
+    fs.mkdirSync(`${root_dir}/roles`, { recursive: true });
+
+    updateRolesContext(ansibleRolesCache, `${root_dir}/roles`, "my_workSpace");
+
+    assert.equal(Object.keys(ansibleRolesCache).length, 0);
+  });
+
+  it("with a file called 'roles'", () => {
+    const ansibleRolesCache: IWorkSpaceRolesContext = {};
+
+    const root_dir = `${tmpDir.name}/role_as_file`;
+    fs.mkdirSync(root_dir, { recursive: true });
+    fs.writeFileSync(`${root_dir}/roles`, "");
+
+    const spiedConsole = sinon.spy(console, "error");
+    updateRolesContext(ansibleRolesCache, `${root_dir}/roles`, "my_workSpace");
+    const console_log_calls = spiedConsole.getCalls();
+    spiedConsole.restore();
+
+    assert.ok(
+      console_log_calls.find((item) =>
+        String(item.firstArg).includes("Cannot read the directory")
+      )
+    );
+
+    assert.equal(Object.keys(ansibleRolesCache).length, 0);
+  });
+
+  it("with a role with just one task'", () => {
+    const ansibleRolesCache: IWorkSpaceRolesContext = {};
+
+    const root_dir = `${tmpDir.name}/role_with_one_task`;
+    fs.mkdirSync(`${root_dir}/roles/my_role/tasks`, { recursive: true });
+    fs.writeFileSync(
+      `${root_dir}/roles/my_role/tasks/main.yaml`,
+      "---\n- debug:\n  var=1\n"
+    );
+
+    updateRolesContext(ansibleRolesCache, `${root_dir}/roles`, "my_workSpace");
+    const cacheEntry =
+      ansibleRolesCache["my_workSpace"][`${root_dir}/roles/my_role`];
+    const tasks = cacheEntry["tasks"];
+    if (!cacheEntry["roleVars"]) {
+      assert.fail("roleVars is not defined.");
+    }
+    const defaults = cacheEntry["roleVars"].defaults;
+    const vars = cacheEntry["roleVars"].vars;
+    assert.equal(tasks && tasks[0], "main");
+    assert.equal(Object.keys(defaults).length, 0);
+    assert.equal(Object.keys(vars).length, 0);
+  });
+
+  it("with a role where 'tasks' is a file, not a directory", () => {
+    const ansibleRolesCache: IWorkSpaceRolesContext = {};
+
+    const root_dir = `${tmpDir.name}/role_with_a_file_called_tasks`;
+    fs.mkdirSync(`${root_dir}/roles/my_role`, { recursive: true });
+    fs.writeFileSync(
+      `${root_dir}/roles/my_role/tasks`,
+      "nothing in particular"
+    );
+
+    const spiedConsole = sinon.spy(console, "error");
+    updateRolesContext(ansibleRolesCache, `${root_dir}/roles`, "my_workSpace");
+    const console_log_calls = spiedConsole.getCalls();
+    spiedConsole.restore();
+
+    assert.ok(
+      console_log_calls.find((item) =>
+        String(item.firstArg).includes(
+          'Failed to read "tasks" directory with error'
+        )
+      )
+    );
+  });
+
+  it("with a role with one task and a vars file'", () => {
+    const ansibleRolesCache: IWorkSpaceRolesContext = {};
+
+    const root_dir = `${tmpDir.name}/role_with_task_and_var_file`;
+    fs.mkdirSync(`${root_dir}/roles/my_role/tasks`, { recursive: true });
+    fs.mkdirSync(`${root_dir}/roles/my_role/vars`, { recursive: true });
+    fs.writeFileSync(
+      `${root_dir}/roles/my_role/tasks/main.yaml`,
+      "---\n- debug:\n  var=1\n"
+    );
+    fs.writeFileSync(
+      `${root_dir}/roles/my_role/vars/main.yaml`,
+      "---\nsome_var: 1\n"
+    );
+
+    updateRolesContext(ansibleRolesCache, `${root_dir}/roles`, "my_workSpace");
+
+    const cacheEntry =
+      ansibleRolesCache["my_workSpace"][`${root_dir}/roles/my_role`];
+    const tasks = cacheEntry["tasks"];
+    if (!cacheEntry["roleVars"]) {
+      assert.fail("roleVars is not defined.");
+    }
+    const defaults = cacheEntry["roleVars"].defaults;
+    const vars = cacheEntry["roleVars"].vars;
+    assert.equal(tasks && tasks[0], "main");
+    assert.equal(Object.keys(defaults).length, 0);
+    assert.equal(Object.keys(vars).length, 1);
+    assert.equal(vars["main.yaml"], 'some_var: ""\n');
+  });
+
+  it("with a role where 'vars' is a file, not a directory", () => {
+    const ansibleRolesCache: IWorkSpaceRolesContext = {};
+
+    const root_dir = `${tmpDir.name}/role_where_vars_is_a_file`;
+    fs.mkdirSync(`${root_dir}/roles/my_role`, { recursive: true });
+    fs.writeFileSync(`${root_dir}/roles/my_role/vars`, "some content");
+    fs.writeFileSync(`${root_dir}/roles/my_role/defaults`, "some content");
+
+    const spiedConsole = sinon.spy(console, "error");
+    updateRolesContext(ansibleRolesCache, `${root_dir}/roles`, "my_workSpace");
+    const console_log_calls = spiedConsole.getCalls();
+    spiedConsole.restore();
+
+    assert.ok(
+      console_log_calls.find((item) =>
+        String(item.firstArg).includes(
+          "Failed to read a var directory with error"
+        )
+      )
+    );
+  });
+  it("with a role where 'defaults' is a file, not a directory, but 'vars' is a directory as expected", () => {
+    const ansibleRolesCache: IWorkSpaceRolesContext = {};
+
+    const root_dir = `${tmpDir.name}/role_where_defaults_is_a_file_and_vars_is_a_directory`;
+    fs.mkdirSync(`${root_dir}/roles/my_role/vars`, { recursive: true });
+    fs.writeFileSync(`${root_dir}/roles/my_role/defaults`, "some content");
+    fs.writeFileSync(
+      `${root_dir}/roles/my_role/vars/main.yaml`,
+      '---\nsome_var: ""\n'
+    );
+
+    const spiedConsole = sinon.spy(console, "error");
+    updateRolesContext(ansibleRolesCache, `${root_dir}/roles`, "my_workSpace");
+    const console_log_calls = spiedConsole.getCalls();
+    spiedConsole.restore();
+
+    assert.ok(
+      console_log_calls.find((item) =>
+        String(item.firstArg).includes(
+          "Failed to read a var directory with error"
+        )
+      )
+    );
+
+    const cacheEntry =
+      ansibleRolesCache["my_workSpace"][`${root_dir}/roles/my_role`];
+    const tasks = cacheEntry["tasks"];
+    if (tasks) {
+      // NOTE: currently, tasks is undefined in this context, but having it
+      // set to {} in
+      // the future is also reasonable.
+      assert.equal(Object.keys(tasks).length, 0);
+    }
+    if (!cacheEntry["roleVars"]) {
+      assert.fail("roleVars is not defined.");
+    }
+
+    const defaults = cacheEntry["roleVars"].defaults;
+    // vars is properly set despite the invalid 'defaults' file.
+    const vars = cacheEntry["roleVars"].vars;
+    assert.equal(Object.keys(defaults).length, 0);
+    assert.equal(Object.keys(vars).length, 1);
+    assert.equal(vars["main.yaml"], 'some_var: ""\n');
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1004,6 +1004,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/tmp@npm:^0.2.6":
+  version: 0.2.6
+  resolution: "@types/tmp@npm:0.2.6"
+  checksum: e14a094c10569d3b56805552b21417860ef21060d969000d5d5b53604a78c2bdac216f064b03797d4b07a081e0141dd3ab22bc36923e75300eb1c023f7252cc7
+  languageName: node
+  linkType: hard
+
 "@types/uuid@npm:^9.0.8":
   version: 9.0.8
   resolution: "@types/uuid@npm:9.0.8"
@@ -1655,6 +1662,7 @@ __metadata:
     "@types/mocha": "npm:^10.0.6"
     "@types/node": "npm:^20.11.7"
     "@types/sinon": "npm:^17.0.3"
+    "@types/tmp": "npm:^0.2.6"
     "@types/uuid": "npm:^9.0.8"
     "@types/vscode": "npm:^1.85.0"
     "@types/vscode-webview": "npm:^1.57.4"


### PR DESCRIPTION
When the `roles` directory of the local workspace is not a regular directory,
`readdirSync()` raises an exception errcode (`ENOTDIR`).
The error was not catched and this was preventing the initialization of the
extension.

The commit also move a couple of functions to be able to properly unit-test
the change. We cannot import from the unit-test any module that use the
`vscode` object.

Finally, the commit changes the `LightSpeedManager.resetContext()` method to
make it a synchronous, this because the method changes an inner state of the
class that is consumed by other method.

Closes: #1084
