### PR TITLE
Playbook Explanation Thumbs button visibility issue

### DIFF
--- a/media/playbookGeneration/style.css
+++ b/media/playbookGeneration/style.css
@@ -165,10 +165,12 @@ a:active {
 }
 
 .feedbackContainer {
+  background-color: var(--vscode-editor-background, #ffffff80);
   position: absolute;
   right: 0px;
   bottom: 0px;
   display: flex;
+  opacity: 0.8;
 }
 
 .generatePlaybookContainer {
@@ -238,6 +240,7 @@ a:active {
   background: var(--button-icon-background);
   border-radius: var(--button-icon-corner-radius);
   color: var(--foreground);
+  opacity: 1.0;
 }
 
 .iconButtonSelected {
@@ -246,6 +249,7 @@ a:active {
   margin: 0.2em;
   background: var(--button-primary-background);
   color: var(--button-primary-foreground);
+  opacity: 1.0;
 }
 
 .outlineContainer {


### PR DESCRIPTION
Improve the visibility of Thumbs Up/Down buttons on the playbook explanation panel when the explanation text overwraps the button.

**Without this PR:**
![image](https://github.com/ansible/vscode-ansible/assets/27698807/89993c6f-3549-40a9-969a-846e062f2681)
![image](https://github.com/ansible/vscode-ansible/assets/27698807/704adc2a-4ee5-489e-9355-b2fbd7d82ce5)

**With this PR:**
![image](https://github.com/ansible/vscode-ansible/assets/27698807/b9c02bcf-e35e-4ec1-b21d-e0aad2ebf1dd)
![image](https://github.com/ansible/vscode-ansible/assets/27698807/aa952360-212a-400c-8308-74d683f2857a)
