### PR TITLE
Update collection path for some als tests

### DIFF
--- a/packages/ansible-language-server/test/providers/completionProvider.test.ts
+++ b/packages/ansible-language-server/test/providers/completionProvider.test.ts
@@ -743,7 +743,7 @@ describe("doCompletion()", () => {
       describe("With EE enabled @ee", () => {
         before(async () => {
           setFixtureAnsibleCollectionPathEnv(
-            "/home/runner/.ansible/collections:/usr/share/ansible",
+            "/home/runner/.ansible/collections:/usr/share/ansible/collections",
           );
           await enableExecutionEnvironmentSettings(docSettings);
         });
@@ -775,7 +775,7 @@ describe("doCompletion()", () => {
       describe("With EE enabled @ee", () => {
         before(async () => {
           setFixtureAnsibleCollectionPathEnv(
-            "/home/runner/.ansible/collections:/usr/share/ansible",
+            "/home/runner/.ansible/collections:/usr/share/ansible/collections",
           );
           await enableExecutionEnvironmentSettings(docSettings);
         });
@@ -811,7 +811,7 @@ describe("doCompletion()", () => {
       describe("With EE enabled @ee", () => {
         before(async () => {
           setFixtureAnsibleCollectionPathEnv(
-            "/home/runner/.ansible/collections:/usr/share/ansible",
+            "/home/runner/.ansible/collections:/usr/share/ansible/collections",
           );
           await enableExecutionEnvironmentSettings(docSettings);
         });
@@ -845,7 +845,7 @@ describe("doCompletion()", () => {
       describe("With EE enabled @ee", () => {
         before(async () => {
           setFixtureAnsibleCollectionPathEnv(
-            "/home/runner/.ansible/collections:/usr/share/ansible",
+            "/home/runner/.ansible/collections:/usr/share/ansible/collections",
           );
           await enableExecutionEnvironmentSettings(docSettings);
         });
@@ -880,7 +880,7 @@ describe("doCompletion()", () => {
       describe("With EE enabled @ee", () => {
         before(async () => {
           setFixtureAnsibleCollectionPathEnv(
-            "/home/runner/.ansible/collections:/usr/share/ansible",
+            "/home/runner/.ansible/collections:/usr/share/ansible/collections",
           );
           await enableExecutionEnvironmentSettings(docSettings);
         });
@@ -906,7 +906,7 @@ describe("doCompletion()", () => {
       describe("With EE enabled @ee", () => {
         before(async () => {
           setFixtureAnsibleCollectionPathEnv(
-            "/home/runner/.ansible/collections:/usr/share/ansible",
+            "/home/runner/.ansible/collections:/usr/share/ansible/collections",
           );
           await enableExecutionEnvironmentSettings(docSettings);
         });
@@ -933,7 +933,7 @@ describe("doCompletion()", () => {
       describe("With EE enabled @ee", () => {
         before(async () => {
           setFixtureAnsibleCollectionPathEnv(
-            "/home/runner/.ansible/collections:/usr/share/ansible",
+            "/home/runner/.ansible/collections:/usr/share/ansible/collections",
           );
           await enableExecutionEnvironmentSettings(docSettings);
         });
@@ -960,7 +960,7 @@ describe("doCompletion()", () => {
       describe("With EE enabled @ee", () => {
         before(async () => {
           setFixtureAnsibleCollectionPathEnv(
-            "/home/runner/.ansible/collections:/usr/share/ansible",
+            "/home/runner/.ansible/collections:/usr/share/ansible/collections",
           );
           await enableExecutionEnvironmentSettings(docSettings);
         });
@@ -987,7 +987,7 @@ describe("doCompletion()", () => {
       describe("With EE enabled @ee", () => {
         before(async () => {
           setFixtureAnsibleCollectionPathEnv(
-            "/home/runner/.ansible/collections:/usr/share/ansible",
+            "/home/runner/.ansible/collections:/usr/share/ansible/collections",
           );
           await enableExecutionEnvironmentSettings(docSettings);
         });
@@ -1022,7 +1022,7 @@ describe("doCompletion()", () => {
       describe("With EE enabled @ee", () => {
         before(async () => {
           setFixtureAnsibleCollectionPathEnv(
-            "/home/runner/.ansible/collections:/usr/share/ansible",
+            "/home/runner/.ansible/collections:/usr/share/ansible/collections",
           );
           await enableExecutionEnvironmentSettings(docSettings);
         });
@@ -1057,7 +1057,7 @@ describe("doCompletion()", () => {
         describe("With EE enabled @ee", () => {
           before(async () => {
             setFixtureAnsibleCollectionPathEnv(
-              "/home/runner/.ansible/collections:/usr/share/ansible",
+              "/home/runner/.ansible/collections:/usr/share/ansible/collections",
             );
             await enableExecutionEnvironmentSettings(docSettings);
           });
@@ -1093,7 +1093,7 @@ describe("doCompletion()", () => {
       describe("With EE enabled @ee", () => {
         before(async () => {
           setFixtureAnsibleCollectionPathEnv(
-            "/home/runner/.ansible/collections:/usr/share/ansible",
+            "/home/runner/.ansible/collections:/usr/share/ansible/collections",
           );
           await enableExecutionEnvironmentSettings(docSettings);
         });
@@ -1129,7 +1129,7 @@ describe("doCompletion()", () => {
       describe("With EE enabled @ee", () => {
         before(async () => {
           setFixtureAnsibleCollectionPathEnv(
-            "/home/runner/.ansible/collections:/usr/share/ansible",
+            "/home/runner/.ansible/collections:/usr/share/ansible/collections",
           );
           await enableExecutionEnvironmentSettings(docSettings);
         });

--- a/packages/ansible-language-server/test/providers/completionResolver.test.ts
+++ b/packages/ansible-language-server/test/providers/completionResolver.test.ts
@@ -225,7 +225,7 @@ describe("doCompletionResolve()", () => {
         describe("with EE enabled @ee", () => {
           before(async () => {
             setFixtureAnsibleCollectionPathEnv(
-              "/home/runner/.ansible/collections:/usr/share/ansible",
+              "/home/runner/.ansible/collections:/usr/share/ansible/collections",
             );
             await enableExecutionEnvironmentSettings(docSettings);
           });
@@ -250,7 +250,7 @@ describe("doCompletionResolve()", () => {
         describe("with EE enabled @ee", () => {
           before(async () => {
             setFixtureAnsibleCollectionPathEnv(
-              "/home/runner/.ansible/collections:/usr/share/ansible",
+              "/home/runner/.ansible/collections:/usr/share/ansible/collections",
             );
             await enableExecutionEnvironmentSettings(docSettings);
             (await docSettings).ansible.useFullyQualifiedCollectionNames =
@@ -286,7 +286,7 @@ describe("doCompletionResolve()", () => {
       describe("with EE enabled @ee", () => {
         before(async () => {
           setFixtureAnsibleCollectionPathEnv(
-            "/home/runner/.ansible/collections:/usr/share/ansible",
+            "/home/runner/.ansible/collections:/usr/share/ansible/collections",
           );
           await enableExecutionEnvironmentSettings(docSettings);
         });

--- a/packages/ansible-language-server/test/providers/definitionProvider.test.ts
+++ b/packages/ansible-language-server/test/providers/definitionProvider.test.ts
@@ -94,7 +94,7 @@ describe("getDefinition()", function () {
     describe("With EE enabled @ee", function () {
       before(async function () {
         setFixtureAnsibleCollectionPathEnv(
-          "/home/runner/.ansible/collections:/usr/share/ansible",
+          "/home/runner/.ansible/collections:/usr/share/ansible/collections",
         );
         if (docSettings) {
           await enableExecutionEnvironmentSettings(docSettings);

--- a/packages/ansible-language-server/test/providers/hoverProvider.test.ts
+++ b/packages/ansible-language-server/test/providers/hoverProvider.test.ts
@@ -289,7 +289,7 @@ describe("doHover()", () => {
     describe("With EE enabled @ee", () => {
       before(async () => {
         setFixtureAnsibleCollectionPathEnv(
-          "/home/runner/.ansible/collections:/usr/share/ansible",
+          "/home/runner/.ansible/collections:/usr/share/ansible/collections",
         );
         if (docSettings) {
           await enableExecutionEnvironmentSettings(docSettings);
@@ -324,7 +324,7 @@ describe("doHover()", () => {
     describe("With EE enabled @ee", () => {
       before(async () => {
         setFixtureAnsibleCollectionPathEnv(
-          "/home/runner/.ansible/collections:/usr/share/ansible",
+          "/home/runner/.ansible/collections:/usr/share/ansible/collections",
         );
         if (docSettings) {
           await enableExecutionEnvironmentSettings(docSettings);
@@ -359,7 +359,7 @@ describe("doHover()", () => {
     describe("With EE enabled @ee", () => {
       before(async () => {
         setFixtureAnsibleCollectionPathEnv(
-          "/home/runner/.ansible/collections:/usr/share/ansible",
+          "/home/runner/.ansible/collections:/usr/share/ansible/collections",
         );
         if (docSettings) {
           await enableExecutionEnvironmentSettings(docSettings);
@@ -402,7 +402,7 @@ describe("doHover()", () => {
     describe("With EE enabled @ee", () => {
       before(async () => {
         setFixtureAnsibleCollectionPathEnv(
-          "/home/runner/.ansible/collections:/usr/share/ansible",
+          "/home/runner/.ansible/collections:/usr/share/ansible/collections",
         );
         if (docSettings) {
           await enableExecutionEnvironmentSettings(docSettings);
@@ -446,7 +446,7 @@ describe("doHover()", () => {
     describe("With EE enabled @ee", () => {
       before(async () => {
         setFixtureAnsibleCollectionPathEnv(
-          "/home/runner/.ansible/collections:/usr/share/ansible",
+          "/home/runner/.ansible/collections:/usr/share/ansible/collections",
         );
         if (docSettings) {
           await enableExecutionEnvironmentSettings(docSettings);
@@ -483,7 +483,7 @@ describe("doHover()", () => {
     describe("With EE enabled @ee", () => {
       before(async () => {
         setFixtureAnsibleCollectionPathEnv(
-          "/home/runner/.ansible/collections:/usr/share/ansible",
+          "/home/runner/.ansible/collections:/usr/share/ansible/collections",
         );
         if (docSettings) {
           await enableExecutionEnvironmentSettings(docSettings);
@@ -526,7 +526,7 @@ describe("doHover()", () => {
     describe("With EE enabled @ee", () => {
       before(async () => {
         setFixtureAnsibleCollectionPathEnv(
-          "/home/runner/.ansible/collections:/usr/share/ansible",
+          "/home/runner/.ansible/collections:/usr/share/ansible/collections",
         );
         if (docSettings) {
           await enableExecutionEnvironmentSettings(docSettings);
@@ -570,7 +570,7 @@ describe("doHover()", () => {
     describe("With EE enabled @ee", () => {
       before(async () => {
         setFixtureAnsibleCollectionPathEnv(
-          "/home/runner/.ansible/collections:/usr/share/ansible",
+          "/home/runner/.ansible/collections:/usr/share/ansible/collections",
         );
         if (docSettings) {
           await enableExecutionEnvironmentSettings(docSettings);

--- a/packages/ansible-language-server/test/providers/validationProvider.test.ts
+++ b/packages/ansible-language-server/test/providers/validationProvider.test.ts
@@ -381,7 +381,7 @@ describe("doValidate()", () => {
       describe("With EE enabled @ee", () => {
         before(async () => {
           setFixtureAnsibleCollectionPathEnv(
-            "/home/runner/.ansible/collections:/usr/share/ansible",
+            "/home/runner/.ansible/collections:/usr/share/ansible/collections",
           );
           await enableExecutionEnvironmentSettings(docSettings);
         });
@@ -409,7 +409,7 @@ describe("doValidate()", () => {
         describe("With EE enabled @ee", () => {
           before(async () => {
             setFixtureAnsibleCollectionPathEnv(
-              "/home/runner/.ansible/collections:/usr/share/ansible",
+              "/home/runner/.ansible/collections:/usr/share/ansible/collections",
             );
             await enableExecutionEnvironmentSettings(docSettings);
           });
@@ -448,7 +448,7 @@ describe("doValidate()", () => {
               before(async () => {
                 (await docSettings).validation.lint.enabled = false;
                 setFixtureAnsibleCollectionPathEnv(
-                  "/home/runner/.ansible/collections:/usr/share/ansible",
+                  "/home/runner/.ansible/collections:/usr/share/ansible/collections",
                 );
                 await enableExecutionEnvironmentSettings(docSettings);
               });
@@ -506,7 +506,7 @@ describe("doValidate()", () => {
               before(async () => {
                 (await docSettings).validation.lint.enabled = false;
                 setFixtureAnsibleCollectionPathEnv(
-                  "/home/runner/.ansible/collections:/usr/share/ansible",
+                  "/home/runner/.ansible/collections:/usr/share/ansible/collections",
                 );
                 await enableExecutionEnvironmentSettings(docSettings);
               });
@@ -561,7 +561,7 @@ describe("doValidate()", () => {
               before(async () => {
                 (await docSettings).validation.lint.enabled = false;
                 setFixtureAnsibleCollectionPathEnv(
-                  "/home/runner/.ansible/collections:/usr/share/ansible",
+                  "/home/runner/.ansible/collections:/usr/share/ansible/collections",
                 );
                 await enableExecutionEnvironmentSettings(docSettings);
               });
@@ -616,7 +616,7 @@ describe("doValidate()", () => {
             before(async () => {
               (await docSettings).validation.lint.enabled = false;
               setFixtureAnsibleCollectionPathEnv(
-                "/home/runner/.ansible/collections:/usr/share/ansible",
+                "/home/runner/.ansible/collections:/usr/share/ansible/collections",
               );
               await enableExecutionEnvironmentSettings(docSettings);
             });
@@ -675,7 +675,7 @@ describe("doValidate()", () => {
                 //   "invalid-ansible-lint-path";
                 (await docSettings).validation.enabled = false;
                 setFixtureAnsibleCollectionPathEnv(
-                  "/home/runner/.ansible/collections:/usr/share/ansible",
+                  "/home/runner/.ansible/collections:/usr/share/ansible/collections",
                 );
                 await enableExecutionEnvironmentSettings(docSettings);
               });
@@ -740,7 +740,7 @@ describe("doValidate()", () => {
                 //   "invalid-ansible-lint-path";
                 (await docSettings).validation.enabled = false;
                 setFixtureAnsibleCollectionPathEnv(
-                  "/home/runner/.ansible/collections:/usr/share/ansible",
+                  "/home/runner/.ansible/collections:/usr/share/ansible/collections",
                 );
                 await enableExecutionEnvironmentSettings(docSettings);
               });
@@ -802,7 +802,7 @@ describe("doValidate()", () => {
         describe("With EE enabled @ee", () => {
           before(async () => {
             setFixtureAnsibleCollectionPathEnv(
-              "/home/runner/.ansible/collections:/usr/share/ansible",
+              "/home/runner/.ansible/collections:/usr/share/ansible/collections",
             );
             await enableExecutionEnvironmentSettings(docSettings);
           });


### PR DESCRIPTION
This PR updates the incorrect collection path 
(from `/usr/share/ansible` to `/usr/share/ansible/collections`) 
which is set before running some als tests.
