### PR TITLE
Do not send ACCEPTED feedback from commit handler

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -257,6 +257,8 @@ export async function activate(context: ExtensionContext): Promise<void> {
             editor.document,
             AnsibleContentUploadTrigger.TAB_CHANGE
           );
+        } else {
+          await ignorePendingSuggestion();
         }
       }
     )

--- a/src/features/lightspeed/inlineSuggestions.ts
+++ b/src/features/lightspeed/inlineSuggestions.ts
@@ -759,14 +759,6 @@ export async function inlineSuggestionTriggerHandler() {
 }
 
 export async function inlineSuggestionCommitHandler() {
-  if (vscode.window.activeTextEditor?.document.languageId !== "ansible") {
-    return;
-  }
-  const editor = vscode.window.activeTextEditor;
-  if (!editor) {
-    return;
-  }
-
   // Commit the suggestion, which might be provided by another provider
   vscode.commands.executeCommand("editor.action.inlineSuggest.commit");
 
@@ -776,14 +768,6 @@ export async function inlineSuggestionCommitHandler() {
   }
 
   console.log("[inline-suggestions] User accepted the inline suggestion.");
-
-  vscode.commands.executeCommand(
-    LightSpeedCommands.LIGHTSPEED_FETCH_TRAINING_MATCHES
-  );
-
-  const suggestionId = inlineSuggestionData["suggestionId"];
-  // Send feedback for accepted suggestion
-  await inlineSuggestionUserActionHandler(suggestionId!, UserAction.ACCEPTED);
 }
 
 export async function inlineSuggestionHideHandler(userAction?: UserAction) {
@@ -923,6 +907,10 @@ export async function inlineSuggestionTextDocumentChangeHandler(
         await inlineSuggestionUserActionHandler(
           suggestionId!,
           UserAction.ACCEPTED
+        );
+        // Show training matches for the accepted suggestion.
+        vscode.commands.executeCommand(
+          LightSpeedCommands.LIGHTSPEED_FETCH_TRAINING_MATCHES
         );
       }
     });

--- a/test/mockLightspeedServer/server.ts
+++ b/test/mockLightspeedServer/server.ts
@@ -25,12 +25,12 @@ export default class Server {
     app.get("/", (req, res) => res.send("Lightspeed Mock"));
 
     app.post(`${API_ROOT}/ai/completions`, async (req, res) => {
-      await new Promise((r) => setTimeout(r, 100)); // fake 100ms latency
+      await new Promise((r) => setTimeout(r, 500)); // fake 500ms latency
       return res.send(completions(req));
     });
 
     app.post(`${API_ROOT}/ai/contentmatches`, async (req, res) => {
-      await new Promise((r) => setTimeout(r, 100)); // fake 100ms latency
+      await new Promise((r) => setTimeout(r, 500)); // fake 500ms latency
       return res.send(contentmatches(req));
     });
 

--- a/test/testScripts/lightspeed/e2eInlineSuggestion.test.ts
+++ b/test/testScripts/lightspeed/e2eInlineSuggestion.test.ts
@@ -152,7 +152,10 @@ export async function testInlineSuggestionProviderCoExistence(): Promise<void> {
     });
 
     it("Test an inline suggestion from another provider is committed", async function () {
-      const editor = await invokeInlineSuggestion(5, 4);
+      // Inline suggestion is triggered at (line, column) = (5, 4).  Note numbers are
+      // zero-origin. Since the file does not contain trailing blanks, we need to send
+      // four spaces through vscode API.
+      const editor = await invokeInlineSuggestion(5, 4, 4);
 
       // Issue Lightspeed's commit command, which is assigned to the Tab key, which
       // should issue vscode's commit command eventually
@@ -235,7 +238,7 @@ export async function testIgnorePendingSuggestion(): Promise<void> {
       // Inline suggestion is triggered at (line, column) = (5, 4).  Note numbers are
       // zero-origin. Since the file does not contain trailing blanks, we need to send
       // four spaces through vscode API.
-      await invokeInlineSuggestion(5, 0, 4);
+      await invokeInlineSuggestion(5, 4, 4);
 
       await ignorePendingSuggestion();
       await sleep(LIGHTSPEED_INLINE_SUGGESTION_AFTER_IGNORE_WAIT_TIME);

--- a/test/testScripts/lightspeed/testLightspeed.test.ts
+++ b/test/testScripts/lightspeed/testLightspeed.test.ts
@@ -14,7 +14,10 @@ import {
 } from "../../helper";
 import { testLightspeedFunctions } from "./testLightSpeedFunctions.test";
 import { lightSpeedManager } from "../../../src/extension";
-import { testInlineSuggestionByAnotherProvider } from "./e2eInlineSuggestion.test";
+import {
+  testInlineSuggestionByAnotherProvider,
+  testInlineSuggestionProviderCoExistence,
+} from "./e2eInlineSuggestion.test";
 import { UserAction } from "../../../src/definitions/lightspeed";
 import { FeedbackRequestParams } from "../../../src/interfaces/lightspeed";
 
@@ -271,6 +274,7 @@ export function testLightspeed(): void {
 
     describe("Test inline suggestion by another provider", () => {
       testInlineSuggestionByAnotherProvider();
+      testInlineSuggestionProviderCoExistence();
     });
 
     describe("Test Ansible Lightspeed Functions", function () {


### PR DESCRIPTION
When there are more than one inline suggestions are available and user selected a suggestion, which was not from Lightspeed, we should not send a feedback with the ACCEPTED action. As the current code assumes that user accepted the Lightspeed suggestion when user pressed Tab key, 