### PR TITLE
WCA: Handle 'HTTP404: Failed to get remaining capacity' response

### DIFF
--- a/src/features/lightspeed/errors.ts
+++ b/src/features/lightspeed/errors.ts
@@ -260,6 +260,14 @@ ERRORS.addError(
 );
 
 ERRORS.addError(
+  418,
+  new Error(
+    "error__wca_instance_deleted",
+    "IBM watsonx Code Assistant instance associated with your Model Id has been deleted. Please contact your administrator.",
+  ),
+);
+
+ERRORS.addError(
   500,
   new Error(
     "internal_server",

--- a/test/units/lightspeed/utils/handleApiError.test.ts
+++ b/test/units/lightspeed/utils/handleApiError.test.ts
@@ -289,6 +289,22 @@ describe("testing the error handling", () => {
   // =================================
 
   // =================================
+  // HTTP 418
+  // ---------------------------------
+  it("err WCA instance deleted", () => {
+    const error = mapError(
+      createError(418, {
+        code: "error__wca_instance_deleted",
+      }),
+    );
+    assert.equal(
+      error.message,
+      "IBM watsonx Code Assistant instance associated with your Model Id has been deleted. Please contact your administrator.",
+    );
+  });
+  // =================================
+
+  // =================================
   // HTTP 429
   // ---------------------------------
   it("err Too Many Requests", () => {


### PR DESCRIPTION
This is the VSCode change supporting https://github.com/ansible/ansible-ai-connect-service/pull/1268