### PR TITLE
Add --readme-path to vsce package and update .vscodeignore

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -7,7 +7,7 @@
 !ansible-language-configuration.json
 !CHANGELOG.md
 !LICENSE
-!README.md
+!docs/README.md
 !images/ansible.svg
 !images/logo.png
 !jinja-language-configuration.json

--- a/tools/package.sh
+++ b/tools/package.sh
@@ -5,7 +5,7 @@ set -Eeuo pipefail
 rm -f ./*.vsix
 yarn run webpack
 VERSION="$(./tools/get-marketplace-version.sh)"
-vsce_package_args=(--no-dependencies --no-git-tag-version --no-update-package-json)
+vsce_package_args=(--no-dependencies --no-git-tag-version --no-update-package-json --readme-path docs/README.md)
 if [[ "$VERSION" != *.0 ]]; then
     vsce_package_args+=("--pre-release")
 fi


### PR DESCRIPTION
#1293 did not resolve the issue of empty overview page on Marketplace.
The `--readme-path` option needed to be added to `vsce package` as well so that the file is packaged in .vsix.  
Also `.vscodeignore` file also needed to be updated.