### PR TITLE
Reject feedback API for unlicensed users after disabling tech preview

### DIFF
--- a/src/features/lightspeed/api.ts
+++ b/src/features/lightspeed/api.ts
@@ -186,10 +186,21 @@ export class LightSpeedAPI {
       return response.data;
     } catch (error) {
       const err = error as AxiosError;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const data: any = err?.response?.data;
       if (err && "response" in err) {
         if (err?.response?.status === 401) {
           vscode.window.showErrorMessage(
             "User not authorized to access Ansible Lightspeed."
+          );
+        } else if (
+          err?.response?.status === 403 &&
+          (data?.code === "permission_denied__user_with_no_seat" ||
+            data?.code ===
+              "permission_denied__org_not_ready_because_wca_not_configured")
+        ) {
+          vscode.window.showErrorMessage(
+            "You must be connected to a model to send Ansible Lightspeed feedback."
           );
         } else if (err?.response?.status === 400) {
           console.error(`Bad Request response. Please open an Github issue.`);

--- a/test/mockLightspeedServer/feedback.ts
+++ b/test/mockLightspeedServer/feedback.ts
@@ -1,0 +1,19 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function feedback(req: any, res: any) {
+  const body = req.body;
+  console.log(JSON.stringify(body, null, 2));
+
+  // If a sentimentFeedback is received and it's feedback starts with
+  // "permission_denied__" respond with a 403 error with the specified code.
+  if (body?.sentimentFeedback?.feedback.startsWith("permission_denied__")) {
+    return res.status(403).send({
+      code: body.sentimentFeedback.feedback,
+      message: "TEST",
+    });
+  } else if (body?.sentimentFeedback) {
+    return res.send({
+      message: "Thanks for your feedback!",
+    });
+  }
+  return res.send({});
+}

--- a/test/mockLightspeedServer/server.ts
+++ b/test/mockLightspeedServer/server.ts
@@ -1,6 +1,7 @@
 // "Mock" Lightspeed Server
 import express, { Application } from "express";
 import { completions } from "./completion";
+import { feedback } from "./feedback";
 import { me } from "./me";
 import { openUrl } from "./openUrl";
 
@@ -28,9 +29,7 @@ export default class Server {
     });
 
     app.post(`${API_ROOT}/ai/feedback`, (req, res) => {
-      const body = req.body;
-      console.log(JSON.stringify(body, null, 2));
-      return res.send({});
+      return feedback(req, res);
     });
 
     app.get(`${API_ROOT}/me`, (req, res) => {


### PR DESCRIPTION
For [AAP-20002](https://issues.redhat.com/browse/AAP-20002).

Note: UI tests (e.g. tests to check the error message on the message box) are not included as we are still trying to re-enable them (#1088).