### PR TITLE
Last lines on Playbook Explanation are hard to read

### DIFF
--- a/media/playbookGeneration/style.css
+++ b/media/playbookGeneration/style.css
@@ -159,6 +159,10 @@ a:active {
   display: flow;
 }
 
+.playbookExplanationSpacer {
+  height: 30px;
+}
+
 .stickyFeedbackContainer {
   position: sticky;
   bottom: 0px;

--- a/src/features/lightspeed/playbookExplanation.ts
+++ b/src/features/lightspeed/playbookExplanation.ts
@@ -184,6 +184,7 @@ export class PlaybookExplanationPanel {
 			<body>
         <div class="playbookGeneration">
           ${htmlSnippet}
+          <div class="playbookExplanationSpacer"></div>
         </div>
         ${showFeedbackBox ? feedbackBoxSnippet : ""}
 


### PR DESCRIPTION
This is the continuation of #1347.

After #1347, the visibility of ThumbsUp/Down icons were improved, but the readability of last lines of playbook explanation has been a problem. This PR inserts a 30-px height div element at the bottom of the explanation and resolve the overlapping issue when the window is scrolled down to the bottom.

![image](https://github.com/ansible/vscode-ansible/assets/27698807/ee45c855-7a13-479f-be92-b4c58219660f)

![image](https://github.com/ansible/vscode-ansible/assets/27698807/2d4d2474-5db4-4cea-a0a9-3856405ce1bd)
