### PR TITLE
lightspeed - Auth refactoring

### DIFF
--- a/src/features/lightspeed/inlineSuggestions.ts
+++ b/src/features/lightspeed/inlineSuggestions.ts
@@ -336,9 +336,7 @@ async function requestSuggestion(
   const rhUserHasSeat =
     await lightSpeedManager.lightSpeedAuthenticationProvider.rhUserHasSeat();
   const lightSpeedStatusbarText =
-    await lightSpeedManager.statusBarProvider.getLightSpeedStatusBarText(
-      rhUserHasSeat,
-    );
+    await lightSpeedManager.statusBarProvider.getLightSpeedStatusBarText();
   const suggestionId = uuidv4();
   try {
     // If there is a suggestion, whose feedback is pending, send a feedback with IGNORED action
@@ -689,7 +687,7 @@ async function requestInlineSuggest(
   parsedAnsibleDocument: any,
   documentUri: string,
   activityId: string,
-  rhUserHasSeat: boolean | undefined,
+  rhUserHasSeat: boolean,
   documentDirPath: string,
   documentFilePath: string,
   ansibleFileType: IAnsibleFileType,

--- a/src/features/lightspeed/playbookExplanation.ts
+++ b/src/features/lightspeed/playbookExplanation.ts
@@ -30,7 +30,7 @@ export const playbookExplanation = async (
 
   const content = document.getText();
   const lightSpeedStatusbarText =
-    await lightSpeedManager.statusBarProvider.getLightSpeedStatusBarText(true);
+    await lightSpeedManager.statusBarProvider.getLightSpeedStatusBarText();
 
   const accessToken = await lightSpeedAuthProvider.grantAccessToken();
   let markdown = "";

--- a/src/features/lightspeed/utils/explorerView.ts
+++ b/src/features/lightspeed/utils/explorerView.ts
@@ -116,9 +116,6 @@ export function setWebviewMessageListener(
   webview.onDidReceiveMessage(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (message: any) => {
-      console.log(
-        `Lightspeed explorer - Message received: ${JSON.stringify(message)}}`,
-      );
       const command = message.command;
 
       switch (command) {

--- a/src/features/lightspeed/utils/webUtils.ts
+++ b/src/features/lightspeed/utils/webUtils.ts
@@ -75,9 +75,6 @@ export function getUserTypeLabel(
   rhOrgHasSubscription?: boolean,
   rhUserHasSeat?: boolean,
 ): LIGHTSPEED_USER_TYPE {
-  if (rhOrgHasSubscription === undefined) {
-    return "Not logged in";
-  }
   return rhOrgHasSubscription && rhUserHasSeat ? "Licensed" : "Unlicensed";
 }
 

--- a/test/testScripts/lightspeed/e2eInlineSuggestion.test.ts
+++ b/test/testScripts/lightspeed/e2eInlineSuggestion.test.ts
@@ -56,7 +56,7 @@ export async function testInlineSuggestionByAnotherProvider(): Promise<void> {
       );
       isAuthenticatedStub = sinon.stub(
         lightSpeedManager.lightSpeedAuthenticationProvider,
-        "isAuthenticated",
+        "getLocalSession",
       );
       isAuthenticatedStub.returns(Promise.resolve(true));
 
@@ -141,7 +141,7 @@ export async function testInlineSuggestionProviderCoExistence(): Promise<void> {
       );
       isAuthenticatedStub = sinon.stub(
         lightSpeedManager.lightSpeedAuthenticationProvider,
-        "isAuthenticated",
+        "getLocalSession",
       );
       isAuthenticatedStub.returns(Promise.resolve(true));
 
@@ -232,7 +232,7 @@ export async function testIgnorePendingSuggestion(): Promise<void> {
       );
       isAuthenticatedStub = sinon.stub(
         lightSpeedManager.lightSpeedAuthenticationProvider,
-        "isAuthenticated",
+        "getLocalSession",
       );
       isAuthenticatedStub.returns(Promise.resolve(true));
     });

--- a/test/testScripts/lightspeed/testLightSpeedFunctions.test.ts
+++ b/test/testScripts/lightspeed/testLightSpeedFunctions.test.ts
@@ -72,13 +72,13 @@ function testGetLightSpeedStatusBarText(): void {
       let text = await statusBarProvider.getLightSpeedStatusBarText();
       assert.equal(text, LIGHTSPEED_STATUS_BAR_TEXT_DEFAULT);
 
-      text = await statusBarProvider.getLightSpeedStatusBarText(true, true);
+      text = await statusBarProvider.getLightSpeedStatusBarText();
       assert.equal(text, "Lightspeed (licensed)");
-      text = await statusBarProvider.getLightSpeedStatusBarText(true, false);
+      text = await statusBarProvider.getLightSpeedStatusBarText();
       assert.equal(text, "Lightspeed (unlicensed)");
-      text = await statusBarProvider.getLightSpeedStatusBarText(false, true);
+      text = await statusBarProvider.getLightSpeedStatusBarText();
       assert.equal(text, "Lightspeed (unlicensed)");
-      text = await statusBarProvider.getLightSpeedStatusBarText(false, false);
+      text = await statusBarProvider.getLightSpeedStatusBarText();
       assert.equal(text, "Lightspeed (unlicensed)");
     });
   });
@@ -91,7 +91,7 @@ function testFeedbackAPI(): void {
   before(async function () {
     isAuthenticated = sinon.stub(
       lightSpeedManager.lightSpeedAuthenticationProvider,
-      "isAuthenticated",
+      "getLocalSession",
     );
     isAuthenticated.returns(Promise.resolve(true));
   });

--- a/test/testScripts/lightspeed/testLightspeed.test.ts
+++ b/test/testScripts/lightspeed/testLightspeed.test.ts
@@ -127,7 +127,7 @@ export function testLightspeed(): void {
         );
         isAuthenticatedStub = sinon.stub(
           lightSpeedManager.lightSpeedAuthenticationProvider,
-          "isAuthenticated",
+          "getLocalSession",
         );
         isAuthenticatedStub.returns(Promise.resolve(true));
       });
@@ -250,7 +250,7 @@ export function testLightspeed(): void {
         );
         isAuthenticatedStub = sinon.stub(
           lightSpeedManager.lightSpeedAuthenticationProvider,
-          "isAuthenticated",
+          "getLocalSession",
         );
         isAuthenticatedStub.returns(Promise.resolve(true));
       });

--- a/test/units/lightspeed/contentmatches.test.ts
+++ b/test/units/lightspeed/contentmatches.test.ts
@@ -177,11 +177,10 @@ describe("GetWebviewContent", () => {
     };
 
     function setRhUserHasSeat(has_seat: boolean) {
-      cmw["lightSpeedAuthProvider"].rhUserHasSeat = async (): Promise<
-        boolean | undefined
-      > => {
-        return has_seat;
-      };
+      cmw["lightSpeedAuthProvider"].rhUserHasSeat =
+        async (): Promise<boolean> => {
+          return has_seat;
+        };
     }
 
     setRhUserHasSeat(false);


### PR DESCRIPTION
Improve the isolation
---------------------

- `lightSpeedOAuthProvider` doesn't handle the statusBar by itself
- `LightspeedExplorerWebviewViewProvider` is now managed by lightspeed/base.ts
- `lightSpeedOAuthProvider`: rename `isAuthenticated()` to `getLocalSession()`
  to reflect the fact it only check for a local session.
- `getLightSpeedStatusBarText()` doesn't take any parameter and generate the status bar text depending on the context.

New exceptions
--------------

- `LightspeedNoLocalSession`: raised when an error is caused by the absance of a
  local LightSpeed `AuthenticationSession` session.
- `LightspeedAccessDenied`: raised when the API /me end-point returns a 401 error.

This allow the simplification of `getApiInstance()`, `getData()`, `getLocalSession()`,
`rhOrgHasSubscription()`.

New attribute: `lightSpeedOAuthProvider.userIsConnected`
--------------------------------------------------------

This attribute is True only if the user has a local session and can reach the `/me`
end-point without getting a 401 (Unauthorized) error.

UI changes
----------

When the user is disconnected, a click on the Lightspeed bar will trigger the
authentication process.
![image](https://github.com/ansible/vscode-ansible/assets/49379/65748c4b-e0a2-4517-9b4c-775fa425007d)
