### PR TITLE
Lightspeed exp/gen: trigger a timeout after 28s

### DIFF
--- a/packages/ansible-language-server/src/ansibleLanguageService.ts
+++ b/packages/ansible-language-server/src/ansibleLanguageService.ts
@@ -380,10 +380,14 @@ export class AnsibleLanguageService {
         });
 
         const result: ExplanationResponse = await axiosInstance
-          .post("/ai/explanations/", {
-            content: content,
-            explanationId: explanationId,
-          })
+          .post(
+            "/ai/explanations/",
+            {
+              content: content,
+              explanationId: explanationId,
+            },
+            { signal: AbortSignal.timeout(28000) },
+          )
           .then((response) => {
             return response.data;
           })
@@ -421,13 +425,17 @@ export class AnsibleLanguageService {
         });
 
         const result: GenerationResponse = await axiosInstance
-          .post("/ai/generations/", {
-            text,
-            createOutline,
-            outline,
-            generationId,
-            wizardId,
-          })
+          .post(
+            "/ai/generations/",
+            {
+              text,
+              createOutline,
+              outline,
+              generationId,
+              wizardId,
+            },
+            { signal: AbortSignal.timeout(28000) },
+          )
           .then((response) => {
             return response.data;
           })

--- a/packages/ansible-language-server/src/errors.ts
+++ b/packages/ansible-language-server/src/errors.ts
@@ -117,6 +117,10 @@ export const ERRORS_CONNECTION_TIMEOUT = new Error(
   "fallback__connection_timeout",
   "Ansible Lightspeed connection timeout. Please try again later.",
 );
+export const ERRORS_CONNECTION_CANCELED_TIMEOUT = new Error(
+  "",
+  "Ansible Lightspeed connection was canceled because of a timeout. Please try again later.",
+);
 
 ERRORS.addError(
   400,

--- a/packages/ansible-language-server/src/utils/handleApiError.ts
+++ b/packages/ansible-language-server/src/utils/handleApiError.ts
@@ -1,10 +1,13 @@
 import { AxiosError } from "axios";
+import { CanceledError } from "axios";
+
 import {
   ERRORS,
   ERRORS_UNAUTHORIZED,
   ERRORS_TOO_MANY_REQUESTS,
   ERRORS_BAD_REQUEST,
   ERRORS_UNKNOWN,
+  ERRORS_CONNECTION_CANCELED_TIMEOUT,
   ERRORS_CONNECTION_TIMEOUT,
   ERRORS_NOT_FOUND,
 } from "../errors";
@@ -20,6 +23,9 @@ export function mapError(err: AxiosError): IError {
   // If the error is unknown fallback to defaults
   const detail = err.response?.data;
   const status: number | string = err?.response?.status ?? err?.code ?? 500;
+  if (err instanceof CanceledError) {
+    return ERRORS_CONNECTION_CANCELED_TIMEOUT;
+  }
   if (status === 400) {
     return ERRORS_BAD_REQUEST.withDetail(detail);
   }


### PR DESCRIPTION
Give up to 28s for the operation to succeed and cancel the call after that.
28s is below our hard limit of 30s that we have server side.
