### PR TITLE
Action field in Recommendation events have a blank/null value

### DIFF
--- a/src/features/lightspeed/api.ts
+++ b/src/features/lightspeed/api.ts
@@ -150,22 +150,10 @@ export class LightSpeedAPI {
       vscode.window.showErrorMessage(mappedError.message ?? UNKNOWN_ERROR);
       return {} as CompletionResponseParams;
     } finally {
-      if (
-        isCompletionSuccess &&
-        !this.completeSuggestionFeedback(suggestionId)
-      ) {
+      if (isCompletionSuccess && !this.cancelSuggestionFeedback(suggestionId)) {
         await inlineSuggestionHideHandler(UserAction.IGNORED, suggestionId);
       }
     }
-  }
-
-  private completeSuggestionFeedback(suggestionId?: string): boolean {
-    const i = this._suggestionFeedbacks.indexOf(suggestionId || "");
-    if (i > -1) {
-      this._suggestionFeedbacks.splice(i, 1);
-      return true;
-    }
-    return false;
   }
 
   public isSuggestionFeedbackInProgress(): boolean {
@@ -174,6 +162,15 @@ export class LightSpeedAPI {
 
   public cancelSuggestionFeedbackInProgress(): void {
     this._suggestionFeedbacks.shift();
+  }
+
+  public cancelSuggestionFeedback(suggestionId?: string): boolean {
+    const i = this._suggestionFeedbacks.indexOf(suggestionId || "");
+    if (i > -1) {
+      this._suggestionFeedbacks.splice(i, 1);
+      return true;
+    }
+    return false;
   }
 
   public async feedbackRequest(

--- a/src/features/lightspeed/api.ts
+++ b/src/features/lightspeed/api.ts
@@ -14,14 +14,14 @@ import {
   LIGHTSPEED_SUGGESTION_CONTENT_MATCHES_URL,
   LIGHTSPEED_SUGGESTION_COMPLETION_URL,
   LIGHTSPEED_SUGGESTION_FEEDBACK_URL,
-  LightSpeedCommands,
+  UserAction,
 } from "../../definitions/lightspeed";
 import { getBaseUri } from "./utils/webUtils";
 import { ANSIBLE_LIGHTSPEED_API_TIMEOUT } from "../../definitions/constants";
-import { UserAction } from "../../definitions/lightspeed";
 import { IError } from "@ansible/ansible-language-server/src/interfaces/lightspeedApi";
 import { lightSpeedManager } from "../../extension";
 import { LightspeedUser } from "./lightspeedUser";
+import { inlineSuggestionHideHandler } from "./inlineSuggestions";
 
 const UNKNOWN_ERROR: string = "An unknown error occurred.";
 
@@ -45,8 +45,7 @@ export class LightSpeedAPI {
   private axiosInstance: AxiosInstance | undefined;
   private settingsManager: SettingsManager;
   private lightspeedAuthenticatedUser: LightspeedUser;
-  private _completionRequestInProgress: boolean;
-  private _inlineSuggestionFeedbackIgnoredPending: boolean;
+  private _suggestionFeedbacks: string[];
   private _extensionVersion: string;
 
   constructor(
@@ -56,21 +55,8 @@ export class LightSpeedAPI {
   ) {
     this.settingsManager = settingsManager;
     this.lightspeedAuthenticatedUser = lightspeedAuthenticatedUser;
-    this._completionRequestInProgress = false;
-    this._inlineSuggestionFeedbackIgnoredPending = false;
+    this._suggestionFeedbacks = [];
     this._extensionVersion = context.extension.packageJSON.version;
-  }
-
-  get completionRequestInProgress(): boolean {
-    return this._completionRequestInProgress;
-  }
-
-  get inlineSuggestionFeedbackIgnoredPending(): boolean {
-    return this._inlineSuggestionFeedbackIgnoredPending;
-  }
-
-  set inlineSuggestionFeedbackIgnoredPending(newValue: boolean) {
-    this._inlineSuggestionFeedbackIgnoredPending = newValue;
   }
 
   private async getApiInstance(): Promise<AxiosInstance | undefined> {
@@ -114,14 +100,15 @@ export class LightSpeedAPI {
       console.error("Ansible Lightspeed instance is not initialized.");
       return {} as CompletionResponseParams;
     }
+    const suggestionId = inputData.suggestionId;
     console.log(
       `[ansible-lightspeed] Completion request sent to lightspeed: ${JSON.stringify(
         inputData,
       )}`,
     );
+    let isCompletionSuccess = true;
     try {
-      this._completionRequestInProgress = true;
-      this._inlineSuggestionFeedbackIgnoredPending = false;
+      this._suggestionFeedbacks.push(suggestionId || "");
       const requestData = {
         ...inputData,
         metadata: {
@@ -142,7 +129,7 @@ export class LightSpeedAPI {
         // currently we only support one inline suggestion
         !response.data.predictions[0]
       ) {
-        this._inlineSuggestionFeedbackIgnoredPending = false;
+        isCompletionSuccess = false;
         vscode.window.showInformationMessage(
           "Ansible Lightspeed does not have a suggestion for this input. Try changing your prompt, or contact your administrator with Suggestion Id " +
             requestData.suggestionId +
@@ -157,21 +144,36 @@ export class LightSpeedAPI {
       );
       return response.data;
     } catch (error) {
-      this._inlineSuggestionFeedbackIgnoredPending = false;
+      isCompletionSuccess = false;
       const err = error as AxiosError;
       const mappedError: IError = await mapError(err);
       vscode.window.showErrorMessage(mappedError.message ?? UNKNOWN_ERROR);
       return {} as CompletionResponseParams;
     } finally {
-      if (this._inlineSuggestionFeedbackIgnoredPending) {
-        this._inlineSuggestionFeedbackIgnoredPending = false;
-        vscode.commands.executeCommand(
-          LightSpeedCommands.LIGHTSPEED_SUGGESTION_HIDE,
-          UserAction.IGNORED,
-        );
+      if (
+        isCompletionSuccess &&
+        !this.completeSuggestionFeedback(suggestionId)
+      ) {
+        await inlineSuggestionHideHandler(UserAction.IGNORED, suggestionId);
       }
-      this._completionRequestInProgress = false;
     }
+  }
+
+  private completeSuggestionFeedback(suggestionId?: string): boolean {
+    const i = this._suggestionFeedbacks.indexOf(suggestionId || "");
+    if (i > -1) {
+      this._suggestionFeedbacks.splice(i, 1);
+      return true;
+    }
+    return false;
+  }
+
+  public isSuggestionFeedbackInProgress(): boolean {
+    return this._suggestionFeedbacks.length > 0;
+  }
+
+  public cancelSuggestionFeedbackInProgress(): void {
+    this._suggestionFeedbacks.shift();
   }
 
   public async feedbackRequest(

--- a/src/features/lightspeed/inlineSuggestions.ts
+++ b/src/features/lightspeed/inlineSuggestions.ts
@@ -347,7 +347,7 @@ async function requestSuggestion(
       documentInfo,
       inlinePosition,
     );
-    inlineSuggestionData["suggestionId"] = suggestionId;
+    setInProgressSuggestionId(suggestionId);
     inlineSuggestionData["documentUri"] = documentInfo.documentUri;
     inlineSuggestionData["activityId"] = activityId;
 
@@ -371,6 +371,10 @@ async function requestSuggestion(
     lightSpeedManager.statusBarProvider.statusBar.text =
       lightSpeedStatusbarText;
   }
+}
+
+export function setInProgressSuggestionId(suggestionId?: string) {
+  inlineSuggestionData["suggestionId"] = suggestionId;
 }
 
 export function setDocumentChanged(value: boolean) {


### PR DESCRIPTION
See https://issues.redhat.com/browse/AAP-24192

**Description**

The goal is to provide some quick fix some more common use cases, where action feedback is being handled in a wrong way, without a need for a bigger refactoring.

This PR improves the lifecycle of completion / feedback events , by assuming that **several completion requests** can be sent, **before the suggestion is displayed to the user**, this way:
- Guarantees that for each successful (`HTTP 200`) completion request, it will end up on an action feedback event, can be accepted, rejected or ignored
- Guarantees that for failed (non-200) completion requests, no action feedback is sent at all

**Tested use cases**
- Accepting/rejecting a suggestion both by clicking on the buttons (`accept`, `acceptKey`) also by using keys (`Tab`, `Esc`)
- Ignored action feedback sent, before suggestion presented, but user pressed some key (eg: whitespace)
- Ignored action feedback sent, once suggestion presented, but user moved to another window, or lost the focus
- Rejected action feedback sent, once suggestion presented, but user pressed some key (eg: whitespace)
- Tested he fix for the steps to reproduce described in https://issues.redhat.com/browse/AAP-24192

**TODO: Update/add unit tests**