### PR TITLE
Remove `xargs` usage in EE cleanup functionality

### DIFF
--- a/packages/ansible-language-server/src/services/executionEnvironment.ts
+++ b/packages/ansible-language-server/src/services/executionEnvironment.ts
@@ -361,9 +361,8 @@ export class ExecutionEnvironment {
 
   private cleanUpContainer(containerName: string): void {
     const cleanUpCommands = [
-      `sh -c '${this._container_engine} ps -q --filter "name=${containerName}" | xargs ${this._container_engine} stop'`,
-      // docker does not have the --ignore flag, so we need to list and pipe
-      `sh -c '${this._container_engine} container ls -aq -f 'name=${containerName}' | xargs ${this._container_engine} rm --force'`,
+      `${this._container_engine} stop ${containerName}`,
+      `${this._container_engine} rm ${containerName}`,
     ];
 
     if (!this.doesContainerNameExist(containerName)) {


### PR DESCRIPTION
Remove xargs usage, which caused adt container removal issues.

Related: https://issues.redhat.com/browse/AAP-30231
