### PR TITLE
Fix handling of syntax-check errors reported by ansible-lint in the extension

### DIFF
--- a/examples/playbooks/lint-issue.yml
+++ b/examples/playbooks/lint-issue.yml
@@ -1,0 +1,6 @@
+---
+- name: example
+  hosts: "{{ hostsvars['sss'] }}"
+  tasks:
+    - name: hello world
+      hello.world:

--- a/packages/ansible-language-server/src/services/ansibleLint.ts
+++ b/packages/ansible-language-server/src/services/ansibleLint.ts
@@ -163,13 +163,19 @@ export class AnsibleLint {
             typeof item.check_name === "string" &&
             item.location &&
             typeof item.location.path === "string" &&
-            item.location.lines &&
-            (item.location.lines.begin ||
-              typeof item.location.lines.begin === "number")
+            ((item.location.positions && item.location.positions.begin) ||
+              (item.location.lines &&
+                (item.location.lines.begin ||
+                  typeof item.location.lines.begin === "number")))
           ) {
-            const begin_line =
-              item.location.lines.begin.line || item.location.lines.begin || 1;
-            const begin_column = item.location.lines.begin.column || 1;
+            const begin_line = item.location.positions
+              ? item.location.positions.begin.line
+              : item.location.lines.begin.line ||
+                item.location.lines.begin ||
+                1;
+            const begin_column = item.location.positions
+              ? item.location.positions.begin.column
+              : item.location.lines.begin.column || 1;
             const start: Position = {
               line: begin_line - 1,
               character: begin_column - 1,

--- a/packages/ansible-language-server/test/fixtures/diagnostics/syntax_check_errors_in_ansible_lint.yml
+++ b/packages/ansible-language-server/test/fixtures/diagnostics/syntax_check_errors_in_ansible_lint.yml
@@ -1,0 +1,7 @@
+---
+- name: Example of syntax-check error reported by ansible-lint
+  hosts: "{{ hostsvars['sss'] }}"
+  tasks:
+    - name: Print hello world
+      ansible.builtin.ping:
+        data: "Hello, world"

--- a/packages/ansible-language-server/test/providers/validationProvider.test.ts
+++ b/packages/ansible-language-server/test/providers/validationProvider.test.ts
@@ -184,6 +184,43 @@ function testAnsibleLintErrors(
   );
 }
 
+function testAnsibleSyntaxCheckErrorsInAnsibleLint(
+  context: WorkspaceFolderContext | undefined,
+  validationManager: ValidationManager,
+  textDoc: TextDocument,
+  validationEnabled: boolean,
+) {
+  const tests: testType[] = [
+    {
+      name: "syntax-check errors in ansible-lint",
+      diagnosticReport: [
+        {
+          severity: 1,
+          message: "--syntax-check",
+          range: {
+            start: { line: 1, character: 2 } as Position,
+            end: {
+              line: 1,
+              character: integer.MAX_VALUE,
+            } as Position,
+          },
+          source: "Ansible",
+        },
+      ],
+    },
+  ];
+  expect(context).to.not.be.undefined;
+  if (context) {
+    assertValidateTests(
+      tests,
+      context,
+      validationManager,
+      textDoc,
+      validationEnabled,
+    );
+  }
+}
+
 function testAnsibleSyntaxCheckNoErrors(
   context: WorkspaceFolderContext | undefined,
   validationManager: ValidationManager,
@@ -405,6 +442,62 @@ describe("doValidate()", () => {
           });
 
           testAnsibleLintErrors(context, validationManager, textDoc, true);
+        });
+
+        describe("Syntax-check errors in ansible-lint", () => {
+          fixtureFilePath =
+            "diagnostics/syntax_check_errors_in_ansible_lint.yml";
+          fixtureFileUri = resolveDocUri(fixtureFilePath);
+          context = workspaceManager.getContext(fixtureFileUri);
+
+          textDoc = getDoc(fixtureFilePath);
+          expect(context).is.not.undefined;
+          if (context) {
+            docSettings = context.documentSettings.get(textDoc.uri);
+
+            describe("With EE enabled @ee", () => {
+              before(async () => {
+                (await docSettings).validation.lint.enabled = false;
+                setFixtureAnsibleCollectionPathEnv(
+                  "/home/runner/.ansible/collections:/usr/share/ansible",
+                );
+                await enableExecutionEnvironmentSettings(docSettings);
+              });
+
+              testAnsibleSyntaxCheckErrorsInAnsibleLint(
+                context,
+                validationManager,
+                textDoc,
+                true,
+              );
+
+              after(async () => {
+                (await docSettings).validation.lint.enabled = true;
+                setFixtureAnsibleCollectionPathEnv();
+                await disableExecutionEnvironmentSettings(docSettings);
+              });
+            });
+
+            describe("With EE disabled", () => {
+              before(async () => {
+                (await docSettings).validation.lint.enabled = false;
+                setFixtureAnsibleCollectionPathEnv();
+                await disableExecutionEnvironmentSettings(docSettings);
+              });
+
+              testAnsibleSyntaxCheckErrorsInAnsibleLint(
+                context,
+                validationManager,
+                textDoc,
+                true,
+              );
+            });
+            after(async () => {
+              (await docSettings).validation.lint.enabled = true;
+              setFixtureAnsibleCollectionPathEnv();
+              await disableExecutionEnvironmentSettings(docSettings);
+            });
+          }
         });
       });
 


### PR DESCRIPTION
The PR will:
1. add a fix to handle syntax-check errors reported by ansible-lint. There was a discrepancy because of the codeclimate format out format parsing in the extension.
2. add a test for the same.

Fixes: #986.