### PR TITLE
Prepare for 2.13 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@
 
 <!-- KEEP-THIS-COMMENT -->
 
+## v2.13
+
+### Minor Changes
+
+- Send IGNORED feedback if feedback was pending (#1116) @TamiTakamiya
+- send ansible extension version in lightspeed requests (#1111) @robinbobbitt
+
+### Bugfixes
+
+- Fix terminal color and navigator command execution (#1118) @priyamsahoo
+- Do not send ACCEPTED feedback from commit handler (#1115) @TamiTakamiya
+- Re-enable Lightspeed UI tests (#1088) @TamiTakamiya
+- Send IGNORED suggestion feedback when active editor/window is changed (#1113)
+  @TamiTakamiya
+- Reject pending suggestion if text selection changes (#1107) @TamiTakamiya
+- No inlineSuggestionFeedback if user accepted it on widget (#1105)
+  @TamiTakamiya
+- Copilot tab completion does not work with v2.12 extension (#1109)
+  @TamiTakamiya
+
 ## v2.12
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -823,7 +823,7 @@
     "_coverage-all": "./tools/coverage-all.sh",
     "coverage-all": "TEST_LIGHTSPEED_URL='http://127.0.0.1:3000' yarn _coverage-all"
   },
-  "version": "2.12.0",
+  "version": "2.13.0",
   "packageManager": "yarn@4.0.2",
   "vsce": {
     "dependencies": false,


### PR DESCRIPTION
Preparation for the coming v2.12 release.

Most of changes are for enhanced coverage for sending Lightspeed inline suggestion feedbacks, which are required for telemetry support. This release also contains the fix for #1108 found on the previous v2.12 release.