### PR TITLE
Prepare for 24.8 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -982,7 +982,7 @@
     "coverage-all": "TEST_LIGHTSPEED_URL='http://127.0.0.1:3000' yarn _coverage-all",
     "als-compile": "yarn workspace @ansible/ansible-language-server compile"
   },
-  "version": "24.6.0",
+  "version": "24.8.0",
   "packageManager": "yarn@4.1.1",
   "vsce": {
     "dependencies": false,


### PR DESCRIPTION
Prepare for 24.8 (24.8.0) release.

After this release, we will use:

-  `YY.(even month number).n` for statble releases. `n` will be a sequential number, `0`, `1`, `2`, ...
- `YY.(odd month number).nnnnnn` for pre-releases.  The logic to determine the patch version `nnnnnnn` will be implemented later.
