### PR TITLE
Enable Lightspeed inline suggestion in untitled editor tabs

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -196,12 +196,14 @@ export async function activate(context: ExtensionContext): Promise<void> {
   );
 
   const lightSpeedSuggestionProvider = new LightSpeedInlineSuggestionProvider();
-  context.subscriptions.push(
-    vscode.languages.registerInlineCompletionItemProvider(
-      { scheme: "file", language: "ansible" },
-      lightSpeedSuggestionProvider,
-    ),
-  );
+  ["file", "untitled"].forEach((scheme) => {
+    context.subscriptions.push(
+      vscode.languages.registerInlineCompletionItemProvider(
+        { scheme, language: "ansible" },
+        lightSpeedSuggestionProvider,
+      ),
+    );
+  });
 
   context.subscriptions.push(
     vscode.commands.registerTextEditorCommand(


### PR DESCRIPTION
Enable Lightspeed inline suggestion in untitled editor tabs when their language is set to Ansible.

Because Playbook Generation feature opens an untitled editor tab with the generated playbook, it is likely some users will add tasks to the generated playbook before saving it to a file. We should be prepared for that scenario. 