### PR TITLE
get-marketplace-version.sh modification

### DIFF
--- a/tools/get-marketplace-version.sh
+++ b/tools/get-marketplace-version.sh
@@ -8,6 +8,33 @@
 # a build and might cause problems when switching from a CI to another. Thus,
 # we opted for number of seconds passed between last tag and last commit. This
 # should generate 0 for tagged commits and other numbers for pull requests.
+#
+# In our CalVar format, where the major segment represents the short year and
+# the minor segment contains the month, saving only the number of seconds passed
+# between last tag and the last commit in the patch segment could result in
+# duplicate version numbers if there are multiple tagged commits occurring
+# within the same month.
+#
+# We will create version numbers based on the following logic to address that
+# possible version duplication issue:
+#
+# 1. If the number of seconds passed between last tag and the last commit in
+#    the patch segment is equal to 0, use the version number stored in
+#    package.json.
+#
+#    (Examples) 24.4.0, 24.12.1
+#
+# 2. Otherwise,
+#    - For the major and minor segments, use the values taken from the version
+#      number stored in package.json.
+#    - For the patch segment, concatenate following two numbers as strings:
+#        * The patch segment taken from the version number stored in package.json
+#          incremented by 1, i.e., transforming 0 into 1, 9 into 10, etc.
+#        * A zero-padded 8-digit number that represents the number of seconds
+#          passed between last tag and the last commit
+#
+#    (Examples) 24.4.100123456, 24.12.200123456
+#
 set -Ee
 LAST_TAG=$(git describe --tags --abbrev=0)
 LAST_TAG_TIMESTAMP=$(git -P log -1 --format=%ct "${LAST_TAG}")
@@ -15,4 +42,9 @@ LAST_COMMIT_TIMESTAMP=$(git -P show --no-patch --format=%ct HEAD)
 VERSION_SUFFIX="$((LAST_COMMIT_TIMESTAMP-LAST_TAG_TIMESTAMP))"
 # We remove the last number from the node reported version.
 VERSION_PREFIX=$(node -p "require('./package.json').version")
-echo -n "${VERSION_PREFIX%.*}.${VERSION_SUFFIX}"
+if [ $VERSION_SUFFIX -eq 0 ]
+then
+  echo -n "${VERSION_PREFIX}"
+else
+  echo -n "${VERSION_PREFIX%.*}.$(printf '%d%08d' $((${VERSION_PREFIX#*.*.} + 1)) ${VERSION_SUFFIX})"
+fi


### PR DESCRIPTION
@ssbarnea  This is my proposal to add some modifications to `get-marketplace-version.sh`.

The current version can generate marketplace-compatible version number with patch=0, such as `24.4.0`, but when the version in `package.json` is set to`24.4.1`, it will converted into `24.4.0`.  I would like to keep the patch portion for tagged comits and still want to generate unique build number for PR builds. Please take a look at the comment lines for details. Thanks!