### PR TITLE
Add CLOSE_ACCEPT/CLOSE_CANCEL to generation actions

### DIFF
--- a/src/definitions/lightspeed.ts
+++ b/src/definitions/lightspeed.ts
@@ -26,8 +26,9 @@ export enum ThumbsUpDownAction {
 
 export enum PlaybookGenerationActionType {
   OPEN = 0, // Open wizard
-  CLOSE = 1, // Close wizard
+  CLOSE_CANCEL = 1, // Close wizard without accepting the generated playbook
   TRANSITION = 2, // Page transition
+  CLOSE_ACCEPT = 3, // Close wizard and open the generated playbook in an editor tab
 }
 
 // eslint-disable-next-line @typescript-eslint/no-namespace

--- a/src/features/lightspeed/playbookGeneration.ts
+++ b/src/features/lightspeed/playbookGeneration.ts
@@ -55,7 +55,6 @@ function contentMatch(generationId: string, playbook: string) {
 async function sendActionEvent(
   action: PlaybookGenerationActionType,
   toPage?: number | undefined,
-  openEditor?: boolean,
 ) {
   if (currentPanel && wizardId) {
     const fromPage = currentPage;
@@ -68,7 +67,6 @@ async function sendActionEvent(
             action,
             fromPage,
             toPage,
-            openEditor,
           },
         },
         process.env.TEST_LIGHTSPEED_ACCESS_TOKEN !== undefined,
@@ -146,7 +144,7 @@ export async function showPlaybookGenerationPage(
   );
 
   panel.onDidDispose(async () => {
-    await sendActionEvent(PlaybookGenerationActionType.CLOSE, undefined, false);
+    await sendActionEvent(PlaybookGenerationActionType.CLOSE_CANCEL, undefined);
     currentPanel = undefined;
     wizardId = undefined;
   });
@@ -255,9 +253,8 @@ export async function showPlaybookGenerationPage(
         const { playbook } = message;
         await openNewPlaybookEditor(playbook);
         await sendActionEvent(
-          PlaybookGenerationActionType.CLOSE,
+          PlaybookGenerationActionType.CLOSE_ACCEPT,
           undefined,
-          true,
         );
         // Clear wizardId to suppress another CLOSE event at dispose()
         wizardId = undefined;

--- a/src/interfaces/lightspeed.ts
+++ b/src/interfaces/lightspeed.ts
@@ -87,7 +87,6 @@ export interface PlaybookGenerationActionEvent {
   action: PlaybookGenerationActionType;
   fromPage?: number;
   toPage?: number;
-  openEditor?: boolean;
 }
 
 export interface FeedbackRequestParams {

--- a/test/ui-test/lightspeedUiTest.ts
+++ b/test/ui-test/lightspeedUiTest.ts
@@ -406,7 +406,7 @@ export function lightspeedUIAssetsTest(): void {
           [PlaybookGenerationActionType.TRANSITION, 2, 3],
           [PlaybookGenerationActionType.TRANSITION, 3, 2],
           [PlaybookGenerationActionType.TRANSITION, 2, 3],
-          [PlaybookGenerationActionType.CLOSE, 3, undefined],
+          [PlaybookGenerationActionType.CLOSE_ACCEPT, 3, undefined],
         ];
         const res = await axios.get(
           `${process.env.TEST_LIGHTSPEED_URL}/__debug__/feedbacks`,
@@ -541,7 +541,7 @@ export function lightspeedUIAssetsTest(): void {
           [PlaybookGenerationActionType.OPEN, undefined, 1],
           [PlaybookGenerationActionType.TRANSITION, 1, 2],
           [PlaybookGenerationActionType.TRANSITION, 2, 3],
-          [PlaybookGenerationActionType.CLOSE, 3, undefined],
+          [PlaybookGenerationActionType.CLOSE_ACCEPT, 3, undefined],
         ];
         const res = await axios.get(
           `${process.env.TEST_LIGHTSPEED_URL}/__debug__/feedbacks`,


### PR DESCRIPTION
In the existing code for capturing user actions on Playbook Generation UI, the `openEditor` flag was used to distinguish between acceptance/rejection of generated playbook.  This PR will split the current `CLOSE` action to `CLOSE_ACCEPT` and `CLOSE_CANCEL` actions to simplify the logic.