### PR TITLE
Message for no access error is displayed at every other attempt for code completion

### DIFF
--- a/src/features/lightspeed/api.ts
+++ b/src/features/lightspeed/api.ts
@@ -160,7 +160,8 @@ export class LightSpeedAPI {
       }
       return {} as CompletionResponseParams;
     } finally {
-      if (isCompletionSuccess && !this.cancelSuggestionFeedback(suggestionId)) {
+      const cancelled = this.cancelSuggestionFeedback(suggestionId);
+      if (isCompletionSuccess && !cancelled) {
         await inlineSuggestionHideHandler(UserAction.IGNORED, suggestionId);
       }
     }

--- a/test/testScripts/lightspeed/testLightSpeedFunctions.test.ts
+++ b/test/testScripts/lightspeed/testLightSpeedFunctions.test.ts
@@ -204,6 +204,7 @@ function testFeedbackCompletionAPI(): void {
         "SuggestionId assertion successful",
       );
 
+      assert.equal(cancelSuggestionFeedbackSpy.called, true);
       assert.equal(inlineSuggestionHideHandlerSpy.called, false);
     });
 
@@ -224,6 +225,7 @@ function testFeedbackCompletionAPI(): void {
         "SuggestionId assertion successful",
       );
 
+      assert.equal(cancelSuggestionFeedbackSpy.called, true);
       assert.equal(inlineSuggestionHideHandlerSpy.called, false);
     });
 
@@ -245,6 +247,7 @@ function testFeedbackCompletionAPI(): void {
         "SuggestionId assertion successful",
       );
 
+      assert.equal(cancelSuggestionFeedbackSpy.called, true);
       assert.equal(inlineSuggestionHideHandlerSpy.called, true);
     });
   });


### PR DESCRIPTION
Ensure the "[feedback] in progress" flag is reset in all scenarios; success and error.