### PR TITLE
Update lightspeed doc link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ holding `ctrl`/`cmd`.
 
 AI based Ansible code recommendations
 
-- [Getting started](https://docs.ai.ansible.redhat.com/vscode_guide/installing_vs/#configuring-the-ansible-vs-code-extension)
+- [Getting started](https://access.redhat.com/documentation/en-us/red_hat_ansible_lightspeed_with_ibm_watsonx_code_assistant/2.x_latest/html/red_hat_ansible_lightspeed_with_ibm_watsonx_code_assistant_user_guide/configuring-with-code-assistant_lightspeed-user-guide#doc-wrapper)
 
 - [Contact](https://matrix.to/#/%23ansible-lightspeed:ansible.im)
 


### PR DESCRIPTION
Currently the "Getting started" link in the Lightspeed section of README.md file points to the doc prepared for Tech Preview. It should be replaced with the production version.

Note: The content of README is published on [the extension's Marketplace page](https://marketplace.visualstudio.com/items?itemName=redhat.ansible).