### PR TITLE
Remove Lightspeed content feedback

### DIFF
--- a/src/definitions/lightspeed.ts
+++ b/src/definitions/lightspeed.ts
@@ -19,12 +19,6 @@ export enum UserAction {
   IGNORED = 2, // ignored the suggestion or didn't wait for suggestion to be displayed
 }
 
-export enum AnsibleContentUploadTrigger {
-  FILE_OPEN = 0,
-  FILE_CLOSE = 1,
-  TAB_CHANGE = 2,
-}
-
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace LightSpeedCommands {
   export const LIGHTSPEED_AUTH_REQUEST = "ansible.lightspeed.oauth";

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -44,7 +44,6 @@ import {
   rejectPendingSuggestion,
 } from "./features/lightspeed/inlineSuggestions";
 import { playbookExplanation } from "./features/lightspeed/playbookExplanation";
-import { AnsibleContentUploadTrigger } from "./definitions/lightspeed";
 import { ContentMatchesWebview } from "./features/lightspeed/contentMatchesWebview";
 import {
   setPythonInterpreter,
@@ -276,12 +275,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
           lightSpeedManager,
           pythonInterpreterManager,
         );
-        if (editor) {
-          await lightSpeedManager.ansibleContentFeedback(
-            editor.document,
-            AnsibleContentUploadTrigger.TAB_CHANGE,
-          );
-        } else {
+        if (!editor) {
           await ignorePendingSuggestion();
         }
         lightSpeedManager.lightspeedExplorerProvider.refreshWebView();
@@ -289,23 +283,11 @@ export async function activate(context: ExtensionContext): Promise<void> {
     ),
   );
   context.subscriptions.push(
-    workspace.onDidOpenTextDocument(async (document: vscode.TextDocument) => {
+    workspace.onDidOpenTextDocument(async () => {
       await updateAnsibleStatusBar(
         metaData,
         lightSpeedManager,
         pythonInterpreterManager,
-      );
-      lightSpeedManager.ansibleContentFeedback(
-        document,
-        AnsibleContentUploadTrigger.FILE_OPEN,
-      );
-    }),
-  );
-  context.subscriptions.push(
-    workspace.onDidCloseTextDocument(async (document: vscode.TextDocument) => {
-      await lightSpeedManager.ansibleContentFeedback(
-        document,
-        AnsibleContentUploadTrigger.FILE_CLOSE,
       );
     }),
   );

--- a/src/features/lightspeed/api.ts
+++ b/src/features/lightspeed/api.ts
@@ -188,9 +188,6 @@ export class LightSpeedAPI {
       if (inputData.inlineSuggestion) {
         delete inputData.inlineSuggestion;
       }
-      if (inputData.ansibleContent) {
-        delete inputData.ansibleContent;
-      }
     }
 
     if (Object.keys(inputData).length === 0) {

--- a/src/features/lightspeed/base.ts
+++ b/src/features/lightspeed/base.ts
@@ -9,12 +9,10 @@ import {
   IIncludeVarsContext,
   IWorkSpaceRolesContext,
 } from "../../interfaces/lightspeed";
-import { LIGHTSPEED_ME_AUTH_URL } from "../../definitions/lightspeed";
 import { ContentMatchesWebview } from "./contentMatchesWebview";
 import {
   ANSIBLE_LIGHTSPEED_AUTH_ID,
   ANSIBLE_LIGHTSPEED_AUTH_NAME,
-  getBaseUri,
 } from "./utils/webUtils";
 import { LightspeedStatusBar } from "./statusBar";
 import { IVarsFileContext } from "../../interfaces/lightspeed";

--- a/src/features/lightspeed/base.ts
+++ b/src/features/lightspeed/base.ts
@@ -1,21 +1,20 @@
 import * as vscode from "vscode";
 import { LanguageClient } from "vscode-languageclient/node";
-import { v4 as uuidv4 } from "uuid";
 import { LightSpeedAPI } from "./api";
 import { TelemetryManager } from "../../utils/telemetryUtils";
 import { SettingsManager } from "../../settings";
 import { LightSpeedAuthenticationProvider } from "./lightSpeedOAuthProvider";
 import {
-  FeedbackRequestParams,
   IDocumentTracker,
   IIncludeVarsContext,
   IWorkSpaceRolesContext,
 } from "../../interfaces/lightspeed";
-import { AnsibleContentUploadTrigger } from "../../definitions/lightspeed";
+import { LIGHTSPEED_ME_AUTH_URL } from "../../definitions/lightspeed";
 import { ContentMatchesWebview } from "./contentMatchesWebview";
 import {
   ANSIBLE_LIGHTSPEED_AUTH_ID,
   ANSIBLE_LIGHTSPEED_AUTH_NAME,
+  getBaseUri,
 } from "./utils/webUtils";
 import { LightspeedStatusBar } from "./statusBar";
 import { IVarsFileContext } from "../../interfaces/lightspeed";
@@ -168,81 +167,6 @@ export class LightSpeedManager {
     for (const rolePath of commonRolesPath) {
       watchRolesDirectory(this, rolePath);
     }
-  }
-  public async ansibleContentFeedback(
-    document: vscode.TextDocument,
-    trigger: AnsibleContentUploadTrigger,
-  ): Promise<void> {
-    if (
-      document.languageId !== "ansible" ||
-      !this.settingsManager.settings.lightSpeedService.enabled ||
-      !this.settingsManager.settings.lightSpeedService.URL.trim()
-    ) {
-      return;
-    }
-
-    const rhUserHasSeat =
-      await this.lightspeedAuthenticatedUser.rhUserHasSeat();
-    const orgTelemetryOptOut =
-      await this.lightspeedAuthenticatedUser.orgOptOutTelemetry();
-
-    if (rhUserHasSeat && orgTelemetryOptOut) {
-      return;
-    }
-
-    const currentFileContent = document.getText();
-    const documentUri = document.uri.toString();
-    let activityId: string;
-    if (!this.lightSpeedActivityTracker.hasOwnProperty(documentUri)) {
-      // Inline suggestion not yet triggered, return without sending event.
-      return;
-    }
-    if (this.lightSpeedActivityTracker.hasOwnProperty(documentUri)) {
-      activityId = this.lightSpeedActivityTracker[documentUri].activityId;
-      const previousFileContent =
-        this.lightSpeedActivityTracker[documentUri].content;
-
-      if (trigger === AnsibleContentUploadTrigger.FILE_CLOSE) {
-        // end previous activity tracker
-        delete this.lightSpeedActivityTracker[documentUri];
-      }
-
-      if (previousFileContent === currentFileContent) {
-        console.log(
-          `[ansible-lightspeed-feedback] Event ansibleContent not sent as the content of file ${documentUri} is same as previous event.`,
-        );
-        return;
-      }
-
-      if (trigger === AnsibleContentUploadTrigger.TAB_CHANGE) {
-        // start a new activity tracker
-        this.lightSpeedActivityTracker[documentUri].activityId = uuidv4();
-      }
-    } else {
-      activityId = uuidv4();
-      this.lightSpeedActivityTracker[documentUri] = {
-        activityId: activityId,
-        content: currentFileContent,
-      };
-    }
-
-    if (!currentFileContent.trim()) {
-      console.log(
-        `[ansible-lightspeed-feedback] Event ansibleContent is not sent as the content of file ${documentUri} is empty.`,
-      );
-      return;
-    }
-
-    const inputData: FeedbackRequestParams = {
-      ansibleContent: {
-        content: document.getText(),
-        documentUri: documentUri,
-        trigger: trigger,
-        activityId: activityId,
-      },
-    };
-    console.log("[ansible-lightspeed-feedback] Event ansibleContent sent.");
-    this.apiInstance.feedbackRequest(inputData);
   }
 
   get inlineSuggestionsEnabled() {

--- a/src/interfaces/lightspeed.ts
+++ b/src/interfaces/lightspeed.ts
@@ -1,9 +1,5 @@
 import { AuthenticationSession } from "vscode";
-import {
-  AnsibleContentUploadTrigger,
-  LIGHTSPEED_USER_TYPE,
-  UserAction,
-} from "../definitions/lightspeed";
+import { LIGHTSPEED_USER_TYPE, UserAction } from "../definitions/lightspeed";
 
 export interface LightspeedAuthSession extends AuthenticationSession {
   rhUserHasSeat: boolean;
@@ -53,13 +49,6 @@ export interface InlineSuggestionEvent {
   activityId?: string;
 }
 
-export interface AnsibleContentEvent {
-  content: string;
-  documentUri: string;
-  trigger: AnsibleContentUploadTrigger;
-  activityId: string | undefined;
-}
-
 export interface SentimentEvent {
   value: number;
   feedback: string;
@@ -80,7 +69,6 @@ export interface IssueFeedbackEvent {
 
 export interface FeedbackRequestParams {
   inlineSuggestion?: InlineSuggestionEvent;
-  ansibleContent?: AnsibleContentEvent;
   sentimentFeedback?: SentimentEvent;
   suggestionQualityFeedback?: SuggestionQualityEvent;
   issueFeedback?: IssueFeedbackEvent;


### PR DESCRIPTION
For [AAP-22260](https://issues.redhat.com/browse/AAP-22260).

With tech preview over, we have no use case for flowing ansibleContent feedback. We don't collect this data for commercial users. This can be removed from the vscode extension, and wisdom service. 