### PR TITLE
Lightspeed Explorer CSS adjustments

### DIFF
--- a/media/lightspeedExplorerView/style.css
+++ b/media/lightspeedExplorerView/style.css
@@ -1,6 +1,19 @@
 #lightspeedExplorerView {
-	margin-left: 10px;
+	color: var(--vscode-foreground);
+	margin-left: 0px;
+	margin-top: 1em;
+	margin-bottom: 1em;
+	line-height: 1.4em;
+	overflow: hidden;
 }
+
+.lightspeedExplorerButton {
+	width: 100%;
+	max-width: 300px;
+	padding: 2px;
+	font-size: var(--vscode-font-size)
+}
+
 .button-container {
 	margin-top: 10px;
 }

--- a/src/features/lightspeed/utils/explorerView.ts
+++ b/src/features/lightspeed/utils/explorerView.ts
@@ -38,7 +38,7 @@ export function getWebviewContentWithLoginForm(
       <form id="playbook-explanation-form">
         <div class="button-container">
           <section class="component-section">
-            <vscode-button id="lightspeed-explorer-connect">Connect</vscode-button>
+            <vscode-button id="lightspeed-explorer-connect" class="lightspeedExplorerButton">Connect</vscode-button>
           </section>
         </div>
         <script type="module" nonce="${nonce}" src="${webviewUri}"></script>
@@ -75,7 +75,7 @@ export function getWebviewContentWithActiveSession(
   const nonce = getNonce();
   const explainForm = `<div class="button-container">
   <form id="playbook-explanation-form">
-    <vscode-button id="lightspeed-explorer-playbook-explanation-submit" ${
+    <vscode-button id="lightspeed-explorer-playbook-explanation-submit" class="lightspeedExplorerButton" ${
       has_playbook_opened
         ? ""
         : "disabled title='The file in the active editor view is not an Ansible playbook' "


### PR DESCRIPTION
Small CSS adjustments to make Lightspeed sidebar section similar to Content Createor section.

## BEFORE
![Screenshot from 2024-06-14 15-51-37](https://github.com/ansible/vscode-ansible/assets/27698807/abde1306-6ea6-4ab5-8ab3-4640ca50d03f)
![Screenshot from 2024-06-14 15-52-34](https://github.com/ansible/vscode-ansible/assets/27698807/cae641b7-6741-4fe6-8335-34c3ab1d137d)
![Screenshot from 2024-06-14 15-54-16](https://github.com/ansible/vscode-ansible/assets/27698807/3708fa73-9fb9-468b-85e8-39dd9ecb38cb)


## AFTER
![Screenshot from 2024-06-14 15-50-10](https://github.com/ansible/vscode-ansible/assets/27698807/eb8fdaef-0f4e-454b-9211-4dd620439500)
![Screenshot from 2024-06-14 15-53-05](https://github.com/ansible/vscode-ansible/assets/27698807/b0ceb63f-9c1b-492e-8d66-b7faba03f99e)
![Screenshot from 2024-06-14 15-54-38](https://github.com/ansible/vscode-ansible/assets/27698807/86a6abec-6c5d-46bf-b3e0-ff6a164a0c47)
