### PR TITLE
Fix terminal color and navigator command execution

### DIFF
--- a/src/features/runner.ts
+++ b/src/features/runner.ts
@@ -55,6 +55,7 @@ export class AnsiblePlaybookRunProvider {
   private addEEArgs(commandLineArgs: string[]): void {
     const eeSettings = this.settings.executionEnvironment;
     if (!eeSettings.enabled) {
+      commandLineArgs.push("--ee false");
       return;
     }
     commandLineArgs.push("--ee true");

--- a/src/features/utils/commandRunner.ts
+++ b/src/features/utils/commandRunner.ts
@@ -20,7 +20,6 @@ export function withInterpreter(
   let command = `${runExecutable} ${cmdArgs}`; // base case
 
   const newEnv = Object.assign({}, process.env, {
-    NO_COLOR: "0",
     ANSIBLE_FORCE_COLOR: "0", // ensure output is parseable (no ANSI)
     PYTHONBREAKPOINT: "0", // We want to be sure that python debugger is never
     // triggered, even if we mistakenly left a breakpoint() there while


### PR DESCRIPTION
The PR fixes:
1. No terminal color while the execution of the ansible-navigator command from the extension (Fixes: #1036)
2. EE=false support while the execution of the ansible-navigator command from the extension (Fixes: #1092)