### PR TITLE
lightspeed/schema1: rename InlineSuggestion for consistency

### DIFF
--- a/src/features/lightspeed/api.ts
+++ b/src/features/lightspeed/api.ts
@@ -201,8 +201,8 @@ export class LightSpeedAPI {
       lightSpeedManager.settingsManager.settings.lightSpeedService.model;
 
     if (rhUserHasSeat && orgOptOutTelemetry) {
-      if (inputData.inlineSuggestion) {
-        delete inputData.inlineSuggestion;
+      if (inputData.inlineSuggestionFeedback) {
+        delete inputData.inlineSuggestionFeedback;
       }
     }
 

--- a/src/features/lightspeed/inlineSuggestions.ts
+++ b/src/features/lightspeed/inlineSuggestions.ts
@@ -10,7 +10,7 @@ import { getCurrentUTCDateTime } from "../utils/dateTime";
 import { lightSpeedManager } from "../../extension";
 import {
   CompletionResponseParams,
-  InlineSuggestionEvent,
+  InlineSuggestionFeedbackEvent,
   CompletionRequestParams,
 } from "../../interfaces/lightspeed";
 import {
@@ -31,7 +31,7 @@ import { LightSpeedServiceSettings } from "../../interfaces/extensionSettings";
 import { SuggestionDisplayed } from "./inlineSuggestion/suggestionDisplayed";
 import { getAdditionalContext } from "./inlineSuggestion/additionalContext";
 
-let inlineSuggestionData: InlineSuggestionEvent = {};
+let inlineSuggestionData: InlineSuggestionFeedbackEvent = {};
 let inlineSuggestionDisplayTime: Date;
 let previousTriggerPosition: vscode.Position;
 let insertTexts: string[] = [];
@@ -926,7 +926,7 @@ export async function inlineSuggestionUserActionHandler(
   suggestionId: string,
   isSuggestionAccepted: UserAction = UserAction.REJECTED,
 ) {
-  const data: InlineSuggestionEvent = {};
+  const data: InlineSuggestionFeedbackEvent = {};
 
   data["userActionTime"] =
     getCurrentUTCDateTime().getTime() - inlineSuggestionDisplayTime.getTime();
@@ -938,7 +938,7 @@ export async function inlineSuggestionUserActionHandler(
   data["action"] = isSuggestionAccepted;
   data["suggestionId"] = suggestionId;
   const inlineSuggestionFeedbackPayload = {
-    inlineSuggestion: data,
+    inlineSuggestionFeedback: data,
   };
   lightSpeedManager.apiInstance.feedbackRequest(
     inlineSuggestionFeedbackPayload,

--- a/src/interfaces/lightspeed.ts
+++ b/src/interfaces/lightspeed.ts
@@ -44,7 +44,7 @@ export interface FeedbackResponseParams {
   message: string;
 }
 
-export interface InlineSuggestionEvent {
+export interface InlineSuggestionFeedbackEvent {
   latency?: number;
   userActionTime?: number;
   documentUri?: string;
@@ -90,7 +90,7 @@ export interface PlaybookGenerationActionEvent {
 }
 
 export interface FeedbackRequestParams {
-  inlineSuggestion?: InlineSuggestionEvent;
+  inlineSuggestionFeedback?: InlineSuggestionFeedbackEvent;
   sentimentFeedback?: SentimentFeedbackEvent;
   suggestionQualityFeedback?: SuggestionQualityEvent;
   issueFeedback?: IssueFeedbackEvent;

--- a/test/testScripts/lightspeed/e2eInlineSuggestion.test.ts
+++ b/test/testScripts/lightspeed/e2eInlineSuggestion.test.ts
@@ -179,7 +179,9 @@ export async function testInlineSuggestionProviderCoExistence(): Promise<void> {
       const feedbackRequestApiCalls = feedbackRequestSpy.getCalls();
       assert.equal(feedbackRequestApiCalls.length, 1);
       const inputData: FeedbackRequestParams = feedbackRequestSpy.args[0][0];
-      assert(inputData?.inlineSuggestion?.action === UserAction.REJECTED);
+      assert(
+        inputData?.inlineSuggestionFeedback?.action === UserAction.REJECTED,
+      );
       const ret = feedbackRequestSpy.returnValues[0];
       assert(Object.keys(ret).length === 0); // ret should be equal to {}
 
@@ -247,7 +249,9 @@ export async function testIgnorePendingSuggestion(): Promise<void> {
       const feedbackRequestApiCalls = feedbackRequestSpy.getCalls();
       assert.equal(feedbackRequestApiCalls.length, 1);
       const inputData: FeedbackRequestParams = feedbackRequestSpy.args[0][0];
-      assert(inputData?.inlineSuggestion?.action === UserAction.IGNORED);
+      assert(
+        inputData?.inlineSuggestionFeedback?.action === UserAction.IGNORED,
+      );
       const ret = feedbackRequestSpy.returnValues[0];
       assert(Object.keys(ret).length === 0); // ret should be equal to {}
     });

--- a/test/testScripts/lightspeed/testLightspeed.test.ts
+++ b/test/testScripts/lightspeed/testLightspeed.test.ts
@@ -28,7 +28,7 @@ import {
 } from "../../../src/definitions/lightspeed";
 import {
   FeedbackRequestParams,
-  InlineSuggestionEvent,
+  InlineSuggestionFeedbackEvent,
 } from "../../../src/interfaces/lightspeed";
 import * as inlineSuggestions from "../../../src/features/lightspeed/inlineSuggestions";
 
@@ -149,7 +149,9 @@ export function testLightspeed(): void {
           assert.equal(feedbackRequestApiCalls.length, 1);
           const inputData: FeedbackRequestParams =
             feedbackRequestSpy.args[0][0];
-          assert(inputData?.inlineSuggestion?.action === UserAction.ACCEPTED);
+          assert(
+            inputData?.inlineSuggestionFeedback?.action === UserAction.ACCEPTED,
+          );
           const ret = feedbackRequestSpy.returnValues[0];
           assert(Object.keys(ret).length === 0); // ret should be equal to {}
         });
@@ -168,7 +170,9 @@ export function testLightspeed(): void {
           assert.equal(feedbackRequestApiCalls.length, 1);
           const inputData: FeedbackRequestParams =
             feedbackRequestSpy.args[0][0];
-          assert(inputData?.inlineSuggestion?.action === UserAction.ACCEPTED);
+          assert(
+            inputData?.inlineSuggestionFeedback?.action === UserAction.ACCEPTED,
+          );
           const ret = feedbackRequestSpy.returnValues[0];
           assert(Object.keys(ret).length === 0); // ret should be equal to {}
         });
@@ -182,7 +186,7 @@ export function testLightspeed(): void {
           const inputData: FeedbackRequestParams =
             feedbackRequestSpy.args[0][0];
           assert(
-            inputData?.inlineSuggestion?.action === UserAction.REJECTED,
+            inputData?.inlineSuggestionFeedback?.action === UserAction.REJECTED,
             JSON.stringify(inputData, null),
           );
           const ret = feedbackRequestSpy.returnValues[0];
@@ -292,7 +296,9 @@ export function testLightspeed(): void {
           assert.equal(feedbackRequestApiCalls.length, 1);
           const inputData: FeedbackRequestParams =
             feedbackRequestSpy.args[0][0];
-          assert(inputData?.inlineSuggestion?.action === UserAction.IGNORED);
+          assert(
+            inputData?.inlineSuggestionFeedback?.action === UserAction.IGNORED,
+          );
           const ret = feedbackRequestSpy.returnValues[0];
           assert(Object.keys(ret).length === 0); // ret should be equal to {}
         });
@@ -461,7 +467,7 @@ export function testLightspeed(): void {
           "df65f5f1-5c27-4dd4-8c58-3336b534321f",
         );
 
-        const requestSuggestion: InlineSuggestionEvent =
+        const requestSuggestion: InlineSuggestionFeedbackEvent =
           feedbackRequest.args[0][0].inlineSuggestion;
         assert.equal(feedbackRequest.called, true);
         assert.equal(
@@ -481,7 +487,7 @@ export function testLightspeed(): void {
           undefined,
         );
 
-        const requestSuggestion: InlineSuggestionEvent =
+        const requestSuggestion: InlineSuggestionFeedbackEvent =
           feedbackRequest.args[0][0].inlineSuggestion;
         assert.equal(feedbackRequest.called, true);
         assert.equal(
@@ -532,7 +538,7 @@ export function testLightspeed(): void {
 
           await inlineSuggestions.rejectPendingSuggestion();
 
-          const requestSuggestion: InlineSuggestionEvent =
+          const requestSuggestion: InlineSuggestionFeedbackEvent =
             feedbackRequest.args[0][0].inlineSuggestion;
           assert.equal(feedbackRequest.called, true);
           assert.equal(
@@ -599,7 +605,7 @@ export function testLightspeed(): void {
 
           await inlineSuggestions.ignorePendingSuggestion();
 
-          const requestSuggestion: InlineSuggestionEvent =
+          const requestSuggestion: InlineSuggestionFeedbackEvent =
             feedbackRequest.args[0][0].inlineSuggestion;
           assert.equal(feedbackRequest.called, true);
           assert.equal(


### PR DESCRIPTION
Rename `inlineSuggestion` key to `inlineSuggestionFeedback` to be consistent
with the other key of the `FeedbackRequestParams` structure.
