### PR TITLE
Replace marked.parse with marked.parseInline to reduce extra vertical spaces

### DIFF
--- a/src/features/lightspeed/lightspeedUser.ts
+++ b/src/features/lightspeed/lightspeedUser.ts
@@ -159,7 +159,7 @@ export class LightspeedUser {
         },
       );
 
-      const markdownData = marked.parse(data.content) as string;
+      const markdownData = marked.parseInline(data.content) as string;
 
       return markdownData;
     } catch (error) {


### PR DESCRIPTION
Repace `marked.parse()` with `marked.parseInline()` to reduce extra vertical spaces. These APIs are used for formatting markdown strings. While `marked.parse()` encloses the input with HTML \<p\> tags, `marked.parseInline()` omits \<p\>. For our usage,  `marked.parseInline()` is more desirable for reducing spaces of the limited real estate of VS Code sidebar.