### PR TITLE
Playbook Generation wizardId support

### DIFF
--- a/packages/ansible-language-server/src/ansibleLanguageService.ts
+++ b/packages/ansible-language-server/src/ansibleLanguageService.ts
@@ -399,6 +399,7 @@ export class AnsibleLanguageService {
         const createOutline: boolean = params["createOutline"];
         const outline: string | undefined = params["outline"];
         const generationId: string = params["generationId"];
+        const wizardId: string | undefined = params["wizardId"];
 
         const headers = {
           "Content-Type": "application/json",
@@ -416,6 +417,7 @@ export class AnsibleLanguageService {
             createOutline,
             outline,
             generationId,
+            wizardId,
           })
           .then((response) => {
             return response.data;

--- a/src/features/lightspeed/playbookGeneration.ts
+++ b/src/features/lightspeed/playbookGeneration.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode";
+import { v4 as uuidv4 } from "uuid";
 import { LanguageClient } from "vscode-languageclient/node";
 import { Webview, Uri, WebviewPanel } from "vscode";
 import { getNonce } from "../utils/getNonce";
@@ -10,6 +11,7 @@ import { GenerationResponse } from "@ansible/ansible-language-server/src/interfa
 import { LightSpeedCommands } from "../../definitions/lightspeed";
 
 let currentPanel: WebviewPanel | undefined;
+let wizardId: string | undefined;
 
 async function openNewPlaybookEditor(playbook: string) {
   const options = {
@@ -71,6 +73,7 @@ async function generatePlaybook(
       outline,
       createOutline,
       generationId,
+      wizardId,
     },
   );
   return playbook;
@@ -109,8 +112,12 @@ export async function showPlaybookGenerationPage(
     },
   );
 
-  panel.onDidDispose(() => (currentPanel = undefined));
+  panel.onDidDispose(() => {
+    currentPanel = undefined;
+    wizardId = undefined;
+  });
   currentPanel = panel;
+  wizardId = uuidv4();
 
   panel.webview.onDidReceiveMessage(async (message) => {
     const command = message.command;
@@ -172,6 +179,7 @@ export async function showPlaybookGenerationPage(
           } catch (e: any) {
             panel.webview.postMessage({ command: "exception" });
             vscode.window.showErrorMessage(e.message);
+            break;
           }
         }
 

--- a/src/webview/apps/lightspeed/playbookGeneration/main.ts
+++ b/src/webview/apps/lightspeed/playbookGeneration/main.ts
@@ -72,7 +72,6 @@ window.addEventListener("message", async (event) => {
 
   switch (message.command) {
     case "init": {
-      generationId = uuidv4();
       textArea.focus();
       break;
     }
@@ -151,10 +150,12 @@ function hideBlockElement(id: string) {
 }
 
 async function submitInput() {
+  // If the saved text is not the current one, clear saved values and assign a new generationId
   if (savedText !== textArea.value) {
     savedText = textArea.value;
     outline.update("");
     savedPlaybook = undefined;
+    generationId = uuidv4();
   }
 
   changeDisplay("spinnerContainer", "block");
@@ -188,10 +189,11 @@ async function generateCode() {
   const text = savedText;
   let playbook: string | undefined;
 
-  // If user did not make any changes to the generated outline, use the saved playbook
-  // installed of calling the generations API again.
+  // If user made any changes to the generated outline, save the edited outline and
+  // generate a new generationId.  Otherwise, just use the generated playbook.
   if (outline.isChanged()) {
     outline.save();
+    generationId = uuidv4();
   } else {
     playbook = savedPlaybook;
   }

--- a/test/mockLightspeedServer/generations.ts
+++ b/test/mockLightspeedServer/generations.ts
@@ -9,8 +9,10 @@ export function generations(
 ) {
   const createOutline = req.body.createOutline;
   const generationId = req.body.generationId ? req.body.generationId : uuidv4();
+  const wizardId = req.body.wizardId;
   logger.info(req.body.text);
   logger.info(req.body.outline);
+  logger.info(`wizardId: ${wizardId}`);
 
   // cSpell: disable
   let outline: string | undefined = `Name: "Create an azure network..."

--- a/test/ui-test/lightspeedUiTest.ts
+++ b/test/ui-test/lightspeedUiTest.ts
@@ -590,7 +590,7 @@ export function lightspeedUIAssetsTest(): void {
       const notification = notifications[0];
       expect(await notification.getMessage()).equals(
         "Enable lightspeed services from settings to use the feature.",
-      ).to.be.true;
+      );
     });
   });
 }


### PR DESCRIPTION
Support wizardId for Playbook Generation feature to provide a unique identifier that belong to a specific Playbook Generation UI session.  

This also changed the behavior of generationId, which was re-used for multiple the generations API calls from a single Playbook Generation UI session, not to be re-used, i.e. always a unique ID will be provided for each generations API call.