### PR TITLE
Setup asdf in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,8 @@ jobs:
         with:
           version: 3.x
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Setup asdf
+        uses: asdf-vm/actions/install@v3
 
       - run: task release -v
         env:


### PR DESCRIPTION
[v24.4.0 release action](https://github.com/ansible/vscode-ansible/actions/runs/8545831293/job/23414963378) failed with:
```
Run task release -v
task: dynamic variable: "echo \"${VIRTUAL_ENV:-${PWD}/out/venvs/}\"" result: "/home/runner/work/vscode-ansible/vscode-ansible/out/venvs/"
task: dynamic variable: "echo ${HOSTNAME:-${HOST:-$(hostname)}}" result: "fv-az[12](https://github.com/ansible/vscode-ansible/actions/runs/8545831293/job/23414963378#step:5:13)05-78"
task: dynamic variable: "bash -c 'if [[ \"$OSTYPE\" == \"linux-gnu\"* ]] && command -v xvfb-run >/dev/null; then echo \"$(command -v xvfb-run) --auto-servernum -e out/log/xvfb.log\"; fi'" result: "/usr/bin/xvfb-run --auto-servernum -e out/log/xvfb.log"
task: dynamic variable: "./tools/get-image-version" result: "v24.2.0"
task: dynamic variable: "echo \"${HOME}/.local/share/virtualenvs/vsa\"" result: "/home/runner/.local/share/virtualenvs/vsa"
task: dynamic variable: "echo \"${VIRTUAL_ENV:-${PWD}/out/venvs/fv-az1205-78}\"" result: "/home/runner/work/vscode-ansible/vscode-ansible/out/venvs/fv-az1205-78"
task: "release" started
task: "install" started
task: "shared:setup" started
task: [shared:setup] python3 ./tools/precheck.py
task: [shared:setup] bash ./tools/test-setup.sh
NOTICE:  Install required build tools
./tools/test-setup.sh: line 78: asdf: command not found
exit status 127
Error: Process completed with exit code 1.
``` 
This PR is for adding a step to set up asdf in front of the `task release -v` step.