### PR TITLE
lightspeed/oneClickTrial: click on info box open the browser

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -607,9 +607,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
     vscode.commands.registerCommand(
       LightSpeedCommands.LIGHTSPEED_OPEN_TRIAL_PAGE,
       () => {
-        window.showInformationMessage(
-          "This feature is coming soon. Stay tuned.",
-        );
+        vscode.env.openExternal(vscode.Uri.parse(lightSpeedManager.settingsManager.settings.lightSpeedService.URL));
       },
     ),
   );

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -607,7 +607,11 @@ export async function activate(context: ExtensionContext): Promise<void> {
     vscode.commands.registerCommand(
       LightSpeedCommands.LIGHTSPEED_OPEN_TRIAL_PAGE,
       () => {
-        vscode.env.openExternal(vscode.Uri.parse(lightSpeedManager.settingsManager.settings.lightSpeedService.URL));
+        vscode.env.openExternal(
+          vscode.Uri.parse(
+            lightSpeedManager.settingsManager.settings.lightSpeedService.URL,
+          ),
+        );
       },
     ),
   );

--- a/test/ui-test/lightspeedOneClickTrialUITest.ts
+++ b/test/ui-test/lightspeedOneClickTrialUITest.ts
@@ -180,7 +180,6 @@ export function lightspeedOneClickTrialUITest(): void {
         "Oh! You don't have an active Lightspeed Subscription",
         true, // click button
       );
-      await expectNotification("This feature is coming soon. Stay tuned.");
       await new EditorView().closeAllEditors();
     });
 
@@ -201,7 +200,6 @@ export function lightspeedOneClickTrialUITest(): void {
         "Oh! You don't have an active Lightspeed Subscription",
         true, // click button
       );
-      await expectNotification("This feature is coming soon. Stay tuned.");
       await new EditorView().closeAllEditors();
     });
 
@@ -224,7 +222,6 @@ export function lightspeedOneClickTrialUITest(): void {
         "Oh! You don't have an active Lightspeed Subscription",
         true, // click button
       );
-      await expectNotification("This feature is coming soon. Stay tuned.");
 
       // Revert changes made
       await tab.select();


### PR DESCRIPTION
The `LIGHTSPEED_OPEN_TRIAL_PAGE` command now open the local web browser and redirect the user to the Trial page.
