### PR TITLE
Show connect on expiry

### DIFF
--- a/src/definitions/lightspeed.ts
+++ b/src/definitions/lightspeed.ts
@@ -72,7 +72,7 @@ export const LIGHTSPEED_SERVICE_LOGIN_TIMEOUT = 120000;
 export type LIGHTSPEED_SUGGESTION_TYPE = "SINGLE-TASK" | "MULTI-TASK";
 
 export type LIGHTSPEED_USER_TYPE = "Licensed" | "Unlicensed" | "Not logged in";
-export const LIGHTSPEED_STATUS_BAR_TEXT_DEFAULT = "Lightspeed (not logged in)";
+export const LIGHTSPEED_STATUS_BAR_TEXT_DEFAULT = "Lightspeed (Not logged in)";
 
 export const LIGHTSPEED_MODEL_DEFAULT = "default";
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -62,7 +62,6 @@ import { withInterpreter } from "./features/utils/commandRunner";
 import { IFileSystemWatchers } from "./interfaces/watchers";
 import { showPlaybookGenerationPage } from "./features/lightspeed/playbookGeneration";
 import { ScaffoldAnsibleProject } from "./features/contentCreator/scaffoldAnsibleProjectPage";
-import { LightspeedExplorerWebviewViewProvider } from "./features/lightspeed/explorerWebviewViewProvider";
 import {
   LightspeedUser,
   AuthProviderType,
@@ -285,7 +284,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
         } else {
           await ignorePendingSuggestion();
         }
-        lightspeedExplorerProvider.refreshWebView();
+        lightSpeedManager.lightspeedExplorerProvider.refreshWebView();
       },
     ),
   );
@@ -348,33 +347,12 @@ export async function activate(context: ExtensionContext): Promise<void> {
       if (!lightSpeedManager.lightspeedAuthenticatedUser.isAuthenticated()) {
         lightSpeedManager.currentModelValue = undefined;
       }
-      if (lightspeedExplorerProvider.webviewView) {
-        lightspeedExplorerProvider.refreshWebView();
+      if (lightSpeedManager.lightspeedExplorerProvider.webviewView) {
+        lightSpeedManager.lightspeedExplorerProvider.refreshWebView();
       }
-      const rhUserHasSeat =
-        await lightSpeedManager.lightspeedAuthenticatedUser.rhUserHasSeat();
-      const rhOrgHasSubscription =
-        await lightSpeedManager.lightspeedAuthenticatedUser.rhOrgHasSubscription();
-      lightSpeedManager.statusBarProvider.statusBar.text =
-        await lightSpeedManager.statusBarProvider.getLightSpeedStatusBarText(
-          rhUserHasSeat,
-          rhOrgHasSubscription,
-        );
-      lightSpeedManager.statusBarProvider.setLightSpeedStatusBarTooltip();
+      lightSpeedManager.statusBarProvider.updateLightSpeedStatusbar();
     }),
   );
-
-  const lightspeedExplorerProvider = new LightspeedExplorerWebviewViewProvider(
-    context.extensionUri,
-    lightSpeedManager.lightspeedAuthenticatedUser,
-  );
-
-  // Register the Lightspeed provider for a Webview View
-  const lightspeedExplorerDisposable = window.registerWebviewViewProvider(
-    LightspeedExplorerWebviewViewProvider.viewType,
-    lightspeedExplorerProvider,
-  );
-  context.subscriptions.push(lightspeedExplorerDisposable);
 
   // handle lightSpeed feedback
   const lightspeedFeedbackProvider = new LightspeedFeedbackWebviewViewProvider(
@@ -405,9 +383,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
     async () => {
       // NOTE: We can't gate this check on if this extension is active,
       // because it only activates on an authentication request.
-      if (
-        !(await vscode.extensions.getExtension("redhat.vscode-redhat-account"))
-      ) {
+      if (!vscode.extensions.getExtension("redhat.vscode-redhat-account")) {
         window.showErrorMessage(
           "You must install the Red Hat Authentication extension to sign in with Red Hat.",
         );
@@ -568,8 +544,9 @@ export async function activate(context: ExtensionContext): Promise<void> {
           "redhat.ansible.lightspeedExperimentalEnabled",
           true,
         );
-        lightspeedExplorerProvider.lightspeedExperimentalEnabled = true;
-        lightspeedExplorerProvider.refreshWebView();
+        lightSpeedManager.lightspeedExplorerProvider.lightspeedExperimentalEnabled =
+          true;
+        lightSpeedManager.lightspeedExplorerProvider.refreshWebView();
       },
     ),
   );

--- a/src/features/lightspeed/base.ts
+++ b/src/features/lightspeed/base.ts
@@ -24,6 +24,7 @@ import { watchRolesDirectory } from "./utils/watchers";
 import { LightSpeedServiceSettings } from "../../interfaces/extensionSettings";
 import { LightspeedUser } from "./lightspeedUser";
 import { Log } from "../../utils/logger";
+import { LightspeedExplorerWebviewViewProvider } from "./explorerWebviewViewProvider";
 
 export class LightSpeedManager {
   private context;
@@ -40,6 +41,7 @@ export class LightSpeedManager {
   public ansibleRolesCache: IWorkSpaceRolesContext = {};
   public ansibleIncludeVarsCache: IIncludeVarsContext = {};
   public currentModelValue: string | undefined = undefined;
+  public lightspeedExplorerProvider: LightspeedExplorerWebviewViewProvider;
   private _logger: Log;
 
   constructor(
@@ -72,22 +74,11 @@ export class LightSpeedManager {
       this.lightSpeedAuthenticationProvider,
       this._logger,
     );
-    if (this.settingsManager.settings.lightSpeedService.enabled) {
-      this.lightspeedAuthenticatedUser.initialize();
-    }
     this.apiInstance = new LightSpeedAPI(
       this.settingsManager,
       this.lightspeedAuthenticatedUser,
       this.context,
     );
-    // this.apiInstance
-    //   .getData(`${getBaseUri(this.settingsManager)}${LIGHTSPEED_ME_AUTH_URL}`)
-    //   .then((userResponse: UserResponse) => {
-    //     this.orgTelemetryOptOut = userResponse.org_telemetry_opt_out;
-    //   })
-    //   .catch((error) => {
-    //     console.error(error);
-    //   });
     this.contentMatchesProvider = new ContentMatchesWebview(
       this.context,
       this.client,
@@ -104,6 +95,17 @@ export class LightSpeedManager {
       client,
       settingsManager,
     );
+
+    this.lightspeedExplorerProvider = new LightspeedExplorerWebviewViewProvider(
+      context.extensionUri,
+      this.lightspeedAuthenticatedUser,
+    );
+    const lightspeedExplorerDisposable =
+      vscode.window.registerWebviewViewProvider(
+        LightspeedExplorerWebviewViewProvider.viewType,
+        this.lightspeedExplorerProvider,
+      );
+    context.subscriptions.push(lightspeedExplorerDisposable);
 
     // create workspace context for ansible roles
     this.setContext();

--- a/src/features/lightspeed/inlineSuggestions.ts
+++ b/src/features/lightspeed/inlineSuggestions.ts
@@ -336,9 +336,7 @@ async function requestSuggestion(
   const rhUserHasSeat =
     await lightSpeedManager.lightspeedAuthenticatedUser.rhUserHasSeat();
   const lightSpeedStatusbarText =
-    await lightSpeedManager.statusBarProvider.getLightSpeedStatusBarText(
-      rhUserHasSeat,
-    );
+    await lightSpeedManager.statusBarProvider.getLightSpeedStatusBarText();
   const suggestionId = uuidv4();
   try {
     // If there is a suggestion, whose feedback is pending, send a feedback with IGNORED action

--- a/src/features/lightspeed/lightSpeedOAuthProvider.ts
+++ b/src/features/lightspeed/lightSpeedOAuthProvider.ts
@@ -5,6 +5,7 @@ import {
   AuthenticationProvider,
   AuthenticationProviderAuthenticationSessionsChangeEvent,
   AuthenticationSession,
+  commands,
   Disposable,
   env,
   EventEmitter,
@@ -33,6 +34,7 @@ import {
   LIGHTSPEED_CLIENT_ID,
   LIGHTSPEED_SERVICE_LOGIN_TIMEOUT,
   LIGHTSPEED_ME_AUTH_URL,
+  LightSpeedCommands,
 } from "../../definitions/lightspeed";
 import { LightspeedAuthSession } from "../../interfaces/lightspeed";
 import { lightSpeedManager } from "../../extension";
@@ -202,18 +204,6 @@ export class LightSpeedAuthenticationProvider
         removed: [],
         changed: [],
       });
-
-      // moved to extension.ts activate with listener - might be problematic because there it's not necessarily on create?
-      // lightSpeedManager.statusBarProvider.statusBar.text =
-      //   await lightSpeedManager.statusBarProvider.getLightSpeedStatusBarText(
-      //     rhUserHasSeat,
-      //     rhOrgHasSubscription,
-      //   );
-
-      // moved to extension.ts activate with listener
-      // lightSpeedManager.statusBarProvider.setLightSpeedStatusBarTooltip(
-      //   session,
-      // );
 
       console.log("[ansible-lightspeed-oauth] Session created...");
 
@@ -513,9 +503,15 @@ export class LightSpeedAuthenticationProvider
       );
 
       if (!result) {
-        window.showErrorMessage(
-          "Failed to refresh token. Please log out and log in again",
+        await this.removeSession(sessionId);
+        const selection = await window.showWarningMessage(
+          "Your Ansible Lightspeed session has expired.\n",
+          "Reconnect",
         );
+        if (selection === "Reconnect") {
+          commands.executeCommand(LightSpeedCommands.LIGHTSPEED_AUTH_REQUEST);
+        }
+        return;
         return;
       }
 

--- a/src/features/lightspeed/lightSpeedOAuthProvider.ts
+++ b/src/features/lightspeed/lightSpeedOAuthProvider.ts
@@ -512,7 +512,6 @@ export class LightSpeedAuthenticationProvider
           commands.executeCommand(LightSpeedCommands.LIGHTSPEED_AUTH_REQUEST);
         }
         return;
-        return;
       }
 
       const newAccount: OAuthAccount = result;

--- a/src/features/lightspeed/playbookExplanation.ts
+++ b/src/features/lightspeed/playbookExplanation.ts
@@ -30,7 +30,7 @@ export const playbookExplanation = async (
 
   const content = document.getText();
   const lightSpeedStatusbarText =
-    await lightSpeedManager.statusBarProvider.getLightSpeedStatusBarText(true);
+    await lightSpeedManager.statusBarProvider.getLightSpeedStatusBarText();
 
   const accessToken =
     await lightspeedAuthenticatedUser.getLightspeedUserAccessToken();

--- a/test/testScripts/lightspeed/e2eInlineSuggestion.test.ts
+++ b/test/testScripts/lightspeed/e2eInlineSuggestion.test.ts
@@ -112,7 +112,6 @@ export async function testInlineSuggestionByAnotherProvider(): Promise<void> {
       executeCommandSpy.restore();
       feedbackRequestSpy.restore();
       isAuthenticatedStub.restore();
-      sinon.restore();
     });
   });
 }
@@ -208,7 +207,6 @@ export async function testInlineSuggestionProviderCoExistence(): Promise<void> {
       executeCommandSpy.restore();
       feedbackRequestSpy.restore();
       isAuthenticatedStub.restore();
-      sinon.restore();
     });
   });
 }
@@ -261,7 +259,6 @@ export async function testIgnorePendingSuggestion(): Promise<void> {
     after(() => {
       feedbackRequestSpy.restore();
       isAuthenticatedStub.restore();
-      sinon.restore();
     });
   });
 }

--- a/test/testScripts/lightspeed/testLightspeed.test.ts
+++ b/test/testScripts/lightspeed/testLightspeed.test.ts
@@ -194,7 +194,6 @@ export function testLightspeed(): void {
       after(async function () {
         feedbackRequestSpy.restore();
         isAuthenticatedStub.restore();
-        sinon.restore();
       });
     });
 
@@ -229,7 +228,7 @@ export function testLightspeed(): void {
       });
 
       after(async function () {
-        sinon.restore();
+        rhUserHasSeatStub.restore();
       });
     });
 
@@ -302,7 +301,6 @@ export function testLightspeed(): void {
       after(async function () {
         feedbackRequestSpy.restore();
         isAuthenticatedStub.restore();
-        sinon.restore();
       });
     });
 

--- a/test/testScripts/lightspeed/testLightspeedUser.test.ts
+++ b/test/testScripts/lightspeed/testLightspeedUser.test.ts
@@ -89,7 +89,7 @@ function testGetAuthProviderOrder() {
         .returns(rhAuthExtension);
     });
     after(() => {
-      sinon.restore();
+      getExtensionStub.restore();
     });
 
     it("Honors LIGHTSPEED_PREFER_RHSSO_AUTH env var", async function () {
@@ -173,7 +173,9 @@ function testRedHatSignInCommand() {
         .returns(rhAuthExtension);
     });
     after(() => {
-      sinon.restore();
+      getLightspeedUserDetailsStub.restore();
+      showInformationMessageStub.restore();
+      getExtensionStub.restore();
     });
     it("Logs in with Red Hat when Red Hat Auth extension is installed", async () => {
       // Trigger Sign in with Red Hat
@@ -206,7 +208,8 @@ function testRedHatSignInCommand() {
         .returns(undefined);
     });
     after(() => {
-      sinon.restore();
+      showErrorMessageStub.restore();
+      getExtensionStub.restore();
     });
     it("Displays an error when signing in with Red Hat without Red Hat Auth extension", async () => {
       // Trigger Sign in with Red Hat


### PR DESCRIPTION
This PR builds on top of https://github.com/ansible/vscode-ansible/pull/1259 and supersedes https://github.com/ansible/vscode-ansible/pull/1258 (which these changes from @goneri are based on). 

When Lightspeed auth provider refresh fails, it offers a reconnect button in the pop-up and re-enables the Connect button in the Ansible Lightspeed side panel.
