### PR TITLE
Change grep option -E to -P to support \d

### DIFF
--- a/tools/release.sh
+++ b/tools/release.sh
@@ -11,7 +11,7 @@ if [[ -n $(git status -s) ]]; then
 fi
 
 RELEASE_NAME=$(gh api 'repos/{owner}/{repo}/releases' --jq '.[0].name')
-echo "${RELEASE_NAME}" | grep -Eq "^v\d+\.\d+\$" || {
+echo "${RELEASE_NAME}" | grep -Pq "^v\d+\.\d+\$" || {
     echo "Release name (${RELEASE_NAME}) is not valid, must be only in X.Y format." 1>&2
     exit 99
 }


### PR DESCRIPTION
["Create release PR" job ](https://github.com/ansible/vscode-ansible/actions/runs/8560939756/job/23461047765) failed on the `Run task release -v` step with:

```
  :
  :
 * [new tag]         v2.7                  -> v2.7
 * [new tag]         v2.8                  -> v2.8
 * [new tag]         v2.9                  -> v2.9
 * [new tag]         v24.4-alpha           -> v24.4-alpha
Release name (v24.4) is not valid, must be only in X.Y format.
task: Failed to run task "release": exit status 99
Error: Process completed with exit code 201.  
```
The failing line used the grep command  with `-E` option `grep -Eq "^v\d+\.\d+\$"`, but `\d` is not supported in extended regular expressions while it is supported in Perl-compatible regular expressions. We need to replace `-E` option with `-P` for enabling Perl-compatible regular expressions.
