### PR TITLE
Include variable values with enhanced context sent from VSCode

### DIFF
--- a/src/features/lightspeed/utils/readVarFiles.ts
+++ b/src/features/lightspeed/utils/readVarFiles.ts
@@ -1,26 +1,6 @@
 import * as fs from "fs";
 import * as yaml from "yaml";
 
-import { IParsedYaml } from "../../../interfaces/yaml";
-
-function removeVarsValues(parsedYaml: IParsedYaml[] | IParsedYaml | "") {
-  if (Array.isArray(parsedYaml)) {
-    for (const item of parsedYaml) {
-      removeVarsValues(item);
-    }
-  } else if (typeof parsedYaml === "object" && parsedYaml !== null) {
-    for (const key in parsedYaml) {
-      if (Object.prototype.hasOwnProperty.call(parsedYaml, key)) {
-        parsedYaml[key] = removeVarsValues(parsedYaml[key]);
-      }
-    }
-  } else {
-    parsedYaml = "";
-  }
-
-  return parsedYaml;
-}
-
 export function readVarFiles(varFile: string): string | undefined {
   try {
     if (!fs.existsSync(varFile)) {
@@ -30,7 +10,6 @@ export function readVarFiles(varFile: string): string | undefined {
     const parsedAnsibleVars = yaml.parse(contents, {
       keepSourceTokens: true,
     });
-    removeVarsValues(parsedAnsibleVars);
     const updatedFileContents = yaml.stringify(parsedAnsibleVars);
     return updatedFileContents;
   } catch (err) {

--- a/test/units/lightspeed/utils/updateRolesContext.ts
+++ b/test/units/lightspeed/utils/updateRolesContext.ts
@@ -130,7 +130,7 @@ describe("testing updateRolesContext", () => {
     assert.equal(tasks && tasks[0], "main");
     assert.equal(Object.keys(defaults).length, 0);
     assert.equal(Object.keys(vars).length, 1);
-    assert.equal(vars["main.yaml"], 'some_var: ""\n');
+    assert.equal(vars["main.yaml"], "some_var: 1\n");
   });
 
   it("with a role where 'vars' is a file, not a directory", () => {


### PR DESCRIPTION
Remove the code that stripped variable values from requests.

Anonymization is performed on the server before submitting to the Model Provider.