### PR TITLE
Disable Generate Playbook button when outline is empty

### DIFF
--- a/src/webview/apps/common/editableList.ts
+++ b/src/webview/apps/common/editableList.ts
@@ -86,6 +86,16 @@ export class EditableList {
     return false;
   }
 
+  isEmpty() {
+    const values = this.getFromUI();
+    for (const value of values) {
+      if (value.length > 0) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   focus() {
     // Move cursor at the end of the last list item before put focus on the list
     const values = this.getFromUI();

--- a/src/webview/apps/lightspeed/playbookGeneration/main.ts
+++ b/src/webview/apps/lightspeed/playbookGeneration/main.ts
@@ -47,6 +47,7 @@ window.addEventListener("load", () => {
   outline = new EditableList("outline-list");
   outline.element.addEventListener("input", () => {
     setButtonEnabled("reset-button", outline.isChanged());
+    setButtonEnabled("generate-button", !outline.isEmpty());
   });
 
   // Detect whether a dark or a light color theme is used.

--- a/test/units/lightspeed/editableList.test.ts
+++ b/test/units/lightspeed/editableList.test.ts
@@ -5,6 +5,7 @@ import { EditableList } from "../../../src/webview/apps/common/editableList";
 
 describe("Test EditableList", () => {
   let dom: JSDOM;
+  let domWithEmptyList: JSDOM;
   const SAMPLE_TEXT = `1. Do this
 2. Do that
 3. Verify them
@@ -19,6 +20,16 @@ describe("Test EditableList", () => {
         "<li>Do this</li>" +
         "<li>Do that</li>" +
         "<li>Verify them</li>" +
+        "</ol>" +
+        "</body>",
+    );
+
+    domWithEmptyList = new JSDOM(
+      "<!DOCTYPE html>\n" +
+        "<body>" +
+        '<ol id="editable-list" contentEditable="true">' +
+        "<li></li>" +
+        "<li></li>" +
         "</ol>" +
         "</body>",
     );
@@ -45,6 +56,16 @@ describe("Test EditableList", () => {
   it("Test listToString", () => {
     const out = EditableList.listToString(SAMPLE_LIST);
     assert.equal(out, SAMPLE_TEXT);
+  });
+
+  it("Test isEmpty", () => {
+    const nonEmptyEditableList = new EditableList("editable-list", dom.window);
+    assert.equal(nonEmptyEditableList.isEmpty(), false);
+    const emptyEditableList = new EditableList(
+      "editable-list",
+      domWithEmptyList.window,
+    );
+    assert.equal(emptyEditableList.isEmpty(), true);
   });
 
   it("Test constructor", async () => {


### PR DESCRIPTION
Disable the "Generate Playbook" button when the outline contains an empty list. Current code does not disable the button and clicking the button ends with with a 400 error.

![image](https://github.com/user-attachments/assets/44159627-7925-4372-8d06-76177ade0748)
