### PR TITLE
Nesting commands to fix container cleanup

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -156,6 +156,9 @@ tasks:
   test-ui:
     desc: Run UI tests {{.XVFB}}
     aliases: [ui]
+    env:
+      MOCHA_GREP: Test One Click Trial feature
+      MOCHA_INVERT: true
     cmds:
       - yarn webpack-dev
       - "{{.VIRTUAL_ENV}}/bin/python3 --version"

--- a/packages/ansible-language-server/src/services/executionEnvironment.ts
+++ b/packages/ansible-language-server/src/services/executionEnvironment.ts
@@ -361,8 +361,8 @@ export class ExecutionEnvironment {
 
   private cleanUpContainer(containerName: string): void {
     const cleanUpCommands = [
-      `${this._container_engine} stop ${containerName}`,
-      `${this._container_engine} rm ${containerName}`,
+      `${this._container_engine} stop $(${this._container_engine} ps -q --filter "name=${containerName}")`,
+      `${this._container_engine} rm $(${this._container_engine} container ls -aq -f 'name=${containerName}')`,
     ];
 
     if (!this.doesContainerNameExist(containerName)) {


### PR DESCRIPTION
This change resolves a bug where containers were improperly stopped when using the extension in EE mode.

The issue resulted in a `podman cp` failure in the logs, in both upstream and downstream containers. This change adds onto the change in #1535, keeping `xargs` out of the command for downstream purposes, while still retaining the ability to get the container name for removal. 

Tests were confirmed to pass with manual local testing. 