### PR TITLE
Add link for the developer docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -255,7 +255,9 @@ which you can learn more about at
 
 ## Development guide
 
-Refer to the [Developer Docs](https://ansible.readthedocs.io/projects/vscode-ansible/development/main/) to get started with developing the extension.
+Refer to the
+[Developer Docs](https://ansible.readthedocs.io/projects/vscode-ansible/development/main/)
+to get started with developing the extension.
 
 ## Contact
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -255,7 +255,7 @@ which you can learn more about at
 
 ## Development guide
 
-Please refer to the [Developer Docs](https://ansible.readthedocs.io/projects/vscode-ansible/development/main/) to get started with developing the extension.
+Refer to the [Developer Docs](https://ansible.readthedocs.io/projects/vscode-ansible/development/main/) to get started with developing the extension.
 
 ## Contact
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -253,6 +253,10 @@ which you can learn more about at
   extension.
 - Jinja _blocks_ (inside Ansible YAML files) are not supported yet.
 
+## Development guide
+
+Please refer to the [Developer Docs](https://ansible.readthedocs.io/projects/vscode-ansible/development/main/) to get started with developing the extension.
+
 ## Contact
 
 - [Ansible Developer Tools matrix channel](https://matrix.to/#/#devtools:ansible.im)


### PR DESCRIPTION
The PR adds a link to the developer docs in the extension's README file.