### PR TITLE
Playbook explanation for task files and playbooks w/o tasks

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -296,6 +296,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
         lightSpeedManager,
         pythonInterpreterManager,
       );
+      lightSpeedManager.lightspeedExplorerProvider.refreshWebView();
       metaData.sendAnsibleMetadataTelemetry();
     }),
   );

--- a/src/features/lightspeed/explorerWebviewViewProvider.ts
+++ b/src/features/lightspeed/explorerWebviewViewProvider.ts
@@ -15,6 +15,7 @@ import {
 import { LightspeedUser } from "./lightspeedUser";
 
 import { getLoggedInUserDetails } from "./utils/webUtils";
+import { isPlaybook } from "./playbookExplanation";
 
 export class LightspeedExplorerWebviewViewProvider
   implements WebviewViewProvider
@@ -84,11 +85,23 @@ export class LightspeedExplorerWebviewViewProvider
         userName,
         userType,
         userRole,
-        window.activeTextEditor?.document.languageId === "ansible",
+        this.hasPlaybookOpened(),
       );
     } else {
       return getWebviewContentWithLoginForm(webview, extensionUri);
     }
+  }
+
+  private hasPlaybookOpened() {
+    const document = window.activeTextEditor?.document;
+    if (document !== undefined && document.languageId === "ansible") {
+      try {
+        return isPlaybook(document.getText());
+      } catch (error) {
+        return false;
+      }
+    }
+    return false;
   }
 
   private async _setWebviewMessageListener(webview: Webview) {

--- a/test/testFixtures/lightspeed/playbook_5.yml
+++ b/test/testFixtures/lightspeed/playbook_5.yml
@@ -1,0 +1,8 @@
+- name: Manage timesync in PTP domain 0, interface eth0
+  hosts: targets
+  vars:
+    timesync_ptp_domains:
+      - number: 0
+        interfaces: [eth0]
+  roles:
+    - linux-system-roles.timesync

--- a/test/ui-test/lightspeedUiTest.ts
+++ b/test/ui-test/lightspeedUiTest.ts
@@ -720,6 +720,35 @@ export function lightspeedUIAssetsTest(): void {
           setTimeout(res, 2000);
         });
 
+        // Locate the group 1 of editor view. Since the file does not contain the "hosts" property,
+        // the explanation view is not opened in the group 1. Therefore, the group 1 should be
+        // undefined.
+        const group = await new EditorView().getEditorGroup(1);
+        expect(group, "Group 1 of the editor view should be undefined").to.be
+          .undefined;
+
+        await workbench.executeCommand("View: Close All Editor Groups");
+      } else {
+        this.skip();
+      }
+    });
+
+    it("Playbook explanation webview with a playbook with no tasks", async function () {
+      if (process.env.TEST_LIGHTSPEED_URL) {
+        const file = "playbook_5.yml";
+        const filePath = getFilePath(file);
+
+        // Open file in the editor
+        await VSBrowser.instance.openResources(filePath);
+
+        // Open playbook explanation webview.
+        await workbench.executeCommand(
+          "Explain the playbook with Ansible Lightspeed",
+        );
+        await new Promise((res) => {
+          setTimeout(res, 2000);
+        });
+
         // Locate the playbook explanation webview
         const webView = (await new EditorView().openEditor(
           "Explanation",
@@ -740,18 +769,11 @@ export function lightspeedUIAssetsTest(): void {
         const text = await mainDiv.getText();
         expect(
           text.includes(
-            "The requested action is not available in your environment.",
+            "Explaining a playbook with no tasks in the playbook is not supported.",
           ),
         ).to.be.true;
 
         await webView.switchBack();
-
-        const notifications = await workbench.getNotifications();
-        const notification = notifications[0];
-        expect(await notification.getMessage()).equals(
-          "The requested action is not available in your environment.",
-        );
-
         await workbench.executeCommand("View: Close All Editor Groups");
       } else {
         this.skip();


### PR DESCRIPTION
Modifications of the playbook explanation feature for 
1. Task files, and
2. Playbooks that do not contain tasks, for example, playbooks that have roles only

For 1. We do not enable playbook explanation. The "Explain the current playbook" button on the sidebar will be grayed out.

For 2. We will display an informational message: `Explaining a playbook with no tasks in the playbook is not supported.`