### PR TITLE
Remove unused playbook generation setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -379,13 +379,6 @@
             "default": "",
             "markdownDescription": "Command line arguments to be passed to ansible-lint.",
             "order": 3
-          },
-          "ansible.lightspeed.playbookGeneration.enabled": {
-            "scope": "resource",
-            "type": "boolean",
-            "default": false,
-            "markdownDescription": "Enable playbook generation feature.",
-            "order": 4
           }
         }
       },


### PR DESCRIPTION
Remove the `ansible.lightspeed.playbookGeneration.enabled` config. It was used to control the visibility of the Ansible Creator PoC UI, but it is no longer used and we should not include it in the official release as it shows up on the Setting panel. 