### PR TITLE
Support Mocha grep option

### DIFF
--- a/test/index.ts
+++ b/test/index.ts
@@ -1,6 +1,7 @@
 import * as path from "path";
 import Mocha from "mocha";
 import { glob } from "glob";
+import { MochaOptions } from "vscode-extension-tester";
 
 function setupCoverage() {
   // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -33,8 +34,7 @@ export async function run(): Promise<void> {
   //   console.log("Glob verification", await nyc.exclude.glob(nyc.cwd));
   // }
 
-  // Create the mocha test
-  const mocha = new Mocha({
+  const mochaOptions: MochaOptions = {
     color: true,
     ui: "bdd",
     timeout: 50000,
@@ -47,7 +47,14 @@ export async function run(): Promise<void> {
       cdn: true,
       charts: true,
     },
-  });
+  };
+
+  if (process.env.MOCHA_GREP) {
+    mochaOptions.grep = process.env.MOCHA_GREP;
+  }
+
+  // Create the mocha test
+  const mocha = new Mocha(mochaOptions);
 
   const testsRoot = path.resolve(__dirname, "..");
 


### PR DESCRIPTION
Add the support for [Mocha's grep option|https://mochajs.org/api/mocha#grep] to allow testers to run test cases selectively. 

The grep pattern is provided with the `MOCHA_GREP` environment variables.  For example, 

```
MOCHA_GREP="Test Ansible Lightspeed multitask inline completion suggestions" yarn coverage-all
```
will run the tests defined under
```
    describe("Test Ansible Lightspeed multitask inline completion suggestions", function () {
```
only.

Note that if a test case has implicit dependencies on others, running it separately may fail.  For example,  currently
```
MOCHA_GREP="Test an inline suggestion from another provider" yarn coverage-al
```
fails while
```
MOCHA_GREP="Test Ansible Lightspeed multitask inline completion suggestions|Test an inline suggestion from another provider" yarn coverage-all
```
completes successfully.  Those implicit dependencies should be removed eventually as each test case should run individually.