### PR TITLE
Reduce e2e test activation wait time to 2 secs

### DIFF
--- a/package.json
+++ b/package.json
@@ -752,6 +752,7 @@
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.1.3",
     "eslint-plugin-tsdoc": "^0.2.17",
+    "find-process": "^1.4.7",
     "glob": "^10.3.10",
     "lodash": "^4.17.21",
     "mocha": "^10.2.0",

--- a/test/testScripts/diagnostics/testAnsibleWithoutEE.test.ts
+++ b/test/testScripts/diagnostics/testAnsibleWithoutEE.test.ts
@@ -5,8 +5,8 @@ import {
   getDocUri,
   activate,
   testDiagnostics,
-  sleep,
   updateSettings,
+  waitForDiagnosisCompletion,
 } from "../../helper";
 
 export function testDiagnosticsAnsibleWithoutEE(): void {
@@ -22,8 +22,7 @@ export function testDiagnosticsAnsibleWithoutEE(): void {
       it("should complain about no task names", async () => {
         await activate(docUri1);
         await vscode.commands.executeCommand("workbench.action.files.save");
-
-        await sleep(2000); // Wait for the diagnostics to compute on this file
+        await waitForDiagnosisCompletion(); // Wait for the diagnostics to compute on this file
 
         await testDiagnostics(docUri1, [
           {
@@ -41,8 +40,7 @@ export function testDiagnosticsAnsibleWithoutEE(): void {
       it("should complain about command syntax-check failed", async function () {
         await activate(docUri2);
         await vscode.commands.executeCommand("workbench.action.files.save");
-
-        await sleep(2000); // Wait for the diagnostics to compute on this file
+        await waitForDiagnosisCompletion(); // Wait for the diagnostics to compute on this file
 
         await testDiagnostics(docUri2, [
           {
@@ -74,8 +72,7 @@ export function testDiagnosticsAnsibleWithoutEE(): void {
       it("should return no diagnostics", async function () {
         await activate(docUri1);
         await vscode.commands.executeCommand("workbench.action.files.save");
-
-        await sleep(2000); // Wait for the diagnostics to compute on this file
+        await waitForDiagnosisCompletion(); // Wait for the diagnostics to compute on this file
 
         await testDiagnostics(docUri1, []);
       });
@@ -83,8 +80,7 @@ export function testDiagnosticsAnsibleWithoutEE(): void {
       it("should complain about missing `hosts` key", async function () {
         await activate(docUri2);
         await vscode.commands.executeCommand("workbench.action.files.save");
-
-        await sleep(2000); // Wait for the diagnostics to compute on this file
+        await waitForDiagnosisCompletion(); // Wait for the diagnostics to compute on this file
 
         await testDiagnostics(docUri2, [
           {
@@ -115,8 +111,7 @@ export function testDiagnosticsAnsibleWithoutEE(): void {
       it("should return no diagnostics even when `hosts` key is missing", async function () {
         await activate(docUri2);
         await vscode.commands.executeCommand("workbench.action.files.save");
-
-        await sleep(2000); // Wait for the diagnostics to compute on this file
+        await waitForDiagnosisCompletion(); // Wait for the diagnostics to compute on this file
 
         await testDiagnostics(docUri2, []);
       });

--- a/test/testScripts/diagnostics/testYamlWithoutEE.test.ts
+++ b/test/testScripts/diagnostics/testYamlWithoutEE.test.ts
@@ -4,9 +4,9 @@ import { integer } from "vscode-languageclient";
 import {
   getDocUri,
   activate,
-  sleep,
   testDiagnostics,
   updateSettings,
+  waitForDiagnosisCompletion,
 } from "../../helper";
 
 export function testDiagnosticsYAMLWithoutEE(): void {
@@ -20,7 +20,7 @@ export function testDiagnosticsYAMLWithoutEE(): void {
     describe("YAML diagnostics in the presence of ansible-lint", () => {
       it("should provide diagnostics with YAML validation (with ansible-lint)", async () => {
         await activate(docUri1);
-        await sleep(2000); // Wait for the diagnostics to compute on this file
+        await waitForDiagnosisCompletion(); // Wait for the diagnostics to compute on this file
 
         await testDiagnostics(docUri1, [
           {
@@ -87,8 +87,7 @@ export function testDiagnosticsYAMLWithoutEE(): void {
       it("should provide diagnostics with YAML validation (with --syntax-check)", async () => {
         await activate(docUri1);
         await vscode.commands.executeCommand("workbench.action.files.save");
-
-        await sleep(2000); // Wait for the diagnostics to compute on this file
+        await waitForDiagnosisCompletion(); // Wait for the diagnostics to compute on this file
 
         await testDiagnostics(docUri1, [
           {
@@ -157,8 +156,7 @@ export function testDiagnosticsYAMLWithoutEE(): void {
       it("should provide no diagnostics with invalid YAML file", async () => {
         await activate(docUri1);
         await vscode.commands.executeCommand("workbench.action.files.save");
-
-        await sleep(2000); // Wait for the diagnostics to compute on this file
+        await waitForDiagnosisCompletion(); // Wait for the diagnostics to compute on this file
 
         await testDiagnostics(docUri1, []);
       });

--- a/test/testScripts/outsideWorkspace/testExtensionForFilesOutsideWorkspace.test.ts
+++ b/test/testScripts/outsideWorkspace/testExtensionForFilesOutsideWorkspace.test.ts
@@ -2,9 +2,9 @@ import { Position, Range, Uri, commands } from "vscode";
 import {
   activate,
   getDocUriOutsideWorkspace,
-  sleep,
   testDiagnostics,
   testHover,
+  waitForDiagnosisCompletion,
 } from "../../helper";
 import { workspace } from "vscode";
 import { expect } from "chai";
@@ -49,7 +49,7 @@ export function testExtensionForFilesOutsideWorkspace() {
     describe("Test diagnostics functionality", function () {
       it("should complain about no task names", async () => {
         await commands.executeCommand("workbench.action.files.save");
-        await sleep(2000); // Wait for the diagnostics to compute on this file
+        await waitForDiagnosisCompletion(); // Wait for the diagnostics to compute on this file
 
         await testDiagnostics(docUri, [
           {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1971,6 +1971,7 @@ __metadata:
     eslint-plugin-prettier: "npm:^5.1.3"
     eslint-plugin-tsdoc: "npm:^0.2.17"
     express: "npm:^4.18.2"
+    find-process: "npm:^1.4.7"
     glob: "npm:^10.3.10"
     ini: "npm:^4.1.1"
     lodash: "npm:^4.17.21"
@@ -2853,6 +2854,13 @@ __metadata:
   version: 2.20.3
   resolution: "commander@npm:2.20.3"
   checksum: 10/90c5b6898610cd075984c58c4f88418a4fb44af08c1b1415e9854c03171bec31b336b7f3e4cefe33de994b3f12b03c5e2d638da4316df83593b9e82554e7e95b
+  languageName: node
+  linkType: hard
+
+"commander@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "commander@npm:5.1.0"
+  checksum: 10/3e2ef5c003c5179250161e42ce6d48e0e69a54af970c65b7f985c70095240c260fd647453efd4c2c5a31b30ce468f373dc70f769c2f54a2c014abc4792aaca28
   languageName: node
   linkType: hard
 
@@ -3992,6 +4000,19 @@ __metadata:
     make-dir: "npm:^3.0.2"
     pkg-dir: "npm:^4.1.0"
   checksum: 10/3907c2e0b15132704ed67083686cd3e68ab7d9ecc22e50ae9da20678245d488b01fa22c0e34c0544dc6edc4354c766f016c8c186a787be7c17f7cde8c5281e85
+  languageName: node
+  linkType: hard
+
+"find-process@npm:^1.4.7":
+  version: 1.4.7
+  resolution: "find-process@npm:1.4.7"
+  dependencies:
+    chalk: "npm:^4.0.0"
+    commander: "npm:^5.1.0"
+    debug: "npm:^4.1.1"
+  bin:
+    find-process: bin/find-process.js
+  checksum: 10/406d70f279e6b2140628d443c43cd8fbbfc32a6abfbb832bce23b3b85ba229ecefaaf1944687f3b559845cf21352197b1121e0646729f4ff70fa8374063cef34
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR is an attempt to shorten the total execution time for E2E tests by reducing the activation wait time, which is currently set to 20 secs.

We knew the wait time was needed for letting language server complete file validation by running either ansible-lint or ansible-playbook (with --syntax-check option). The challenge is in how we could detect the completion of file vaidation.

This PR contains basically two changes:

1. Reduce the activation wait time from 20 secs to 2 secs.
2. Implement a logic to detect the process which runs either ansible-lint or ansible-playbook and wait for the completion of such a process.  Then insert the logic to where validations are expected.

With these changes, the total execution time for E2E tests is reduced to less than half  (about 8.5 mins to 4 mins).

Note that still some activation wait time seems to be needed.  If it is too short, some unexpected behavior was found, for example, ansible-lint validation ran even it was disabled in the begin() method of a test case.