### PR TITLE
Modify the logic to set the pre-release version number

### DIFF
--- a/tools/helper
+++ b/tools/helper
@@ -25,7 +25,7 @@ def cli():
     logging.basicConfig(level=logging.INFO, format='%(message)s')
 
     pre_release = False
-    result = subprocess.run('git describe --dirty --tags --long --match "v*.*"', shell=True, capture_output=True, check=True, text=True)
+    result = subprocess.run('git describe --dirty --tags --long --match "v*.*.0"', shell=True, capture_output=True, check=True, text=True)
     git_tag = result.stdout.rstrip()
     logging.debug("git describe returned: %s", git_tag)
     tag, commits_since, suffix = git_tag.split("-", 2)
@@ -41,7 +41,13 @@ def cli():
             logging.error(msg)
             sys.exit(2)
         if version_info[1] % 2 == 0:
-            version_info[1] += 1
+            # if the second segment of version_info is equal to 12 (December), increment the first segment (year) and set the second segment to 1 (January)
+            if version_info[1] == 12:
+                version_info[0] += 1
+                version_info[1] = 1
+            # otherwise, increment the second segment of version_info to point to the next month with an odd number
+            else:
+                version_info[1] += 1
         else:
             msg = f"Last git tag ({tag}) had a MINOR version number ({version_info[1]}) that was odd. Odd numbers are reserved for pre-release versions. Remove the tag and try again."
             logging.error(msg)


### PR DESCRIPTION
Two changes in the logic to set the pre-release version number:

1. **Year Boundary:**  Currently it will set `13`  if the minor version is set to `12`. It does work, but since we are using the minor version to store a number that represents a month, we'd better store `1` (=January) and increment the major version (year) to point to the next year. For example, if the current stable release is `24.12.n`, the pre-releases will have version numbers like `25.1.nnnnnnnn`.
2. **Elapsed Time:** Current logic looks for a latest git tag with the pattern `v*.*`. However, since the pre-release are grouped per month, the elapsed time should be calculated based on the first stable release of the month. So the pattern for tag search should be `v*.*.0`.