### PR TITLE
Tami takamiya/content creator visibility issue with light color theme

### DIFF
--- a/media/playbookGeneration/playbookGeneration.css
+++ b/media/playbookGeneration/playbookGeneration.css
@@ -33,8 +33,7 @@ a .codicon {
 	display: flex;
 	flex-direction: row;
 	margin-top: 14px;
-	background-color: #023020;
-	border-radius: 4px;
+	background-color: var(--vscode-input-background);
 }
 
 .codicon.codicon-pass {
@@ -47,12 +46,10 @@ a .codicon {
 	display: flex;
 	flex-direction: row;
 	margin-top: 14px;
-	background-color: #023020;
-	background-color: #610000;
-	border-radius: 4px;
+	background-color: var(--vscode-input-background);
 }
 
-.codicon.codicon-error{
+.codicon.codicon-error {
 	margin: 10px;
 	color: red;
 }
@@ -70,8 +67,6 @@ a .codicon {
 
 #install-status {
 	padding: 0px 10px 0px 10px;
-	border-style: dotted;
-	border-color:  var(--vscode-input-background);
 	width: fit-content;
 	background-color: var(--vscode-input-background);
 }
@@ -112,19 +107,19 @@ a .codicon {
 
 .playbookGenerationContainer .title {
 	border: none;
-    font-size: 2.7em;
-    font-weight: 400;
-    color: var(--vscode-foreground);
-    white-space: nowrap;
+	font-size: 2.7em;
+	font-weight: 400;
+	color: var(--vscode-foreground);
+	white-space: nowrap;
 	margin-bottom: 12px;
 }
 
 .playbookGenerationContainer .subtitle {
 	color: var(--vscode-descriptionForeground);
-    line-height: 1.4em;
-    display: block;
-    font-size: 2em;
-    margin: 0px;
+	line-height: 1.4em;
+	display: block;
+	font-size: 2em;
+	margin: 0px;
 }
 
 .monaco-workbench.hc-black .part.editor>.content .playbookGenerationContainer .subtitle,
@@ -152,6 +147,7 @@ a .codicon {
 	margin: 0px;
 	font-weight: normal;
 }
+
 .catalogue p {
 	margin: 0px;
 }
@@ -239,4 +235,11 @@ a .codicon {
 
 .playbookGenerationContainer .playbookGenerationSlideCategories .gap {
 	flex: 150px 0 1000
+}
+
+.statusDisplay {
+	border-color: var(--panel-view-border);
+	border-width: thin;
+	border-style: solid;
+	border-radius: 4px;
 }

--- a/src/features/playbookGeneration/welcomePage.ts
+++ b/src/features/playbookGeneration/welcomePage.ts
@@ -115,9 +115,9 @@ export class AnsibleCreatorMenu {
             <h2>Create</h2>
             <div class="catalogue">
               <h3>
-                <vscode-link href="command:ansible.lightspeed.playbookGeneration">
+                <a href="command:ansible.lightspeed.playbookGeneration">
                   <span class="codicon codicon-file-code"></span> Playbook with Ansible Lightspeed
-                </vscode-link>
+                </a>
               </h3>
               <p>Create a lists of tasks that automatically execute for your specified inventory or groups of hosts.</p>
             </div>

--- a/src/features/playbookGeneration/welcomePage.ts
+++ b/src/features/playbookGeneration/welcomePage.ts
@@ -107,7 +107,7 @@ export class AnsibleCreatorMenu {
           <h1 class="title caption">Welcome to Ansible content creator</h1>
           <p class="subtitle description">Create Ansible content with ease</p>
 
-          <div id="system-readiness"></div>
+          <div id="system-readiness" class="statusDisplay"></div>
 
         </div>
         <div class="categories-column-left">
@@ -182,7 +182,7 @@ export class AnsibleCreatorMenu {
                 <h2>System requirements:</h2>
               </div>
 
-              <div id=install-status></div>
+              <div id=install-status class="statusDisplay"></div>
 
               <div class="refresh-button-div">
                 <vscode-button id="refresh">

--- a/src/webview/apps/contentCreator/welcomePageApp.ts
+++ b/src/webview/apps/contentCreator/welcomePageApp.ts
@@ -79,13 +79,14 @@ function updateAnsibleCreatorAvailabilityStatus() {
         );
 
         if (systemStatus) {
-          if (systemReadinessDiv)
-            systemReadinessDiv.style.backgroundColor = "#023020";
+          // Commented out temporarily for visibility issue with a light color theme
+          // if (systemReadinessDiv)
+          //   systemReadinessDiv.style.backgroundColor = "#023020";
           systemReadinessIcon.innerHTML = `<span class="codicon codicon-pass"></span>`;
           systemReadinessDescription.innerHTML = `<p class="system-description"><b>All the tools are installed</b>.<br>Your environment is ready and you can start creating ansible content.</p>`;
         } else {
-          if (systemReadinessDiv)
-            systemReadinessDiv.style.backgroundColor = "#610000";
+          // if (systemReadinessDiv)
+          //   systemReadinessDiv.style.backgroundColor = "#610000";
           systemReadinessIcon.innerHTML = `<span class="codicon codicon-error"></span>`;
           systemReadinessDescription.innerHTML = `<p class="system-description"><b>Looks like your environment is missing some tools</b>.<br>Follow the description in the 'System requirements' section to set up your environment.</p>`;
         }

--- a/test/ui-test/lightspeedUiTest.ts
+++ b/test/ui-test/lightspeedUiTest.ts
@@ -204,7 +204,7 @@ export function lightspeedUIAssetsTest(): void {
 
         const createContentButton = await contentCreatorWebView.findWebElement(
           By.xpath(
-            "//vscode-link[contains(@href,'command:ansible.lightspeed.playbookGeneration')]",
+            "//a[contains(@href,'command:ansible.lightspeed.playbookGeneration')]",
           ),
         );
         expect(createContentButton).not.to.be.undefined;


### PR DESCRIPTION
An visiblity issue was found on the status div on the new Ansible content creator page when a light color theme was used. This PR is for fixing that issue.  We may want to add more changes (background color for errors, border radius, etc.) later.

## BEFORE
### With a light color theem
![image](https://github.com/ansible/vscode-ansible/assets/27698807/2c8b3195-1b6c-4686-b0cd-c92be865e33e)

### With a dark color theme
![image](https://github.com/ansible/vscode-ansible/assets/27698807/4233d0ab-4ac3-407c-b0df-ca65e5f812e6)

## AFTER
### With a light color theem
![image](https://github.com/ansible/vscode-ansible/assets/27698807/5368a01b-7403-474f-b0a4-1ecd8ea56af9)

### With a dark color theme
![image](https://github.com/ansible/vscode-ansible/assets/27698807/47f37a8d-fc6c-426a-b503-89f73e2089d1)
