### PR TITLE
Support content match for playbooks w/o tasks

### DIFF
--- a/src/features/lightspeed/contentMatchesWebview.ts
+++ b/src/features/lightspeed/contentMatchesWebview.ts
@@ -13,6 +13,7 @@ import {
 import { getCurrentUTCDateTime } from "../utils/dateTime";
 import * as yaml from "yaml";
 import { LightspeedUser } from "./lightspeedUser";
+import { parsePlays } from "./utils/parsePlays";
 
 export class ContentMatchesWebview implements vscode.WebviewViewProvider {
   public static readonly viewType = "ansible.lightspeed.trainingMatchPanel";
@@ -224,18 +225,8 @@ export class ContentMatchesWebview implements vscode.WebviewViewProvider {
       return noContentMatchesFoundHtml;
     }
     if (isPlaybook) {
-      if (
-        !suggestedTasks ||
-        !Array.isArray(suggestedTasks) ||
-        suggestedTasks.length === 0
-      ) {
-        return noContentMatchesFoundHtml;
-      }
-      let tasks = suggestedTasks[0].tasks;
-      for (let i = 1; i < suggestedTasks.length; i++) {
-        tasks = tasks.concat(suggestedTasks[i].tasks);
-      }
-      suggestedTasks = tasks;
+      // Note: When isPlaybook is True, suggestedTasks contains plays in a playbook instead of tasks.
+      suggestedTasks = parsePlays(suggestedTasks);
     }
     if (
       !suggestedTasks ||

--- a/src/features/lightspeed/utils/parsePlays.ts
+++ b/src/features/lightspeed/utils/parsePlays.ts
@@ -1,0 +1,19 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function parsePlays(plays: any[]): any[] {
+  if (!plays || !Array.isArray(plays) || plays.length === 0) {
+    return [];
+  }
+  let tasks: string[] = [];
+  for (let i = 0; i < plays.length; i++) {
+    const play = plays[i];
+    const tasksInAPlay = play.tasks;
+    if (tasksInAPlay) {
+      tasks = tasks.concat(tasksInAPlay);
+    } else {
+      // If tasks are not found in the play,
+      // add the play itself to the tasks list
+      tasks.push(play);
+    }
+  }
+  return tasks;
+}

--- a/test/units/lightspeed/parsePlays.test.ts
+++ b/test/units/lightspeed/parsePlays.test.ts
@@ -1,0 +1,70 @@
+import assert from "assert";
+import * as yaml from "yaml";
+import { parsePlays } from "../../../src/features/lightspeed/utils/parsePlays";
+
+function parseYaml(yamlString: string) {
+  return yaml.parse(yamlString, {
+    keepSourceTokens: true,
+  });
+}
+
+describe("Test parsePlays", () => {
+  it("Test a playbook with tasks", () => {
+    const PLAYBOOK = `---
+- name: Test 1
+  hosts: all
+  tasks:
+    - name: Task 1
+      ansible.builtin.debug:
+        msg: Task 1
+    - name: Task 2
+      ansible.builtin.debug:
+        msg: Task 2
+`;
+    const out = parsePlays(parseYaml(PLAYBOOK));
+    assert.ok(out);
+    assert.equal(out.length, 2);
+    assert.equal(out[0].name, "Task 1");
+    assert.equal(out[1].name, "Task 2");
+  });
+
+  it("Test a playbook without tasks", () => {
+    const PLAYBOOK = `---
+- name: Test 2
+  hosts: all
+  roles:
+    - my_role
+`;
+    const out = parsePlays(parseYaml(PLAYBOOK));
+    assert.ok(out);
+    assert.equal(out.length, 1);
+    assert.equal(out[0].name, "Test 2");
+  });
+
+  it("Test a playbook with multiple plays", () => {
+    const PLAYBOOK = `---
+- name: Test 3-1
+  hosts: all
+  roles:
+    - my_role
+- name: Test 3-2
+  hosts: all
+  tasks:
+    - name: Task 1
+      ansible.builtin.debug:
+        msg: Task 1
+    - ansible.builtin.debug: # task w/o name
+        msg: Task 2b
+- hosts: localhost # play w/o name
+  roles:
+    - my_role_2
+`;
+    const out = parsePlays(parseYaml(PLAYBOOK));
+    assert.ok(out);
+    assert.equal(out.length, 4);
+    assert.equal(out[0].name, "Test 3-1");
+    assert.equal(out[1].name, "Task 1");
+    assert.equal(out[2].name, undefined);
+    assert.equal(out[3].name, undefined);
+  });
+});


### PR DESCRIPTION
When a playbook is given to WCA codematch API, it tries to find tasks defined in each play.  If no tasks are found, API attempts to find matching sources for the play itself. 

Currently VS Code extension assumes tasks are always found in a playbook. We need to update VS Code extension to be consistent with the WCA codematch API.