### PR TITLE
TextArea on Playbook Generation page should expand automatically

### DIFF
--- a/src/features/lightspeed/playbookGeneration.ts
+++ b/src/features/lightspeed/playbookGeneration.ts
@@ -182,7 +182,7 @@ export function getWebviewContent(webview: Webview, extensionUri: Uri) {
         </div>
         <div class="mainContainer">
           <div class="editArea">
-            <vscode-text-area rows=5 resize="both"
+            <vscode-text-area rows=5 resize="vertical"
                 placeholder="Describe the goal in your own words."
                 id="playbook-text-area">
             </vscode-text-area>
@@ -215,7 +215,7 @@ export function getWebviewContent(webview: Webview, extensionUri: Uri) {
             <h4>Examples</h4>
             <div class="exampleTextContainer">
               <p>
-                Create IIS websites on port 8080 and 8081 an open firewall
+                Create IIS websites on port 8080 and 8081 and open firewall
               </p>
             </div>
             <div class="exampleTextContainer">


### PR DESCRIPTION
A few changes made on Playbook Generation UI:

1. Previously, both vertical and horizontal resizing were permitted for the text area. Now it can only be resized in a vertical direction.
1. As more rows of input text are added to the text area, it will expand accordingly. However, it does not shrink automatically. Unfortunately, I was unable to find an effective way to implement this...
1. The number of rows of the text area on the second page, which displays the result of the summary request is expanded 15 to 25 as I though 15 would not be enough. If we can change the number of rows dynamically based on the result of API, it would be preferable. I have yet to discover a reliable method for implementing such functionality.