### PR TITLE
Delete ALS EE cache before and after E2E and ALS tests

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -35,6 +35,7 @@ WSLENV
 Webviews
 YOLO
 aarch
+afterall
 ajinkyau
 akira
 alefragnani

--- a/packages/ansible-language-server/test/helper.ts
+++ b/packages/ansible-language-server/test/helper.ts
@@ -10,6 +10,7 @@ import {
 } from "vscode-languageserver/node";
 import { ValidationManager } from "../src/services/validationManager";
 import { ExtensionSettings } from "../src/interfaces/extensionSettings";
+import { rmSync } from "fs";
 
 import Fuse from "fuse.js";
 
@@ -28,6 +29,13 @@ export const ANSIBLE_CONFIG_FILE = path.resolve(
   "completion",
   "ansible.cfg",
 );
+
+export function deleteAlsCache(): void {
+  const hostCacheBasePath = path.resolve(
+    `${process.env.HOME}/.cache/ansible-language-server/`,
+  );
+  rmSync(hostCacheBasePath, { recursive: true, force: true });
+}
 
 export function setFixtureAnsibleCollectionPathEnv(prePendPath?: string): void {
   if (prePendPath) {

--- a/packages/ansible-language-server/test/rootMochaHooks.ts
+++ b/packages/ansible-language-server/test/rootMochaHooks.ts
@@ -1,6 +1,6 @@
 import * as chai from "chai";
 import { ConsoleOutput } from "./consoleOutput";
-import { skipEE, console } from "./helper";
+import { skipEE, console, deleteAlsCache } from "./helper";
 
 chai.config.truncateThreshold = 0; // disable truncating
 
@@ -8,6 +8,9 @@ export const mochaHooks = (): Mocha.RootHookObject => {
   const consoleOutput = new ConsoleOutput();
 
   return {
+    beforeAll(this: Mocha.Context) {
+      deleteAlsCache();
+    },
     beforeEach(this: Mocha.Context) {
       if (skipEE() && this.currentTest?.fullTitle().includes("@ee")) {
         console.warn(
@@ -25,6 +28,9 @@ export const mochaHooks = (): Mocha.RootHookObject => {
           consoleOutput.release();
         }
       }
+    },
+    afterAll(this: Mocha.Context) {
+      deleteAlsCache();
     },
   };
 };

--- a/test/helper.ts
+++ b/test/helper.ts
@@ -9,6 +9,7 @@ import { integer } from "vscode-languageclient";
 import axios from "axios";
 import { LIGHTSPEED_ME_AUTH_URL } from "../src/definitions/lightspeed";
 import { getInlineSuggestionItems } from "../src/features/lightspeed/inlineSuggestions";
+import { rmSync } from "fs";
 
 export let doc: vscode.TextDocument;
 export let editor: vscode.TextEditor;
@@ -90,6 +91,13 @@ export async function updateSettings(
 ): Promise<void> {
   const ansibleConfiguration = vscode.workspace.getConfiguration(section);
   return ansibleConfiguration.update(setting, value);
+}
+
+export function deleteAlsCache(): void {
+  const hostCacheBasePath = path.resolve(
+    `${process.env.HOME}/.cache/ansible-language-server/`,
+  );
+  rmSync(hostCacheBasePath, { recursive: true, force: true });
 }
 
 export function setFixtureAnsibleCollectionPathEnv(

--- a/test/testScripts/e2eTestSuiteLauncher.test.ts
+++ b/test/testScripts/e2eTestSuiteLauncher.test.ts
@@ -5,8 +5,10 @@ import { testHoverWithoutEE } from "./hover/testWithoutEE.test";
 import {
   updateSettings,
   setFixtureAnsibleCollectionPathEnv,
+  unSetFixtureAnsibleCollectionPathEnv,
   enableExecutionEnvironmentSettings,
   disableExecutionEnvironmentSettings,
+  deleteAlsCache,
 } from "../helper";
 import { testLightspeed } from "./lightspeed/testLightspeed.test";
 import { testExtensionForFilesOutsideWorkspace } from "./outsideWorkspace/testExtensionForFilesOutsideWorkspace.test";
@@ -38,6 +40,7 @@ describe("END-TO-END TEST SUITE FOR REDHAT.ANSIBLE EXTENSION", () => {
   if (skip_ee !== "1" && run_lightspeed_tests_only !== "1") {
     describe("TEST EXTENSION IN EXECUTION ENVIRONMENT", () => {
       before(async () => {
+        deleteAlsCache();
         setFixtureAnsibleCollectionPathEnv(
           "/home/runner/.ansible/collections:/usr/share/ansible/collections",
         );
@@ -46,6 +49,8 @@ describe("END-TO-END TEST SUITE FOR REDHAT.ANSIBLE EXTENSION", () => {
 
       after(async () => {
         await disableExecutionEnvironmentSettings(); // Revert back the default settings
+        unSetFixtureAnsibleCollectionPathEnv();
+        deleteAlsCache();
       });
 
       testHoverEE();


### PR DESCRIPTION
This resolves an issue where EE volume mounts were incorrect after running EE tests in either e2e or ALS test suites.

Fixes #1473.