### PR TITLE
Set environment variables at step level using matrix properties in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -158,6 +158,10 @@ jobs:
           # http://[::1]:3000 both on Linux and MacOS to get rid of the following conditional statement.
           TEST_LIGHTSPEED_URL:  "${{ contains(matrix.name, 'macos') && 'http://127.0.0.1:3000' || 'http://ip6-localhost:3000' }}"
 
+          # Set environment variables using matrix properties.
+          SKIP_PODMAN: "${{ matrix.env.SKIP_PODMAN || '0' }}"
+          SKIP_DOCKER: "${{ matrix.env.SKIP_DOCKER || '0' }}"
+
           # For using an actual Lightspeed server instance, uncomment following two lines.
           # TEST_LIGHTSPEED_ACCESS_TOKEN: ${{ secrets.TEST_LIGHTSPEED_ACCESS_TOKEN }}
           # TEST_LIGHTSPEED_URL: ${{ secrets.TEST_LIGHTSPEED_URL }}


### PR DESCRIPTION
According to the [GitHub Actions documentation](https://docs.github.com/en/actions/learn-github-actions/variables#defining-environment-variables-for-a-single-workflow), You can define variables that are scoped for:

1. The entire **workflow**, by using [env](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#env) at the top level of the workflow file.
1. The contents of a **job** within a workflow, by using [jobs.<job_id>.env](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idenv).
1. A specific **step** within a job, by using [jobs.<job_id>.steps[*].env](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsenv).

It implies that each **matrix** cannot have their own environment variables.  Instead, they are treated as "matrix properties" ([reference](https://docs.github.com/en/actions/learn-github-actions/contexts#matrix-context)), i.e., [following lines in ci.yaml](https://github.com/ansible/vscode-ansible/blob/091b14fe7fee7d6238d42cd7e4d01c1caf4299a1/.github/workflows/ci.yaml#L65-L70):

```
          - name: test (macos)
            task-name: test
            os: macos-12
            env:
              SKIP_PODMAN: 1
              SKIP_DOCKER: 1
```
defines matrix properties `matrix.env.SKIP_PODMAN` and `matrix.env.SKIP_DOCKER`.

Therefore, for setting environment variables per matrix, we need to define them at step level using values of matrix properties.

With this change, executions for tests with EE will be skipped on macos and test failures are expected to be resolved.