### PR TITLE
"undefined" is displayed in sidebar when Lightspeed is not enabled

### DIFF
--- a/src/features/lightspeed/explorerWebviewViewProvider.ts
+++ b/src/features/lightspeed/explorerWebviewViewProvider.ts
@@ -71,7 +71,7 @@ export class LightspeedExplorerWebviewViewProvider
     const content =
       await this.lightspeedAuthenticatedUser.getLightspeedUserContent();
 
-    if (content !== "undefined") {
+    if (content) {
       return getWebviewContentWithActiveSession(
         webview,
         extensionUri,

--- a/src/features/lightspeed/lightspeedUser.ts
+++ b/src/features/lightspeed/lightspeedUser.ts
@@ -389,8 +389,8 @@ export class LightspeedUser {
       await this.getMarkdownLightspeedUserDetails(false);
     const userDetails = await this.getLightspeedUserDetails(false);
 
-    let content = "undefined";
-    if (markdownUserDetails !== "") {
+    let content;
+    if (markdownUserDetails) {
       content = String(markdownUserDetails);
     } else {
       if (userDetails) {

--- a/test/ui-test/lightspeedUiTest.ts
+++ b/test/ui-test/lightspeedUiTest.ts
@@ -74,7 +74,7 @@ export function lightspeedUIAssetsTest(): void {
     });
   });
 
-  describe("Verify the presence of lightspeed element in the status bar", () => {
+  describe("Verify the presence of lightspeed element in the status bar and the explorer view", () => {
     let statusBar: StatusBar;
     let settingsEditor: SettingsEditor;
     let editorView: EditorView;
@@ -102,6 +102,22 @@ export function lightspeedUIAssetsTest(): void {
         ),
       );
       expect(items.length).equals(0);
+    });
+
+    it("Connect button exists in Lightspeed explorer view when settings not enabled", async function () {
+      await new Workbench().executeCommand(
+        "Ansible: Focus on Ansible Lightspeed View",
+      );
+      await sleep(3000);
+      const explorerView = new WebviewView();
+      expect(explorerView, "contentCreatorWebView should not be undefined").not
+        .to.be.undefined;
+      await explorerView.switchToFrame(5000);
+      const connectButton = await explorerView.findWebElement(
+        By.id("lightspeed-explorer-connect"),
+      );
+      expect(connectButton).not.to.be.undefined;
+      await explorerView.switchBack();
     });
 
     it("Ansible Lightspeed status bar item present when only lightspeed is enabled (with warning color)", async () => {


### PR DESCRIPTION
Fix the bug reported in #1442 

Closes: #1442