### PR TITLE
log response data to console when /me request fails

### DIFF
--- a/src/features/lightspeed/lightSpeedOAuthProvider.ts
+++ b/src/features/lightspeed/lightSpeedOAuthProvider.ts
@@ -574,6 +574,10 @@ export class LightSpeedAuthenticationProvider
           "[ansible-lightspeed-oauth] error message: ",
           error.message,
         );
+        console.error(
+          "[ansible-lightspeed-oauth] error response data: ",
+          error.response?.data,
+        );
         throw new Error(error.message);
       } else {
         console.error("[ansible-lightspeed-oauth] unexpected error: ", error);

--- a/src/features/lightspeed/lightspeedUser.ts
+++ b/src/features/lightspeed/lightspeedUser.ts
@@ -130,6 +130,10 @@ export class LightspeedUser {
         this._logger.error(
           `[ansible-lightspeed-user] error message: ${error.message}`,
         );
+        console.error(
+          "[ansible-lightspeed-user] error response data: ",
+          error.response?.data,
+        );
         throw new Error(error.message);
       } else {
         this._logger.error(


### PR DESCRIPTION
We have had several users report problems connecting to Lightspeed through a proxy. Debugging the response body for requests to our /me endpoint when they fail help us quickly pinpoint if the request is failing when it hits our service or if it is being rejected by the proxy.