### PR TITLE
test: use python3 executable everywhere

### DIFF
--- a/examples/collections/ansible_collections/my_namespace/my_collection/plugins/modules/my_test.py
+++ b/examples/collections/ansible_collections/my_namespace/my_collection/plugins/modules/my_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 # Copyright: (c) 2018, Terry Jones <terry.jones@example.org>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/packages/ansible-language-server/test/utils/getAnsibleMetaData.test.ts
+++ b/packages/ansible-language-server/test/utils/getAnsibleMetaData.test.ts
@@ -46,7 +46,7 @@ function getAnsibleTestInfo() {
 function getPythonTestInfo() {
   const pythonInfo: ansibleMetaDataEntryType = {};
   pythonInfo["version"] = ".";
-  pythonInfo["location"] = "/python";
+  pythonInfo["location"] = "/python3";
   return pythonInfo;
 }
 

--- a/packages/ansible-language-server/test/utils/runCommand.test.ts
+++ b/packages/ansible-language-server/test/utils/runCommand.test.ts
@@ -57,7 +57,7 @@ describe("commandRunner", () => {
     },
     {
       args: [
-        "python",
+        "python3",
         "-c",
         "\"import os; print(os.environ.get('VIRTUAL_ENV'))\"",
       ],

--- a/packages/ansible-language-server/test/utils/withInterpreter.test.ts
+++ b/packages/ansible-language-server/test/utils/withInterpreter.test.ts
@@ -44,7 +44,7 @@ describe("withInterpreter", () => {
       scenario: "when absolute path of interpreter is provided",
       executable: "/absolute/path/to/ansible-lint",
       args: "playbook.yml",
-      interpreterPath: "/path/to/venv/bin/python",
+      interpreterPath: "/path/to/venv/bin/python3",
       activationScript: "",
       expectedCommand: "/absolute/path/to/ansible-lint playbook.yml",
       expectedEnv: {

--- a/test/units/contentCreator/utilities.test.ts
+++ b/test/units/contentCreator/utilities.test.ts
@@ -11,7 +11,7 @@ const homeDir = homedir();
 const getBinDetailTests = [
   {
     name: "valid binary (python)",
-    command: "python",
+    command: "python3",
     arg: "--version",
     expected: "Python 3.",
   },

--- a/tools/test-setup.sh
+++ b/tools/test-setup.sh
@@ -474,7 +474,7 @@ tools:
   node: $(get_version node)
   npm: $(get_version npm)
   pre-commit: $(get_version pre-commit)
-  python: $(get_version python)
+  python: $(get_version python3)
   task: $(get_version task)
   yarn: $(get_version yarn || echo null)
 containers:


### PR DESCRIPTION
Use python3 executable everywhere.

Related: #1140