### PR TITLE
Playbook Generation UI glitches

### DIFF
--- a/test/ui-test/lightspeedOneClickTrialUITest.ts
+++ b/test/ui-test/lightspeedOneClickTrialUITest.ts
@@ -125,6 +125,7 @@ export function lightspeedOneClickTrialUITest(): void {
       const text = await div.getText();
       expect(text).contains("Logged in as: ONE_CLICK_USER (unlicensed)");
       await explorerView.switchBack();
+      await expectNotification("Welcome back ONE_CLICK_USER (unlicensed)");
     });
 
     it("Invoke Playbook generation without experimental features enabled", async () => {


### PR DESCRIPTION
This PR fixes issues reported in [AAP-25779](https://issues.redhat.com/browse/AAP-25779) and a few more issues found while working on them:

1. Currently Playbook Generation UI opened even when a user is not logged in to Lightspeed while Playbook Generation works only with a connection to Lightspeed --> Added a login status check before opening the UI
2. Just in case the user logged out while Playbook Generation UI is opend and click Analyze button, the Login notification is displayed, but the spinner keeps rolling --> Start the spinner right before the API is called and stop it immediately it is returned from API.
3. Analyze/Generate (and other) buttons are enabled while the spinner is spinning --> Disabled them once the Analyze/Generate button is clicked.
4. There are still dead codes for Thumbs Up/Down buttons, which are no longer used --> Removed them.