### PR TITLE
lightspeed: drop permission_denied__org_ready_user_has_no_seat error check

### DIFF
--- a/packages/ansible-language-server/src/errors.ts
+++ b/packages/ansible-language-server/src/errors.ts
@@ -197,13 +197,6 @@ ERRORS.addError(
 ERRORS.addError(
   403,
   new Error(
-    "permission_denied__org_ready_user_has_no_seat",
-    "You do not have a licensed seat for Ansible Lightspeed and your organization is using the paid commercial service. Contact your Red Hat Organization's administrator for more information on how to get a licensed seat.",
-  ),
-);
-ERRORS.addError(
-  403,
-  new Error(
     "permission_denied__org_not_ready_because_wca_not_configured",
     "Contact your administrator to configure IBM watsonx Code Assistant model settings for your organization.",
   ),

--- a/packages/ansible-language-server/test/utils/handleApiError.test.ts
+++ b/packages/ansible-language-server/test/utils/handleApiError.test.ts
@@ -105,18 +105,6 @@ describe("testing the error handling", () => {
   // =================================
   // HTTP 403
   // ---------------------------------
-  it("err Forbidden - Org ready, No seat", () => {
-    const error = mapError(
-      createError(403, {
-        code: "permission_denied__org_ready_user_has_no_seat",
-      }),
-    );
-    assert.equal(
-      error.message,
-      "You do not have a licensed seat for Ansible Lightspeed and your organization is using the paid commercial service. Contact your Red Hat Organization's administrator for more information on how to get a licensed seat.",
-    );
-  });
-
   it("err Forbidden - No Seat", () => {
     const error = mapError(
       createError(403, {


### PR DESCRIPTION
The `permission_denied__org_ready_user_has_no_seat` error code is now deprecated, we don't need to check this key anymore.
