### PR TITLE
README: add Forum

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -261,7 +261,22 @@ to get started with developing the extension.
 
 ## Contact
 
-- [Ansible Developer Tools matrix channel](https://matrix.to/#/#devtools:ansible.im)
+We welcome your feedback, questions and ideas. Here's how to reach the community.
+
+### Forum
+
+Join the [Ansible Forum](https://forum.ansible.com) as a single starting point and our default communication platform for questions and help, development discussions, events, and much more. [Register](https://forum.ansible.com/signup?) to join the community. Search by categories and tags to find interesting topics or start a new one; subscribe only to topics you need!
+
+- [Get Help](https://forum.ansible.com/c/help/6): get help or help others. Please add appropriate tags if you start new discussions, for example `vscode-ansible`.
+- [Posts tagged with 'vscode-ansible'](https://forum.ansible.com/tag/vscode-ansible): subscribe to participate in project-related conversations.
+- [Social Spaces](https://forum.ansible.com/c/chat/4): gather and interact with fellow enthusiasts.
+- [News & Announcements](https://forum.ansible.com/c/news/5): track project-wide announcements including social events. The [Bullhorn newsletter](https://docs.ansible.com/ansible/devel/community/communication.html#the-bullhorn), which is used to announce releases and important changes, can also be found here.
+
+For more information on the forum navigation, see [Navigating the Ansible forum](https://forum.ansible.com/t/navigating-the-ansible-forum-tags-categories-and-concepts/39) post.
+
+### Matrix
+
+- [#devtools:ansible.im](https://matrix.to/#/#devtools:ansible.im): a chat channel via the Matrix protocol. See the [Ansible communication guide](https://docs.ansible.com/ansible/devel/community/communication.html#real-time-chat) to learn how to join.
 
 ## Credit
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -261,22 +261,41 @@ to get started with developing the extension.
 
 ## Contact
 
-We welcome your feedback, questions and ideas. Here's how to reach the community.
+We welcome your feedback, questions and ideas. Here's how to reach the
+community.
 
 ### Forum
 
-Join the [Ansible Forum](https://forum.ansible.com) as a single starting point and our default communication platform for questions and help, development discussions, events, and much more. [Register](https://forum.ansible.com/signup?) to join the community. Search by categories and tags to find interesting topics or start a new one; subscribe only to topics you need!
+Join the [Ansible Forum](https://forum.ansible.com) as a single starting point
+and our default communication platform for questions and help, development
+discussions, events, and much more.
+[Register](https://forum.ansible.com/signup?) to join the community. Search by
+categories and tags to find interesting topics or start a new one; subscribe
+only to topics you need!
 
-- [Get Help](https://forum.ansible.com/c/help/6): get help or help others. Please add appropriate tags if you start new discussions, for example `vscode-ansible`.
-- [Posts tagged with 'vscode-ansible'](https://forum.ansible.com/tag/vscode-ansible): subscribe to participate in project-related conversations.
-- [Social Spaces](https://forum.ansible.com/c/chat/4): gather and interact with fellow enthusiasts.
-- [News & Announcements](https://forum.ansible.com/c/news/5): track project-wide announcements including social events. The [Bullhorn newsletter](https://docs.ansible.com/ansible/devel/community/communication.html#the-bullhorn), which is used to announce releases and important changes, can also be found here.
+- [Get Help](https://forum.ansible.com/c/help/6): get help or help others.
+  Please add appropriate tags if you start new discussions, for example
+  `vscode-ansible`.
+- [Posts tagged with 'vscode-ansible'](https://forum.ansible.com/tag/vscode-ansible):
+  subscribe to participate in project-related conversations.
+- [Social Spaces](https://forum.ansible.com/c/chat/4): gather and interact with
+  fellow enthusiasts.
+- [News & Announcements](https://forum.ansible.com/c/news/5): track project-wide
+  announcements including social events. The
+  [Bullhorn newsletter](https://docs.ansible.com/ansible/devel/community/communication.html#the-bullhorn),
+  which is used to announce releases and important changes, can also be found
+  here.
 
-For more information on the forum navigation, see [Navigating the Ansible forum](https://forum.ansible.com/t/navigating-the-ansible-forum-tags-categories-and-concepts/39) post.
+For more information on the forum navigation, see
+[Navigating the Ansible forum](https://forum.ansible.com/t/navigating-the-ansible-forum-tags-categories-and-concepts/39)
+post.
 
 ### Matrix
 
-- [#devtools:ansible.im](https://matrix.to/#/#devtools:ansible.im): a chat channel via the Matrix protocol. See the [Ansible communication guide](https://docs.ansible.com/ansible/devel/community/communication.html#real-time-chat) to learn how to join.
+- [#devtools:ansible.im](https://matrix.to/#/#devtools:ansible.im): a chat
+  channel via the Matrix protocol. See the
+  [Ansible communication guide](https://docs.ansible.com/ansible/devel/community/communication.html#real-time-chat)
+  to learn how to join.
 
 ## Credit
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -286,7 +286,9 @@ only to topics you need!
   which is used to announce releases and important changes, can also be found
   here.
 
-See `Navigating the Ansible forum <https://forum.ansible.com/t/navigating-the-ansible-forum-tags-categories-and-concepts/39>`_ for some practical advice on finding your way around.
+See
+`Navigating the Ansible forum <https://forum.ansible.com/t/navigating-the-ansible-forum-tags-categories-and-concepts/39>`\_
+for some practical advice on finding your way around.
 
 ### Matrix
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -286,9 +286,7 @@ only to topics you need!
   which is used to announce releases and important changes, can also be found
   here.
 
-For more information on the forum navigation, see
-[Navigating the Ansible forum](https://forum.ansible.com/t/navigating-the-ansible-forum-tags-categories-and-concepts/39)
-post.
+See `Navigating the Ansible forum <https://forum.ansible.com/t/navigating-the-ansible-forum-tags-categories-and-concepts/39>`_ for some practical advice on finding your way around.
 
 ### Matrix
 


### PR DESCRIPTION
Dear maintainers,
As a part of the [Consolidating Ansible discussion platforms initiative](https://forum.ansible.com/t/proposal-consolidating-ansible-discussion-platforms/6812), this PR adds the communication section template defined by the community to the README and the docsite. Similar PRs are now being raised across all the Ansible ecosystem projects.

Thank you