### PR TITLE
Playbook Generation link shown w/ a smaller font

### DIFF
--- a/src/features/playbookGeneration/welcomePage.ts
+++ b/src/features/playbookGeneration/welcomePage.ts
@@ -115,9 +115,9 @@ export class AnsibleCreatorMenu {
             <h2>Create</h2>
             <div class="catalogue">
               <h3>
-                <vscode-link href="command:ansible.lightspeed.playbookGeneration">
+                <a href="command:ansible.lightspeed.playbookGeneration">
                   <span class="codicon codicon-file-code"></span> Playbook with Ansible Lightspeed
-                </vscode-link>
+                </a>
               </h3>
               <p>Create a lists of tasks that automatically execute for your specified inventory or groups of hosts.</p>
             </div>

--- a/test/ui-test/lightspeedUiTest.ts
+++ b/test/ui-test/lightspeedUiTest.ts
@@ -204,7 +204,7 @@ export function lightspeedUIAssetsTest(): void {
 
         const createContentButton = await contentCreatorWebView.findWebElement(
           By.xpath(
-            "//vscode-link[contains(@href,'command:ansible.lightspeed.playbookGeneration')]",
+            "//a[contains(@href,'command:ansible.lightspeed.playbookGeneration')]",
           ),
         );
         expect(createContentButton).not.to.be.undefined;


### PR DESCRIPTION
The Playook Generation link on Ansible content creator page is displayed with a smaller font compared to other links. It is because the link uses the `vscode-link` tag instead of the `a` tag.  This PR is for replacing the `vscode-link` tag with an `a` tag and corresponding changes in a UI test case.