### PR TITLE
Add ansible-playbook argument setting option

### DIFF
--- a/.config/requirements.in
+++ b/.config/requirements.in
@@ -1,6 +1,7 @@
 cython>=3.0.5; python_version >= "3.12"
 ansible-core>=2.13.0
 ansible-lint>=6.8.7
+ansible-navigator
 mypy # used by vscode
 pip>=22.3.1
 pip-tools>=6.12.1

--- a/docs/README.md
+++ b/docs/README.md
@@ -231,6 +231,8 @@ any level (User, Remote, Workspace and/or Folder).
 - `ansible.lightspeed.modelIdOverride`: Model ID to override your organization's
   default model. This setting is only applicable to commercial users with an
   Ansible Lightspeed seat assignment.
+- `ansible.playbook.arguments`: Specify additional arguments to append to
+  ansible-playbook invocation. e.g. `--syntax-check`
 
 ## Data and Telemetry
 

--- a/package.json
+++ b/package.json
@@ -448,6 +448,18 @@
         }
       },
       {
+        "title": "Ansible Playbook",
+        "properties": {
+          "ansible.playbook.arguments": {
+            "default": "",
+            "markdownDescription": "%configuration.playbook.arguments%",
+            "order": 0,
+            "scope": "resource",
+            "type": "string"
+          }
+        }
+      },
+      {
         "title": "Completion",
         "properties": {
           "ansible.completion.provideRedirectModules": {

--- a/package.nls.json
+++ b/package.nls.json
@@ -5,6 +5,7 @@
   "commands.title.ansible-navigator": "Run playbook via `ansible-navigator run`",
   "commands.title.ansible-playbook": "Run playbook via `ansible-playbook`",
   "commands.title.ansible-vault": "Encrypt/decrypt via `ansible-vault`",
+  "configuration.playbook.arguments": "Add arguments to `ansible-playbook` command",
   "configuration.navigate.executablePath": "Points to the ansible-navigator executable.",
   "configuration.run.executablePath": "Points to the ansible-playbook executable.",
   "configuration.suggest.basic": "Controls whether the built-in Ansible language suggestions are enabled. The support suggests Ansible globals and variables.",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -131,7 +131,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
   const extSettings = new SettingsManager();
   await extSettings.initialize();
 
-  new AnsiblePlaybookRunProvider(context, extSettings.settings, telemetry);
+  new AnsiblePlaybookRunProvider(context, extSettings, telemetry);
 
   // handle metadata status bar
   const metaData = new MetadataManager(context, client, telemetry, extSettings);

--- a/src/interfaces/extensionSettings.ts
+++ b/src/interfaces/extensionSettings.ts
@@ -7,6 +7,7 @@ export interface ExtensionSettings {
   interpreterPath: string | undefined;
   executionEnvironment: ExecutionEnvironmentSettings;
   lightSpeedService: LightSpeedServiceSettings;
+  playbook: PlaybookSettings;
 }
 
 export interface IVolumeMounts {
@@ -22,6 +23,10 @@ export interface ExecutionEnvironmentSettings {
   image: string;
   pull: { arguments: string; policy: IPullPolicy };
   volumeMounts: Array<IVolumeMounts>;
+}
+
+export interface PlaybookSettings {
+  arguments: string;
 }
 
 export interface UserResponse {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -16,6 +16,8 @@ export class SettingsManager {
     );
     const lightSpeedSettings =
       vscode.workspace.getConfiguration("ansible.lightspeed");
+    const playbookSettings =
+      vscode.workspace.getConfiguration("ansible.playbook");
     this.settings = {
       activationScript: (await ansibleSettings.get(
         "python.activationScript",
@@ -42,6 +44,9 @@ export class SettingsManager {
           waitWindow: lightSpeedSettings.get("suggestions.waitWindow", 0),
         },
         model: lightSpeedSettings.get("modelIdOverride", undefined),
+      },
+      playbook: {
+        arguments: playbookSettings.get("arguments", ""),
       },
     };
 

--- a/test/testFixtures/settings.json
+++ b/test/testFixtures/settings.json
@@ -7,6 +7,7 @@
   "ansible.validation.lint.enabled": true,
   "ansible.validation.lint.path": "ansible-lint",
   "ansible.ansibleNavigator.path": "ansible-navigator",
+  "ansible.playbook.arguments": "",
   "ansible.executionEnvironment.containerEngine": "docker",
   "ansible.executionEnvironment.containerOptions": "",
   "ansible.executionEnvironment.enabled": false,

--- a/test/testFixtures/terminal/playbook.yml
+++ b/test/testFixtures/terminal/playbook.yml
@@ -1,0 +1,7 @@
+---
+- name: Test playbook
+  hosts: localhost
+  tasks:
+    - name: Test output
+      ansible.builtin.debug:
+        msg: Hello world!

--- a/test/ui-test/allTestsSuite.ts
+++ b/test/ui-test/allTestsSuite.ts
@@ -2,11 +2,13 @@ import { extensionUIAssetsTest } from "./extensionUITest";
 import { lightspeedUILoginTest } from "./lightspeedAuthUiTest";
 import { lightspeedOneClickTrialUITest } from "./lightspeedOneClickTrialUITest";
 import { lightspeedUIAssetsTest } from "./lightspeedUiTest";
+import { terminalUITests } from "./terminalUiTest";
 
 describe("VSCode Ansible - UI tests", function () {
   this.timeout(30000);
   extensionUIAssetsTest();
   lightspeedUIAssetsTest();
+  terminalUITests();
 
   // Skip this on MacOS due to the functional limitation on menu support
   if (process.platform === "darwin") {

--- a/test/ui-test/lightspeedOneClickTrialUITest.ts
+++ b/test/ui-test/lightspeedOneClickTrialUITest.ts
@@ -14,7 +14,7 @@ import {
 } from "vscode-extension-tester";
 import {
   expectNotification,
-  getFilePath,
+  getFixturePath,
   getModalDialogAndMessage,
   sleep,
   updateSettings,
@@ -210,8 +210,9 @@ export function lightspeedOneClickTrialUITest(): void {
     });
 
     it("Invoke Playbook explanation with experimental features enabled", async () => {
+      const folder = "lightspeed";
       const file = "playbook_4.yml";
-      const filePath = getFilePath(file);
+      const filePath = getFixturePath(folder, file);
 
       // Open file in the editor
       await VSBrowser.instance.openResources(filePath);
@@ -230,8 +231,9 @@ export function lightspeedOneClickTrialUITest(): void {
     });
 
     it("Invoke Completion with experimental features enabled", async () => {
+      const folder = "lightspeed";
       const file = "playbook_3.yml";
-      const filePath = getFilePath(file);
+      const filePath = getFixturePath(folder, file);
       await VSBrowser.instance.openResources(filePath);
       await sleep(1000);
 

--- a/test/ui-test/lightspeedUiTest.ts
+++ b/test/ui-test/lightspeedUiTest.ts
@@ -17,7 +17,7 @@ import {
 } from "vscode-extension-tester";
 import {
   expectNotification,
-  getFilePath,
+  getFixturePath,
   sleep,
   updateSettings,
 } from "./uiTestHelper";
@@ -79,8 +79,9 @@ export function lightspeedUIAssetsTest(): void {
     let settingsEditor: SettingsEditor;
     let editorView: EditorView;
     let workbench: Workbench;
+    const folder = "lightspeed";
     const file = "playbook_1.yml";
-    const filePath = getFilePath(file);
+    const filePath = getFixturePath(folder, file);
 
     before(async function () {
       statusBar = new StatusBar();
@@ -630,8 +631,9 @@ export function lightspeedUIAssetsTest(): void {
 
     it("Playbook explanation webview works as expected", async function () {
       if (process.env.TEST_LIGHTSPEED_URL) {
+        const folder = "lightspeed";
         const file = "playbook_4.yml";
-        const filePath = getFilePath(file);
+        const filePath = getFixturePath(folder, file);
 
         // Open file in the editor
         await VSBrowser.instance.openResources(filePath);
@@ -671,8 +673,9 @@ export function lightspeedUIAssetsTest(): void {
 
     it("Playbook explanation webview works as expected (feature unavailable)", async function () {
       if (process.env.TEST_LIGHTSPEED_URL) {
+        const folder = "lightspeed";
         const file = "playbook_explanation_feature_unavailable.yml";
-        const filePath = getFilePath(file);
+        const filePath = getFixturePath(folder, file);
 
         // Open file in the editor
         await VSBrowser.instance.openResources(filePath);
@@ -698,8 +701,9 @@ export function lightspeedUIAssetsTest(): void {
 
     it("Playbook explanation webview with a playbook with no tasks", async function () {
       if (process.env.TEST_LIGHTSPEED_URL) {
+        const folder = "lightspeed";
         const file = "playbook_5.yml";
-        const filePath = getFilePath(file);
+        const filePath = getFixturePath(folder, file);
 
         // Open file in the editor
         await VSBrowser.instance.openResources(filePath);

--- a/test/ui-test/terminalUiTest.ts
+++ b/test/ui-test/terminalUiTest.ts
@@ -1,0 +1,134 @@
+import { expect, config } from "chai";
+import fs from "fs";
+import {
+  Workbench,
+  BottomBarPanel,
+  VSBrowser,
+  SettingsEditor,
+} from "vscode-extension-tester";
+import { getFixturePath, updateSettings, sleep } from "./uiTestHelper";
+
+config.truncateThreshold = 0;
+
+export function terminalUITests(): void {
+  describe("Verify the execution of playbook using ansible-playbook command", () => {
+    let workbench: Workbench;
+    let settingsEditor: SettingsEditor;
+    const folder = "terminal";
+    const file = "playbook.yml";
+    const playbookFile = getFixturePath(folder, file);
+
+    before(async function () {
+      workbench = new Workbench();
+    });
+    it("Execute ansible-playbook command with arg", async function () {
+      settingsEditor = await workbench.openSettings();
+      await updateSettings(
+        settingsEditor,
+        "ansible.playbook.arguments",
+        "--syntax-check",
+      );
+
+      await VSBrowser.instance.openResources(playbookFile);
+
+      await workbench.executeCommand("Run playbook via `ansible-playbook`");
+
+      const terminalView = await new BottomBarPanel().openTerminalView();
+      const text = await terminalView.getText();
+
+      expect(text).contains("ansible-playbook --syntax-check");
+      await terminalView.killTerminal();
+    });
+    it("Execute ansible-playbook command without arg", async function () {
+      const settingsEditor = await workbench.openSettings();
+      await updateSettings(settingsEditor, "ansible.playbook.arguments", " ");
+      await VSBrowser.instance.openResources(playbookFile);
+
+      await workbench.executeCommand("Run playbook via `ansible-playbook`");
+
+      const terminalView = await new BottomBarPanel().openTerminalView();
+      const text = await terminalView.getText();
+
+      expect(text).contains("ansible-playbook ");
+      expect(text).does.not.contain("ansible-playbook --");
+
+      await terminalView.killTerminal();
+    });
+  });
+  describe("Verify the execution of playbook using ansible-navigator command", () => {
+    let workbench: Workbench;
+    let settingsEditor: SettingsEditor;
+    const folder = "terminal";
+    const file = "playbook.yml";
+    const playbookFile = getFixturePath(folder, file);
+    before(async function () {
+      workbench = new Workbench();
+    });
+    // Skip this test on macOS due to CI container settings
+    it("Execute playbook with ansible-navigator EE mode", async function () {
+      if (process.platform !== "darwin") {
+        settingsEditor = await workbench.openSettings();
+        await updateSettings(
+          settingsEditor,
+          "ansible.executionEnvironment.enabled",
+          true,
+        );
+        await updateSettings(
+          settingsEditor,
+          "ansible.executionEnvironment.containerEngine",
+          "podman",
+        );
+
+        await VSBrowser.instance.openResources(playbookFile);
+
+        await workbench.executeCommand(
+          "Run playbook via `ansible-navigator run`",
+        );
+        await sleep(3500);
+
+        const terminalView = await new BottomBarPanel().openTerminalView();
+        const text = await terminalView.getText();
+
+        // assert with just "Play " rather than "Play name" due to CI output formatting issues
+        expect(text).contains("Play ");
+        await terminalView.killTerminal();
+      }
+    });
+    it("Execute playbook with ansible-navigator without EE mode", async function () {
+      settingsEditor = await workbench.openSettings();
+      await updateSettings(
+        settingsEditor,
+        "ansible.executionEnvironment.enabled",
+        false,
+      );
+      await VSBrowser.instance.openResources(playbookFile);
+      await workbench.executeCommand(
+        "Run playbook via `ansible-navigator run``",
+      );
+      await sleep(3000);
+
+      const terminalView = await new BottomBarPanel().openTerminalView();
+      const text = await terminalView.getText();
+      await terminalView.killTerminal();
+
+      // assert with just "Play " rather than "Play name" due to CI output formatting issues
+      expect(text).contains("Play ");
+    });
+    after(async function () {
+      const folder = "terminal";
+      const fixtureFolder = getFixturePath(folder) + "/";
+      settingsEditor = await workbench.openSettings();
+
+      await updateSettings(
+        settingsEditor,
+        "ansible.executionEnvironment.containerEngine",
+        "docker",
+      );
+      fs.readdirSync(fixtureFolder).forEach((file) => {
+        if (file.includes("playbook-artifact")) {
+          fs.unlinkSync(fixtureFolder + file);
+        }
+      });
+    });
+  });
+}

--- a/test/ui-test/uiTestHelper.ts
+++ b/test/ui-test/uiTestHelper.ts
@@ -8,19 +8,12 @@ import {
   Workbench,
 } from "vscode-extension-tester";
 
-export function getFilePath(file: string): string {
+// Returns testFixtures/ path by default, and can
+// return testFixtures/ subfolders and files.
+export function getFixturePath(subdir: string = "", file: string = ""): string {
   return path.resolve(
     __dirname,
-    path.join(
-      "..",
-      "..",
-      "..",
-      "..",
-      "test",
-      "testFixtures",
-      "lightspeed",
-      file,
-    ),
+    path.join("..", "..", "..", "..", "test", "testFixtures", subdir, file),
   );
 }
 


### PR DESCRIPTION
Adds an extension setting under `ansible.playbook.arguments` to add arguments to `ansible-playbook` runs.

Demo:

`ansible-playbook` run,  without arguments set:

![Without setting](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExanZ0NmVyN3l4NHM0bnZnYjc1bm9kY21wd2NieTl2eG5sMXdkaWcyNyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/JdgpJF7OHAM4ilmFvV/giphy.gif)


How to set the argument in settings, and then running `ansible-playbook`:

![With setting](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExZzlmcjV4OW94cDRpNGdwdzlpdzQ4MmQzbW8wbm05MzBjZHZxdzFmYyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/esq0rILsVhPMQFkEYi/giphy.gif)

Additional changes:

- Made a minor bugfix in `src/features/runner.ts`. The `SettingsManager` class now replaces `ExtensionSettings`. 
- Refactored the `getFilePath()` helper function (now `getFixturePath()` )to be more generic , and adjusted function calls as needed. 
- Added tests for `ansible-playbook` and `ansible-navigator` commands.

Closes #1042.
