### PR TITLE
Upload artifacts from matrix "test (linux)"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -266,7 +266,7 @@ jobs:
         run: task als ${{ matrix.env.TASKFILE_ARGS }}
 
       - name: Upload vsix artifact
-        if: ${{ matrix.name == 'test' }}
+        if: ${{ matrix.name == 'test (linux)' }}
         uses: actions/upload-artifact@v4
         with:
           name: ansible-extension-build-${{ github.event.number || github.ref_name }}.zip
@@ -275,7 +275,7 @@ jobs:
           retention-days: 90
 
       - name: Upload ansible-language-server npm package
-        if: ${{ matrix.name == 'test' }}
+        if: ${{ matrix.name == 'test (linux)' }}
         uses: actions/upload-artifact@v4
         with:
           name: "@ansible-ansible-language-server-build-${{ github.event.number || github.ref_name }}.tgz"


### PR DESCRIPTION
Upload artifacts from matrix "test (linux)". Previously the matrix was named as "test".  As it was renamed to "test (linux)", the workflow needs to updated accordingly.