### PR TITLE
Add safeguard for @types/vscode version

### DIFF
--- a/.depcheckrc.yml
+++ b/.depcheckrc.yml
@@ -1,5 +1,8 @@
+# https://github.com/yarnpkg/yarn/issues/3368
 ignores:
   - "@ansible/ansible-language-server"
+  # determined by (package.json).engines.vscode
+  - "@types/vscode"
   - "@types/vscode-webview" # provides VSCodeAPI
   - "@vscode/vsce"
   - depcheck

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,8 @@ updates:
       dependencies:
         patterns:
           - "*"
+        exclude-patterns:
+          - "@types/vscode"
   - package-ecosystem: npm
     directory: /packages/ansible-language-server/
     schedule:
@@ -26,6 +28,8 @@ updates:
       dependencies:
         patterns:
           - "*"
+        exclude-patterns:
+          - "@types/vscode"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -82,11 +82,16 @@ tasks:
     desc: Update dependencies
     deps:
       - install
+    env:
+      VSCODE_VERSION:
+        sh: node -p "require('./package.json').engines.vscode"
     cmds:
       # upgrade yarn itself
       - yarn set version latest
       # bumps some developments dependencies
       - yarn upgrade-interactive
+      # restores a potential update of @types/vscode
+      - yarn up "@types/vscode@${VSCODE_VERSION}"
       - yarn dedupe
       # running install after upgrade is needed in order to update the lock file
       - yarn install

--- a/packages/ansible-language-server/package.json
+++ b/packages/ansible-language-server/package.json
@@ -66,7 +66,7 @@
     "@types/mocha": "^10.0.6",
     "@types/node": "^20.12.4",
     "@types/uuid": "^9.0.8",
-    "@types/vscode": "^1.76.0",
+    "@types/vscode": "^1.85.0",
     "chai": "^4.4.1",
     "fuse.js": "^7.0.0",
     "handlebars": "^4.7.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -34,7 +34,7 @@ __metadata:
     "@types/mocha": "npm:^10.0.6"
     "@types/node": "npm:^20.12.4"
     "@types/uuid": "npm:^9.0.8"
-    "@types/vscode": "npm:^1.76.0"
+    "@types/vscode": "npm:^1.85.0"
     antsibull-docs: "npm:^1.0.1"
     axios: "npm:^1.6.8"
     chai: "npm:^4.4.1"
@@ -1299,10 +1299,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/vscode@npm:^1.76.0, @types/vscode@npm:^1.85.0":
-  version: 1.87.0
-  resolution: "@types/vscode@npm:1.87.0"
-  checksum: 10/6f10df10d9fbe305ccd69ad5432357f05de267c72100a5f5aa54341c454b4b3505a98580d0308a5dcd9562268a22701c46e70b744080c50955d44ac415f60cf1
+"@types/vscode@npm:^1.85.0":
+  version: 1.88.0
+  resolution: "@types/vscode@npm:1.88.0"
+  checksum: 10/9c9965154cb0e79039973d6a7c221e4152e4d6436015e17762a43465a7e261ee97c671d2b5dbe36853678f1f08c67be1ae2ca8b7f4647eb9ba402cd55980201d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Use the `(package.json).engines.version` to establish vscode dependency version.
- Ideally we should retrieve the minimal version from extester but  [vscode-extension-tester#1241](https://github.com/redhat-developer/vscode-extension-tester/issues/1241) prevents us from doing it.
- Prevents dependabot from touching @types/vscode