### PR TITLE
Send IGNORED feedback if feedback was pending

### DIFF
--- a/src/features/lightspeed/inlineSuggestions.ts
+++ b/src/features/lightspeed/inlineSuggestions.ts
@@ -344,6 +344,9 @@ async function requestSuggestion(
     );
   const suggestionId = uuidv4();
   try {
+    // If there is a suggestion, whose feedback is pending, ignore it before making a new request
+    await ignorePendingSuggestion();
+
     const activityId = retrieveActivityIdFromTracker(
       documentInfo,
       inlinePosition

--- a/src/features/lightspeed/inlineSuggestions.ts
+++ b/src/features/lightspeed/inlineSuggestions.ts
@@ -344,7 +344,8 @@ async function requestSuggestion(
     );
   const suggestionId = uuidv4();
   try {
-    // If there is a suggestion, whose feedback is pending, ignore it before making a new request
+    // If there is a suggestion, whose feedback is pending, send a feedback with IGNORED action
+    // before making a new request
     await ignorePendingSuggestion();
 
     const activityId = retrieveActivityIdFromTracker(

--- a/test/testScripts/lightspeed/testLightspeed.test.ts
+++ b/test/testScripts/lightspeed/testLightspeed.test.ts
@@ -273,13 +273,13 @@ export function testLightspeed(): void {
       });
     });
 
+    describe("Test ignore pending suggestions", () => {
+      testIgnorePendingSuggestion();
+    });
+
     describe("Test inline suggestion by another provider", () => {
       testInlineSuggestionByAnotherProvider();
       testInlineSuggestionProviderCoExistence();
-    });
-
-    describe("Test ignore pending suggestions", () => {
-      testIgnorePendingSuggestion();
     });
 
     describe("Test Ansible Lightspeed Functions", function () {

--- a/test/testScripts/lightspeed/testLightspeed.test.ts
+++ b/test/testScripts/lightspeed/testLightspeed.test.ts
@@ -17,6 +17,7 @@ import { lightSpeedManager } from "../../../src/extension";
 import {
   testInlineSuggestionByAnotherProvider,
   testInlineSuggestionProviderCoExistence,
+  testIgnorePendingSuggestion,
 } from "./e2eInlineSuggestion.test";
 import { UserAction } from "../../../src/definitions/lightspeed";
 import { FeedbackRequestParams } from "../../../src/interfaces/lightspeed";
@@ -275,6 +276,10 @@ export function testLightspeed(): void {
     describe("Test inline suggestion by another provider", () => {
       testInlineSuggestionByAnotherProvider();
       testInlineSuggestionProviderCoExistence();
+    });
+
+    describe("Test ignore pending suggestions", () => {
+      testIgnorePendingSuggestion();
     });
 
     describe("Test Ansible Lightspeed Functions", function () {


### PR DESCRIPTION
When an inline suggestion is requested and there is the previous suggestion, whose feedback has not been sent, send a feedback with IGNORED action.  This code will not be used in normal use cases, but I believe we should have such a fall-back mechanism.