### PR TITLE
Update outline only after successful playbook generation

### DIFF
--- a/src/webview/apps/lightspeed/playbookGeneration/main.ts
+++ b/src/webview/apps/lightspeed/playbookGeneration/main.ts
@@ -90,6 +90,7 @@ window.addEventListener("message", async (event) => {
       setupPage(3);
       savedPlaybook = message.playbook.playbook;
       generationId = message.playbook.generationId;
+      outline.save();
 
       const element = document.getElementById("formatted-code") as Element;
       element.innerHTML = message.playbook.html;
@@ -195,10 +196,9 @@ async function generateCode() {
   const text = savedText;
   let playbook: string | undefined;
 
-  // If user made any changes to the generated outline, save the edited outline and
-  // generate a new generationId.  Otherwise, just use the generated playbook.
+  // If user made any changes to the generated outline, generate a playbook with a new generationId.
+  // Otherwise, just use the generated playbook.
   if (outline.isChanged()) {
-    outline.save();
     generationId = uuidv4();
   } else {
     playbook = savedPlaybook;
@@ -211,7 +211,7 @@ async function generateCode() {
   vscode.postMessage({
     command: "generateCode",
     text,
-    outline: outline.getSavedValueAsString(),
+    outline: EditableList.listToString(outline.getFromUI()),
     playbook,
     generationId,
     darkMode,

--- a/test/mockLightspeedServer/generations.ts
+++ b/test/mockLightspeedServer/generations.ts
@@ -15,6 +15,24 @@ export function generations(
   logger.info(`outline: ${req.body.outline}`);
   logger.info(`wizardId: ${wizardId}`);
 
+  // If the text or outline contains "status=nnn" (like "status=400"), return the specified
+  // status code.
+  let index = text.search(/status=\d\d\d/);
+  if (index !== -1) {
+    const status = parseInt(index.substring(index + 7, index + 10));
+    return res.status(status).send();
+  }
+
+  if (req.body?.outline) {
+    index = req.body?.outline.search(/status=\d\d\d/);
+    if (index !== -1) {
+      const status = parseInt(
+        req.body.outline.substring(index + 7, index + 10),
+      );
+      return res.status(status).send();
+    }
+  }
+
   if (options.oneClick) {
     return res.status(403).json(permissionDeniedCanApplyForTrial());
   }

--- a/test/ui-test/lightspeedUiTest.ts
+++ b/test/ui-test/lightspeedUiTest.ts
@@ -13,8 +13,14 @@ import {
   WebView,
   ModalDialog,
   WebviewView,
+  WebElement,
 } from "vscode-extension-tester";
-import { getFilePath, updateSettings } from "./uiTestHelper";
+import {
+  expectNotification,
+  getFilePath,
+  sleep,
+  updateSettings,
+} from "./uiTestHelper";
 import { PlaybookGenerationActionType } from "../../src/definitions/lightspeed";
 import { PlaybookGenerationActionEvent } from "../../src/interfaces/lightspeed";
 
@@ -139,6 +145,9 @@ export function lightspeedUIAssetsTest(): void {
   describe("Verify playbook generation and explanation features work as expected", function () {
     let workbench: Workbench;
     let settingsEditor: SettingsEditor;
+    let webView: WebView;
+    let outlineList: WebElement;
+    let resetButton: WebElement;
 
     before(async function () {
       if (process.env.TEST_LIGHTSPEED_URL) {
@@ -167,325 +176,261 @@ export function lightspeedUIAssetsTest(): void {
       }
     });
 
-    it("Playbook generation webview works as expected (full path)", async function () {
-      // Execute only when TEST_LIGHTSPEED_URL environment variable is defined.
-      if (process.env.TEST_LIGHTSPEED_URL) {
-        // Open Ansible Content Creator by clicking the Getting started button on the side bar
-        const view = (await new ActivityBar().getViewControl(
-          "Ansible",
-        )) as ViewControl;
-        const sideBar = await view.openView();
+    it("Playbook generation webview works as expected (full path) - part 1", async function () {
+      // Open Ansible Content Creator by clicking the Getting started button on the side bar
+      const view = (await new ActivityBar().getViewControl(
+        "Ansible",
+      )) as ViewControl;
+      const sideBar = await view.openView();
 
-        const getStartedButton = await sideBar.findElement(
-          By.xpath(
-            "//a[contains(@class, 'monaco-button') and " +
-              ".//span/text()='Get started']",
-          ),
-        );
-        expect(getStartedButton).not.to.be.undefined;
-        if (getStartedButton) {
-          await getStartedButton.click();
-        }
-        await new Promise((res) => {
-          setTimeout(res, 5000);
-        });
+      const getStartedButton = await sideBar.findElement(
+        By.xpath(
+          "//a[contains(@class, 'monaco-button') and " +
+            ".//span/text()='Get started']",
+        ),
+      );
+      expect(getStartedButton).not.to.be.undefined;
+      if (getStartedButton) {
+        await getStartedButton.click();
+      }
+      await sleep(5000);
 
-        // Open Playbook Generation UI by clicking the create content button on Ansible Content Creator
-        const contentCreatorWebView = await new WebView();
-        expect(
-          contentCreatorWebView,
-          "contentCreatorWebView should not be undefined",
-        ).not.to.be.undefined;
-        await contentCreatorWebView.switchToFrame(5000);
-        expect(
-          contentCreatorWebView,
-          "contentCreatorWebView should not be undefined after switching to its frame",
-        ).not.to.be.undefined;
+      // Open Playbook Generation UI by clicking the create content button on Ansible Content Creator
+      const contentCreatorWebView = await new WebView();
+      expect(
+        contentCreatorWebView,
+        "contentCreatorWebView should not be undefined",
+      ).not.to.be.undefined;
+      await contentCreatorWebView.switchToFrame(5000);
+      expect(
+        contentCreatorWebView,
+        "contentCreatorWebView should not be undefined after switching to its frame",
+      ).not.to.be.undefined;
 
-        const createContentButton = await contentCreatorWebView.findWebElement(
-          By.xpath(
-            "//a[contains(@href,'command:ansible.lightspeed.playbookGeneration')]",
-          ),
-        );
-        expect(createContentButton).not.to.be.undefined;
-        if (createContentButton) {
-          await createContentButton.click();
-        }
-        await contentCreatorWebView.switchBack();
-        await new EditorView().closeEditor("Ansible content creator");
-        await new Promise((res) => {
-          setTimeout(res, 2000);
-        });
+      const createContentButton = await contentCreatorWebView.findWebElement(
+        By.xpath(
+          "//a[contains(@href,'command:ansible.lightspeed.playbookGeneration')]",
+        ),
+      );
+      expect(createContentButton).not.to.be.undefined;
+      if (createContentButton) {
+        await createContentButton.click();
+      }
+      await contentCreatorWebView.switchBack();
+      await new EditorView().closeEditor("Ansible content creator");
+      await sleep(2000);
 
-        // Start operations on Playbook Generation UI
-        const webView = await new WebView();
-        expect(webView, "webView should not be undefined").not.to.be.undefined;
-        await webView.switchToFrame(5000);
-        expect(
-          webView,
-          "webView should not be undefined after switching to its frame",
-        ).not.to.be.undefined;
+      // Start operations on Playbook Generation UI
+      webView = await new WebView();
+      expect(webView, "webView should not be undefined").not.to.be.undefined;
+      await webView.switchToFrame(5000);
+      expect(
+        webView,
+        "webView should not be undefined after switching to its frame",
+      ).not.to.be.undefined;
 
-        // Set input text and invoke summaries API
-        const textArea = await webView.findWebElement(
-          By.xpath("//vscode-text-area"),
-        );
-        expect(textArea, "textArea should not be undefined").not.to.be
-          .undefined;
-        const submitButton = await webView.findWebElement(
-          By.xpath("//vscode-button[@id='submit-button']"),
-        );
-        expect(submitButton, "submitButton should not be undefined").not.to.be
-          .undefined;
-        //
-        // Note: Following line should succeed, but fails for some unknown reasons.
-        //
-        // expect((await submitButton.isEnabled()), "submit button should be disabled by default").is.false;
-        await textArea.sendKeys("Create an azure network.");
-        expect(
-          await submitButton.isEnabled(),
-          "submit button should be enabled now",
-        ).to.be.true;
-        await submitButton.click();
-        await new Promise((res) => {
-          setTimeout(res, 2000);
-        });
+      // Set input text and invoke summaries API
+      const textArea = await webView.findWebElement(
+        By.xpath("//vscode-text-area"),
+      );
+      expect(textArea, "textArea should not be undefined").not.to.be.undefined;
+      const submitButton = await webView.findWebElement(
+        By.xpath("//vscode-button[@id='submit-button']"),
+      );
+      expect(submitButton, "submitButton should not be undefined").not.to.be
+        .undefined;
+      //
+      // Note: Following line should succeed, but fails for some unknown reasons.
+      //
+      // expect((await submitButton.isEnabled()), "submit button should be disabled by default").is.false;
+      await textArea.sendKeys("Create an azure network.");
+      expect(
+        await submitButton.isEnabled(),
+        "submit button should be enabled now",
+      ).to.be.true;
+      await submitButton.click();
+      await sleep(2000);
 
-        // Verify outline output and text edit
-        const outlineList = await webView.findWebElement(
-          By.xpath("//ol[@id='outline-list']"),
-        );
-        expect(outlineList, "An ordered list should exist.");
-        let text = await outlineList.getText();
-        expect(
-          text.includes("Create virtual network peering"),
-          "Text should include the expected outline",
-        );
-        await outlineList.sendKeys("# COMMENT\n");
-        text = await outlineList.getText();
-        expect(text.includes("# COMMENT\n"));
+      // Verify outline output and text edit
+      outlineList = await webView.findWebElement(
+        By.xpath("//ol[@id='outline-list']"),
+      );
+      expect(outlineList, "An ordered list should exist.");
+      let text = await outlineList.getText();
+      expect(
+        text.includes("Create virtual network peering"),
+        "Text should include the expected outline",
+      );
+      await outlineList.sendKeys("# COMMENT\n");
+      text = await outlineList.getText();
+      expect(text.includes("# COMMENT\n"));
 
-        // Verify the prompt is displayed as a static text
-        const prompt = await webView.findWebElement(
-          By.xpath("//span[@id='prompt']"),
-        );
-        text = await prompt.getText();
-        expect(text.includes("Create an azure network."));
+      // Verify the prompt is displayed as a static text
+      const prompt = await webView.findWebElement(
+        By.xpath("//span[@id='prompt']"),
+      );
+      text = await prompt.getText();
+      expect(text.includes("Create an azure network."));
 
-        // Test Reset button
-        const resetButton = await webView.findWebElement(
-          By.xpath("//vscode-button[@id='reset-button']"),
-        );
-        expect(resetButton, "resetButton should not be undefined").not.to.be
-          .undefined;
-        await resetButton.click();
-        await new Promise((res) => {
-          setTimeout(res, 500);
-        });
-        text = await outlineList.getText();
-        expect(!text.includes("# COMMENT\n"));
+      // Test Reset button
+      resetButton = await webView.findWebElement(
+        By.xpath("//vscode-button[@id='reset-button']"),
+      );
+      expect(resetButton, "resetButton should not be undefined").not.to.be
+        .undefined;
+      await resetButton.click();
+      await sleep(500);
+      text = await outlineList.getText();
+      expect(!text.includes("# COMMENT\n"));
 
-        // Test Back button
-        const backButton = await webView.findWebElement(
-          By.xpath("//vscode-button[@id='back-button']"),
-        );
-        expect(backButton, "backButton should not be undefined").not.to.be
-          .undefined;
-        await backButton.click();
-        await new Promise((res) => {
-          setTimeout(res, 500);
-        });
+      // Test Back button
+      const backButton = await webView.findWebElement(
+        By.xpath("//vscode-button[@id='back-button']"),
+      );
+      expect(backButton, "backButton should not be undefined").not.to.be
+        .undefined;
+      await backButton.click();
+      await sleep(500);
 
-        text = await textArea.getText();
-        expect(text.startsWith("Create an azure network."));
-        await submitButton.click();
-        await new Promise((res) => {
-          setTimeout(res, 1000);
-        });
-        text = await outlineList.getText();
-        expect(text.includes("Create virtual network peering"));
+      text = await textArea.getText();
+      expect(text.startsWith("Create an azure network."));
+      await submitButton.click();
+      await sleep(1000);
+      text = await outlineList.getText();
+      expect(text.includes("Create virtual network peering"));
 
-        // Test Edit link next to the prompt text
-        const backAnchor = await webView.findWebElement(
-          By.xpath("//a[@id='back-anchor']"),
-        );
-        expect(backAnchor, "backAnchor should not be undefined").not.to.be
-          .undefined;
-        await backAnchor.click();
-        await new Promise((res) => {
-          setTimeout(res, 500);
-        });
+      // Test Edit link next to the prompt text
+      const backAnchor = await webView.findWebElement(
+        By.xpath("//a[@id='back-anchor']"),
+      );
+      expect(backAnchor, "backAnchor should not be undefined").not.to.be
+        .undefined;
+      await backAnchor.click();
+      await sleep(500);
 
-        text = await textArea.getText();
-        expect(text.startsWith("Create an azure network."));
-        await submitButton.click();
-        await new Promise((res) => {
-          setTimeout(res, 1000);
-        });
-        text = await outlineList.getText();
-        expect(text.includes("Create virtual network peering"));
+      text = await textArea.getText();
+      expect(text.startsWith("Create an azure network."));
+      await submitButton.click();
+      await sleep(1000);
+      text = await outlineList.getText();
+      expect(text.includes("Create virtual network peering"));
+    });
 
-        // Click Generate playbook button to invoke the generations API
-        const generatePlaybookButton = await webView.findWebElement(
-          By.xpath("//vscode-button[@id='generate-button']"),
-        );
-        expect(
-          generatePlaybookButton,
-          "generatePlaybookButton should not be undefined",
-        ).not.to.be.undefined;
-        generatePlaybookButton.click();
-        await new Promise((res) => {
-          setTimeout(res, 2000);
-        });
+    it("Playbook generation webview works as expected (full path) - part 2", async function () {
+      // Click Generate playbook button to invoke the generations API
+      const generatePlaybookButton = await webView.findWebElement(
+        By.xpath("//vscode-button[@id='generate-button']"),
+      );
+      expect(
+        generatePlaybookButton,
+        "generatePlaybookButton should not be undefined",
+      ).not.to.be.undefined;
 
-        // Make sure the generated playbook is displayed
-        const formattedCode = await webView.findWebElement(
-          By.xpath("//span[@id='formatted-code']"),
-        );
-        expect(formattedCode, "formattedCode should not be undefined").not.to.be
-          .undefined;
-        text = await formattedCode.getText();
-        expect(text.startsWith("---")).to.be.true;
+      // Input "(status=400)" to simulate an API error
+      await outlineList.sendKeys("(status=400)");
+      let text = await outlineList.getText();
+      expect(text.includes("(status=400)"));
+      await generatePlaybookButton.click(); // Click Generate Playbook button
 
-        // Test ThumbsUp button
-        // const thumbsUpButton = await webView.findWebElement(
-        //   By.xpath("//vscode-button[@id='thumbsup-button']"),
-        // );
-        // expect(thumbsUpButton, "thumbsUpButton should not be undefined").not.to
-        //   .be.undefined;
-        // expect(
-        //   await thumbsUpButton.isEnabled(),
-        //   "thumbsUpButton should be enabled",
-        // );
-        // await thumbsUpButton.click();
-        // await new Promise((res) => {
-        //   setTimeout(res, 500);
-        // });
-        // expect(
-        //   !thumbsUpButton.isEnabled,
-        //   "thumbsUpButton should not be enabled",
-        // );
+      await webView.switchBack();
+      await sleep(2000);
+      await expectNotification("Bad Request response. Please try again.");
+      await webView.switchToFrame(5000);
 
-        // await webView.switchBack();
-        // const notifications = await workbench.getNotifications();
-        // const notification = notifications[0];
-        // const message = await notification.getMessage();
-        // expect(message).equals("Thanks for your feedback!");
-        // await notification.dismiss();
+      // Click reset button and make sure the string "(status=400)" is removed
+      await resetButton.click();
+      await sleep(500);
+      text = await outlineList.getText();
+      expect(!text.includes("(status=400)"));
 
-        // Test Back (to Page 2) button
-        // await webView.switchToFrame(5000);
-        const backToPage2Button = await webView.findWebElement(
-          By.xpath("//vscode-button[@id='back-to-page2-button']"),
-        );
-        expect(backToPage2Button, "backToPage2Button should not be undefined")
-          .not.to.be.undefined;
-        await backToPage2Button.click();
-        await new Promise((res) => {
-          setTimeout(res, 500);
-        });
+      // Click Generate Playbook button again
+      await generatePlaybookButton.click();
+      await sleep(2000);
 
-        // Type in something extra
-        await outlineList.sendKeys("\nSomething extra");
-        const savedOutline = await outlineList.getText();
+      // Make sure the generated playbook is displayed
+      const formattedCode = await webView.findWebElement(
+        By.xpath("//span[@id='formatted-code']"),
+      );
+      expect(formattedCode, "formattedCode should not be undefined").not.to.be
+        .undefined;
+      text = await formattedCode.getText();
+      expect(text.startsWith("---")).to.be.true;
 
-        // Click generate playbook button again
-        generatePlaybookButton.click();
-        await new Promise((res) => {
-          setTimeout(res, 2000);
-        });
+      // Test Back (to Page 2) button
+      const backToPage2Button = await webView.findWebElement(
+        By.xpath("//vscode-button[@id='back-to-page2-button']"),
+      );
+      expect(backToPage2Button, "backToPage2Button should not be undefined").not
+        .to.be.undefined;
+      await backToPage2Button.click();
+      await sleep(500);
 
-        // Click Back page again
-        await backToPage2Button.click();
-        await new Promise((res) => {
-          setTimeout(res, 500);
-        });
+      // Type in something extra
+      await outlineList.sendKeys("\nSomething extra");
+      const savedOutline = await outlineList.getText();
 
-        // Make sure outline is not updated.
-        expect(savedOutline).equal(await outlineList.getText());
+      // Click generate playbook button again
+      generatePlaybookButton.click();
+      await sleep(2000);
 
-        // Click generate playbook button again
-        generatePlaybookButton.click();
-        await new Promise((res) => {
-          setTimeout(res, 500);
-        });
+      // Click Back page again
+      await backToPage2Button.click();
+      await sleep(500);
 
-        // Test ThumbsDown button
-        // const thumbsDownButton = await webView.findWebElement(
-        //   By.xpath("//vscode-button[@id='thumbsdown-button']"),
-        // );
-        // expect(thumbsDownButton, "thumbsDownButton should not be undefined").not
-        //   .to.be.undefined;
-        // expect(
-        //   await thumbsDownButton.isEnabled(),
-        //   "thumbsDownButton should be enabled",
-        // );
-        // await thumbsDownButton.click();
-        // await new Promise((res) => {
-        //   setTimeout(res, 500);
-        // });
-        // expect(!thumbsDownButton.isEnabled, "ThumbsDown should not be enabled");
+      // Make sure outline is not updated.
+      expect(savedOutline).equal(await outlineList.getText());
 
-        // await webView.switchBack();
-        // notifications = await workbench.getNotifications();
-        // notification = notifications[0];
-        // message = await notification.getMessage();
-        // expect(message).equals("Thanks for your feedback!");
-        // await notification.dismiss();
+      // Click generate playbook button again
+      generatePlaybookButton.click();
+      await sleep(500);
 
-        // Click Open editor button to open the generated playbook in the editor
-        // await webView.switchToFrame(5000);
-        const openEditorButton = await webView.findWebElement(
-          By.xpath("//vscode-button[@id='open-editor-button']"),
-        );
-        expect(openEditorButton, "openEditorButton should not be undefined").not
-          .to.be.undefined;
-        await openEditorButton.click();
-        await new Promise((res) => {
-          setTimeout(res, 2000);
-        });
-        await webView.switchBack();
+      // Click Open editor button to open the generated playbook in the editor
+      const openEditorButton = await webView.findWebElement(
+        By.xpath("//vscode-button[@id='open-editor-button']"),
+      );
+      expect(openEditorButton, "openEditorButton should not be undefined").not
+        .to.be.undefined;
+      await openEditorButton.click();
+      await sleep(2000);
+      await webView.switchBack();
 
-        // Verify a playbook was generated.
-        const editor = await new EditorView().openEditor("Untitled-1");
-        text = await editor.getText();
-        expect(
-          text.startsWith("---"),
-          'The generated playbook should start with "---"',
-        ).to.be.true;
+      // Verify a playbook was generated.
+      const editor = await new EditorView().openEditor("Untitled-1");
+      text = await editor.getText();
+      expect(
+        text.startsWith("---"),
+        'The generated playbook should start with "---"',
+      ).to.be.true;
 
-        await workbench.executeCommand("View: Close All Editor Groups");
-        const dialog = new ModalDialog();
-        await dialog.pushButton(`Don't Save`);
+      await workbench.executeCommand("View: Close All Editor Groups");
+      const dialog = new ModalDialog();
+      await dialog.pushButton(`Don't Save`);
 
-        /* verify generated events */
-        const expected = [
-          [PlaybookGenerationActionType.OPEN, undefined, 1],
-          [PlaybookGenerationActionType.TRANSITION, 1, 2],
-          [PlaybookGenerationActionType.TRANSITION, 2, 1],
-          [PlaybookGenerationActionType.TRANSITION, 1, 2],
-          [PlaybookGenerationActionType.TRANSITION, 2, 1],
-          [PlaybookGenerationActionType.TRANSITION, 1, 2],
-          [PlaybookGenerationActionType.TRANSITION, 2, 3],
-          [PlaybookGenerationActionType.TRANSITION, 3, 2],
-          [PlaybookGenerationActionType.TRANSITION, 2, 3],
-          [PlaybookGenerationActionType.TRANSITION, 3, 2],
-          [PlaybookGenerationActionType.TRANSITION, 2, 3],
-          [PlaybookGenerationActionType.CLOSE_ACCEPT, 3, undefined],
-        ];
-        const res = await axios.get(
-          `${process.env.TEST_LIGHTSPEED_URL}/__debug__/feedbacks`,
-        );
-        expect(res.data.feedbacks.length).equals(expected.length);
-        for (let i = 0; i < expected.length; i++) {
-          const evt: PlaybookGenerationActionEvent =
-            res.data.feedbacks[i].playbookGenerationAction;
-          expect(evt.action).equals(expected[i][0]);
-          expect(evt.fromPage).equals(expected[i][1]);
-          expect(evt.toPage).equals(expected[i][2]);
-        }
-      } else {
-        this.skip();
+      /* verify generated events */
+      const expected = [
+        [PlaybookGenerationActionType.OPEN, undefined, 1],
+        [PlaybookGenerationActionType.TRANSITION, 1, 2],
+        [PlaybookGenerationActionType.TRANSITION, 2, 1],
+        [PlaybookGenerationActionType.TRANSITION, 1, 2],
+        [PlaybookGenerationActionType.TRANSITION, 2, 1],
+        [PlaybookGenerationActionType.TRANSITION, 1, 2],
+        [PlaybookGenerationActionType.TRANSITION, 2, 3],
+        [PlaybookGenerationActionType.TRANSITION, 3, 2],
+        [PlaybookGenerationActionType.TRANSITION, 2, 3],
+        [PlaybookGenerationActionType.TRANSITION, 3, 2],
+        [PlaybookGenerationActionType.TRANSITION, 2, 3],
+        [PlaybookGenerationActionType.CLOSE_ACCEPT, 3, undefined],
+      ];
+      const res = await axios.get(
+        `${process.env.TEST_LIGHTSPEED_URL}/__debug__/feedbacks`,
+      );
+      expect(res.data.feedbacks.length).equals(expected.length);
+      for (let i = 0; i < expected.length; i++) {
+        const evt: PlaybookGenerationActionEvent =
+          res.data.feedbacks[i].playbookGenerationAction;
+        expect(evt.action).equals(expected[i][0]);
+        expect(evt.fromPage).equals(expected[i][1]);
+        expect(evt.toPage).equals(expected[i][2]);
       }
     });
 
@@ -496,9 +441,7 @@ export function lightspeedUIAssetsTest(): void {
         await workbench.executeCommand(
           "Ansible Lightspeed: Playbook generation",
         );
-        await new Promise((res) => {
-          setTimeout(res, 2000);
-        });
+        await sleep(2000);
         const webView = await new WebView();
         expect(webView, "webView should not be undefined").not.to.be.undefined;
         await webView.switchToFrame(5000);
@@ -528,9 +471,7 @@ export function lightspeedUIAssetsTest(): void {
           "submit button should be enabled now",
         ).to.be.true;
         await submitButton.click();
-        await new Promise((res) => {
-          setTimeout(res, 1000);
-        });
+        await sleep(1000);
 
         // Verify outline output and text edit
         const outlineList = await webView.findWebElement(
@@ -559,9 +500,7 @@ export function lightspeedUIAssetsTest(): void {
 
         const start = new Date().getTime();
         await generatePlaybookButton.click();
-        await new Promise((res) => {
-          setTimeout(res, 300);
-        });
+        await sleep(300);
 
         // Verify a playbook was generated.
         const formattedCode = await webView.findWebElement(
@@ -585,9 +524,7 @@ export function lightspeedUIAssetsTest(): void {
         expect(openEditorButton, "openEditorButton should not be undefined").not
           .to.be.undefined;
         await openEditorButton.click();
-        await new Promise((res) => {
-          setTimeout(res, 500);
-        });
+        await sleep(500);
         await webView.switchBack();
 
         const editor = await new EditorView().openEditor("Untitled-1");
@@ -631,9 +568,7 @@ export function lightspeedUIAssetsTest(): void {
         await workbench.executeCommand(
           "Ansible Lightspeed: Playbook generation",
         );
-        await new Promise((res) => {
-          setTimeout(res, 2000);
-        });
+        await sleep(2000);
         const webView = await new WebView();
         expect(webView, "webView should not be undefined").not.to.be.undefined;
         await webView.switchToFrame(5000);
@@ -663,9 +598,7 @@ export function lightspeedUIAssetsTest(): void {
           "submit button should be enabled now",
         ).to.be.true;
         await submitButton.click();
-        await new Promise((res) => {
-          setTimeout(res, 2000);
-        });
+        await sleep(2000);
 
         await webView.switchBack();
 
@@ -691,9 +624,7 @@ export function lightspeedUIAssetsTest(): void {
         await workbench.executeCommand(
           "Explain the playbook with Ansible Lightspeed",
         );
-        await new Promise((res) => {
-          setTimeout(res, 2000);
-        });
+        await sleep(2000);
 
         // Locate the playbook explanation webview
         const webView = (await new EditorView().openEditor(
@@ -734,9 +665,7 @@ export function lightspeedUIAssetsTest(): void {
         await workbench.executeCommand(
           "Explain the playbook with Ansible Lightspeed",
         );
-        await new Promise((res) => {
-          setTimeout(res, 2000);
-        });
+        await sleep(2000);
 
         // Locate the group 1 of editor view. Since the file does not contain the "hosts" property,
         // the explanation view is not opened in the group 1. Therefore, the group 1 should be
@@ -763,9 +692,7 @@ export function lightspeedUIAssetsTest(): void {
         await workbench.executeCommand(
           "Explain the playbook with Ansible Lightspeed",
         );
-        await new Promise((res) => {
-          setTimeout(res, 2000);
-        });
+        await sleep(2000);
 
         // Locate the playbook explanation webview
         const webView = (await new EditorView().openEditor(
@@ -829,9 +756,7 @@ export function lightspeedUIAssetsTest(): void {
     it("Playbook generation command shows an error message when Lightspeed is not enabled", async function () {
       // Open playbook generation webview.
       await workbench.executeCommand("Ansible Lightspeed: Playbook generation");
-      await new Promise((res) => {
-        setTimeout(res, 2000);
-      });
+      await sleep(2000);
       const notifications = await new Workbench().getNotifications();
       const notification = notifications[0];
       expect(await notification.getMessage()).equals(
@@ -864,9 +789,7 @@ export function lightspeedUIAssetsTest(): void {
       // Execute only when TEST_LIGHTSPEED_URL environment variable is defined.
       if (process.env.TEST_LIGHTSPEED_URL) {
         await workbench.executeCommand("Ansible Lightspeed: Feedback");
-        await new Promise((res) => {
-          setTimeout(res, 2000);
-        });
+        await sleep(2000);
         // Locate the playbook explanation webview
         const webView = (await editorView.openEditor(
           "Ansible Lightspeed Feedback",
@@ -874,9 +797,7 @@ export function lightspeedUIAssetsTest(): void {
         expect(webView, "webView should not be undefined").not.to.be.undefined;
         // Issuing the Lightspeed feedback command should not open a new tab
         await workbench.executeCommand("Ansible Lightspeed: Feedback");
-        await new Promise((res) => {
-          setTimeout(res, 2000);
-        });
+        await sleep(2000);
         const titles = await editorView.getOpenEditorTitles();
         expect(titles.length).equals(1);
         await workbench.executeCommand("View: Close All Editor Groups");


### PR DESCRIPTION
When outline was edited on the page 2 of Playbook Generation UI, we should save the updated outline only after playbook generation was successful.  Previously, the updated outline was saved when the Generate Playbook button is clicked and the Reset button could not reset to the original outline if the playbook generation failed.