### PR TITLE
lightspeedExplorerView: hide role is undefined

### DIFF
--- a/src/features/lightspeed/utils/explorerView.ts
+++ b/src/features/lightspeed/utils/explorerView.ts
@@ -101,7 +101,7 @@ export function getWebviewContentWithActiveSession(
     <div id="lightspeedExplorerView">
       Logged in as: ${userName}<br />
       User Type: ${userType}<br />
-      Role: ${userRole}<br />
+      ${userRole ? "Role: " + userRole : ""}
       ${lightspeedExperimentalEnabled ? explainForm : ""}
     </div>
     </body>


### PR DESCRIPTION
Hide the `Role: XXX` line if there is no role set.
