### PR TITLE
Fix "not under rootDir" issue in webpack

### DIFF
--- a/test/ui-test/lightspeedUiTest.ts
+++ b/test/ui-test/lightspeedUiTest.ts
@@ -198,7 +198,7 @@ export function lightspeedUIAssetsTest(): void {
         ).to.be.true;
         await submitButton.click();
         await new Promise((res) => {
-          setTimeout(res, 1000);
+          setTimeout(res, 2000);
         });
 
         // Verify outline output and text edit

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -28,7 +28,7 @@ const config = {
     rules: [
       {
         test: /\.ts$/,
-        exclude: /node_modules/,
+        exclude: [/node_modules/, /packages/],
         use: [
           {
             // configure TypeScript loader:
@@ -37,6 +37,7 @@ const config = {
             loader: "ts-loader",
             options: {
               compilerOptions: {
+                configFile: "./tsconfig.json",
                 sourceMap: true,
               },
             },
@@ -45,6 +46,25 @@ const config = {
         parser: {
           commonjsMagicComments: true, // enable magic comments support for CommonJS
         },
+      },
+      {
+        test: /\.ts$/,
+        exclude: /node_modules/,
+        include: /packages/,
+        use: [
+          {
+            // configure TypeScript loader:
+            // * enable sources maps for end-to-end source maps
+            // * does not work for server code
+            loader: "ts-loader",
+            options: {
+              compilerOptions: {
+                configFile: "./packages/ansible-language-server/tsconfig.json",
+                sourceMap: true,
+              },
+            },
+          },
+        ],
       },
     ],
   },


### PR DESCRIPTION
After #1346 is merged, we started seeing errors like folowing during `yarn webpack`:
```
ERROR in /Users/runner/work/vscode-ansible/vscode-ansible/packages/ansible-language-server/tsconfig.json
  /Users/runner/work/vscode-ansible/vscode-ansible/packages/ansible-language-server/tsconfig.json
  [tsl] ERROR
        TS6059: File '/Users/runner/work/vscode-ansible/vscode-ansible/src/features/utils/syntaxHighlighter.ts' is not under 'rootDir' '/Users/runner/work/vscode-ansible/vscode-ansible/packages/ansible-language-server'. 'rootDir' is expected to contain all source files.
    The file is in the program because:
      Root file specified for compilation
```
The error message suggests the `tsconfig.json` for ALS is used for compiling non-ALS file. This PR is for specifying a correct `tsconfig.json` file for each source file by looking at file path.


