### PR TITLE
Skip Lightspeed Inline Completion "keeping typing" test case temporarily

### DIFF
--- a/test/testScripts/lightspeed/testLightspeed.test.ts
+++ b/test/testScripts/lightspeed/testLightspeed.test.ts
@@ -233,7 +233,7 @@ export function testLightspeed(): void {
       });
     });
 
-    describe("Test Ansible Lightspeed inline completion suggestions with keeping typing", function () {
+    describe.skip("Test Ansible Lightspeed inline completion suggestions with keeping typing", function () {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       let feedbackRequestSpy: any;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
Temporarily skip `"Test Ansible Lightspeed inline completion suggestions with keeping typing"` test case, which fails randomly & rather frequently until we could find a way to make it more stable.