### PR TITLE
Playbook Generation ThumbsUp/Down UI fix

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -576,7 +576,6 @@ export async function activate(context: ExtensionContext): Promise<void> {
             true,
           );
         }
-        window.showInformationMessage("Thank you for your feedback!");
       },
     ),
   );

--- a/src/webview/apps/lightspeed/playbookGeneration/main.ts
+++ b/src/webview/apps/lightspeed/playbookGeneration/main.ts
@@ -59,6 +59,8 @@ window.addEventListener("message", (event) => {
       changeDisplay("generatePlaybookContainer", "block");
       changeDisplay("promptContainer", "block");
 
+      updateThumbsUpDownButtons(false, false);
+
       const element = document.getElementById("playbook-text-area") as TextArea;
       savedSummary = element.value = message.summary.content;
       outlineId = message.summary.summaryId;
@@ -161,13 +163,24 @@ async function generatePlaybook() {
   vscode.postMessage({ command: "generatePlaybook", content });
 }
 
-function sendThumbsup() {
+function updateThumbsUpDownButtons(selectUp: boolean, selectDown: boolean) {
   const thumbsUpButton = document.getElementById("thumbsup-button") as Button;
   const thumbsDownButton = document.getElementById(
     "thumbsdown-button",
   ) as Button;
-  thumbsUpButton.setAttribute("class", "iconButtonSelected");
-  thumbsDownButton.setAttribute("class", "iconButton");
+  thumbsUpButton.setAttribute(
+    "class",
+    selectUp ? "iconButtonSelected" : "iconButton",
+  );
+  thumbsDownButton.setAttribute(
+    "class",
+    selectDown ? "iconButtonSelected" : "iconButton",
+  );
+  thumbsUpButton.disabled = thumbsDownButton.disabled = selectUp || selectDown;
+}
+
+function sendThumbsup() {
+  updateThumbsUpDownButtons(true, false);
   vscode.postMessage({
     command: "thumbsUp",
     action: ThumbsUpDownAction.UP,
@@ -176,12 +189,7 @@ function sendThumbsup() {
 }
 
 function sendThumbsdown() {
-  const thumbsUpButton = document.getElementById("thumbsup-button") as Button;
-  const thumbsDownButton = document.getElementById(
-    "thumbsdown-button",
-  ) as Button;
-  thumbsUpButton.setAttribute("class", "iconButton");
-  thumbsDownButton.setAttribute("class", "iconButtonSelected");
+  updateThumbsUpDownButtons(false, true);
   vscode.postMessage({
     command: "thumbsDown",
     action: ThumbsUpDownAction.DOWN,

--- a/test/ui-test/lightspeedUiTest.ts
+++ b/test/ui-test/lightspeedUiTest.ts
@@ -228,7 +228,34 @@ export function lightspeedUIAssetsTest(): void {
         text = await textArea.getText();
         expect(!text.includes("# COMMENT\n"));
 
+        // Test ThumbsUp button
+        const thumbsUpButton = await webView.findWebElement(
+          By.xpath("//vscode-button[@id='thumbsup-button']"),
+        );
+        expect(thumbsUpButton, "thumbsUpButton should not be undefined").not.to
+          .be.undefined;
+        expect(
+          await thumbsUpButton.isEnabled(),
+          "thumbsUpButton should be enabled",
+        );
+        thumbsUpButton.click();
+        await new Promise((res) => {
+          setTimeout(res, 500);
+        });
+        expect(
+          !thumbsUpButton.isEnabled,
+          "thumbsUpButton should not be enabled",
+        );
+
+        await webView.switchBack();
+        let notifications = await workbench.getNotifications();
+        let notification = notifications[0];
+        let message = await notification.getMessage();
+        expect(message).equals("Thanks for your feedback!");
+        await notification.dismiss();
+
         // Test Back button
+        await webView.switchToFrame(5000);
         const backButton = await webView.findWebElement(
           By.xpath("//vscode-button[@id='back-button']"),
         );
@@ -248,7 +275,31 @@ export function lightspeedUIAssetsTest(): void {
         text = await textArea.getText();
         expect(text.includes('Name: "Create an azure network..."'));
 
+        // Test ThumbsDown button
+        const thumbsDownButton = await webView.findWebElement(
+          By.xpath("//vscode-button[@id='thumbsdown-button']"),
+        );
+        expect(thumbsDownButton, "thumbsDownButton should not be undefined").not
+          .to.be.undefined;
+        expect(
+          await thumbsUpButton.isEnabled(),
+          "thumbsDownButton should be enabled",
+        );
+        thumbsUpButton.click();
+        await new Promise((res) => {
+          setTimeout(res, 500);
+        });
+        expect(!thumbsUpButton.isEnabled, "ThumbsDown should not be enabled");
+
+        await webView.switchBack();
+        notifications = await workbench.getNotifications();
+        notification = notifications[0];
+        message = await notification.getMessage();
+        expect(message).equals("Thanks for your feedback!");
+        await notification.dismiss();
+
         // Test Edit link next to the prompt text
+        await webView.switchToFrame(5000);
         const backAnchor = await webView.findWebElement(
           By.xpath("//a[@id='back-anchor']"),
         );


### PR DESCRIPTION
This PR addresses to fix following two problems:

1. When either Thumbs Up or Thumbs Down button is clicked for the outline result, two notification messages
```
Thanks for your feedback!
Thank you for your feedback!
```
are displayed. 
2. Thumbs Up or Thumbs/Down button s for one summary result can be clicked more than one time.

For 1, I removed the message issued from `extension.ts`.
For 2, I added a logic to disable Thumbs Up/Down buttons after one was clicked.  If the user clicks the Back button and re-issue the outline API, these buttons are enabled again.

Attached screenshot shows how the disabled buttons look on the UI:

![image](https://github.com/ansible/vscode-ansible/assets/27698807/7ae4edc3-4867-4697-affb-f34070206db6)
