### PR TITLE
Send IGNORED suggestion feedback when active editor/window is changed

### DIFF
--- a/src/features/lightspeed/inlineSuggestions.ts
+++ b/src/features/lightspeed/inlineSuggestions.ts
@@ -843,13 +843,15 @@ export async function inlineSuggestionUserActionHandler(
   resetSuggestionData();
 }
 
-function inlineSuggestionPending(): boolean {
-  if (vscode.window.activeTextEditor?.document.languageId !== "ansible") {
-    return false;
-  }
-  const editor = vscode.window.activeTextEditor;
-  if (!editor) {
-    return false;
+function inlineSuggestionPending(checkActiveTextEditor = true): boolean {
+  if (checkActiveTextEditor) {
+    if (vscode.window.activeTextEditor?.document.languageId !== "ansible") {
+      return false;
+    }
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) {
+      return false;
+    }
   }
   if (!inlineSuggestionData["suggestionId"]) {
     return false;
@@ -872,6 +874,23 @@ export async function rejectPendingSuggestion() {
       await inlineSuggestionUserActionHandler(
         suggestionId!,
         UserAction.REJECTED
+      );
+    } else {
+      suggestionDisplayed.reset();
+    }
+  }
+}
+
+export async function ignorePendingSuggestion() {
+  if (suggestionDisplayed.get() && lightSpeedManager.inlineSuggestionsEnabled) {
+    if (inlineSuggestionPending(false)) {
+      console.log(
+        "[inline-suggestions] Send a IGNORED feedback for a pending suggestion."
+      );
+      const suggestionId = inlineSuggestionData["suggestionId"];
+      await inlineSuggestionUserActionHandler(
+        suggestionId!,
+        UserAction.IGNORED
       );
     } else {
       suggestionDisplayed.reset();

--- a/test/testFixtures/lightspeed/playbook_3.yml
+++ b/test/testFixtures/lightspeed/playbook_3.yml
@@ -1,0 +1,5 @@
+---
+- name:
+  hosts: all
+  tasks:
+    - name: Create a file foo.txt

--- a/test/testScripts/lightspeed/e2eInlineSuggestion.test.ts
+++ b/test/testScripts/lightspeed/e2eInlineSuggestion.test.ts
@@ -12,14 +12,25 @@ import {
   TextDocument,
 } from "vscode";
 import { assert } from "chai";
-import { activate, getDocUri, sleep } from "../../helper";
-import { LightSpeedCommands } from "../../../src/definitions/lightspeed";
 import sinon from "sinon";
+
+import {
+  LightSpeedCommands,
+  UserAction,
+} from "../../../src/definitions/lightspeed";
+import { lightSpeedManager } from "../../../src/extension";
+import { ignorePendingSuggestion } from "../../../src/features/lightspeed/inlineSuggestions";
+import { FeedbackRequestParams } from "../../../src/interfaces/lightspeed";
+
+import { activate, getDocUri, sleep } from "../../helper";
+import { integer } from "vscode-languageclient";
 
 const INSERT_TEXT = "**** I'm not a pilot ****";
 
 const LIGHTSPEED_INLINE_SUGGESTION_WAIT_TIME = 1000;
 const LIGHTSPEED_INLINE_SUGGESTION_AFTER_COMMIT_WAIT_TIME = 200;
+const LIGHTSPEED_INLINE_SUGGESTION_AFTER_IGNORE_WAIT_TIME =
+  LIGHTSPEED_INLINE_SUGGESTION_AFTER_COMMIT_WAIT_TIME;
 
 const LINE_TO_ACTIVATE = 1;
 const COLUMN_TO_ACTIVATE = 8;
@@ -29,12 +40,25 @@ export async function testInlineSuggestionByAnotherProvider(): Promise<void> {
     let disposable: Disposable;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let executeCommandSpy: any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let feedbackRequestSpy: any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let isAuthenticatedStub: any;
 
     before(async () => {
       // This file does not contain trigger keywords for Lightspeed
       const docUri = getDocUri("lightspeed/playbook_2.yml");
       // Spy vscode's executeCommand API
       executeCommandSpy = sinon.spy(vscode.commands, "executeCommand");
+      feedbackRequestSpy = sinon.spy(
+        lightSpeedManager.apiInstance,
+        "feedbackRequest"
+      );
+      isAuthenticatedStub = sinon.stub(
+        lightSpeedManager.lightSpeedAuthenticationProvider,
+        "isAuthenticated"
+      );
+      isAuthenticatedStub.returns(Promise.resolve(true));
 
       // Register the bare minimum inline suggestion provider. which is
       // activated at (line, column) = (1, 8). Note numbers are zero-origin.
@@ -47,22 +71,10 @@ export async function testInlineSuggestionByAnotherProvider(): Promise<void> {
     });
 
     it("Test an inline suggestion from another provider is committed", async function () {
-      const editor = vscode.window.activeTextEditor;
-      assert(editor);
-      const doc = editor?.document;
-      assert(doc);
-
-      // Set the cursor to the position where the bare minimum provider provides
-      // its inline suggestion
-      const newPosition = new Position(
+      const editor = await invokeInlineSuggestion(
         LINE_TO_ACTIVATE,
-        COLUMN_TO_ACTIVATE - 1
+        COLUMN_TO_ACTIVATE
       );
-      editor.selection = new Selection(newPosition, newPosition);
-      editor.revealRange(new Range(newPosition, newPosition));
-
-      await vscode.commands.executeCommand("type", { text: " " });
-      await sleep(LIGHTSPEED_INLINE_SUGGESTION_WAIT_TIME);
 
       // Issue Lightspeed's commit command, which is assigned to the Tab key, which
       // should issue vscode's commit command eventually
@@ -90,16 +102,102 @@ export async function testInlineSuggestionByAnotherProvider(): Promise<void> {
         new Position(currentPosition.line, COLUMN_TO_ACTIVATE),
         new Position(currentPosition.line, currentPosition.character)
       );
-      const committedSuggestion = doc.getText(suggestionRange).trim();
+      const committedSuggestion = editor.document
+        .getText(suggestionRange)
+        .trim();
       assert(committedSuggestion === INSERT_TEXT);
+    });
+
+    afterEach(() => {
+      executeCommandSpy.resetHistory();
+      feedbackRequestSpy.resetHistory();
     });
 
     after(() => {
       // Dispose the bare minimum inline suggestion provider
       disposable.dispose();
       executeCommandSpy.restore();
+      feedbackRequestSpy.restore();
+      isAuthenticatedStub.restore();
+      sinon.restore();
     });
   });
+}
+
+export async function testIgnorePendingSuggestion(): Promise<void> {
+  describe("Test to ignore a pending suggestion", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let feedbackRequestSpy: any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let isAuthenticatedStub: any;
+
+    before(async () => {
+      const docUri = getDocUri("lightspeed/playbook_3.yml");
+      feedbackRequestSpy = sinon.spy(
+        lightSpeedManager.apiInstance,
+        "feedbackRequest"
+      );
+      isAuthenticatedStub = sinon.stub(
+        lightSpeedManager.lightSpeedAuthenticationProvider,
+        "isAuthenticated"
+      );
+      isAuthenticatedStub.returns(Promise.resolve(true));
+
+      await vscode.commands.executeCommand("workbench.action.closeAllEditors");
+      await activate(docUri);
+    });
+
+    it("Test ignorePendingSuggestion method", async () => {
+      // Inline suggestion is triggered at (line, column) = (5, 4).  Note numbers are
+      // zero-origin. Since the file does not contain trailing blanks, we need to send
+      // four spaces through vscode API.
+      await invokeInlineSuggestion(5, 0, 4);
+
+      await ignorePendingSuggestion();
+      await sleep(LIGHTSPEED_INLINE_SUGGESTION_AFTER_IGNORE_WAIT_TIME);
+
+      const feedbackRequestApiCalls = feedbackRequestSpy.getCalls();
+      assert.equal(feedbackRequestApiCalls.length, 1);
+      const inputData: FeedbackRequestParams = feedbackRequestSpy.args[0][0];
+      assert(inputData?.inlineSuggestion?.action === UserAction.IGNORED);
+      const ret = feedbackRequestSpy.returnValues[0];
+      assert(Object.keys(ret).length === 0); // ret should be equal to {}
+    });
+
+    afterEach(() => {
+      feedbackRequestSpy.resetHistory();
+    });
+
+    after(() => {
+      feedbackRequestSpy.restore();
+      isAuthenticatedStub.restore();
+      sinon.restore();
+    });
+  });
+}
+
+async function invokeInlineSuggestion(
+  lineToActivate: integer,
+  columnToActivate: integer,
+  spaces = 1
+): Promise<vscode.TextEditor> {
+  const editor = vscode.window.activeTextEditor;
+  assert(editor);
+  const doc = editor?.document;
+  assert(doc);
+
+  // Set the cursor to the position where the bare minimum provider provides
+  // its inline suggestion
+  const newPosition = new Position(lineToActivate, columnToActivate - spaces);
+  editor.selection = new Selection(newPosition, newPosition);
+  editor.revealRange(new Range(newPosition, newPosition));
+
+  for (let i = 0; i < spaces; i++) {
+    await vscode.commands.executeCommand("type", { text: " " });
+  }
+  await sleep(LIGHTSPEED_INLINE_SUGGESTION_WAIT_TIME);
+
+  return editor;
 }
 
 // "Bare minimum" VS Code inline suggestion provider

--- a/test/testScripts/lightspeed/testLightspeed.test.ts
+++ b/test/testScripts/lightspeed/testLightspeed.test.ts
@@ -138,7 +138,6 @@ export function testLightspeed(): void {
           assert(inputData?.inlineSuggestion?.action === UserAction.ACCEPTED);
           const ret = feedbackRequestSpy.returnValues[0];
           assert(Object.keys(ret).length === 0); // ret should be equal to {}
-          feedbackRequestSpy.resetHistory();
         });
       });
 
@@ -158,7 +157,6 @@ export function testLightspeed(): void {
           assert(inputData?.inlineSuggestion?.action === UserAction.ACCEPTED);
           const ret = feedbackRequestSpy.returnValues[0];
           assert(Object.keys(ret).length === 0); // ret should be equal to {}
-          feedbackRequestSpy.resetHistory();
         });
       });
 
@@ -173,12 +171,16 @@ export function testLightspeed(): void {
           assert(inputData?.inlineSuggestion?.action === UserAction.REJECTED);
           const ret = feedbackRequestSpy.returnValues[0];
           assert(Object.keys(ret).length === 0); // ret should be equal to {}
-          feedbackRequestSpy.resetHistory();
         });
+      });
+
+      this.afterEach(() => {
+        feedbackRequestSpy.resetHistory();
       });
 
       after(async function () {
         feedbackRequestSpy.restore();
+        isAuthenticatedStub.restore();
         sinon.restore();
       });
     });


### PR DESCRIPTION
There are a few scenarios where inlineSuggestionFeedback events are not sent after an inline suggestion from Lightspeed server is displayed on Ansible VS Code extension. This ticket is for resolving the following two scenarios:

1. The active text editor is changed with a click on a different tab in the editor section of VS Code.
2. The active window is changed with a click on a different window (e.g. web browser)

In either cases, a REJECTED feedback will be sent eventually if user returns to the editor tab and start typing ([AAP-21028](https://issues.redhat.com/browse/AAP-21028)), however it is desirable to send IGNORED feedbacks in more timely manner.