### PR TITLE
Push disposals to context.subscriptions

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -234,52 +234,60 @@ export async function activate(context: ExtensionContext): Promise<void> {
   );
 
   // register ansible meta data in the statusbar tooltip (client-server)
-  window.onDidChangeActiveTextEditor(
-    async (editor: vscode.TextEditor | undefined) => {
+  context.subscriptions.push(
+    window.onDidChangeActiveTextEditor(
+      async (editor: vscode.TextEditor | undefined) => {
+        await updateAnsibleStatusBar(
+          metaData,
+          lightSpeedManager,
+          pythonInterpreterManager
+        );
+        if (editor) {
+          await lightSpeedManager.ansibleContentFeedback(
+            editor.document,
+            AnsibleContentUploadTrigger.TAB_CHANGE
+          );
+        }
+      }
+    )
+  );
+  context.subscriptions.push(
+    workspace.onDidOpenTextDocument(async (document: vscode.TextDocument) => {
       await updateAnsibleStatusBar(
         metaData,
         lightSpeedManager,
         pythonInterpreterManager
       );
-      if (editor) {
-        await lightSpeedManager.ansibleContentFeedback(
-          editor.document,
-          AnsibleContentUploadTrigger.TAB_CHANGE
-        );
-      }
-    }
+      lightSpeedManager.ansibleContentFeedback(
+        document,
+        AnsibleContentUploadTrigger.FILE_OPEN
+      );
+    })
   );
-  workspace.onDidOpenTextDocument(async (document: vscode.TextDocument) => {
-    await updateAnsibleStatusBar(
-      metaData,
-      lightSpeedManager,
-      pythonInterpreterManager
-    );
-    lightSpeedManager.ansibleContentFeedback(
-      document,
-      AnsibleContentUploadTrigger.FILE_OPEN
-    );
-  });
-  workspace.onDidCloseTextDocument(async (document: vscode.TextDocument) => {
-    await lightSpeedManager.ansibleContentFeedback(
-      document,
-      AnsibleContentUploadTrigger.FILE_CLOSE
-    );
-  });
+  context.subscriptions.push(
+    workspace.onDidCloseTextDocument(async (document: vscode.TextDocument) => {
+      await lightSpeedManager.ansibleContentFeedback(
+        document,
+        AnsibleContentUploadTrigger.FILE_CLOSE
+      );
+    })
+  );
 
-  workspace.onDidChangeConfiguration(async () => {
-    await updateConfigurationChanges(
-      metaData,
-      pythonInterpreterManager,
-      extSettings,
-      lightSpeedManager
-    );
-    await updateAnsibleStatusBar(
-      metaData,
-      lightSpeedManager,
-      pythonInterpreterManager
-    );
-  });
+  context.subscriptions.push(
+    workspace.onDidChangeConfiguration(async () => {
+      await updateConfigurationChanges(
+        metaData,
+        pythonInterpreterManager,
+        extSettings,
+        lightSpeedManager
+      );
+      await updateAnsibleStatusBar(
+        metaData,
+        lightSpeedManager,
+        pythonInterpreterManager
+      );
+    })
+  );
 
   context.subscriptions.push(
     workspace.onDidChangeTextDocument((e: vscode.TextDocumentChangeEvent) => {


### PR DESCRIPTION
In VS Code extension development, all disposable objects created by the extension should be pushed to `context.subscriptions` so that they can be properly cleaned up when your extension is unloaded ([reference](https://stackoverflow.com/questions/55554018/purpose-for-subscribing-a-command-in-vscode-extension)). Most of disposables created in the `activate()` method of Ansible VS Code extension are already pushed to it, but there are few exceptions. This PR is for pushing those disposables, which have not been pushed to it.