### PR TITLE
AAP-19001: No training matches found for the latest accepted suggestion.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ coverage
 *.pyc
 
 test/testFixtures/.vscode/
+examples/.vscode/

--- a/src/features/lightspeed/api.ts
+++ b/src/features/lightspeed/api.ts
@@ -220,7 +220,12 @@ export class LightSpeedAPI {
     } catch (error) {
       const err = error as AxiosError;
       const mappedError: IError = mapError(err);
-      vscode.window.showErrorMessage(mappedError.message ?? UNKNOWN_ERROR);
+      const errorMessage: string = mappedError.message ?? UNKNOWN_ERROR;
+      if (showInfoMessage) {
+        vscode.window.showErrorMessage(errorMessage);
+      } else {
+        console.error(errorMessage);
+      }
       return {} as FeedbackResponseParams;
     }
   }
@@ -262,7 +267,6 @@ export class LightSpeedAPI {
     } catch (error) {
       const err = error as AxiosError;
       const mappedError: IError = mapError(err);
-      vscode.window.showErrorMessage(mappedError.message ?? UNKNOWN_ERROR);
       return mappedError;
     }
   }

--- a/src/features/lightspeed/api.ts
+++ b/src/features/lightspeed/api.ts
@@ -9,6 +9,7 @@ import {
   FeedbackResponseParams,
   ContentMatchesRequestParams,
   ContentMatchesResponseParams,
+  IError,
 } from "../../interfaces/lightspeed";
 import {
   LIGHTSPEED_SUGGESTION_CONTENT_MATCHES_URL,
@@ -20,8 +21,10 @@ import { LightSpeedAuthenticationProvider } from "./lightSpeedOAuthProvider";
 import { getBaseUri } from "./utils/webUtils";
 import { ANSIBLE_LIGHTSPEED_API_TIMEOUT } from "../../definitions/constants";
 import { UserAction } from "../../definitions/lightspeed";
-import { retrieveError } from "./handleApiError";
+import { mapError } from "./handleApiError";
 import { lightSpeedManager } from "../../extension";
+
+const UNKNOWN_ERROR: string = "An unknown error occurred.";
 
 export class LightSpeedAPI {
   private axiosInstance: AxiosInstance | undefined;
@@ -142,7 +145,8 @@ export class LightSpeedAPI {
     } catch (error) {
       this._inlineSuggestionFeedbackIgnoredPending = false;
       const err = error as AxiosError;
-      vscode.window.showErrorMessage(retrieveError(err));
+      const mappedError: IError = mapError(err);
+      vscode.window.showErrorMessage(mappedError.message ?? UNKNOWN_ERROR);
       return {} as CompletionResponseParams;
     } finally {
       if (this._inlineSuggestionFeedbackIgnoredPending) {
@@ -215,14 +219,15 @@ export class LightSpeedAPI {
       return response.data;
     } catch (error) {
       const err = error as AxiosError;
-      vscode.window.showErrorMessage(retrieveError(err));
+      const mappedError: IError = mapError(err);
+      vscode.window.showErrorMessage(mappedError.message ?? UNKNOWN_ERROR);
       return {} as FeedbackResponseParams;
     }
   }
 
   public async contentMatchesRequest(
     inputData: ContentMatchesRequestParams
-  ): Promise<ContentMatchesResponseParams> {
+  ): Promise<ContentMatchesResponseParams | IError> {
     // return early if the user is not authenticated
     if (!(await this.lightSpeedAuthProvider.isAuthenticated())) {
       vscode.window.showErrorMessage(
@@ -256,8 +261,9 @@ export class LightSpeedAPI {
       return response.data;
     } catch (error) {
       const err = error as AxiosError;
-      vscode.window.showErrorMessage(retrieveError(err));
-      return {} as ContentMatchesResponseParams;
+      const mappedError: IError = mapError(err);
+      vscode.window.showErrorMessage(mappedError.message ?? UNKNOWN_ERROR);
+      return mappedError;
     }
   }
 }

--- a/src/features/lightspeed/contentMatchesWebview.ts
+++ b/src/features/lightspeed/contentMatchesWebview.ts
@@ -9,6 +9,7 @@ import {
   IContentMatch,
   IContentMatchParams,
   ISuggestionDetails,
+  IError,
 } from "../../interfaces/lightspeed";
 import { getCurrentUTCDateTime } from "../utils/dateTime";
 import * as yaml from "yaml";
@@ -61,7 +62,7 @@ export class ContentMatchesWebview implements vscode.WebviewViewProvider {
   async requestInlineSuggestContentMatches(
     suggestion: string,
     suggestionId: string
-  ): Promise<ContentMatchesResponseParams> {
+  ): Promise<ContentMatchesResponseParams | IError> {
     const taskArray = suggestion
       .trim()
       .split(/\n\s*\n/)
@@ -83,7 +84,7 @@ export class ContentMatchesWebview implements vscode.WebviewViewProvider {
       )}`
     );
 
-    const outputData: ContentMatchesResponseParams =
+    const outputData: ContentMatchesResponseParams | IError =
       await this.apiInstance.contentMatchesRequest(contentMatchesRequestData);
     this.log(
       `${getCurrentUTCDateTime().toISOString()}: response data from Ansible lightspeed:\n${JSON.stringify(
@@ -107,22 +108,82 @@ export class ContentMatchesWebview implements vscode.WebviewViewProvider {
     this._view.webview.html = "";
   }
 
+  public isError(
+    contentMatchResponses: ContentMatchesResponseParams | IError
+  ): contentMatchResponses is IError {
+    return (contentMatchResponses as IError).code !== undefined;
+  }
+
   private async getWebviewContent(): Promise<string> {
-    const noContentMatchesFoundHtml = `<html><body>No training matches found for the latest accepted suggestion.</body></html>`;
+    const noActiveSuggestionHtml = `
+      <html>
+        <body>
+          <p>Training matches cannot be retrieved. No active suggestion found.</p>
+        </body>
+      </html>`;
     if (
       this.suggestionDetails.length === 0 ||
       !this.suggestionDetails[0].suggestion
     ) {
-      return noContentMatchesFoundHtml;
+      return noActiveSuggestionHtml;
     }
+
     const suggestion = this.suggestionDetails[0].suggestion;
     const suggestionId = this.suggestionDetails[0].suggestionId;
-
     const contentMatchResponses = await this.requestInlineSuggestContentMatches(
       suggestion,
       suggestionId
     );
     this.log(contentMatchResponses);
+
+    if (this.isError(contentMatchResponses)) {
+      return this.getErrorWebviewContent(contentMatchResponses);
+    } else {
+      return this.getContentMatchWebviewContent(
+        suggestion,
+        contentMatchResponses
+      );
+    }
+  }
+
+  private async getErrorWebviewContent(error: IError) {
+    let detail: unknown = error.detail;
+    if (typeof error.detail === "string") {
+      detail = error.detail as string;
+    } else if (typeof error.detail === "object") {
+      detail = JSON.stringify(error.detail, undefined, "  ");
+    }
+
+    const errorHtml = `
+      <html>
+        <head>
+          <!-- https://code.visualstudio.com/api/extension-guides/webview#content-security-policy -->
+          <meta http-equiv="Content-Security-Policy" content="default-src 'none';">
+        </head>
+        <body>
+        <p>An error occurred trying to retrieve the training matches.</p>
+        <p><b>Message:</b> ${error.message}</p>
+        <details>
+          <summary><b>Detail:</b></summary>
+          <p>${detail}</p>
+        </details>
+        </body>
+      </html>
+    `;
+    return errorHtml;
+  }
+
+  private async getContentMatchWebviewContent(
+    suggestion: string,
+    contentMatchResponses: ContentMatchesResponseParams
+  ) {
+    const noContentMatchesFoundHtml = `
+      <html>
+        <body>
+          <p>No training matches found for the latest accepted suggestion.</p>
+        </body>
+      </html>
+    `;
     if (
       Object.keys(contentMatchResponses).length === 0 ||
       contentMatchResponses.contentmatches.length === 0
@@ -168,12 +229,13 @@ export class ContentMatchesWebview implements vscode.WebviewViewProvider {
         rhUserHasSeat === true
       );
     }
-    const html = `<html>
+    const html = `
+      <html>
         <body>
           ${contentMatchesHtml}
         </body>
       </html>
-      `;
+    `;
     return html;
   }
 

--- a/src/features/lightspeed/contentMatchesWebview.ts
+++ b/src/features/lightspeed/contentMatchesWebview.ts
@@ -118,7 +118,7 @@ export class ContentMatchesWebview implements vscode.WebviewViewProvider {
     const noActiveSuggestionHtml = `
       <html>
         <body>
-          <p>Training matches cannot be retrieved. No active suggestion found.</p>
+          <p>Training matches will be displayed here after you accept an inline suggestion.</p>
         </body>
       </html>`;
     if (
@@ -153,6 +153,15 @@ export class ContentMatchesWebview implements vscode.WebviewViewProvider {
     } else if (typeof error.detail === "object") {
       detail = JSON.stringify(error.detail, undefined, "  ");
     }
+    let htmlDetail: string | undefined = undefined;
+    if (detail !== undefined) {
+      htmlDetail = `
+        <details>
+          <summary><b>Detail:</b></summary>
+          <p>${detail}</p>
+        </details>
+      `;
+    }
 
     const errorHtml = `
       <html>
@@ -163,10 +172,7 @@ export class ContentMatchesWebview implements vscode.WebviewViewProvider {
         <body>
         <p>An error occurred trying to retrieve the training matches.</p>
         <p><b>Message:</b> ${error.message}</p>
-        <details>
-          <summary><b>Detail:</b></summary>
-          <p>${detail}</p>
-        </details>
+        ${htmlDetail}
         </body>
       </html>
     `;

--- a/src/features/lightspeed/errors.ts
+++ b/src/features/lightspeed/errors.ts
@@ -1,36 +1,49 @@
-class ErrorHolder {
-  code: string;
-  message?: string;
+import { IError } from "../../interfaces/lightspeed";
 
-  public constructor(code: string, message?: string) {
+class Error implements IError {
+  readonly code: string;
+  readonly message?: string;
+  readonly detail?: unknown;
+
+  public constructor(code: string, message?: string, detail?: unknown) {
     this.code = code;
     this.message = message;
+    this.detail = detail;
+  }
+
+  public withMessage(message?: string): Error {
+    return new Error(this.code, message, this.detail);
+  }
+
+  public withDetail(detail?: unknown): Error {
+    return new Error(this.code, this.message, detail);
   }
 }
 
 class Errors {
-  private errors: Map<number, Array<ErrorHolder>> = new Map();
+  private errors: Map<number, Array<IError>> = new Map();
 
-  public addError(statusCode: number, error: ErrorHolder) {
+  public addError(statusCode: number, error: IError) {
     if (!this.errors.has(statusCode)) {
       this.errors.set(statusCode, []);
     }
     this.errors.get(statusCode)?.push(error);
   }
 
-  public getError(statusCode: number, code: string): ErrorHolder | undefined {
+  public getError(statusCode: number, code: string): Error | undefined {
     if (!this.errors.has(statusCode)) {
       return undefined;
     }
-    const errors: Array<ErrorHolder> | undefined = this.errors.get(statusCode);
+    const errors: Array<IError> | undefined = this.errors.get(statusCode);
     if (!errors) {
       return undefined;
     }
-    const e: ErrorHolder | undefined = errors.find(function (el: ErrorHolder) {
+    const e: IError | undefined = errors.find(function (el: IError) {
       return el.code === code;
     });
     if (e) {
-      return e;
+      // Clone the object as we may update the associated message
+      return new Error(e.code, e.message);
     }
     return undefined;
   }
@@ -38,51 +51,61 @@ class Errors {
 
 export const ERRORS = new Errors();
 
-export const ERRORS_UNAUTHORIZED = new ErrorHolder(
+export const ERRORS_UNAUTHORIZED = new Error(
   "fallback__unauthorized",
   "You are not authorized to access Ansible Lightspeed. Please contact your administrator."
 );
-export const ERRORS_TOO_MANY_REQUESTS = new ErrorHolder(
+export const ERRORS_NOT_FOUND = new Error(
+  "fallback__not_found",
+  "The resource could not be found. Please try again later."
+);
+export const ERRORS_TOO_MANY_REQUESTS = new Error(
   "fallback__too_many_requests",
   "Too many requests to Ansible Lightspeed. Please try again later."
 );
-export const ERRORS_BAD_REQUEST = new ErrorHolder(
+export const ERRORS_BAD_REQUEST = new Error(
   "fallback__bad_request",
   "Bad Request response. Please try again."
 );
-export const ERRORS_UNKNOWN = new ErrorHolder(
+export const ERRORS_UNKNOWN = new Error(
   "fallback__unknown",
   "An error occurred attempting to complete your request. Please try again later."
 );
-export const ERRORS_CONNECTION_TIMEOUT = new ErrorHolder(
+export const ERRORS_CONNECTION_TIMEOUT = new Error(
   "fallback__connection_timeout",
   "Ansible Lightspeed connection timeout. Please try again later."
+);
+export const ERRORS_CLOUDFRONT = new Error(
+  "permission_denied__cloudfront",
+  "Something in your editor content has caused your inline suggestion request to be blocked. \n" +
+    "Please open a ticket with Red Hat support and include the content of your editor up to the \n" +
+    "line and column where you requested a suggestion."
 );
 
 ERRORS.addError(
   204,
-  new ErrorHolder(
+  new Error(
     "postprocess_error",
     "An error occurred post-processing the inline suggestion. Please contact your administrator."
   )
 );
 ERRORS.addError(
   204,
-  new ErrorHolder(
+  new Error(
     "model_timeout",
     "Ansible Lightspeed timed out processing your request. Please try again later."
   )
 );
 ERRORS.addError(
   204,
-  new ErrorHolder(
+  new Error(
     "error__wca_bad_request",
     "IBM watsonx Code Assistant returned a bad request response. Please contact your administrator."
   )
 );
 ERRORS.addError(
   204,
-  new ErrorHolder(
+  new Error(
     "error__wca_empty_response",
     "IBM watsonx Code Assistant returned an empty response. Please contact your administrator."
   )
@@ -90,22 +113,22 @@ ERRORS.addError(
 
 ERRORS.addError(
   400,
-  new ErrorHolder(
+  new Error(
     "error__wca_cloud_flare_rejection",
     "Cloudflare rejected the request. Please contact your administrator."
   )
 );
 ERRORS.addError(
   400,
-  new ErrorHolder(
+  new Error(
     "error__preprocess_invalid_yaml",
     "An error occurred pre-processing the inline suggestion due to invalid YAML. Please contact your administrator."
   )
 );
-ERRORS.addError(400, new ErrorHolder("error__feedback_validation"));
+ERRORS.addError(400, new Error("error__feedback_validation"));
 ERRORS.addError(
   400,
-  new ErrorHolder(
+  new Error(
     "error__wca_suggestion_correlation_failed",
     "IBM watsonx Code Assistant request/response correlation failed. Please contact your administrator."
   )
@@ -113,70 +136,70 @@ ERRORS.addError(
 
 ERRORS.addError(
   403,
-  new ErrorHolder(
+  new Error(
     "error__wca_invalid_model_id",
     "IBM watsonx Code Assistant Model ID is invalid. Please contact your administrator."
   )
 );
 ERRORS.addError(
   403,
-  new ErrorHolder(
+  new Error(
     "error__wca_key_not_found",
     "Could not find an API Key for IBM watsonx Code Assistant. Please contact your administrator."
   )
 );
 ERRORS.addError(
   403,
-  new ErrorHolder(
+  new Error(
     "error__wca_model_id_not_found",
     "Could not find a Model Id for IBM watsonx Code Assistant. Please contact your administrator."
   )
 );
 ERRORS.addError(
   403,
-  new ErrorHolder(
+  new Error(
     "permission_denied__user_trial_expired",
     "Your trial to the generative AI model has expired. Refer to your IBM Cloud Account to re-enable access to the IBM watsonx Code Assistant by moving to one of the paid plans."
   )
 );
 ERRORS.addError(
   403,
-  new ErrorHolder(
+  new Error(
     "permission_denied__terms_of_use_not_accepted",
     "You have not accepted the Terms of Use. Please accept them before proceeding."
   )
 );
 ERRORS.addError(
   403,
-  new ErrorHolder(
+  new Error(
     "permission_denied__user_not_org_administrator",
     "You are not an Administrator of the Organization."
   )
 );
 ERRORS.addError(
   403,
-  new ErrorHolder(
+  new Error(
     "permission_denied__user_has_no_subscription",
     "Your organization does not have a subscription. Please contact your administrator."
   )
 );
 ERRORS.addError(
   403,
-  new ErrorHolder(
+  new Error(
     "permission_denied__org_ready_user_has_no_seat",
     "You do not have a licensed seat for Ansible Lightspeed and your organization is using the paid commercial service. Contact your Red Hat Organization's administrator for more information on how to get a licensed seat."
   )
 );
 ERRORS.addError(
   403,
-  new ErrorHolder(
+  new Error(
     "permission_denied__org_not_ready_because_wca_not_configured",
     "Contact your administrator to configure IBM watsonx Code Assistant model settings for your organization."
   )
 );
 ERRORS.addError(
   403,
-  new ErrorHolder(
+  new Error(
     "permission_denied__user_with_no_seat",
     "You don't have access to IBM watsonx Code Assistant. Please contact your administrator."
   )
@@ -184,14 +207,14 @@ ERRORS.addError(
 
 ERRORS.addError(
   500,
-  new ErrorHolder(
+  new Error(
     "internal_server",
     "An error occurred attempting to complete your request. Please try again later."
   )
 );
 ERRORS.addError(
   500,
-  new ErrorHolder(
+  new Error(
     "error__feedback_internal_server",
     "An error occurred attempting to submit your feedback. Please try again later."
   )
@@ -199,14 +222,14 @@ ERRORS.addError(
 
 ERRORS.addError(
   503,
-  new ErrorHolder(
+  new Error(
     "error__attribution_exception",
     "An error occurred attempting to complete your request. Please try again later."
   )
 );
 ERRORS.addError(
   503,
-  new ErrorHolder(
+  new Error(
     "service_unavailable",
     "The IBM watsonx Code Assistant is unavailable. Please try again later."
   )

--- a/src/interfaces/lightspeed.ts
+++ b/src/interfaces/lightspeed.ts
@@ -51,6 +51,7 @@ export interface AnsibleContentEvent {
   trigger: AnsibleContentUploadTrigger;
   activityId: string | undefined;
 }
+
 export interface SentimentEvent {
   value: number;
   feedback: string;
@@ -62,6 +63,7 @@ export interface SuggestionQualityEvent {
   expectedSuggestion: string;
   additionalComment: string;
 }
+
 export interface IssueFeedbackEvent {
   type: "bug-report" | "feature-request";
   title: string;
@@ -138,12 +140,14 @@ export interface IRoleVarsContext {
   defaults: IVarsFileContext;
   vars: IVarsFileContext;
 }
+
 export interface IRoleContext {
   name?: string;
   tasks?: string[];
   roleVars?: IRoleVarsContext;
   includeVars?: IIncludeVarsContext;
 }
+
 export interface IRolesContext {
   [rolePath: string]: IRoleContext;
 }
@@ -162,6 +166,7 @@ export interface IPlaybookContext {
   taskFileNames?: string[];
   includeVars?: IIncludeVarsContext;
 }
+
 export interface IAdditionalContext {
   playbookContext?: IPlaybookContext;
   roleContext?: IRoleContext;
@@ -177,7 +182,14 @@ export interface LightspeedSessionUserInfo {
 export interface LightspeedSessionModelInfo {
   model?: string;
 }
+
 export interface LightspeedSessionInfo {
   userInfo?: LightspeedSessionUserInfo;
   modelInfo?: LightspeedSessionModelInfo;
+}
+
+export interface IError {
+  code: string;
+  message?: string;
+  detail?: unknown;
 }

--- a/test/units/lightspeed/contentmatches.test.ts
+++ b/test/units/lightspeed/contentmatches.test.ts
@@ -113,7 +113,7 @@ describe("GetWebviewContent", () => {
     assert.match(
       res,
       new RegExp(
-        "Training matches cannot be retrieved. No active suggestion found."
+        "Training matches will be displayed here after you accept an inline suggestion."
       )
     );
   });
@@ -239,5 +239,27 @@ describe("GetWebviewContent", () => {
     );
     assert.match(res, new RegExp("An error occurred"));
     assert.match(res, new RegExp('{\n  "cheese": "edam"\n}'));
+  });
+
+  it("no suggestion with error - undefined", async function () {
+    const cmw = createContentMatchesWebview();
+    cmw.suggestionDetails = [
+      {
+        suggestion: "- name: foo\n  my.mod:\n",
+        suggestionId: "bar",
+      } as ISuggestionDetails,
+    ];
+    cmw.apiInstance.contentMatchesRequest = async (
+      inputData: ContentMatchesRequestParams // eslint-disable-line @typescript-eslint/no-unused-vars
+    ): Promise<IError> => {
+      return createMatchErrorResponse(undefined);
+    };
+
+    const res = await cmw["getWebviewContent"]();
+    assert.match(
+      res,
+      new RegExp("An error occurred trying to retrieve the training matches.")
+    );
+    assert.doesNotMatch(res, new RegExp("<details>"));
   });
 });

--- a/test/units/lightspeed/handleApiError.test.ts
+++ b/test/units/lightspeed/handleApiError.test.ts
@@ -1,7 +1,7 @@
 require("assert");
 
 import { AxiosError, AxiosHeaders } from "axios";
-import { retrieveError } from "../../../src/features/lightspeed/handleApiError";
+import { mapError } from "../../../src/features/lightspeed/handleApiError";
 import assert from "assert";
 
 function createError(
@@ -41,9 +41,9 @@ describe("testing the error handling", () => {
   // HTTP 200
   // ---------------------------------
   it("err generic", () => {
-    const msg = retrieveError(createError(200));
+    const error = mapError(createError(200));
     assert.equal(
-      msg,
+      error.message,
       "An error occurred attempting to complete your request. Please try again later."
     );
   });
@@ -53,49 +53,49 @@ describe("testing the error handling", () => {
   // HTTP 204
   // ---------------------------------
   it("err Postprocessing error", () => {
-    const msg = retrieveError(
+    const error = mapError(
       createError(204, {
         code: "postprocess_error",
       })
     );
     assert.equal(
-      msg,
+      error.message,
       "An error occurred post-processing the inline suggestion. Please contact your administrator."
     );
   });
 
   it("err Model timeout", () => {
-    const msg = retrieveError(
+    const error = mapError(
       createError(204, {
         code: "model_timeout",
       })
     );
     assert.equal(
-      msg,
+      error.message,
       "Ansible Lightspeed timed out processing your request. Please try again later."
     );
   });
 
   it("err WCA Bad Request", () => {
-    const msg = retrieveError(
+    const error = mapError(
       createError(204, {
         code: "error__wca_bad_request",
       })
     );
     assert.equal(
-      msg,
+      error.message,
       "IBM watsonx Code Assistant returned a bad request response. Please contact your administrator."
     );
   });
 
   it("err WCA Empty Response", () => {
-    const msg = retrieveError(
+    const error = mapError(
       createError(204, {
         code: "error__wca_empty_response",
       })
     );
     assert.equal(
-      msg,
+      error.message,
       "IBM watsonx Code Assistant returned an empty response. Please contact your administrator."
     );
   });
@@ -105,50 +105,50 @@ describe("testing the error handling", () => {
   // HTTP 400
   // ---------------------------------
   it("err Bad Request from Cloudflare", () => {
-    const msg = retrieveError(
+    const error = mapError(
       createError(400, { code: "error__wca_cloud_flare_rejection" })
     );
     assert.equal(
-      msg,
+      error.message,
       "Cloudflare rejected the request. Please contact your administrator."
     );
   });
 
   it("err Bad Request", () => {
-    const msg = retrieveError(createError(400));
-    assert.equal(msg, "Bad Request response. Please try again.");
+    const error = mapError(createError(400));
+    assert.equal(error.message, "Bad Request response. Please try again.");
   });
 
   it("err Postprocessing error", () => {
-    const msg = retrieveError(
+    const error = mapError(
       createError(400, {
         code: "error__preprocess_invalid_yaml",
       })
     );
     assert.equal(
-      msg,
+      error.message,
       "An error occurred pre-processing the inline suggestion due to invalid YAML. Please contact your administrator."
     );
   });
 
   it("err Feedback validation error", () => {
-    const msg = retrieveError(
+    const error = mapError(
       createError(400, {
         code: "error__feedback_validation",
         message: "A field was invalid.",
       })
     );
-    assert.equal(msg, "A field was invalid.");
+    assert.equal(error.message, "A field was invalid.");
   });
 
   it("err WCA Suggestion Correlation failure", () => {
-    const msg = retrieveError(
+    const error = mapError(
       createError(400, {
         code: "error__wca_suggestion_correlation_failed",
       })
     );
     assert.equal(
-      msg,
+      error.message,
       "IBM watsonx Code Assistant request/response correlation failed. Please contact your administrator."
     );
   });
@@ -158,9 +158,9 @@ describe("testing the error handling", () => {
   // HTTP 401
   // ---------------------------------
   it("err Unauthorized", () => {
-    const msg = retrieveError(createError(401));
+    const error = mapError(createError(401));
     assert.equal(
-      msg,
+      error.message,
       "You are not authorized to access Ansible Lightspeed. Please contact your administrator."
     );
   });
@@ -170,63 +170,63 @@ describe("testing the error handling", () => {
   // HTTP 403
   // ---------------------------------
   it("err Forbidden - Org ready, No seat", () => {
-    const msg = retrieveError(
+    const error = mapError(
       createError(403, {
         code: "permission_denied__org_ready_user_has_no_seat",
       })
     );
     assert.equal(
-      msg,
+      error.message,
       "You do not have a licensed seat for Ansible Lightspeed and your organization is using the paid commercial service. Contact your Red Hat Organization's administrator for more information on how to get a licensed seat."
     );
   });
 
   it("err Forbidden - No Seat", () => {
-    const msg = retrieveError(
+    const error = mapError(
       createError(403, {
         code: "permission_denied__user_with_no_seat",
       })
     );
     assert.equal(
-      msg,
+      error.message,
       "You don't have access to IBM watsonx Code Assistant. Please contact your administrator."
     );
   });
 
   it("err Forbidden - Trial expired", () => {
-    const msg = retrieveError(
+    const error = mapError(
       createError(403, {
         code: "permission_denied__user_trial_expired",
       })
     );
     assert.equal(
-      msg,
+      error.message,
       "Your trial to the generative AI model has expired. Refer to your IBM Cloud Account to re-enable access to the IBM watsonx Code Assistant by moving to one of the paid plans."
     );
   });
 
   it("err Forbidden - WCA not ready", () => {
-    const msg = retrieveError(
+    const error = mapError(
       createError(403, {
         code: "permission_denied__org_not_ready_because_wca_not_configured",
       })
     );
     assert.equal(
-      msg,
+      error.message,
       "Contact your administrator to configure IBM watsonx Code Assistant model settings for your organization."
     );
   });
 
   it("err Forbidden", () => {
-    const msg = retrieveError(createError(403));
+    const error = mapError(createError(403));
     assert.equal(
-      msg,
+      error.message,
       "You are not authorized to access Ansible Lightspeed. Please contact your administrator."
     );
   });
 
   it("err Bad Request from CloudFront", () => {
-    const msg = retrieveError(
+    const error = mapError(
       createError(
         403,
         { data: "Some string from CloudFront." },
@@ -234,68 +234,80 @@ describe("testing the error handling", () => {
       )
     );
     assert.match(
-      msg,
+      error.message ?? "",
       /Something in your editor content has caused your inline suggestion request to be blocked.*/
     );
   });
 
   it("err WCA API Key missing", () => {
-    const msg = retrieveError(
+    const error = mapError(
       createError(403, {
         code: "error__wca_key_not_found",
       })
     );
     assert.equal(
-      msg,
+      error.message,
       "Could not find an API Key for IBM watsonx Code Assistant. Please contact your administrator."
     );
   });
 
   it("err WCA Model Id missing", () => {
-    const msg = retrieveError(
+    const error = mapError(
       createError(403, {
         code: "error__wca_model_id_not_found",
       })
     );
     assert.equal(
-      msg,
+      error.message,
       "Could not find a Model Id for IBM watsonx Code Assistant. Please contact your administrator."
     );
   });
 
   it("err WCA Model Id is invalid", () => {
-    const msg = retrieveError(
+    const error = mapError(
       createError(403, {
         code: "error__wca_invalid_model_id",
       })
     );
     assert.equal(
-      msg,
+      error.message,
       "IBM watsonx Code Assistant Model ID is invalid. Please contact your administrator."
     );
   });
 
   it("err Terms of Use not accepted", () => {
-    const msg = retrieveError(
+    const error = mapError(
       createError(403, {
         code: "permission_denied__terms_of_use_not_accepted",
       })
     );
     assert.equal(
-      msg,
+      error.message,
       "You have not accepted the Terms of Use. Please accept them before proceeding."
     );
   });
 
   it("err User has no subscription", () => {
-    const msg = retrieveError(
+    const error = mapError(
       createError(403, {
         code: "permission_denied__user_has_no_subscription",
       })
     );
     assert.equal(
-      msg,
+      error.message,
       "Your organization does not have a subscription. Please contact your administrator."
+    );
+  });
+  // =================================
+
+  // =================================
+  // HTTP 404
+  // ---------------------------------
+  it("err Not found", () => {
+    const error = mapError(createError(404));
+    assert.equal(
+      error.message,
+      "The resource could not be found. Please try again later."
     );
   });
   // =================================
@@ -304,9 +316,9 @@ describe("testing the error handling", () => {
   // HTTP 429
   // ---------------------------------
   it("err Too Many Requests", () => {
-    const msg = retrieveError(createError(429));
+    const error = mapError(createError(429));
     assert.equal(
-      msg,
+      error.message,
       "Too many requests to Ansible Lightspeed. Please try again later."
     );
   });
@@ -316,29 +328,29 @@ describe("testing the error handling", () => {
   // HTTP 500
   // ---------------------------------
   it("err Internal Server Error - Generic", () => {
-    const msg = retrieveError(createError(500));
+    const error = mapError(createError(500));
     assert.equal(
-      msg,
+      error.message,
       "An error occurred attempting to complete your request. Please try again later."
     );
   });
 
   it("err Internal Server Error - Codified", () => {
-    const msg = retrieveError(createError(500, { code: "internal_server" }));
+    const error = mapError(createError(500, { code: "internal_server" }));
     assert.equal(
-      msg,
+      error.message,
       "An error occurred attempting to complete your request. Please try again later."
     );
   });
 
   it("err Error submitting feedback", () => {
-    const msg = retrieveError(
+    const error = mapError(
       createError(500, {
         code: "error__feedback_internal_server",
       })
     );
     assert.equal(
-      msg,
+      error.message,
       "An error occurred attempting to submit your feedback. Please try again later."
     );
   });
@@ -348,25 +360,25 @@ describe("testing the error handling", () => {
   // HTTP 503
   // ---------------------------------
   it("err Attribution error", () => {
-    const msg = retrieveError(
+    const error = mapError(
       createError(503, {
         code: "error__attribution_exception",
       })
     );
     assert.equal(
-      msg,
+      error.message,
       "An error occurred attempting to complete your request. Please try again later."
     );
   });
 
   it("err Service unavailable", () => {
-    const msg = retrieveError(
+    const error = mapError(
       createError(503, {
         code: "service_unavailable",
       })
     );
     assert.equal(
-      msg,
+      error.message,
       "The IBM watsonx Code Assistant is unavailable. Please try again later."
     );
   });
@@ -378,25 +390,25 @@ describe("testing the error handling", () => {
   it("err Timeout", () => {
     const err = createError(0);
     err.code = AxiosError.ECONNABORTED;
-    const msg = retrieveError(err);
+    const error = mapError(err);
     assert.equal(
-      msg,
+      error.message,
       "Ansible Lightspeed connection timeout. Please try again later."
     );
   });
 
   it("err Unexpected Client error", () => {
-    const msg = retrieveError(createError(0));
+    const error = mapError(createError(0));
     assert.equal(
-      msg,
+      error.message,
       "An error occurred attempting to complete your request. Please try again later."
     );
   });
 
   it("err Unexpected Err code", () => {
-    const msg = retrieveError(createError(999));
+    const error = mapError(createError(999));
     assert.equal(
-      msg,
+      error.message,
       "An error occurred attempting to complete your request. Please try again later."
     );
   });


### PR DESCRIPTION
See https://issues.redhat.com/browse/AAP-19001

**Suggestion not set - this should not happen**

![suggestion-not-set](https://github.com/ansible/vscode-ansible/assets/497544/c181f54b-4ca6-465b-b4f9-b8e4e3b85542)


**No codematches found**

![codematches-not-found](https://github.com/ansible/vscode-ansible/assets/497544/df507f7c-548c-4421-bc32-a3e00be6bb5f)


**Codematch returns an error (string)**

In this example the URL for codematch was not found and a HTTP404 was returned.

The "Details" content is what was returned from a network device somewhere (e.g. CloudFront, nginx etc). 

I added "Content-Security-Policy" [metadata](https://github.com/ansible/vscode-ansible/pull/1166/files#diff-198a5926cd0cb3ec2d793da7b74c1d00b0b72abd8bc38a2f2b44022c7aedd4aaR160-R161) so we _should_ be safe rendering whatever we get). 

![codematches-error-string](https://github.com/ansible/vscode-ansible/assets/497544/d949c99c-a458-451f-98ec-6b9e3a6349f7)


**Codematch returns an error (object)**

![codematches-error-object](https://github.com/ansible/vscode-ansible/assets/497544/765cbec5-b2f6-4e69-8974-7e52322d2707)
