### PR TITLE
Remove one of two examples for Lightspeed completion tests

### DIFF
--- a/test/testScripts/lightspeed/testLightspeed.test.ts
+++ b/test/testScripts/lightspeed/testLightspeed.test.ts
@@ -38,10 +38,6 @@ function testSuggestionPrompts() {
       taskName: "Print hello world",
       expectedModule: "ansible.builtin.debug",
     },
-    {
-      taskName: "Create a file foo.txt",
-      expectedModule: "ansible.builtin.file",
-    },
   ];
 
   return tests;
@@ -51,7 +47,6 @@ function testSuggestionExpectedInsertTexts() {
   // Based on the responses defined in the mock lightspeed server codes
   const insertTexts = [
     `  ${LIGHTSPEED_SUGGESTION_GHOST_TEXT_COMMENT}      ansible.builtin.debug:\n        msg: Hello World\n    `,
-    `  ${LIGHTSPEED_SUGGESTION_GHOST_TEXT_COMMENT}      ansible.builtin.file:\n        path: ~/foo.txt\n        state: touch\n    `,
   ];
 
   return insertTexts;


### PR DESCRIPTION
Right now each of Lightspeed completions API tests is executed twice for `taskName: "Print hello world"` and `taskName: "Create a file foo.txt"`.  When we used a real Lightspeed instance, running the test twice using different samples were somehow meaningful, but now we are using a mock server and running the test twice just increases the possibility of the failure on timing-dependent test cases.  This PR remove one of the two examples to improve the stability of completions API tests.







