### PR TITLE
send ansible extension version in lightspeed requests

### DIFF
--- a/src/features/lightspeed/api.ts
+++ b/src/features/lightspeed/api.ts
@@ -26,15 +26,18 @@ export class LightSpeedAPI {
   private lightSpeedAuthProvider: LightSpeedAuthenticationProvider;
   private _completionRequestInProgress: boolean;
   private _inlineSuggestionFeedbackSent: boolean;
+  private _extensionVersion: string;
 
   constructor(
     settingsManager: SettingsManager,
-    lightSpeedAuthProvider: LightSpeedAuthenticationProvider
+    lightSpeedAuthProvider: LightSpeedAuthenticationProvider,
+    context: vscode.ExtensionContext,
   ) {
     this.settingsManager = settingsManager;
     this.lightSpeedAuthProvider = lightSpeedAuthProvider;
     this._completionRequestInProgress = false;
     this._inlineSuggestionFeedbackSent = false;
+    this._extensionVersion = context.extension.packageJSON.version;
   }
 
   get completionRequestInProgress(): boolean {
@@ -101,9 +104,10 @@ export class LightSpeedAPI {
     try {
       this._completionRequestInProgress = true;
       this._inlineSuggestionFeedbackSent = false;
+      const requestData = { ...inputData, "metadata": { ...inputData.metadata, ansibleExtensionVersion: this._extensionVersion } }
       const response = await axiosInstance.post(
         LIGHTSPEED_SUGGESTION_COMPLETION_URL,
-        inputData,
+        requestData,
         {
           timeout: ANSIBLE_LIGHTSPEED_API_TIMEOUT,
         }
@@ -167,15 +171,16 @@ export class LightSpeedAPI {
     if (Object.keys(inputData).length === 0) {
       return {} as FeedbackResponseParams;
     }
+    const requestData = { ...inputData, "metadata": { ansibleExtensionVersion: this._extensionVersion } }
     console.log(
       `[ansible-lightspeed] Feedback request sent to lightspeed: ${JSON.stringify(
-        inputData
+        requestData
       )}`
     );
     try {
       const response = await axiosInstance.post(
         LIGHTSPEED_SUGGESTION_FEEDBACK_URL,
-        inputData,
+        requestData,
         {
           timeout: ANSIBLE_LIGHTSPEED_API_TIMEOUT,
         }
@@ -233,14 +238,15 @@ export class LightSpeedAPI {
       return {} as ContentMatchesResponseParams;
     }
     try {
+      const requestData = { ...inputData, "metadata": { ansibleExtensionVersion: this._extensionVersion } }
       console.log(
         `[ansible-lightspeed] Content Match request sent to lightspeed: ${JSON.stringify(
-          inputData
+          requestData
         )}`
       );
       const response = await axiosInstance.post(
         LIGHTSPEED_SUGGESTION_CONTENT_MATCHES_URL,
-        inputData,
+        requestData,
         {
           timeout: ANSIBLE_LIGHTSPEED_API_TIMEOUT,
         }

--- a/src/features/lightspeed/api.ts
+++ b/src/features/lightspeed/api.ts
@@ -31,7 +31,7 @@ export class LightSpeedAPI {
   constructor(
     settingsManager: SettingsManager,
     lightSpeedAuthProvider: LightSpeedAuthenticationProvider,
-    context: vscode.ExtensionContext,
+    context: vscode.ExtensionContext
   ) {
     this.settingsManager = settingsManager;
     this.lightSpeedAuthProvider = lightSpeedAuthProvider;
@@ -104,7 +104,13 @@ export class LightSpeedAPI {
     try {
       this._completionRequestInProgress = true;
       this._inlineSuggestionFeedbackSent = false;
-      const requestData = { ...inputData, "metadata": { ...inputData.metadata, ansibleExtensionVersion: this._extensionVersion } }
+      const requestData = {
+        ...inputData,
+        metadata: {
+          ...inputData.metadata,
+          ansibleExtensionVersion: this._extensionVersion,
+        },
+      };
       const response = await axiosInstance.post(
         LIGHTSPEED_SUGGESTION_COMPLETION_URL,
         requestData,
@@ -171,7 +177,10 @@ export class LightSpeedAPI {
     if (Object.keys(inputData).length === 0) {
       return {} as FeedbackResponseParams;
     }
-    const requestData = { ...inputData, "metadata": { ansibleExtensionVersion: this._extensionVersion } }
+    const requestData = {
+      ...inputData,
+      metadata: { ansibleExtensionVersion: this._extensionVersion },
+    };
     console.log(
       `[ansible-lightspeed] Feedback request sent to lightspeed: ${JSON.stringify(
         requestData
@@ -238,7 +247,10 @@ export class LightSpeedAPI {
       return {} as ContentMatchesResponseParams;
     }
     try {
-      const requestData = { ...inputData, "metadata": { ansibleExtensionVersion: this._extensionVersion } }
+      const requestData = {
+        ...inputData,
+        metadata: { ansibleExtensionVersion: this._extensionVersion },
+      };
       console.log(
         `[ansible-lightspeed] Content Match request sent to lightspeed: ${JSON.stringify(
           requestData

--- a/src/features/lightspeed/base.ts
+++ b/src/features/lightspeed/base.ts
@@ -71,7 +71,8 @@ export class LightSpeedManager {
     }
     this.apiInstance = new LightSpeedAPI(
       this.settingsManager,
-      this.lightSpeedAuthenticationProvider
+      this.lightSpeedAuthenticationProvider,
+      this.context
     );
     this.apiInstance
       .getData(`${getBaseUri(this.settingsManager)}${LIGHTSPEED_ME_AUTH_URL}`)


### PR DESCRIPTION
Adds the extension version to Lightspeed API requests for telemetry and troubleshooting purposes.