### PR TITLE
Improve auto-assignment of `ansible` language to files

### DIFF
--- a/package.json
+++ b/package.json
@@ -709,6 +709,7 @@
           "site.yml",
           "site.yaml"
         ],
+        "firstLine": "# code: language=ansible",
         "configuration": "./ansible-language-configuration.json"
       },
       {

--- a/package.json
+++ b/package.json
@@ -701,7 +701,9 @@
           "**/playbooks/*.yml",
           "**/playbooks/*.yaml",
           "**/*playbook*.yml",
-          "**/*playbook*.yaml"
+          "**/*playbook*.yaml",
+          "**/roles/**/main.yml",
+          "**/roles/**/main.yaml"
         ],
         "filenames": [
           "site.yml",


### PR DESCRIPTION
The PR:
1. adds the ability to assign `ansible` language to `main.yml` files inside roles. (Fixes: [AAP-23425](https://issues.redhat.com/browse/AAP-23425)).
2. adds the ability to assign `ansible` language based on `modelines` present in the files.