### PR TITLE
Upload als test code coverage data

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -294,6 +294,22 @@ jobs:
           fail_ci_if_error: true
           use_oidc: true # cspell:ignore oidc
 
+      - name: Convert coverage data (als)
+        if: contains(matrix.task-name-als, 'test') || contains(matrix.task-name, 'als:test')
+        run: |
+          ./tools/convert-als-coverage-lcov.sh
+
+      - name: Upload coverage data (als)
+        if: contains(matrix.task-name-als, 'test') || contains(matrix.task-name, 'als:test')
+        uses: codecov/codecov-action@v4
+        with:
+          name: ${{ matrix.name }}
+          files: out/coverage/als/lcov.info
+          disable_search: true
+          flags: als
+          fail_ci_if_error: true
+          use_oidc: true # cspell:ignore oidc
+
       - name: Upload vsix artifact
         if: ${{ matrix.name == 'test' }}
         uses: actions/upload-artifact@v4

--- a/packages/ansible-language-server/package.json
+++ b/packages/ansible-language-server/package.json
@@ -85,8 +85,8 @@
     "prepare": "yarn run compile",
     "watch": "tsc --watch -p .",
     "test": "nyc -s -a mocha && nyc report --check-coverage",
-    "test-with-ee": "nyc -s -a mocha --grep @ee && nyc report --check-coverage",
-    "test-without-ee": "nyc -s -a mocha --grep @ee --invert && nyc report --check-coverage"
+    "test-with-ee": "nyc -s -a mocha --grep @ee && nyc report --check-coverage && yarn coverage",
+    "test-without-ee": "nyc -s -a mocha --grep @ee --invert && nyc report --check-coverage && yarn coverage"
   },
   "all": true
 }

--- a/tools/convert-als-coverage-lcov.sh
+++ b/tools/convert-als-coverage-lcov.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+mkdir -p out/coverage/als
+sed -E -e 's#SF:src/#SF:packages/ansible-language-server/src/#' \
+  packages/ansible-language-server/out/coverage.lcov \
+  > out/coverage/als/lcov.info


### PR DESCRIPTION
In addition to unit, e2e and ui-test code coverage data, upload ansible-language-server test code coverage data to codecov.