### PR TITLE
AAP-24192: Action field in Recommendation events have a blank/null value

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -41,8 +41,8 @@ import {
   inlineSuggestionTextDocumentChangeHandler,
   inlineSuggestionTriggerHandler,
   LightSpeedInlineSuggestionProvider,
-  rejectPendingSuggestion,
   setDocumentChanged,
+  processInProgessSuggestion,
 } from "./features/lightspeed/inlineSuggestions";
 import { playbookExplanation } from "./features/lightspeed/playbookExplanation";
 import { ContentMatchesWebview } from "./features/lightspeed/contentMatchesWebview";
@@ -260,7 +260,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
   // Listen for text selection changes
   context.subscriptions.push(
     vscode.window.onDidChangeTextEditorSelection(async () => {
-      rejectPendingSuggestion();
+      processInProgessSuggestion();
     }),
   );
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -42,7 +42,7 @@ import {
   inlineSuggestionTriggerHandler,
   LightSpeedInlineSuggestionProvider,
   setDocumentChanged,
-  processInProgessSuggestion,
+  processInProgressSuggestion,
 } from "./features/lightspeed/inlineSuggestions";
 import { playbookExplanation } from "./features/lightspeed/playbookExplanation";
 import { ContentMatchesWebview } from "./features/lightspeed/contentMatchesWebview";
@@ -260,7 +260,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
   // Listen for text selection changes
   context.subscriptions.push(
     vscode.window.onDidChangeTextEditorSelection(async () => {
-      processInProgessSuggestion();
+      processInProgressSuggestion();
     }),
   );
 

--- a/src/features/lightspeed/inlineSuggestions.ts
+++ b/src/features/lightspeed/inlineSuggestions.ts
@@ -877,7 +877,7 @@ export async function inlineSuggestionCommitHandler() {
   vscode.commands.executeCommand("editor.action.inlineSuggest.commit");
 
   // If the suggestion does not seem to be ours, exit early.
-  if (!inlineSuggestionData["suggestionId"]) {
+  if (!isPredictionInProgress()) {
     return;
   }
 
@@ -952,7 +952,7 @@ function inlineSuggestionPending(checkActiveTextEditor = true): boolean {
       return false;
     }
   }
-  if (!inlineSuggestionData["suggestionId"]) {
+  if (!isPredictionInProgress()) {
     return false;
   }
   return true;
@@ -963,8 +963,15 @@ function resetSuggestionData(): void {
   insertTexts = [];
 }
 
+function isPredictionInProgress(): boolean {
+  return "suggestionId" in inlineSuggestionData;
+}
+
 export async function rejectPendingSuggestion() {
-  if (suggestionDisplayed.get() && lightSpeedManager.inlineSuggestionsEnabled) {
+  if (
+    (suggestionDisplayed.get() || isPredictionInProgress()) &&
+    lightSpeedManager.inlineSuggestionsEnabled
+  ) {
     if (inlineSuggestionPending()) {
       console.log(
         "[inline-suggestions] Send a REJECTED feedback for a pending suggestion.",

--- a/src/features/lightspeed/inlineSuggestions.ts
+++ b/src/features/lightspeed/inlineSuggestions.ts
@@ -174,7 +174,7 @@ function getCompletionState(
 
   // If users continue to without pressing configured keys to
   // either accept or reject the suggestion, we will consider it as ignored.
-  if (inlinesuggestionDisplayed() && !positionHasChanged) {
+  if (isInlineSuggestionDisplayed() && !positionHasChanged) {
     /* The following approach is implemented to address a specific issue related to the
      * behavior of inline suggestion in the 'automated' trigger scenario:
      *
@@ -193,7 +193,7 @@ function getCompletionState(
     return CompletionState.CacheSuggestion;
   }
 
-  if (inlinesuggestionDisplayed()) {
+  if (isInlineSuggestionDisplayed()) {
     return CompletionState.RefusedSuggestion;
   }
 
@@ -877,7 +877,7 @@ export async function inlineSuggestionCommitHandler() {
   vscode.commands.executeCommand("editor.action.inlineSuggest.commit");
 
   // If the suggestion does not seem to be ours, exit early.
-  if (!inlineSuggestionInProgess()) {
+  if (!isInlineSuggestionInProgress()) {
     return;
   }
 
@@ -953,15 +953,15 @@ function checkSameEditor(): boolean {
   return true;
 }
 
-function inlinesuggestionDisplayed(): boolean {
+function isInlineSuggestionDisplayed(): boolean {
   return suggestionDisplayed.get();
 }
 
-function inlineSuggestionPending(): boolean {
-  return inlineSuggestionInProgess() && inlinesuggestionDisplayed();
+function isInlineSuggestionPending(): boolean {
+  return isInlineSuggestionInProgress() && isInlineSuggestionDisplayed();
 }
 
-function inlineSuggestionInProgess(): boolean {
+function isInlineSuggestionInProgress(): boolean {
   return (
     lightSpeedManager.inlineSuggestionsEnabled &&
     "suggestionId" in inlineSuggestionData
@@ -973,8 +973,8 @@ function resetSuggestionData(): void {
   insertTexts = [];
 }
 
-export async function processInProgessSuggestion() {
-  if (inlinesuggestionDisplayed()) {
+export async function processInProgressSuggestion() {
+  if (isInlineSuggestionDisplayed()) {
     rejectPendingSuggestion();
   } else {
     ignoreInProgressSuggestion();
@@ -982,7 +982,7 @@ export async function processInProgessSuggestion() {
 }
 
 async function rejectPendingSuggestion() {
-  if (inlineSuggestionPending() && checkSameEditor()) {
+  if (isInlineSuggestionPending() && checkSameEditor()) {
     console.log(
       "[inline-suggestions] Send a REJECTED feedback for a pending suggestion.",
     );
@@ -993,7 +993,7 @@ async function rejectPendingSuggestion() {
 }
 
 export async function ignorePendingSuggestion() {
-  if (inlineSuggestionPending()) {
+  if (isInlineSuggestionPending()) {
     console.log(
       "[inline-suggestions] Send a IGNORED feedback for a pending suggestion.",
     );
@@ -1003,8 +1003,8 @@ export async function ignorePendingSuggestion() {
   }
 }
 
-export async function ignoreInProgressSuggestion() {
-  if (checkSameEditor() && inlineSuggestionInProgess()) {
+async function ignoreInProgressSuggestion() {
+  if (checkSameEditor() && isInlineSuggestionInProgress()) {
     console.log(
       "[inline-suggestions] Send a IGNORED feedback for a pending suggestion.",
     );
@@ -1032,9 +1032,8 @@ export async function inlineSuggestionTextDocumentChangeHandler(
   // suggestion was found. If such a change was detected, we assume that the user accepted
   // the suggestion on the widget.
   if (
-    lightSpeedManager.inlineSuggestionsEnabled &&
+    isInlineSuggestionInProgress() &&
     checkSameEditor() &&
-    inlineSuggestionInProgess() &&
     insertTexts &&
     e.document.languageId === "ansible" &&
     e.contentChanges.length > 0

--- a/test/testScripts/lightspeed/testLightspeed.test.ts
+++ b/test/testScripts/lightspeed/testLightspeed.test.ts
@@ -340,7 +340,7 @@ export function testLightspeed(): void {
       });
 
       tests.forEach(({ taskName, expectedModule }) => {
-        it(`Should not return an inline feedback '${taskName}'`, async function () {
+        it(`Should return an inline feedback '${taskName}'`, async function () {
           await testInlineSuggestion(
             // with the mock lightspeed server, adding "status=nnn" to prompt will
             // return the specified status code in the response
@@ -354,7 +354,7 @@ export function testLightspeed(): void {
           const completionRequestApiCalls = completionRequestSpy.getCalls();
           assert.equal(completionRequestApiCalls.length, 1);
           const feedbackRequestApiCalls = feedbackRequestSpy.getCalls();
-          assert.equal(feedbackRequestApiCalls.length, 0);
+          assert.equal(feedbackRequestApiCalls.length, 1);
         });
       });
 


### PR DESCRIPTION
Hey @robinbobbitt @TamiTakamiya 

See https://issues.redhat.com/browse/AAP-24192

**Goal**

The goal is to guarantee the correlation between `completion`/`Recommendation Generated` events, along with the `inlineSuggestionFeeadback`/`Recommendation Action` ones, from the VSCode (client) perspective. It means this fix applies to both `schema1` and `schema2` (although "seated" users actually don't send schema1 feedback events ...) 

**Steps to reproduce**

The actual vscode plugin behavior works as:
1- User writes a prompt and press Enter, so a completion request starts
2- Meanwhile the completion request is in progress (so suggestion not yet displayed to the user), if f.i. a WHITESPACE key is pressed, it does not send any feedback event. But completion event has been already sent.
3- But once pressing the BACKSPACE key (before completion req. above is in progress), the cursor is back to the original position, and another completion request is started, so another completion event is sent, which may end with some suggestion displayed, and the user accepting/rejecting/igrnoing the suggestion (feedback event)
4- Instead of step 3, the user, while the completion request above is in progress, can also press another key again, so the iteration starts again


**Solution**

Assuming once a completion is in progress, and the user press some other key that may cause completion to abort, at least send a IGNORED feedback event for each. This solution may result in an increase of the number of feedback events, but at least guarantees that once a copmletion req. (so event as well) is in progress, it send an IGNORED event once the user does something that "cancels" current completion

I understand I am changing the actual "desired" behavior , as some tests where not expecting that, so feel free to let me know your concerns or feedback please, or if I miss something. :)


Thanks!
