### PR TITLE
AAP-26820: Task not found in ARI postprocess results

### DIFF
--- a/src/features/lightspeed/inlineSuggestions.ts
+++ b/src/features/lightspeed/inlineSuggestions.ts
@@ -669,6 +669,7 @@ async function getInlineSuggestionState(
     shouldTriggerMultiTaskSuggestion(
       documentInfo.documentContent,
       suggestionMatchInfo.spacesBeforePromptStart,
+      inlinePosition.position.line,
       documentInfo.ansibleFileType,
     ) ||
     shouldRequestInlineSuggestions(

--- a/test/testScripts/lightspeed/e2eInlineSuggestion.test.ts
+++ b/test/testScripts/lightspeed/e2eInlineSuggestion.test.ts
@@ -24,6 +24,7 @@ import { FeedbackRequestParams } from "../../../src/interfaces/lightspeed";
 
 import { activate, getDocUri, sleep } from "../../helper";
 import { integer } from "vscode-languageclient";
+import { shouldTriggerMultiTaskSuggestion } from "../../../src/features/lightspeed/utils/data";
 
 const INSERT_TEXT = "**** I'm not a pilot ****";
 
@@ -259,6 +260,93 @@ export async function testIgnorePendingSuggestion(): Promise<void> {
     after(() => {
       feedbackRequestSpy.restore();
       isAuthenticatedStub.restore();
+    });
+  });
+}
+
+export async function testTriggerTaskSuggestion(): Promise<void> {
+  describe("Test when a inline suggestion should be triggered.", () => {
+    const taskFileCollection =
+      "collections:\n" + "  - name: Deploy web servers\n";
+    it("Test taskFileCollection.", async () => {
+      const taskFileCollectionResult = shouldTriggerMultiTaskSuggestion(
+        taskFileCollection,
+        2,
+        3,
+        "tasks_in_role",
+      );
+      assert(!taskFileCollectionResult);
+    });
+
+    const taskFileCollectionEmpty = "collections:\n";
+    it("Test taskFileCollectionEmpty.", async () => {
+      const taskFileCollectionResultEmpty = shouldTriggerMultiTaskSuggestion(
+        taskFileCollectionEmpty,
+        0,
+        1,
+        "tasks_in_role",
+      );
+      assert(!taskFileCollectionResultEmpty);
+    });
+
+    const taskFileTask = "- name: install redis on Debian based distributions\n";
+    it("Test taskFileTask.", async () => {
+      const taskFileTaskResult = shouldTriggerMultiTaskSuggestion(
+        taskFileTask,
+        0,
+        2,
+        "tasks",
+      );
+      assert(taskFileTaskResult);
+    });
+
+    const taskFileTaskAlreadySuggested =
+      "- name: install redis on Debian based distributions\n" +
+      "  apt:\n" +
+      "    name: redis-server\n" +
+      "    state: present\n" +
+      "    update_cache: true\n" +
+      "  become: true";
+    it("Test taskFileTaskAlreadySuggested.", async () => {
+      const taskFileTaskAlreadySuggestedResult =
+        shouldTriggerMultiTaskSuggestion(
+          taskFileTaskAlreadySuggested,
+          0,
+          7,
+          "tasks",
+        );
+      assert(!taskFileTaskAlreadySuggestedResult);
+    });
+
+    const taskFileBlock =
+      "block:\n" + "  - name: Install httpd and memcached\n";
+    it("Test taskFileBlock.", async () => {
+      const taskFileBlockResult = shouldTriggerMultiTaskSuggestion(
+        taskFileBlock,
+        2,
+        3,
+        "tasks",
+      );
+      assert(taskFileBlockResult);
+    });
+
+    const taskFileBlockTwoTasks =
+      "block:\n" +
+      "  - name: Install httpd and memcached\n" +
+      "    ansible.builtin.yum:\n" +
+      "      name:\n" +
+      "      - httpd\n" +
+      "      - memcached\n" +
+      "      state: present\n" +
+      "  - name: Display something";
+    it("Test taskFileBlockTwoTasks.", async () => {
+      const taskFileBlockTwoTasksResult = shouldTriggerMultiTaskSuggestion(
+        taskFileBlockTwoTasks,
+        2,
+        9,
+        "tasks",
+      );
+      assert(taskFileBlockTwoTasksResult);
     });
   });
 }

--- a/test/testScripts/lightspeed/e2eInlineSuggestion.test.ts
+++ b/test/testScripts/lightspeed/e2eInlineSuggestion.test.ts
@@ -289,7 +289,8 @@ export async function testTriggerTaskSuggestion(): Promise<void> {
       assert(!taskFileCollectionResultEmpty);
     });
 
-    const taskFileTask = "- name: install redis on Debian based distributions\n";
+    const taskFileTask =
+      "- name: install redis on Debian based distributions\n";
     it("Test taskFileTask.", async () => {
       const taskFileTaskResult = shouldTriggerMultiTaskSuggestion(
         taskFileTask,

--- a/test/testScripts/lightspeed/testLightspeed.test.ts
+++ b/test/testScripts/lightspeed/testLightspeed.test.ts
@@ -20,7 +20,7 @@ import { lightSpeedManager } from "../../../src/extension";
 import {
   testInlineSuggestionByAnotherProvider,
   testInlineSuggestionProviderCoExistence,
-  testIgnorePendingSuggestion,
+  testIgnorePendingSuggestion, testTriggerTaskSuggestion,
 } from "./e2eInlineSuggestion.test";
 import {
   UserAction,
@@ -435,6 +435,10 @@ export function testLightspeed(): void {
 
     describe("Test LightspeedUser", function () {
       testLightspeedUser();
+    });
+
+    describe("Test when a inline suggestion should be triggered", () => {
+      testTriggerTaskSuggestion();
     });
 
     describe("Test suggestion event handlers.", function () {

--- a/test/testScripts/lightspeed/testLightspeed.test.ts
+++ b/test/testScripts/lightspeed/testLightspeed.test.ts
@@ -20,7 +20,8 @@ import { lightSpeedManager } from "../../../src/extension";
 import {
   testInlineSuggestionByAnotherProvider,
   testInlineSuggestionProviderCoExistence,
-  testIgnorePendingSuggestion, testTriggerTaskSuggestion,
+  testIgnorePendingSuggestion,
+  testTriggerTaskSuggestion,
 } from "./e2eInlineSuggestion.test";
 import {
   UserAction,


### PR DESCRIPTION
Hey @TamiTakamiya 

Please see https://issues.redhat.com/browse/AAP-26820

This PR ensures that lightspeed is not triggered in case the prompt is not for a "task" context, for task files.  
For more info, plse see my latest comment on the ticket https://issues.redhat.com/browse/AAP-26820 

Thanks!