### PR TITLE
Fix Jenkins build failure

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,6 +21,7 @@ node('rhel8') {
 
   stage('build') {
     sh 'yarn install'
+    sh 'yarn run als-compile'
     sh 'yarn run compile'
     sh 'yarn run webpack'
   }

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -64,7 +64,7 @@ tasks:
       # Workaround for https://github.com/redhat-developer/vscode-extension-tester/pull/460#issuecomment-1166315428
       # - cd node_modules/vscode-extension-tester && npm update vsce
       - yarn run clean
-      - yarn workspace @ansible/ansible-language-server compile
+      - yarn run als-compile
       - yarn run compile
       - npx tsc -p ./
     sources:

--- a/package.json
+++ b/package.json
@@ -827,7 +827,8 @@
     "mock-lightspeed-server": "DEBUG='express:*' node ./out/client/test/mockLightspeedServer/server.js",
     "kill-mock-lightspeed-server": "pkill -f mockLightspeedServer/server.js",
     "_coverage-all": "./tools/coverage-all.sh",
-    "coverage-all": "TEST_LIGHTSPEED_URL='http://127.0.0.1:3000' yarn _coverage-all"
+    "coverage-all": "TEST_LIGHTSPEED_URL='http://127.0.0.1:3000' yarn _coverage-all",
+    "als-compile": "yarn workspace @ansible/ansible-language-server compile"
   },
   "version": "2.13.0",
   "packageManager": "yarn@4.1.1",


### PR DESCRIPTION
Fix [an issue in jenkins builds](https://studio-jenkins-csb-codeready.apps.ocp-c1.prod.psi.redhat.com/job/ansible/job/vscode-ansible/150/console) by adding the same change made on Taskfile.yml with #1135.  I have added a new npm script `als-compile` to package.json with this change for easier compilation of Ansible Language Server.

```
08:43:29  + yarn run compile
08:43:33  [Pipeline] sh
08:43:33  + yarn run webpack
08:44:12  90 assets
08:44:12  503 modules
08:44:12  
08:44:12  ERROR in server
08:44:12  Module not found: Error: Can't resolve './node_modules/@ansible/ansible-language-server/out/server/src/server.js' in '/jenkins/workspace/ansible/vscode-ansible'
08:44:12  resolve './node_modules/@ansible/ansible-language-server/out/server/src/server.js' in '/jenkins/workspace/ansible/vscode-ansible'
08:44:12    using description file: /jenkins/workspace/ansible/vscode-ansible/package.json (relative path: .)
08:44:12      using description file: /jenkins/workspace/ansible/vscode-ansible/node_modules/@ansible/ansible-language-server/package.json (relative path: ./out/server/src/server.js)
08:44:12        no extension
08:44:12          /jenkins/workspace/ansible/vscode-ansible/node_modules/@ansible/ansible-language-server/out/server/src/server.js doesn't exist
08:44:12        .ts
08:44:12          /jenkins/workspace/ansible/vscode-ansible/node_modules/@ansible/ansible-language-server/out/server/src/server.js.ts doesn't exist
08:44:12        .js
08:44:12          /jenkins/workspace/ansible/vscode-ansible/node_modules/@ansible/ansible-language-server/out/server/src/server.js.js doesn't exist
08:44:12        as directory
08:44:12          /jenkins/workspace/ansible/vscode-ansible/node_modules/@ansible/ansible-language-server/out/server/src/server.js doesn't exist
08:44:12  
08:44:12  webpack 5.90.0 compiled with 1 error in 30973 ms
```