### PR TITLE
Specify --readme-path to vsce

### DIFF
--- a/tools/publish.sh
+++ b/tools/publish.sh
@@ -9,6 +9,6 @@ for FILE in ./*.vsix; do
         publish_args+=("--pre-release")
     fi
     echo "Publishing ${VERSION}" "${publish_args[@]}"
-    yarn run vsce publish "${publish_args[@]}" --skip-duplicate --packagePath "${FILE}"
+    yarn run vsce publish "${publish_args[@]}" --skip-duplicate --packagePath "${FILE}" --readme-path docs/README.md
     yarn run ovsx publish "${publish_args[@]}" --skip-duplicate "${FILE}"
 done


### PR DESCRIPTION
Specify --readme-path to vsce and let vsce know the location of README.md (it's docs/README.md).  Without it, no "Overview" is displayed on the Marketpace page:


![image](https://github.com/ansible/vscode-ansible/assets/27698807/2f933d0e-0390-4bf6-a7c3-ff0479f08e36)


We also need to have a solution for Open VSX Registry, but `osvx` CLI does not have `--readme-path` (or equivalent) parameter.  We will work on the issue with a separate PR for Open VSX Registry.

![image](https://github.com/ansible/vscode-ansible/assets/27698807/4e1bc692-d230-400d-8001-8e5ef105240a)


