### PR TITLE
Make the 'upgrade status' key in ansible-lint metadata consistent

### DIFF
--- a/packages/ansible-language-server/src/utils/getAnsibleMetaData.ts
+++ b/packages/ansible-language-server/src/utils/getAnsibleMetaData.ts
@@ -188,7 +188,7 @@ async function getAnsibleLintInfo() {
   if (ansibleLintVersionStdout.length >= 2) {
     ansibleLintInfo["upgrade status"] = ansibleLintVersionStdout[1];
   } else {
-    ansibleLintInfo["upgrade status"] = "nill";
+    ansibleLintInfo["upgrade status"] = "nil";
   }
 
   ansibleLintInfo["version"] =

--- a/packages/ansible-language-server/src/utils/getAnsibleMetaData.ts
+++ b/packages/ansible-language-server/src/utils/getAnsibleMetaData.ts
@@ -187,6 +187,8 @@ async function getAnsibleLintInfo() {
   const ansibleLintVersion = ansibleLintVersionStdout[0];
   if (ansibleLintVersionStdout.length >= 2) {
     ansibleLintInfo["upgrade status"] = ansibleLintVersionStdout[1];
+  } else {
+    ansibleLintInfo["upgrade status"] = "nill";
   }
 
   ansibleLintInfo["version"] =


### PR DESCRIPTION
The PR will make the `upgrade status` key in ansible-lint metadata shown in the extension status bar consistent. As a result, this will also fix the flaky MacOS unit test for `getAnsibleMedata()`.