### PR TITLE
Additional logging when proxy block requests to lightspeed

### DIFF
--- a/src/features/lightspeed/lightSpeedOAuthProvider.ts
+++ b/src/features/lightspeed/lightSpeedOAuthProvider.ts
@@ -400,6 +400,10 @@ export class LightSpeedAuthenticationProvider
           "[ansible-lightspeed-oauth] error message: ",
           error.message,
         );
+        console.error(
+          "[ansible-lightspeed-oauth] error response data: ",
+          error.response?.data,
+        );
         throw new Error("An unexpected error occurred");
       } else {
         console.error("[ansible-lightspeed-oauth] unexpected error: ", error);

--- a/src/features/lightspeed/lightSpeedOAuthProvider.ts
+++ b/src/features/lightspeed/lightSpeedOAuthProvider.ts
@@ -400,6 +400,7 @@ export class LightSpeedAuthenticationProvider
           "[ansible-lightspeed-oauth] error message: ",
           error.message,
         );
+        /* istanbul ignore next */
         console.error(
           "[ansible-lightspeed-oauth] error response data: ",
           error.response?.data,

--- a/src/features/lightspeed/lightspeedUser.ts
+++ b/src/features/lightspeed/lightspeedUser.ts
@@ -173,6 +173,7 @@ export class LightspeedUser {
         this._logger.error(
           `[ansible-lightspeed-user] error message: ${error.message}`,
         );
+        /* istanbul ignore next */
         console.error(
           "[ansible-lightspeed-user] error response data: ",
           error.response?.data,

--- a/src/features/lightspeed/lightspeedUser.ts
+++ b/src/features/lightspeed/lightspeedUser.ts
@@ -173,6 +173,10 @@ export class LightspeedUser {
         this._logger.error(
           `[ansible-lightspeed-user] error message: ${error.message}`,
         );
+        console.error(
+          "[ansible-lightspeed-user] error response data: ",
+          error.response?.data,
+        );
         throw new Error(error.message);
       } else {
         this._logger.error(


### PR DESCRIPTION
Follow up to https://github.com/ansible/vscode-ansible/pull/1437 for token exchange blocked by proxy. Debugging the response body for requests to Lightspeed when they fail help us quickly pinpoint if the request is failing when it hits our service or if it is being rejected by the proxy.