### PR TITLE
LightspeedExplorer view as a Webview and new button

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -25,6 +25,7 @@
 !media/playbookGeneration/style.css
 !out/client/src/extension.js
 !out/client/webview/apps/lightspeed/main.js
+!out/client/webview/apps/lightspeed/explorer/main.js
 !out/client/webview/apps/lightspeed/playbookExplanation/main.js
 !out/client/webview/apps/lightspeed/playbookGeneration/main.js
 !out/client/webview/apps/contentCreator/welcomePageApp.js

--- a/package.json
+++ b/package.json
@@ -68,8 +68,9 @@
           "name": "Ansible Creator"
         },
         {
-          "id": "lightspeed-explorer-treeview",
-          "name": "Ansible Lightspeed Login"
+          "id": "lightspeed-explorer-webview",
+          "name": "Ansible Lightspeed",
+          "type": "webview"
         },
         {
           "id": "lightspeed-feedback-webview",
@@ -93,11 +94,6 @@
       {
         "view": "ansible-creator",
         "contents": "Welcome to Ansible Creator. Elevate automation with a toolkit for efficient ansible content creation. [Learn more](https://github.com/ansible-community/ansible-creator)\n[Get started](command:ansible.content-creator.menu)"
-      },
-      {
-        "view": "lightspeed-explorer-treeview",
-        "contents": "Welcome to Ansible Lightspeed for Visual Studio Code.\nExperience smarter automation using Ansible Lightspeed with watsonx Code Assistant solutions for your playbook. [Learn more](https://www.redhat.com/en/engage/project-wisdom)\nLet's simplify your workflow by connecting VS Code with Ansible Lightspeed.\n[Connect](command:ansible.lightspeed.oauth)",
-        "enablement": "lightspeedConnectReady"
       }
     ],
     "jsonValidation": [

--- a/src/features/lightspeed/explorerWebviewViewProvider.ts
+++ b/src/features/lightspeed/explorerWebviewViewProvider.ts
@@ -1,0 +1,98 @@
+import {
+  CancellationToken,
+  Uri,
+  window,
+  Webview,
+  WebviewView,
+  WebviewViewProvider,
+  WebviewViewResolveContext,
+} from "vscode";
+import {
+  getWebviewContentWithLoginForm,
+  getWebviewContentWithActiveSession,
+  setWebviewMessageListener,
+} from "./utils/explorerView";
+
+import { getLoggedInSessionDetails } from "./utils/webUtils";
+import { LightSpeedAuthenticationProvider } from "./lightSpeedOAuthProvider";
+
+export class LightspeedExplorerWebviewViewProvider
+  implements WebviewViewProvider
+{
+  public static readonly viewType = "lightspeed-explorer-webview";
+
+  //sessionInfo: LightspeedSessionInfo = {};
+  //sessionData: LightspeedAuthSession = {} as LightspeedAuthSession;
+  private lightSpeedAuthProvider: LightSpeedAuthenticationProvider;
+  public webviewView: WebviewView | undefined;
+  public lightspeedExperimentalEnabled: boolean = false;
+
+  constructor(
+    private readonly _extensionUri: Uri,
+    lightSpeedAuthProvider: LightSpeedAuthenticationProvider,
+  ) {
+    this.lightSpeedAuthProvider = lightSpeedAuthProvider;
+  }
+
+  public async refreshWebView() {
+    if (!this.webviewView) {
+      return;
+    }
+    this.webviewView.webview.html = await this._getWebviewContent(
+      this.webviewView.webview,
+      this._extensionUri,
+    );
+  }
+
+  public async resolveWebviewView(
+    webviewView: WebviewView,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    context: WebviewViewResolveContext,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _token: CancellationToken,
+  ) {
+    // Allow scripts in the webview
+    webviewView.webview.options = {
+      // Enable JavaScript in the webview
+      enableScripts: true,
+      // Restrict the webview to only load resources from the `out` and `media` directory
+      localResourceRoots: [
+        Uri.joinPath(this._extensionUri, "out"),
+        Uri.joinPath(this._extensionUri, "media"),
+      ],
+    };
+    this.webviewView = webviewView;
+    this.refreshWebView();
+
+    this._setWebviewMessageListener(webviewView.webview);
+  }
+
+  private async _getWebviewContent(webview: Webview, extensionUri: Uri) {
+    const session =
+      await this.lightSpeedAuthProvider.getLightSpeedAuthSession();
+    if (session) {
+      const sessionInfo = getLoggedInSessionDetails(session);
+      const userName = session.account.label;
+      const userType = sessionInfo.userInfo?.userType || "";
+      const userRole =
+        sessionInfo.userInfo?.role !== undefined
+          ? sessionInfo.userInfo?.role
+          : "";
+      return getWebviewContentWithActiveSession(
+        webview,
+        extensionUri,
+        userName,
+        userType,
+        userRole,
+        window.activeTextEditor?.document.languageId === "ansible",
+        this.lightspeedExperimentalEnabled,
+      );
+    } else {
+      return getWebviewContentWithLoginForm(webview, extensionUri);
+    }
+  }
+
+  private async _setWebviewMessageListener(webview: Webview) {
+    await setWebviewMessageListener(webview, []);
+  }
+}

--- a/src/features/lightspeed/lightSpeedOAuthProvider.ts
+++ b/src/features/lightspeed/lightSpeedOAuthProvider.ts
@@ -17,7 +17,6 @@ import {
 import { v4 as uuid } from "uuid";
 import { PromiseAdapter, promiseFromEvent } from "./utils/promiseHandlers";
 import axios from "axios";
-import { TreeDataProvider } from "../../treeView";
 import { SettingsManager } from "../../settings";
 import {
   generateCodeVerifier,
@@ -226,10 +225,6 @@ export class LightSpeedAuthenticationProvider
           removed: [session],
           changed: [],
         });
-        window.registerTreeDataProvider(
-          "lightspeed-explorer-treeview",
-          new TreeDataProvider(undefined),
-        );
       }
     }
     lightSpeedManager.statusBarProvider.statusBar.text =

--- a/src/features/lightspeed/utils/explorerView.ts
+++ b/src/features/lightspeed/utils/explorerView.ts
@@ -1,0 +1,122 @@
+import { Disposable, Webview, Uri, commands } from "vscode";
+import { getUri } from "../../utils/getUri";
+import { getNonce } from "../../utils/getNonce";
+
+export function getWebviewContentWithLoginForm(
+  webview: Webview,
+  extensionUri: Uri,
+) {
+  const webviewUri = getUri(webview, extensionUri, [
+    "out",
+    "client",
+    "webview",
+    "apps",
+    "lightspeed",
+    "explorer",
+    "main.js",
+  ]);
+  const styleUri = getUri(webview, extensionUri, ["media", "style.css"]);
+  const nonce = getNonce();
+
+  return /*html*/ `
+  <!DOCTYPE html>
+  <html lang="en">
+    <head>
+      <meta charset="UTF-8">
+      <meta name="viewport" content="width=device-width, initial-scale=1.0">
+      <link rel="stylesheet" href="${styleUri}">
+      <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${webview.cspSource}; script-src 'nonce-${nonce}';">
+      <title>Ansible Lightspeed Explorer!</title>
+    </head>
+    <body>
+    Welcome to Ansible Lightspeed for Visual Studio Code.\nExperience smarter automation using Ansible Lightspeed with watsonx Code Assistant solutions for your playbook. <a href="https://www.redhat.com/en/engage/project-wisdom">Learn more</a><br />Let's simplify your workflow by connecting VS Code with Ansible Lightspeed.<br />
+    <form id="playbook-explanation-form">
+      <div class="component-container">
+        <section class="component-section">
+          <vscode-button id="lightspeed-explorer-connect">Connect</vscode-button>
+        </section>
+      </section>
+      <script type="module" nonce="${nonce}" src="${webviewUri}"></script>
+    </form>
+    </body>
+  </html>
+        `;
+}
+
+export function getWebviewContentWithActiveSession(
+  webview: Webview,
+  extensionUri: Uri,
+  userName: string,
+  userType: string,
+  userRole: string,
+  has_playbook_opened: boolean,
+  lightspeedExperimentalEnabled: boolean,
+) {
+  const webviewUri = getUri(webview, extensionUri, [
+    "out",
+    "client",
+    "webview",
+    "apps",
+    "lightspeed",
+    "explorer",
+    "main.js",
+  ]);
+  const styleUri = getUri(webview, extensionUri, ["media", "style.css"]);
+  const nonce = getNonce();
+  const explainForm = `<div class="button-container">
+  <form id="playbook-explanation-form">
+    <vscode-button id="lightspeed-explorer-playbook-explanation-submit" ${
+      has_playbook_opened ? "" : "disabled"
+    }>Explain the current playbook</vscode-button>
+  <script type="module" nonce="${nonce}" src="${webviewUri}"></script>
+  </form>
+  </div>`;
+
+  return /*html*/ `
+  <!DOCTYPE html>
+  <html lang="en">
+    <head>
+      <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${
+        webview.cspSource
+      }; script-src 'nonce-${nonce}';">
+      <meta charset="UTF-8">
+      <meta name="viewport" content="width=device-width, initial-scale=1.0">
+      <link rel="stylesheet" href="${styleUri}">
+      <title>Ansible Lightspeed Explorer!</title>
+    </head>
+    <body>
+
+    Logged in as: ${userName}<br />
+    User Type: ${userType}<br />
+    Role: ${userRole}<br />
+    ${lightspeedExperimentalEnabled ? explainForm : ""}
+    </body>
+  </html>
+        `;
+}
+
+export function setWebviewMessageListener(
+  webview: Webview,
+  disposables: Disposable[] = [],
+) {
+  webview.onDidReceiveMessage(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (message: any) => {
+      console.log(
+        `Lightspeed explorer - Message received: ${JSON.stringify(message)}}`,
+      );
+      const command = message.command;
+
+      switch (command) {
+        case "connect":
+          commands.executeCommand("ansible.lightspeed.oauth");
+          return;
+        case "explain":
+          commands.executeCommand("ansible.lightspeed.playbookExplanation");
+          return;
+      }
+    },
+    undefined,
+    disposables,
+  );
+}

--- a/src/webview/apps/lightspeed/explorer/main.ts
+++ b/src/webview/apps/lightspeed/explorer/main.ts
@@ -1,0 +1,34 @@
+import {
+  allComponents,
+  provideVSCodeDesignSystem,
+  Button,
+} from "@vscode/webview-ui-toolkit";
+
+provideVSCodeDesignSystem().register(allComponents);
+
+const vscode = acquireVsCodeApi();
+window.addEventListener("load", main);
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function setListener(id: string, func: any) {
+  const button = document.getElementById(id) as Button;
+  if (button) {
+    button.addEventListener("click", () => func());
+  }
+}
+
+function main() {
+  setListener("lightspeed-explorer-connect", lightspeedConnect);
+  setListener(
+    "lightspeed-explorer-playbook-explanation-submit",
+    lightspeedExplorerPlaybookExplanation,
+  );
+}
+
+function lightspeedConnect() {
+  vscode.postMessage({ command: "connect" });
+}
+
+function lightspeedExplorerPlaybookExplanation() {
+  vscode.postMessage({ command: "explain" });
+}

--- a/test/ui-test/lightspeedUiTest.ts
+++ b/test/ui-test/lightspeedUiTest.ts
@@ -4,7 +4,6 @@ import {
   By,
   SideBarView,
   ViewControl,
-  ExtensionsViewSection,
   Workbench,
   StatusBar,
   VSBrowser,
@@ -12,45 +11,55 @@ import {
   SettingsEditor,
   WebView,
   ModalDialog,
+  WebviewView,
 } from "vscode-extension-tester";
 import { getFilePath, updateSettings } from "./uiTestHelper";
 
 config.truncateThreshold = 0;
 export function lightspeedUIAssetsTest(): void {
   describe("Verify the presence of lightspeed login button in the activity bar", () => {
+    let workbench: Workbench;
     let view: ViewControl;
     let sideBar: SideBarView;
-    let lightspeedServiceSection: ExtensionsViewSection;
+    let webviewView: InstanceType<typeof WebviewView>;
 
     before(async function () {
+      workbench = new Workbench();
+      const settingsEditor = await workbench.openSettings();
+      await updateSettings(settingsEditor, "ansible.lightspeed.enabled", true);
+
       view = (await new ActivityBar().getViewControl("Ansible")) as ViewControl;
       sideBar = await view.openView();
 
-      lightspeedServiceSection = (await sideBar
-        .getContent()
-        .getSection("Ansible Lightspeed Login")) as ExtensionsViewSection;
+      await sideBar.getContent().getSection("Ansible Lightspeed");
+
+      await workbench.executeCommand(
+        "Ansible: Focus on Ansible Lightspeed View",
+      );
+      webviewView = new WebviewView();
+      expect(webviewView).not.undefined;
+      await webviewView.switchToFrame(1000);
+    });
+
+    after(async function () {
+      if (webviewView) {
+        await webviewView.switchBack();
+      }
+      const settingsEditor = await workbench.openSettings();
+      await updateSettings(settingsEditor, "ansible.lightspeed.enabled", false);
     });
 
     it("Ansible Lightspeed welcome message is present", async function () {
-      const welcomeMessage = await lightspeedServiceSection
-        .findWelcomeContent()
-        .then(async (val) => {
-          return val?.getText();
-        });
-
+      const body = await webviewView.findWebElement(By.xpath("//body"));
+      const welcomeMessage = await body.getText();
       expect(welcomeMessage).to.contain(
         "Welcome to Ansible Lightspeed for Visual Studio Code.",
       );
     });
 
     it("Ansible Lightspeed login button is present", async function () {
-      const welcomeContent =
-        await lightspeedServiceSection.findWelcomeContent();
-      expect(welcomeContent).not.undefined;
-
-      // The following lines replaced the original code that was using ExtensionsViewSection APIs.
-      const loginButton = await welcomeContent?.findElement(
-        By.xpath("//a[.//span/text()='Connect']"),
+      const loginButton = await webviewView.findWebElement(
+        By.xpath("//vscode-button[text()='Connect']"),
       );
       expect(loginButton).not.undefined;
     });

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -112,6 +112,19 @@ const contentCreatorInitWebviewConfig = {
   },
 };
 
+const playbookExplorerWebviewConfig = {
+  ...config,
+  target: ["web", "es2020"],
+  entry: "./src/webview/apps/lightspeed/explorer/main.ts",
+  experiments: { outputModule: true },
+  output: {
+    path: path.resolve(__dirname, "out"),
+    filename: "./client/webview/apps/lightspeed/explorer/main.js",
+    libraryTarget: "module",
+    chunkFormat: "module",
+  },
+};
+
 const playbookGenerationWebviewConfig = {
   ...config,
   target: ["web", "es2020"],
@@ -143,6 +156,7 @@ module.exports = [
   webviewConfig,
   contentCreatorMenuWebviewConfig,
   contentCreatorInitWebviewConfig,
+  playbookExplorerWebviewConfig,
   playbookGenerationWebviewConfig,
   playbookExplanationWebviewConfig,
 ];


### PR DESCRIPTION
Convert the "Ansible Lighspeed Login" panel from a TreeView to a WebView. The goal
is to be able to expose an addition button icon.

This commit also adds a new "Explain the current playbook" button to this view to
trigger a playbook explanation.
Convert the "Ansible Lighspeed Login" panel from a TreeView to a WebView. The goal
is to be able to expose an addition button icon.

This commit also adds a new "Explain the current playbook" button to this view to
trigger a playbook explanation