### PR TITLE
Unmount volumes when execution environment is disabled

### DIFF
--- a/packages/ansible-language-server/test/helper.ts
+++ b/packages/ansible-language-server/test/helper.ts
@@ -58,12 +58,12 @@ export async function enableExecutionEnvironmentSettings(
     {
       src: ANSIBLE_COLLECTIONS_FIXTURES_BASE_PATH,
       dest: ANSIBLE_COLLECTIONS_FIXTURES_BASE_PATH,
-      options: undefined,
+      options: "ro", // read-only option for volume mounts
     },
     {
       src: ANSIBLE_ADJACENT_COLLECTIONS__PATH,
       dest: ANSIBLE_ADJACENT_COLLECTIONS__PATH,
-      options: undefined,
+      options: "ro", // read-only option for volume mounts
     },
   ];
 }
@@ -72,6 +72,7 @@ export async function disableExecutionEnvironmentSettings(
   docSettings: Thenable<ExtensionSettings>,
 ): Promise<void> {
   (await docSettings).executionEnvironment.enabled = false;
+  (await docSettings).executionEnvironment.volumeMounts = [];
 }
 
 export function resolveDocUri(filename: string): string {

--- a/test/helper.ts
+++ b/test/helper.ts
@@ -115,7 +115,7 @@ export async function enableExecutionEnvironmentSettings(): Promise<void> {
     {
       src: ANSIBLE_COLLECTIONS_FIXTURES_BASE_PATH,
       dest: ANSIBLE_COLLECTIONS_FIXTURES_BASE_PATH,
-      options: undefined,
+      options: "ro", // read-only option for volume mounts
     },
   ];
   await updateSettings("executionEnvironment.volumeMounts", volumeMounts);
@@ -123,6 +123,7 @@ export async function enableExecutionEnvironmentSettings(): Promise<void> {
 
 export async function disableExecutionEnvironmentSettings(): Promise<void> {
   await updateSettings("executionEnvironment.enabled", false);
+  await updateSettings("executionEnvironment.volumeMounts", []);
 }
 
 export async function enableLightspeedSettings(): Promise<void> {


### PR DESCRIPTION
This PR removes volume mounts when we disable execution environments.
Also, the volumes will be read-only when mounted
