### PR TITLE
remove extra whitespace after lightspeed suggestion

### DIFF
--- a/src/features/lightspeed/inlineSuggestions.ts
+++ b/src/features/lightspeed/inlineSuggestions.ts
@@ -789,6 +789,45 @@ export async function inlineSuggestionReplaceMarker(position: vscode.Position) {
     return;
   }
 
+  console.log(
+    `[inline-suggestions] Inline Suggestion Marker Handler triggered using command at ${position.line}`
+  );
+
+  if (
+    lightSpeedManager.settingsManager.settings.lightSpeedService
+      .disableContentSuggestionHeader
+  ) {
+      // Get the current text
+      const line = position.line;
+
+      const text = editor.document.getText(
+        new vscode.Range(
+          new vscode.Position(line, 0),
+          new vscode.Position(line + 1, 0)
+        )
+      );
+      // Remove the prepended text
+      const commentPosition = text.indexOf(
+        LIGHTSPEED_SUGGESTION_GHOST_TEXT_COMMENT
+      );
+      if (commentPosition === -1) {
+        return;
+      }
+  
+      // Update the editor with the new text
+      await editor.edit((editBuilder) => {
+        editBuilder.delete(
+          new vscode.Range(
+            new vscode.Position(line, 0),
+            new vscode.Position(line + 1, 0)
+          )
+        );
+      });
+  }
+  console.log(
+    '[inline-suggestions] Inline Suggestion Marker Handler removing extra whitespace'
+  );
+  
   // Clear the line of extra whitespace after the suggestion
   // that causes ansible-lint errors
   const selection = editor.selection;
@@ -799,44 +838,6 @@ export async function inlineSuggestionReplaceMarker(position: vscode.Position) {
       });
   }
 
-  if (
-    !lightSpeedManager.settingsManager.settings.lightSpeedService
-      .disableContentSuggestionHeader
-  ) {
-    return;
-  }
-
-  console.log(
-    `[inline-suggestions] Inline Suggestion Marker Handler triggered using command at ${position.line}`
-  );
-  if (editor) {
-    // Get the current text
-    const line = position.line;
-
-    const text = editor.document.getText(
-      new vscode.Range(
-        new vscode.Position(line, 0),
-        new vscode.Position(line + 1, 0)
-      )
-    );
-    // Remove the prepended text
-    const commentPosition = text.indexOf(
-      LIGHTSPEED_SUGGESTION_GHOST_TEXT_COMMENT
-    );
-    if (commentPosition === -1) {
-      return;
-    }
-
-    // Update the editor with the new text
-    editor.edit((editBuilder) => {
-      editBuilder.delete(
-        new vscode.Range(
-          new vscode.Position(line, 0),
-          new vscode.Position(line + 1, 0)
-        )
-      );
-    });
-  }
 }
 
 export async function inlineSuggestionCommitHandler() {

--- a/src/features/lightspeed/inlineSuggestions.ts
+++ b/src/features/lightspeed/inlineSuggestions.ts
@@ -788,6 +788,17 @@ export async function inlineSuggestionReplaceMarker(position: vscode.Position) {
   if (!editor) {
     return;
   }
+
+  // Clear the line of extra whitespace after the suggestion
+  // that causes ansible-lint errors
+  const selection = editor.selection;
+  const lineText = editor.document.lineAt(selection.active.line).text;
+  if (/^\s*$/.test(lineText)) {
+      editor.edit(editBuilder => {
+          editBuilder.delete(new vscode.Range(selection.active.line, 0, selection.active.line, lineText.length));
+      });
+  }
+
   if (
     !lightSpeedManager.settingsManager.settings.lightSpeedService
       .disableContentSuggestionHeader
@@ -798,7 +809,6 @@ export async function inlineSuggestionReplaceMarker(position: vscode.Position) {
   console.log(
     `[inline-suggestions] Inline Suggestion Marker Handler triggered using command at ${position.line}`
   );
-  vscode.commands.executeCommand("editor.action.inlineSuggest.trigger");
   if (editor) {
     // Get the current text
     const line = position.line;


### PR DESCRIPTION
Currently when adding tasks via Lightspeed, the cursor is automatically indented in the following row to the appropriate column for the content of the task. However, it's expected that most likely a user is moving from prompt to prompt/task to task, rather than line by line manual development. As a result, they end up with a number of tasks with lines between them containing a bunch of whitespace, whereas ansible-lint expects them to be empty. This PR removes the extra whitespace. It also removes a stray `vscode.commands.executeCommand("editor.action.inlineSuggest.trigger");` that should not have been in this function originally. This PR is most easily reviewed with whitespace ignored (`?w=1`).