### PR TITLE
Playbook Generation UI editable list edge cases

### DIFF
--- a/src/webview/apps/common/editableList.ts
+++ b/src/webview/apps/common/editableList.ts
@@ -103,7 +103,13 @@ export class EditableList {
 
   static stringToList(str: string): string[] {
     const values: string[] = [];
-    const re = /\d+\.\s*(.+)/;
+    // Even when no data was found in the input, add an empty entry so that user
+    // can edit the list.
+    if (!str) {
+      return [""];
+    }
+    str = str.trim();
+    const re = /\d+\.\s*(.*)/;
     for (let s of str.split("\n")) {
       s = s.trim();
       if (s) {

--- a/test/units/lightspeed/editableList.test.ts
+++ b/test/units/lightspeed/editableList.test.ts
@@ -32,6 +32,16 @@ describe("Test EditableList", () => {
     assert.equal(out[2], SAMPLE_LIST[2]);
   });
 
+  it("Test stringToList edge cases", () => {
+    const out1 = EditableList.stringToList("1.");
+    assert.equal(out1.length, 1);
+    assert.equal(out1[0], "");
+
+    const out2 = EditableList.stringToList("");
+    assert.equal(out2.length, 1);
+    assert.equal(out2[0], "");
+  });
+
   it("Test listToString", () => {
     const out = EditableList.listToString(SAMPLE_LIST);
     assert.equal(out, SAMPLE_TEXT);


### PR DESCRIPTION
When `An empty playbook` is given to the Playbook Generation WCA API, it generates an outline with one list item with an empty text, i.e `1.`.  VS Code extension UI now displays it as `1. 1.`, which should be `1.`.

The editable list code should also be able to handle empty outline inputs.  Even when an empty outline is given, it should generate one list item.  If no list item was generated, user cannot add a new outline item. This PR includes a fix for that issue as well.

![image](https://github.com/ansible/vscode-ansible/assets/27698807/ec5d52d9-70d0-4ab4-af99-be3f7c4280c7)
