### PR TITLE
lightspeed: rename SentimentEvent to SentimentFeedbackEvent

### DIFF
--- a/src/interfaces/lightspeed.ts
+++ b/src/interfaces/lightspeed.ts
@@ -53,7 +53,7 @@ export interface InlineSuggestionEvent {
   activityId?: string;
 }
 
-export interface SentimentEvent {
+export interface SentimentFeedbackEvent {
   value: number;
   feedback: string;
 }
@@ -79,7 +79,7 @@ export interface PlaybookFeedbackEvent {
 
 export interface FeedbackRequestParams {
   inlineSuggestion?: InlineSuggestionEvent;
-  sentimentFeedback?: SentimentEvent;
+  sentimentFeedback?: SentimentFeedbackEvent;
   suggestionQualityFeedback?: SuggestionQualityEvent;
   issueFeedback?: IssueFeedbackEvent;
   playbookExplanationFeedback?: PlaybookFeedbackEvent;


### PR DESCRIPTION
This to be consistent with the other Event interfaces.
When they are triggered by a user action, the name finishes with `FeedbackEvent`
