### PR TITLE
Re-enable Lightspeed UI tests

### DIFF
--- a/src/definitions/lightspeed.ts
+++ b/src/definitions/lightspeed.ts
@@ -61,6 +61,9 @@ export const LIGHTSPEED_SERVICE_LOGIN_TIMEOUT = 120000;
 
 export type LIGHTSPEED_SUGGESTION_TYPE = "SINGLE-TASK" | "MULTI-TASK";
 
+export type LIGHTSPEED_USER_TYPE = "Licensed" | "Unlicensed" | "Not logged in";
+export const LIGHTSPEED_STATUS_BAR_TEXT_DEFAULT = "Lightspeed (not logged in)";
+
 export const LIGHTSPEED_MODEL_DEFAULT = "default";
 
 export const tasksInPlaybookKeywords = [

--- a/src/features/lightspeed/lightSpeedOAuthProvider.ts
+++ b/src/features/lightspeed/lightSpeedOAuthProvider.ts
@@ -36,6 +36,7 @@ import {
   LIGHTSPEED_CLIENT_ID,
   LIGHTSPEED_SERVICE_LOGIN_TIMEOUT,
   LIGHTSPEED_ME_AUTH_URL,
+  LIGHTSPEED_STATUS_BAR_TEXT_DEFAULT,
 } from "../../definitions/lightspeed";
 import { LightspeedAuthSession } from "../../interfaces/lightspeed";
 import { lightSpeedManager } from "../../extension";
@@ -231,7 +232,7 @@ export class LightSpeedAuthenticationProvider
         );
       }
     }
-    lightSpeedManager.statusBarProvider.statusBar.text = "Lightspeed";
+    lightSpeedManager.statusBarProvider.statusBar.text = LIGHTSPEED_STATUS_BAR_TEXT_DEFAULT;
     lightSpeedManager.statusBarProvider.statusBar.tooltip = undefined;
     lightSpeedManager.currentModelValue = undefined;
   }

--- a/src/features/lightspeed/lightSpeedOAuthProvider.ts
+++ b/src/features/lightspeed/lightSpeedOAuthProvider.ts
@@ -232,7 +232,8 @@ export class LightSpeedAuthenticationProvider
         );
       }
     }
-    lightSpeedManager.statusBarProvider.statusBar.text = LIGHTSPEED_STATUS_BAR_TEXT_DEFAULT;
+    lightSpeedManager.statusBarProvider.statusBar.text =
+      LIGHTSPEED_STATUS_BAR_TEXT_DEFAULT;
     lightSpeedManager.statusBarProvider.statusBar.tooltip = undefined;
     lightSpeedManager.currentModelValue = undefined;
   }

--- a/src/features/lightspeed/statusBar.ts
+++ b/src/features/lightspeed/statusBar.ts
@@ -48,6 +48,7 @@ export class LightspeedStatusBar {
     );
     lightSpeedStatusBarItem.command =
       LightSpeedCommands.LIGHTSPEED_STATUS_BAR_CLICK;
+    lightSpeedStatusBarItem.text = this.getLightSpeedStatusBarTextSync();
     this.getLightSpeedStatusBarText().then((text) => {
       lightSpeedStatusBarItem.text = text;
     });
@@ -66,12 +67,23 @@ export class LightspeedStatusBar {
       rhOrgHasSubscription =
         await this.lightSpeedAuthProvider.rhOrgHasSubscription();
     }
+    return this.getLightSpeedStatusBarTextSync(
+      rhOrgHasSubscription,
+      rhUserHasSeat
+    );
+  }
+
+  private getLightSpeedStatusBarTextSync(
+    rhUserHasSeat?: boolean,
+    rhOrgHasSubscription?: boolean
+  ): string {
     const userTypeLabel = getUserTypeLabel(
       rhOrgHasSubscription,
       rhUserHasSeat
     ).toLowerCase();
     return `Lightspeed (${userTypeLabel})`;
   }
+
   private handleStatusBar() {
     if (!this.client.isRunning()) {
       return;

--- a/src/features/lightspeed/statusBar.ts
+++ b/src/features/lightspeed/statusBar.ts
@@ -5,6 +5,7 @@ import { SettingsManager } from "../../settings";
 import {
   LightSpeedCommands,
   LIGHTSPEED_MODEL_DEFAULT,
+  LIGHTSPEED_STATUS_BAR_TEXT_DEFAULT,
 } from "../../definitions/lightspeed";
 import { LightSpeedAuthenticationProvider } from "./lightSpeedOAuthProvider";
 import { LightspeedAuthSession } from "../../interfaces/lightspeed";
@@ -48,7 +49,7 @@ export class LightspeedStatusBar {
     );
     lightSpeedStatusBarItem.command =
       LightSpeedCommands.LIGHTSPEED_STATUS_BAR_CLICK;
-    lightSpeedStatusBarItem.text = this.getLightSpeedStatusBarTextSync();
+    lightSpeedStatusBarItem.text = LIGHTSPEED_STATUS_BAR_TEXT_DEFAULT;
     this.getLightSpeedStatusBarText().then((text) => {
       lightSpeedStatusBarItem.text = text;
     });

--- a/src/features/lightspeed/utils/webUtils.ts
+++ b/src/features/lightspeed/utils/webUtils.ts
@@ -7,6 +7,7 @@ import {
   LightspeedSessionUserInfo,
   LightspeedSessionInfo,
 } from "../../../interfaces/lightspeed";
+import { LIGHTSPEED_USER_TYPE } from "../../../definitions/lightspeed";
 import { lightSpeedManager } from "../../../extension";
 
 export const ANSIBLE_LIGHTSPEED_AUTH_ID = `auth-lightspeed`;
@@ -73,23 +74,26 @@ export function getBaseUri(settingsManager: SettingsManager) {
 export function getUserTypeLabel(
   rhOrgHasSubscription?: boolean,
   rhUserHasSeat?: boolean
-): "Licensed" | "Unlicensed" {
+): LIGHTSPEED_USER_TYPE {
+  if (rhOrgHasSubscription === undefined) {
+    return "Not logged in";
+  }
   return rhOrgHasSubscription && rhUserHasSeat ? "Licensed" : "Unlicensed";
 }
 
 export function getLoggedInSessionDetails(
-  sessionData: LightspeedAuthSession
+  sessionData?: LightspeedAuthSession
 ): LightspeedSessionInfo {
   const userInfo: LightspeedSessionUserInfo = {};
   const modelInfo: LightspeedSessionModelInfo = {};
   userInfo.userType = getUserTypeLabel(
-    sessionData.rhOrgHasSubscription,
-    sessionData.rhUserHasSeat
+    sessionData?.rhOrgHasSubscription,
+    sessionData?.rhUserHasSeat
   );
-  if (sessionData.rhUserIsOrgAdmin) {
+  if (sessionData?.rhUserIsOrgAdmin) {
     userInfo.role = "Administrator";
   }
-  if (sessionData.rhOrgHasSubscription) {
+  if (sessionData?.rhOrgHasSubscription) {
     userInfo.subscribed = true;
   }
   if (lightSpeedManager.currentModelValue) {

--- a/src/interfaces/lightspeed.ts
+++ b/src/interfaces/lightspeed.ts
@@ -1,6 +1,7 @@
 import { AuthenticationSession } from "vscode";
 import {
   AnsibleContentUploadTrigger,
+  LIGHTSPEED_USER_TYPE,
   UserAction,
 } from "../definitions/lightspeed";
 
@@ -167,7 +168,7 @@ export interface IAdditionalContext {
 }
 
 export interface LightspeedSessionUserInfo {
-  userType?: "Licensed" | "Unlicensed";
+  userType?: LIGHTSPEED_USER_TYPE;
   role?: string;
   subscribed?: boolean;
 }

--- a/test/testScripts/lightspeed/testLightSpeedFunctions.test.ts
+++ b/test/testScripts/lightspeed/testLightSpeedFunctions.test.ts
@@ -4,6 +4,7 @@ import { LightspeedAuthSession } from "../../../src/interfaces/lightspeed";
 import { lightSpeedManager } from "../../../src/extension";
 import { v4 as uuid } from "uuid";
 import { assert } from "chai";
+import { LIGHTSPEED_STATUS_BAR_TEXT_DEFAULT } from "../../../src/definitions/lightspeed";
 
 function getLightSpeedAuthSession(
   rhUserHasSeat: boolean,
@@ -66,7 +67,11 @@ function testGetLightSpeedStatusBarText(): void {
   describe("Test getLightSpeedStatusBarTest", function () {
     it("Verify status bar text for various user types", async function () {
       const statusBarProvider = lightSpeedManager.statusBarProvider;
-      let text = await statusBarProvider.getLightSpeedStatusBarText(true, true);
+
+      let text = await statusBarProvider.getLightSpeedStatusBarText();
+      assert.equal(text, LIGHTSPEED_STATUS_BAR_TEXT_DEFAULT);
+
+      text = await statusBarProvider.getLightSpeedStatusBarText(true, true);
       assert.equal(text, "Lightspeed (licensed)");
       text = await statusBarProvider.getLightSpeedStatusBarText(true, false);
       assert.equal(text, "Lightspeed (unlicensed)");

--- a/test/ui-test/allTestsSuite.ts
+++ b/test/ui-test/allTestsSuite.ts
@@ -1,8 +1,8 @@
 import { extensionUIAssetsTest } from "./extensionUITest";
-// import { lightspeedUIAssetsTest } from "./lightspeedUiTest";
+import { lightspeedUIAssetsTest } from "./lightspeedUiTest";
 
 describe("VSCode Ansible - UI tests", function () {
   this.timeout(30000);
   extensionUIAssetsTest();
-  // lightspeedUIAssetsTest();
+  lightspeedUIAssetsTest();
 });

--- a/test/ui-test/lightspeedUiTest.ts
+++ b/test/ui-test/lightspeedUiTest.ts
@@ -78,7 +78,7 @@ export function lightspeedUIAssetsTest(): void {
       const items = await statusBar.findElements(
         By.xpath(
           "//div[contains(@class, 'statusbar-item') and " +
-            ".//a/text()='Lightspeed (unlicensed)']"
+            ".//a/text()='Lightspeed (not logged in))']"
         )
       );
       expect(items.length).equals(0);
@@ -95,7 +95,7 @@ export function lightspeedUIAssetsTest(): void {
           "//div[contains(@class, 'statusbar-item') and " +
             "contains(@class, 'has-background-color') and " +
             "contains(@class, 'warning-kind') and " +
-            ".//a/text()='Lightspeed (unlicensed)']"
+            ".//a/text()='Lightspeed (not logged in)']"
         )
       );
       expect(lightspeedStatusBarItem).not.to.be.undefined;
@@ -115,7 +115,7 @@ export function lightspeedUIAssetsTest(): void {
         By.xpath(
           "//div[contains(@class, 'statusbar-item') and " +
             "not (contains(@class, 'has-background-color')) and " +
-            ".//a/text()='Lightspeed (unlicensed)']"
+            ".//a/text()='Lightspeed (not logged in)']"
         )
       );
       expect(lightspeedStatusBarItem).not.to.be.undefined;

--- a/test/ui-test/lightspeedUiTest.ts
+++ b/test/ui-test/lightspeedUiTest.ts
@@ -1,11 +1,11 @@
 import { expect, config } from "chai";
 import {
   ActivityBar,
+  By,
   SideBarView,
   ViewControl,
   ExtensionsViewSection,
   Workbench,
-  WelcomeContentButton,
   StatusBar,
   VSBrowser,
   EditorView,
@@ -27,7 +27,7 @@ export function lightspeedUIAssetsTest(): void {
 
       lightspeedServiceSection = (await sideBar
         .getContent()
-        .getSection("Ansible Lightspeed")) as ExtensionsViewSection;
+        .getSection("Ansible Lightspeed Login")) as ExtensionsViewSection;
     });
 
     it("Ansible Lightspeed welcome message is present", async function () {
@@ -49,15 +49,22 @@ export function lightspeedUIAssetsTest(): void {
       // this.retries(3);
       // this.timeout(20000); // even 18s failed
 
-      const loginButton = lightspeedServiceSection
-        .findWelcomeContent()
-        .then(async (val) => {
-          return (await val?.getButtons()) as WelcomeContentButton[];
-        });
+      const welcomeContent = await lightspeedServiceSection.findWelcomeContent();
+      expect(welcomeContent).not.undefined;
+      const loginButton = await welcomeContent?.findElement(By.xpath("//a[.//span/text()='Connect']"));
+      expect(loginButton).not.undefined;
 
-      const loginButtonTitle = await (await loginButton)[0].getTitle();
+      // **** ORIGINAL CODE ****
+      // const loginButton = lightspeedServiceSection
+      //   .findWelcomeContent()
+      //   .then(async (val) => {
+      //// *** Following getButtons() call does not seem to get buttons...
+      //     return (await val?.getButtons()) as WelcomeContentButton[];
+      //   });
 
-      expect(loginButtonTitle).to.equal("Connect");
+      // const loginButtonTitle = await (await loginButton)[0].getTitle();
+
+      // expect(loginButtonTitle).to.equal("Connect");      
     });
   });
 
@@ -82,21 +89,37 @@ export function lightspeedUIAssetsTest(): void {
 
     it("Ansible Lightspeed status bar item absent when settings not enabled", async function () {
       await editorView.openEditor(file);
-      const lightspeedStatusBarItem = await statusBar.getItem("Lightspeed");
-      expect(lightspeedStatusBarItem).to.be.undefined;
+      const items = await statusBar.findElements(By.xpath((
+        "//div[contains(@class, 'statusbar-item') and " 
+        + ".//a/text()='Lightspeed (unlicensed)']")));
+      expect(items.length).equals(0);
+
+      // **** ORIGINAL CODE ****
+      //   *** statusBar.getItem() does not seem to get items correctly.
+      // const lightspeedStatusBarItem = await statusBar.getItem("Lightspeed");
+      // expect(lightspeedStatusBarItem).to.be.undefined;
     });
 
     it("Ansible Lightspeed status bar item present when only lightspeed is enabled (with warning color)", async () => {
       settingsEditor = await workbench.openSettings();
       await updateSettings(settingsEditor, "ansible.lightspeed.enabled", true);
       await editorView.openEditor(file);
-      const lightspeedStatusBarItem = await statusBar.getItem("Lightspeed");
+      const lightspeedStatusBarItem = await statusBar.findElement(By.xpath((
+        "//div[contains(@class, 'statusbar-item') and " 
+        + "contains(@class, 'has-background-color') and "
+        + "contains(@class, 'warning-kind') and "
+        + ".//a/text()='Lightspeed (unlicensed)']")));
       expect(lightspeedStatusBarItem).not.to.be.undefined;
 
-      // getAttribute('style') returns a string with "background-color" in case of different color, else returns nothing
-      expect(await lightspeedStatusBarItem?.getAttribute("style")).to.include(
-        "background-color"
-      );
+      // **** ORIGINAL CODE ****
+      //   *** statusBar.getItem() does not seem to get items correctly.
+      // const lightspeedStatusBarItem = await statusBar.getItem("Lightspeed");
+      // expect(lightspeedStatusBarItem).not.to.be.undefined;
+
+      //  // getAttribute('style') returns a string with "background-color" in case of different color, else returns nothing
+      // expect(await lightspeedStatusBarItem?.getAttribute("style")).to.include(
+      //   "background-color"
+      // );
     });
 
     it("Ansible Lightspeed status bar item present when lightspeed and lightspeed suggestions are enabled (with normal color)", async () => {
@@ -108,11 +131,19 @@ export function lightspeedUIAssetsTest(): void {
         true
       );
       await editorView.openEditor(file);
-      const lightspeedStatusBarItem = await statusBar.getItem("Lightspeed");
+      const lightspeedStatusBarItem = await statusBar.findElement(By.xpath((
+        "//div[contains(@class, 'statusbar-item') and " 
+        + "not (contains(@class, 'has-background-color')) and "
+        + ".//a/text()='Lightspeed (unlicensed)']")));
       expect(lightspeedStatusBarItem).not.to.be.undefined;
+      
+      // **** ORIGINAL CODE ****
+      //   *** statusBar.getItem() does not seem to get items correctly.
+      // const lightspeedStatusBarItem = await statusBar.getItem("Lightspeed");
+      // expect(lightspeedStatusBarItem).not.to.be.undefined;
 
-      // getAttribute('style') returns a string with "background-color" in case of different color, else returns nothing
-      expect(await lightspeedStatusBarItem?.getAttribute("style")).to.be.empty;
+      // // getAttribute('style') returns a string with "background-color" in case of different color, else returns nothing
+      // expect(await lightspeedStatusBarItem?.getAttribute("style")).to.be.empty;
     });
   });
 }

--- a/test/ui-test/lightspeedUiTest.ts
+++ b/test/ui-test/lightspeedUiTest.ts
@@ -49,9 +49,12 @@ export function lightspeedUIAssetsTest(): void {
       // this.retries(3);
       // this.timeout(20000); // even 18s failed
 
-      const welcomeContent = await lightspeedServiceSection.findWelcomeContent();
+      const welcomeContent =
+        await lightspeedServiceSection.findWelcomeContent();
       expect(welcomeContent).not.undefined;
-      const loginButton = await welcomeContent?.findElement(By.xpath("//a[.//span/text()='Connect']"));
+      const loginButton = await welcomeContent?.findElement(
+        By.xpath("//a[.//span/text()='Connect']")
+      );
       expect(loginButton).not.undefined;
 
       // **** ORIGINAL CODE ****
@@ -64,7 +67,7 @@ export function lightspeedUIAssetsTest(): void {
 
       // const loginButtonTitle = await (await loginButton)[0].getTitle();
 
-      // expect(loginButtonTitle).to.equal("Connect");      
+      // expect(loginButtonTitle).to.equal("Connect");
     });
   });
 
@@ -89,9 +92,12 @@ export function lightspeedUIAssetsTest(): void {
 
     it("Ansible Lightspeed status bar item absent when settings not enabled", async function () {
       await editorView.openEditor(file);
-      const items = await statusBar.findElements(By.xpath((
-        "//div[contains(@class, 'statusbar-item') and " 
-        + ".//a/text()='Lightspeed (unlicensed)']")));
+      const items = await statusBar.findElements(
+        By.xpath(
+          "//div[contains(@class, 'statusbar-item') and " +
+            ".//a/text()='Lightspeed (unlicensed)']"
+        )
+      );
       expect(items.length).equals(0);
 
       // **** ORIGINAL CODE ****
@@ -104,11 +110,14 @@ export function lightspeedUIAssetsTest(): void {
       settingsEditor = await workbench.openSettings();
       await updateSettings(settingsEditor, "ansible.lightspeed.enabled", true);
       await editorView.openEditor(file);
-      const lightspeedStatusBarItem = await statusBar.findElement(By.xpath((
-        "//div[contains(@class, 'statusbar-item') and " 
-        + "contains(@class, 'has-background-color') and "
-        + "contains(@class, 'warning-kind') and "
-        + ".//a/text()='Lightspeed (unlicensed)']")));
+      const lightspeedStatusBarItem = await statusBar.findElement(
+        By.xpath(
+          "//div[contains(@class, 'statusbar-item') and " +
+            "contains(@class, 'has-background-color') and " +
+            "contains(@class, 'warning-kind') and " +
+            ".//a/text()='Lightspeed (unlicensed)']"
+        )
+      );
       expect(lightspeedStatusBarItem).not.to.be.undefined;
 
       // **** ORIGINAL CODE ****
@@ -131,12 +140,15 @@ export function lightspeedUIAssetsTest(): void {
         true
       );
       await editorView.openEditor(file);
-      const lightspeedStatusBarItem = await statusBar.findElement(By.xpath((
-        "//div[contains(@class, 'statusbar-item') and " 
-        + "not (contains(@class, 'has-background-color')) and "
-        + ".//a/text()='Lightspeed (unlicensed)']")));
+      const lightspeedStatusBarItem = await statusBar.findElement(
+        By.xpath(
+          "//div[contains(@class, 'statusbar-item') and " +
+            "not (contains(@class, 'has-background-color')) and " +
+            ".//a/text()='Lightspeed (unlicensed)']"
+        )
+      );
       expect(lightspeedStatusBarItem).not.to.be.undefined;
-      
+
       // **** ORIGINAL CODE ****
       //   *** statusBar.getItem() does not seem to get items correctly.
       // const lightspeedStatusBarItem = await statusBar.getItem("Lightspeed");

--- a/test/ui-test/lightspeedUiTest.ts
+++ b/test/ui-test/lightspeedUiTest.ts
@@ -21,7 +21,6 @@ export function lightspeedUIAssetsTest(): void {
     let lightspeedServiceSection: ExtensionsViewSection;
 
     before(async function () {
-      // this.timeout(10000);
       view = (await new ActivityBar().getViewControl("Ansible")) as ViewControl;
       sideBar = await view.openView();
 
@@ -31,9 +30,6 @@ export function lightspeedUIAssetsTest(): void {
     });
 
     it("Ansible Lightspeed welcome message is present", async function () {
-      // this.retries(3);
-      // this.timeout(20000); // even 18s failed
-
       const welcomeMessage = await lightspeedServiceSection
         .findWelcomeContent()
         .then(async (val) => {
@@ -46,28 +42,15 @@ export function lightspeedUIAssetsTest(): void {
     });
 
     it("Ansible Lightspeed login button is present", async function () {
-      // this.retries(3);
-      // this.timeout(20000); // even 18s failed
-
       const welcomeContent =
         await lightspeedServiceSection.findWelcomeContent();
       expect(welcomeContent).not.undefined;
+
+      // The following lines replaced the original code that was using ExtensionsViewSection APIs.
       const loginButton = await welcomeContent?.findElement(
         By.xpath("//a[.//span/text()='Connect']")
       );
       expect(loginButton).not.undefined;
-
-      // **** ORIGINAL CODE ****
-      // const loginButton = lightspeedServiceSection
-      //   .findWelcomeContent()
-      //   .then(async (val) => {
-      //// *** Following getButtons() call does not seem to get buttons...
-      //     return (await val?.getButtons()) as WelcomeContentButton[];
-      //   });
-
-      // const loginButtonTitle = await (await loginButton)[0].getTitle();
-
-      // expect(loginButtonTitle).to.equal("Connect");
     });
   });
 
@@ -80,8 +63,6 @@ export function lightspeedUIAssetsTest(): void {
     const filePath = getFilePath(file);
 
     before(async function () {
-      // this.timeout(100000);
-
       statusBar = new StatusBar();
       editorView = new EditorView();
       workbench = new Workbench();
@@ -92,6 +73,8 @@ export function lightspeedUIAssetsTest(): void {
 
     it("Ansible Lightspeed status bar item absent when settings not enabled", async function () {
       await editorView.openEditor(file);
+
+      // The following lines replaced the original code that was using StatusBar.getItem() API.
       const items = await statusBar.findElements(
         By.xpath(
           "//div[contains(@class, 'statusbar-item') and " +
@@ -99,17 +82,14 @@ export function lightspeedUIAssetsTest(): void {
         )
       );
       expect(items.length).equals(0);
-
-      // **** ORIGINAL CODE ****
-      //   *** statusBar.getItem() does not seem to get items correctly.
-      // const lightspeedStatusBarItem = await statusBar.getItem("Lightspeed");
-      // expect(lightspeedStatusBarItem).to.be.undefined;
     });
 
     it("Ansible Lightspeed status bar item present when only lightspeed is enabled (with warning color)", async () => {
       settingsEditor = await workbench.openSettings();
       await updateSettings(settingsEditor, "ansible.lightspeed.enabled", true);
       await editorView.openEditor(file);
+
+      // The following lines replaced the original code that was using StatusBar.getItem() API.
       const lightspeedStatusBarItem = await statusBar.findElement(
         By.xpath(
           "//div[contains(@class, 'statusbar-item') and " +
@@ -119,27 +99,18 @@ export function lightspeedUIAssetsTest(): void {
         )
       );
       expect(lightspeedStatusBarItem).not.to.be.undefined;
-
-      // **** ORIGINAL CODE ****
-      //   *** statusBar.getItem() does not seem to get items correctly.
-      // const lightspeedStatusBarItem = await statusBar.getItem("Lightspeed");
-      // expect(lightspeedStatusBarItem).not.to.be.undefined;
-
-      //  // getAttribute('style') returns a string with "background-color" in case of different color, else returns nothing
-      // expect(await lightspeedStatusBarItem?.getAttribute("style")).to.include(
-      //   "background-color"
-      // );
     });
 
     it("Ansible Lightspeed status bar item present when lightspeed and lightspeed suggestions are enabled (with normal color)", async () => {
       settingsEditor = await workbench.openSettings();
-      // await updateSettings(settingsEditor, "ansible.lightspeed.enabled", true);
       await updateSettings(
         settingsEditor,
         "ansible.lightspeed.suggestions.enabled",
         true
       );
       await editorView.openEditor(file);
+
+      // The following lines replaced the original code that was using StatusBar.getItem() API.
       const lightspeedStatusBarItem = await statusBar.findElement(
         By.xpath(
           "//div[contains(@class, 'statusbar-item') and " +
@@ -148,14 +119,6 @@ export function lightspeedUIAssetsTest(): void {
         )
       );
       expect(lightspeedStatusBarItem).not.to.be.undefined;
-
-      // **** ORIGINAL CODE ****
-      //   *** statusBar.getItem() does not seem to get items correctly.
-      // const lightspeedStatusBarItem = await statusBar.getItem("Lightspeed");
-      // expect(lightspeedStatusBarItem).not.to.be.undefined;
-
-      // // getAttribute('style') returns a string with "background-color" in case of different color, else returns nothing
-      // expect(await lightspeedStatusBarItem?.getAttribute("style")).to.be.empty;
     });
   });
 }


### PR DESCRIPTION
Re-enable Lightspeed UI tests, which have been commented out and not executed for a while. Changes include:

- Applied changes corresponding to the latest Lightspeed code base (e.g. side panel section name: "Ansible Lightspeed" --> "Ansbile Lightspeed Login")
- Replaced a few vscode-extension-tester fucntions, which seemed not working as expected, with findElement/findElements calls with XPath locators. Although this might be somehow controversial one, I think this is a realistic approach for writing reliable UI tests for VS Code now.
- Intentionally kept original codes for the reference purpose. We may want to clean them up in the future.

Codes were tested with `yarn test-ui-current` command.  `yarn test-ui-oldest` fails due to current extension's vscode version requirement.