### PR TITLE
lightspeed trial: point direct on /trial

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -609,8 +609,9 @@ export async function activate(context: ExtensionContext): Promise<void> {
       () => {
         vscode.env.openExternal(
           vscode.Uri.parse(
-            lightSpeedManager.settingsManager.settings.lightSpeedService.URL + "/trial",
-          )
+            lightSpeedManager.settingsManager.settings.lightSpeedService.URL +
+              "/trial",
+          ),
         );
       },
     ),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -609,8 +609,8 @@ export async function activate(context: ExtensionContext): Promise<void> {
       () => {
         vscode.env.openExternal(
           vscode.Uri.parse(
-            lightSpeedManager.settingsManager.settings.lightSpeedService.URL,
-          ),
+            lightSpeedManager.settingsManager.settings.lightSpeedService.URL + "/trial",
+          )
         );
       },
     ),


### PR DESCRIPTION
Go directly on the /trial page. We will disable it server side when the
user has admin privilege and we want to be sure they are still reaching the
right page.
