### PR TITLE
Fix creator folder opening

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "onLanguage:ansible",
     "onLanguage:yaml",
     "onCommand:extension.resync-ansible-inventory",
-    "workspaceContains:tox-ansible.ini"
+    "workspaceContains:tox-ansible.ini",
+    "onWebviewPanel:ansible-content-creator"
   ],
   "badges": [
     {

--- a/src/features/contentCreator/createAnsibleCollectionPage.ts
+++ b/src/features/contentCreator/createAnsibleCollectionPage.ts
@@ -480,9 +480,13 @@ export class CreateAnsibleCollection {
     //   { uri: folderUri },
     // );
 
-    await vscode.commands.executeCommand("vscode.openFolder", folderUri, {
-      forceNewWindow: true,
-    });
+    if (vscode.workspace.workspaceFolders?.length === 0) {
+      vscode.workspace.updateWorkspaceFolders(0, null, { uri: folderUri });
+    } else {
+      await vscode.commands.executeCommand("vscode.openFolder", folderUri, {
+        forceNewWindow: true,
+      });
+    }
 
     // open the galaxy file in the editor
     const galaxyFileUrl = vscode.Uri.joinPath(

--- a/src/features/contentCreator/createAnsibleProjectPage.ts
+++ b/src/features/contentCreator/createAnsibleProjectPage.ts
@@ -397,9 +397,13 @@ export class CreateAnsibleProject {
     // add folder to a new workspace
     // vscode.workspace.updateWorkspaceFolders(0, 1, { uri: folderUri });
 
-    await vscode.commands.executeCommand("vscode.openFolder", folderUri, {
-      forceNewWindow: true,
-    });
+    if (vscode.workspace.workspaceFolders?.length === 0) {
+      vscode.workspace.updateWorkspaceFolders(0, null, { uri: folderUri });
+    } else {
+      await vscode.commands.executeCommand("vscode.openFolder", folderUri, {
+        forceNewWindow: true,
+      });
+    }
 
     // open site.yml file in the editor
     const playbookFileUrl = vscode.Uri.joinPath(


### PR DESCRIPTION
Adds the ability to open the workspace folder after scaffolding is done based on the workspace folder count. This resolves the issue of ansible-creator scaffolding not working when used multiple times.
Fixes: #1217.