### PR TITLE
Remove --readme-path flag from ovsx

### DIFF
--- a/tools/helper
+++ b/tools/helper
@@ -64,7 +64,7 @@ def cli():
             logging.error(msg)
             sys.exit(2)
         run(f"yarn run vsce publish {pre_release_arg} --skip-duplicate --packagePath {vsix_files[0]} --readme-path docs/README.md")
-        run(f"yarn run ovsx publish {pre_release_arg} --skip-duplicate {vsix_files[0]} --readme-path docs/README.md")
+        run(f"yarn run ovsx publish {pre_release_arg} --skip-duplicate {vsix_files[0]}")
         sys.exit()
     if opt.package:
         run("rm -f ./*.vsix")


### PR DESCRIPTION
Remove --readme-path flag from ovsx as it is not supported by ovsx.  With the flag, publish fails with the following error:
````
error: unknown option '--readme-path'
Traceback (most recent call last):
  File "/home/runner/work/vscode-ansible/vscode-ansible/./tools/helper", line 81, in <module>
    cli()
  File "/home/runner/work/vscode-ansible/vscode-ansible/./tools/helper", line 67, in cli
    run(f"yarn run ovsx publish {pre_release_arg} --skip-duplicate {vsix_files[0]} --readme-path docs/README.md")
  File "/home/runner/work/vscode-ansible/vscode-ansible/./tools/helper", line 12, in run
    return subprocess.run(cmd, shell=True, check=True)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.12.4/x64/lib/python3.12/subprocess.py", line 571, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command 'yarn run ovsx publish  --skip-duplicate ansible-[24](https://github.com/ansible/vscode-ansible/actions/runs/9620394779/job/26658180955#step:8:25).8.0.vsix --readme-path docs/README.md' returned non-zero exit status 1.
```