### PR TITLE
Make playbook generation work even with an empty outline

### DIFF
--- a/src/webview/apps/common/editableList.ts
+++ b/src/webview/apps/common/editableList.ts
@@ -39,7 +39,7 @@ export class EditableList {
         values.push(node.textContent.trim());
       }
     });
-    return values;
+    return values.length === 0 ? [""] : values;
   }
 
   setToUI(values: string[]) {
@@ -71,9 +71,6 @@ export class EditableList {
   }
 
   isChanged() {
-    if (!this.savedValues) {
-      return true;
-    }
     const values = this.getFromUI();
     if (this.savedValues.length !== values.length) {
       return true;

--- a/src/webview/apps/lightspeed/playbookGeneration/main.ts
+++ b/src/webview/apps/lightspeed/playbookGeneration/main.ts
@@ -47,7 +47,7 @@ window.addEventListener("load", () => {
   outline = new EditableList("outline-list");
   outline.element.addEventListener("input", () => {
     setButtonEnabled("reset-button", outline.isChanged());
-    setButtonEnabled("generate-button", !outline.isEmpty());
+    // setButtonEnabled("generate-button", !outline.isEmpty());
   });
 
   // Detect whether a dark or a light color theme is used.

--- a/test/units/lightspeed/editableList.test.ts
+++ b/test/units/lightspeed/editableList.test.ts
@@ -66,6 +66,8 @@ describe("Test EditableList", () => {
       domWithEmptyList.window,
     );
     assert.equal(emptyEditableList.isEmpty(), true);
+    assert.equal(emptyEditableList.getFromUI().length, 1);
+    assert.equal(emptyEditableList.getFromUI()[0], "");
   });
 
   it("Test constructor", async () => {


### PR DESCRIPTION
This is an attempt to make the Playbook Generation UI work even when WCA return an empty outline for the first API call made from the first page of the Playbook Generation UI.