### PR TITLE
Handle exceptions raised from uncorrelated x-request-id headers

### DIFF
--- a/packages/ansible-language-server/src/errors.ts
+++ b/packages/ansible-language-server/src/errors.ts
@@ -133,13 +133,6 @@ ERRORS.addError(
   ),
 );
 ERRORS.addError(400, new Error("error__feedback_validation"));
-ERRORS.addError(
-  400,
-  new Error(
-    "error__wca_suggestion_correlation_failed",
-    "IBM watsonx Code Assistant request/response correlation failed. Please contact your administrator.",
-  ),
-);
 
 ERRORS.addError(
   403,
@@ -246,6 +239,7 @@ ERRORS.addError(
     },
   ),
 );
+
 ERRORS.addError(
   404,
   new Error(
@@ -266,6 +260,23 @@ ERRORS.addError(
   new Error(
     "error__feedback_internal_server",
     "An error occurred attempting to submit your feedback. Please try again later.",
+  ),
+);
+// error__wca_suggestion_correlation_failed is deprecated but
+// kept for backwards compatibility between new versions of the VSCode
+// extension and older ansible-ai-connect-service instances.
+ERRORS.addError(
+  500,
+  new Error(
+    "error__wca_suggestion_correlation_failed",
+    "IBM watsonx Code Assistant request/response correlation failed. Please contact your administrator.",
+  ),
+);
+ERRORS.addError(
+  500,
+  new Error(
+    "error__wca_request_id_correlation_failed",
+    "IBM watsonx Code Assistant request/response correlation failed. Please contact your administrator.",
   ),
 );
 

--- a/packages/ansible-language-server/test/utils/handleApiError.test.ts
+++ b/packages/ansible-language-server/test/utils/handleApiError.test.ts
@@ -88,18 +88,6 @@ describe("testing the error handling", () => {
     );
     assert.equal(error.message, "A field was invalid.");
   });
-
-  it("err WCA Suggestion Correlation failure", () => {
-    const error = mapError(
-      createError(400, {
-        code: "error__wca_suggestion_correlation_failed",
-      }),
-    );
-    assert.equal(
-      error.message,
-      "IBM watsonx Code Assistant request/response correlation failed. Please contact your administrator.",
-    );
-  });
   // =================================
 
   // =================================
@@ -342,6 +330,30 @@ describe("testing the error handling", () => {
     assert.equal(
       error.message,
       "An error occurred attempting to submit your feedback. Please try again later.",
+    );
+  });
+
+  it("err WCA Suggestion Correlation failure", () => {
+    const error = mapError(
+      createError(500, {
+        code: "error__wca_suggestion_correlation_failed",
+      }),
+    );
+    assert.equal(
+      error.message,
+      "IBM watsonx Code Assistant request/response correlation failed. Please contact your administrator.",
+    );
+  });
+
+  it("err WCA X-Request-ID Correlation failure", () => {
+    const error = mapError(
+      createError(500, {
+        code: "error__wca_request_id_correlation_failed",
+      }),
+    );
+    assert.equal(
+      error.message,
+      "IBM watsonx Code Assistant request/response correlation failed. Please contact your administrator.",
     );
   });
   // =================================


### PR DESCRIPTION
This PR adds exception mapping for server-side errors resulting from mismatched `X-Request-ID` headers.

Furthermore the HTTP response code is more correctly 500 and not 400.