### PR TITLE
AAP-30427: VS Code Extension settings page to take  a new custom_prompt field

### DIFF
--- a/package.json
+++ b/package.json
@@ -644,6 +644,18 @@
             "type": "string",
             "markdownDescription": "Model ID to override your organization's default model. This setting is only applicable to commercial users with an Ansible Lightspeed seat assignment.",
             "order": 4
+          },
+          "ansible.lightspeed.playbookGenerationCustomPrompt": {
+            "scope": "resource",
+            "type": "string",
+            "markdownDescription": "Custom Prompt for Playbook generation. This setting is only applicable to commercial users with an Ansible Lightspeed seat assignment.",
+            "order": 5
+          },
+          "ansible.lightspeed.playbookExplanationCustomPrompt": {
+            "scope": "resource",
+            "type": "string",
+            "markdownDescription": "Custom Prompt for Playbook explanation. This setting is only applicable to commercial users with an Ansible Lightspeed seat assignment.",
+            "order": 6
           }
         }
       },

--- a/src/features/lightspeed/api.ts
+++ b/src/features/lightspeed/api.ts
@@ -297,6 +297,12 @@ export class LightSpeedAPI {
       return {} as ExplanationResponseParams;
     }
     try {
+      const customPrompt =
+        lightSpeedManager.settingsManager.settings.lightSpeedService
+          .playbookExplanationCustomPrompt;
+      if (customPrompt && customPrompt.length > 0) {
+        inputData.customPrompt = customPrompt;
+      }
       const requestData = {
         ...inputData,
         metadata: { ansibleExtensionVersion: this._extensionVersion },
@@ -336,6 +342,13 @@ export class LightSpeedAPI {
       return {} as GenerationResponseParams;
     }
     try {
+      const customPrompt =
+        lightSpeedManager.settingsManager.settings.lightSpeedService
+          .playbookGenerationCustomPrompt;
+      if (customPrompt && customPrompt.length > 0) {
+        inputData.customPrompt = customPrompt;
+      }
+
       const requestData = {
         ...inputData,
         metadata: { ansibleExtensionVersion: this._extensionVersion },

--- a/src/features/lightspeed/errors.ts
+++ b/src/features/lightspeed/errors.ts
@@ -83,28 +83,51 @@ class Errors {
           ? responseErrorData.message
           : "unknown";
       }
-
-      let detail: string = "";
-      if (typeof responseErrorData.message == "string") {
-        detail = responseErrorData.message ?? "";
-      } else if (Array.isArray(responseErrorData.message)) {
-        const messages = responseErrorData.message as [];
-        messages.forEach((value: string, index: number) => {
-          detail =
-            detail +
-            "(" +
-            (index + 1) +
-            ") " +
-            value +
-            (index < messages.length - 1 ? " " : "");
-        });
-      }
+      const items = (err?.response?.data as Record<string, unknown>) ?? {};
+      const detail = Object.hasOwn(items, "detail")
+        ? items["detail"]
+        : undefined;
 
       // Clone the Error to preserve the original definition
-      return new Error(e.code, message, detail, e.check);
+      return new Error(
+        e.code,
+        message,
+        this.prettyPrintDetail(detail),
+        e.check,
+      );
     }
 
     return undefined;
+  }
+
+  public prettyPrintDetail(detail: unknown): string | undefined {
+    let pretty: string = "";
+    if (detail === undefined) {
+      return undefined;
+    } else if (typeof detail == "string") {
+      pretty = detail ?? "";
+    } else if (Array.isArray(detail)) {
+      const items = detail as [];
+      items.forEach((value: string, index: number) => {
+        pretty =
+          pretty +
+          "(" +
+          (index + 1) +
+          ") " +
+          value +
+          (index < items.length - 1 ? " " : "");
+      });
+    } else if (detail instanceof Object && detail.constructor === Object) {
+      const items = detail as Record<string, unknown>;
+      const keys: string[] = Object.keys(detail);
+      keys.forEach((key, index) => {
+        pretty =
+          pretty +
+          `${key}: ${items[key]}` +
+          (index < keys.length - 1 ? " " : "");
+      });
+    }
+    return pretty;
   }
 }
 

--- a/src/features/lightspeed/handleApiError.ts
+++ b/src/features/lightspeed/handleApiError.ts
@@ -21,33 +21,38 @@ export function mapError(err: AxiosError): IError {
   }
 
   // If the error is unknown fallback to defaults
-  const detail = err.response?.data;
+  const items = (err?.response?.data as Record<string, unknown>) ?? {};
+  const detail = Object.hasOwn(items, "detail") ? items["detail"] : undefined;
   const status: number | string = err?.response?.status ?? err?.code ?? 500;
   if (err instanceof CanceledError) {
     return ERRORS_CONNECTION_CANCELED_TIMEOUT;
   }
   if (status === 400) {
-    return ERRORS_BAD_REQUEST.withDetail(detail);
+    return ERRORS_BAD_REQUEST.withDetail(ERRORS.prettyPrintDetail(detail));
   }
   if (status === 401) {
-    return ERRORS_UNAUTHORIZED.withDetail(detail);
+    return ERRORS_UNAUTHORIZED.withDetail(ERRORS.prettyPrintDetail(detail));
   }
   if (status === 403) {
-    return ERRORS_UNAUTHORIZED.withDetail(detail);
+    return ERRORS_UNAUTHORIZED.withDetail(ERRORS.prettyPrintDetail(detail));
   }
   if (status === 404) {
-    return ERRORS_NOT_FOUND.withDetail(detail);
+    return ERRORS_NOT_FOUND.withDetail(ERRORS.prettyPrintDetail(detail));
   }
   if (status === 429) {
-    return ERRORS_TOO_MANY_REQUESTS.withDetail(detail);
+    return ERRORS_TOO_MANY_REQUESTS.withDetail(
+      ERRORS.prettyPrintDetail(detail),
+    );
   }
   if (status === 500) {
-    return ERRORS_UNKNOWN.withDetail(detail);
+    return ERRORS_UNKNOWN.withDetail(ERRORS.prettyPrintDetail(detail));
   }
   if (status === AxiosError.ECONNABORTED) {
-    return ERRORS_CONNECTION_TIMEOUT.withDetail(detail);
+    return ERRORS_CONNECTION_TIMEOUT.withDetail(
+      ERRORS.prettyPrintDetail(detail),
+    );
   }
 
   console.log(`Lightspeed request failed with unknown error ${err}`);
-  return ERRORS_UNKNOWN.withDetail(detail);
+  return ERRORS_UNKNOWN.withDetail(ERRORS.prettyPrintDetail(detail));
 }

--- a/src/features/lightspeed/playbookGeneration.ts
+++ b/src/features/lightspeed/playbookGeneration.ts
@@ -156,9 +156,8 @@ export async function showPlaybookGenerationPage(
               if (isError(response)) {
                 const oneClickTrialProvider = getOneClickTrialProvider();
                 if (!(await oneClickTrialProvider.showPopup(response))) {
-                  vscode.window.showErrorMessage(
-                    response.message ?? UNKNOWN_ERROR,
-                  );
+                  const errorMessage: string = `${response.message ?? UNKNOWN_ERROR} ${response.detail ?? ""}`;
+                  vscode.window.showErrorMessage(errorMessage);
                 }
               } else {
                 panel.webview.postMessage({
@@ -198,7 +197,8 @@ export async function showPlaybookGenerationPage(
               panel,
             );
             if (isError(response)) {
-              vscode.window.showErrorMessage(response.message ?? UNKNOWN_ERROR);
+              const errorMessage: string = `${response.message ?? UNKNOWN_ERROR} ${response.detail ?? ""}`;
+              vscode.window.showErrorMessage(errorMessage);
               break;
             }
             playbook = response.playbook;

--- a/src/interfaces/extensionSettings.ts
+++ b/src/interfaces/extensionSettings.ts
@@ -44,4 +44,6 @@ export interface LightSpeedServiceSettings {
   URL: string;
   suggestions: { enabled: boolean; waitWindow: number };
   model: string | undefined;
+  playbookGenerationCustomPrompt: string | undefined;
+  playbookExplanationCustomPrompt: string | undefined;
 }

--- a/src/interfaces/lightspeed.ts
+++ b/src/interfaces/lightspeed.ts
@@ -142,6 +142,7 @@ export interface ISuggestionDetails {
 
 export interface GenerationRequestParams {
   text: string;
+  customPrompt?: string;
   outline?: string;
   generationId: string;
   createOutline: boolean;
@@ -156,6 +157,7 @@ export interface GenerationResponseParams {
 
 export interface ExplanationRequestParams {
   content: string;
+  customPrompt?: string;
   explanationId: string;
 }
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -47,6 +47,14 @@ export class SettingsManager {
           waitWindow: lightSpeedSettings.get("suggestions.waitWindow", 0),
         },
         model: lightSpeedSettings.get("modelIdOverride", undefined),
+        playbookGenerationCustomPrompt: lightSpeedSettings.get(
+          "playbookGenerationCustomPrompt",
+          undefined,
+        ),
+        playbookExplanationCustomPrompt: lightSpeedSettings.get(
+          "playbookExplanationCustomPrompt",
+          undefined,
+        ),
       },
       playbook: {
         arguments: playbookSettings.get("arguments", ""),

--- a/src/webview/apps/lightspeed/playbookGeneration/main.ts
+++ b/src/webview/apps/lightspeed/playbookGeneration/main.ts
@@ -76,6 +76,7 @@ window.addEventListener("message", async (event) => {
     }
     case "outline": {
       setupPage(2);
+
       outline.update(message.outline.outline);
       savedPlaybook = message.outline.playbook;
       generationId = message.outline.generationId;

--- a/test/mockLightspeedServer/generations.ts
+++ b/test/mockLightspeedServer/generations.ts
@@ -8,6 +8,7 @@ export function generations(
   res: any,
 ) {
   const text = req.body.text;
+  const customPrompt = req.body.customPrompt;
   const createOutline = req.body.createOutline;
   const generationId = req.body.generationId ? req.body.generationId : uuidv4();
   const wizardId = req.body.wizardId;
@@ -43,6 +44,16 @@ export function generations(
     return res.status(404).send({
       code: "feature_not_available",
       message: "The feature is not available",
+    });
+  }
+
+  // Special case to replicate a broken custom prompt
+  if (customPrompt && customPrompt === "custom prompt broken") {
+    logger.info("Returning 400. Custom prompt is invalid");
+    return res.status(400).send({
+      code: "validation",
+      message: "invalid",
+      detail: { customPrompt: "custom prompt is invalid" },
     });
   }
 
@@ -96,6 +107,10 @@ export function generations(
 
   if (createOutline && outline) {
     outline += "\n4. Some extra step.";
+  }
+
+  if (customPrompt) {
+    outline += "\n5. Custom prompt step.";
   }
 
   return res.send({

--- a/test/testFixtures/lightspeed/playbook_explanation_none.yml
+++ b/test/testFixtures/lightspeed/playbook_explanation_none.yml
@@ -1,0 +1,5 @@
+---
+- name:
+  hosts: all
+  tasks:
+    - name: No explanation available...

--- a/test/ui-test/lightspeedUiTest.ts
+++ b/test/ui-test/lightspeedUiTest.ts
@@ -498,6 +498,7 @@ export function lightspeedUIAssetsTest(): void {
           .undefined;
         let text = await outlineList.getText();
         expect(text.includes("Create virtual network peering")).to.be.true;
+        expect(text.includes("Custom prompt step")).not.to.be.true;
 
         // Verify the prompt is displayed as a static text
         const prompt = await webView.findWebElement(
@@ -629,6 +630,132 @@ export function lightspeedUIAssetsTest(): void {
       }
     });
 
+    it("Playbook generation webview works as expected (fast path, custom prompt)", async function () {
+      // Execute only when TEST_LIGHTSPEED_URL environment variable is defined.
+      if (process.env.TEST_LIGHTSPEED_URL) {
+        // Set Playbook generation custom prompt
+        settingsEditor = await workbench.openSettings();
+        await updateSettings(
+          settingsEditor,
+          "ansible.lightspeed.playbookGenerationCustomPrompt",
+          "custom prompt",
+        );
+        await workbench.executeCommand("View: Close All Editor Groups");
+
+        // Open playbook generation webview.
+        await workbench.executeCommand(
+          "Ansible Lightspeed: Playbook generation",
+        );
+        await sleep(2000);
+        const webView = await new WebView();
+        expect(webView, "webView should not be undefined").not.to.be.undefined;
+        await webView.switchToFrame(5000);
+        expect(
+          webView,
+          "webView should not be undefined after switching to its frame",
+        ).not.to.be.undefined;
+
+        // Set input text and invoke summaries API
+        const textArea = await webView.findWebElement(
+          By.xpath("//vscode-text-area"),
+        );
+        expect(textArea, "textArea should not be undefined").not.to.be
+          .undefined;
+        const submitButton = await webView.findWebElement(
+          By.xpath("//vscode-button[@id='submit-button']"),
+        );
+        expect(submitButton, "submitButton should not be undefined").not.to.be
+          .undefined;
+        //
+        // Note: Following line should succeed, but fails for some unknown reasons.
+        //
+        // expect((await submitButton.isEnabled()), "submit button should be disabled by default").is.false;
+        await textArea.sendKeys("Create an azure network.");
+        expect(
+          await submitButton.isEnabled(),
+          "submit button should be enabled now",
+        ).to.be.true;
+        await submitButton.click();
+        await sleep(1000);
+
+        // Verify outline output and text edit
+        const outlineList = await webView.findWebElement(
+          By.xpath("//ol[@id='outline-list']"),
+        );
+        expect(outlineList, "An ordered list should exist.").to.be.not
+          .undefined;
+        const text = await outlineList.getText();
+        expect(text.includes("Custom prompt step")).to.be.true;
+
+        await webView.switchBack();
+        await workbench.executeCommand("View: Close All Editor Groups");
+      } else {
+        this.skip();
+      }
+    });
+
+    it("Playbook generation webview works as expected (fast path, custom prompt, broken)", async function () {
+      // Execute only when TEST_LIGHTSPEED_URL environment variable is defined.
+      if (process.env.TEST_LIGHTSPEED_URL) {
+        // Set Playbook generation custom prompt
+        settingsEditor = await workbench.openSettings();
+        await updateSettings(
+          settingsEditor,
+          "ansible.lightspeed.playbookGenerationCustomPrompt",
+          "custom prompt broken",
+        );
+        await workbench.executeCommand("View: Close All Editor Groups");
+
+        // Open playbook generation webview.
+        await workbench.executeCommand(
+          "Ansible Lightspeed: Playbook generation",
+        );
+        await sleep(2000);
+        const webView = await new WebView();
+        expect(webView, "webView should not be undefined").not.to.be.undefined;
+        await webView.switchToFrame(5000);
+        expect(
+          webView,
+          "webView should not be undefined after switching to its frame",
+        ).not.to.be.undefined;
+
+        // Set input text and invoke summaries API
+        const textArea = await webView.findWebElement(
+          By.xpath("//vscode-text-area"),
+        );
+        expect(textArea, "textArea should not be undefined").not.to.be
+          .undefined;
+        const submitButton = await webView.findWebElement(
+          By.xpath("//vscode-button[@id='submit-button']"),
+        );
+        expect(submitButton, "submitButton should not be undefined").not.to.be
+          .undefined;
+        //
+        // Note: Following line should succeed, but fails for some unknown reasons.
+        //
+        // expect((await submitButton.isEnabled()), "submit button should be disabled by default").is.false;
+        await textArea.sendKeys("Create an azure network.");
+        expect(
+          await submitButton.isEnabled(),
+          "submit button should be enabled now",
+        ).to.be.true;
+        await submitButton.click();
+        await sleep(2000);
+
+        await webView.switchBack();
+
+        const notifications = await workbench.getNotifications();
+        const notification = notifications[0];
+        expect(await notification.getMessage()).equals(
+          "Bad Request response. Please try again. customPrompt: custom prompt is invalid",
+        );
+
+        await workbench.executeCommand("View: Close All Editor Groups");
+      } else {
+        this.skip();
+      }
+    });
+
     it("Playbook explanation webview works as expected", async function () {
       if (process.env.TEST_LIGHTSPEED_URL) {
         const folder = "lightspeed";
@@ -663,6 +790,7 @@ export function lightspeedUIAssetsTest(): void {
         expect(mainDiv, "mainDiv should not be undefined").not.to.be.undefined;
         const text = await mainDiv.getText();
         expect(text.includes("Playbook Overview and Structure")).to.be.true;
+        expect(text.includes("Custom prompt explanation")).not.to.be.true;
 
         await webView.switchBack();
         await workbench.executeCommand("View: Close All Editor Groups");
@@ -693,6 +821,7 @@ export function lightspeedUIAssetsTest(): void {
         expect(group, "Group 1 of the editor view should be undefined").to.be
           .undefined;
 
+        await webView.switchBack();
         await workbench.executeCommand("View: Close All Editor Groups");
       } else {
         this.skip();
@@ -745,6 +874,216 @@ export function lightspeedUIAssetsTest(): void {
       }
     });
 
+    it("Playbook explanation webview works as expected, no explanation", async function () {
+      if (process.env.TEST_LIGHTSPEED_URL) {
+        const folder = "lightspeed";
+        const file = "playbook_explanation_none.yml";
+        const filePath = getFixturePath(folder, file);
+
+        // Open file in the editor
+        await VSBrowser.instance.openResources(filePath);
+
+        // Open playbook explanation webview.
+        await workbench.executeCommand(
+          "Explain the playbook with Ansible Lightspeed",
+        );
+        await sleep(2000);
+
+        // Locate the playbook explanation webview
+        const webView = (await new EditorView().openEditor(
+          "Explanation",
+          1,
+        )) as WebView;
+        expect(webView, "webView should not be undefined").not.to.be.undefined;
+        await webView.switchToFrame(5000);
+        expect(
+          webView,
+          "webView should not be undefined after switching to its frame",
+        ).not.to.be.undefined;
+
+        // Find the main div element of the webview and verify the expected text is found.
+        const mainDiv = await webView.findWebElement(
+          By.xpath("//div[contains(@class, 'playbookGeneration') ]"),
+        );
+        expect(mainDiv, "mainDiv should not be undefined").not.to.be.undefined;
+        const text = await mainDiv.getText();
+        expect(text.includes("No explanation provided")).to.be.true;
+
+        await webView.switchBack();
+        await workbench.executeCommand("View: Close All Editor Groups");
+      } else {
+        this.skip();
+      }
+    });
+
+    it("Playbook explanation webview works as expected, no explanation, custom prompt", async function () {
+      if (process.env.TEST_LIGHTSPEED_URL) {
+        const folder = "lightspeed";
+        const file = "playbook_explanation_none.yml";
+        const filePath = getFixturePath(folder, file);
+
+        // Set Playbook generation custom prompt
+        settingsEditor = await workbench.openSettings();
+        await updateSettings(
+          settingsEditor,
+          "ansible.lightspeed.playbookExplanationCustomPrompt",
+          "custom prompt",
+        );
+        await workbench.executeCommand("View: Close All Editor Groups");
+
+        // Open file in the editor
+        await VSBrowser.instance.openResources(filePath);
+
+        // Open playbook explanation webview.
+        await workbench.executeCommand(
+          "Explain the playbook with Ansible Lightspeed",
+        );
+        await sleep(2000);
+
+        // Locate the playbook explanation webview
+        const webView = (await new EditorView().openEditor(
+          "Explanation",
+          1,
+        )) as WebView;
+        expect(webView, "webView should not be undefined").not.to.be.undefined;
+        await webView.switchToFrame(5000);
+        expect(
+          webView,
+          "webView should not be undefined after switching to its frame",
+        ).not.to.be.undefined;
+
+        // Find the main div element of the webview and verify the expected text is found.
+        const mainDiv = await webView.findWebElement(
+          By.xpath("//div[contains(@class, 'playbookGeneration') ]"),
+        );
+        expect(mainDiv, "mainDiv should not be undefined").not.to.be.undefined;
+        const text = await mainDiv.getText();
+        expect(text.includes("No explanation provided")).to.be.true;
+        expect(
+          text.includes("You may want to consider amending your custom prompt"),
+        ).to.be.true;
+
+        await webView.switchBack();
+        await workbench.executeCommand("View: Close All Editor Groups");
+      } else {
+        this.skip();
+      }
+    });
+
+    it("Playbook explanation webview works as expected, custom prompt", async function () {
+      if (process.env.TEST_LIGHTSPEED_URL) {
+        const folder = "lightspeed";
+        const file = "playbook_4.yml";
+        const filePath = getFixturePath(folder, file);
+
+        // Set Playbook generation custom prompt
+        settingsEditor = await workbench.openSettings();
+        await updateSettings(
+          settingsEditor,
+          "ansible.lightspeed.playbookExplanationCustomPrompt",
+          "custom prompt",
+        );
+        await workbench.executeCommand("View: Close All Editor Groups");
+
+        // Open file in the editor
+        await VSBrowser.instance.openResources(filePath);
+
+        // Open playbook explanation webview.
+        await workbench.executeCommand(
+          "Explain the playbook with Ansible Lightspeed",
+        );
+        await sleep(2000);
+
+        // Locate the playbook explanation webview
+        const webView = (await new EditorView().openEditor(
+          "Explanation",
+          1,
+        )) as WebView;
+        expect(webView, "webView should not be undefined").not.to.be.undefined;
+        await webView.switchToFrame(5000);
+        expect(
+          webView,
+          "webView should not be undefined after switching to its frame",
+        ).not.to.be.undefined;
+
+        // Find the main div element of the webview and verify the expected text is found.
+        const mainDiv = await webView.findWebElement(
+          By.xpath("//div[contains(@class, 'playbookGeneration') ]"),
+        );
+        expect(mainDiv, "mainDiv should not be undefined").not.to.be.undefined;
+        const text = await mainDiv.getText();
+        expect(text.includes("Playbook Overview and Structure")).to.be.true;
+        expect(text.includes("Custom prompt explanation")).to.be.true;
+
+        await webView.switchBack();
+        await workbench.executeCommand("View: Close All Editor Groups");
+      } else {
+        this.skip();
+      }
+    });
+
+    it("Playbook explanation webview works as expected, custom prompt, broken", async function () {
+      if (process.env.TEST_LIGHTSPEED_URL) {
+        const folder = "lightspeed";
+        const file = "playbook_4.yml";
+        const filePath = getFixturePath(folder, file);
+
+        // Set Playbook generation custom prompt
+        settingsEditor = await workbench.openSettings();
+        await updateSettings(
+          settingsEditor,
+          "ansible.lightspeed.playbookExplanationCustomPrompt",
+          "custom prompt broken",
+        );
+        await workbench.executeCommand("View: Close All Editor Groups");
+
+        // Open file in the editor
+        await VSBrowser.instance.openResources(filePath);
+
+        // Open playbook explanation webview.
+        await workbench.executeCommand(
+          "Explain the playbook with Ansible Lightspeed",
+        );
+        await sleep(2000);
+
+        // Locate the playbook explanation webview
+        const webView = (await new EditorView().openEditor(
+          "Explanation",
+          1,
+        )) as WebView;
+        expect(webView, "webView should not be undefined").not.to.be.undefined;
+        await webView.switchToFrame(5000);
+        expect(
+          webView,
+          "webView should not be undefined after switching to its frame",
+        ).not.to.be.undefined;
+
+        // Find the main div element of the webview and verify the expected text is found.
+        const mainDiv = await webView.findWebElement(
+          By.xpath("//div[contains(@class, 'playbookGeneration') ]"),
+        );
+        expect(mainDiv, "mainDiv should not be undefined").not.to.be.undefined;
+        const text = await mainDiv.getText();
+        expect(
+          text.includes(
+            "Bad Request response. Please try again. customPrompt: custom prompt is invalid",
+          ),
+        ).to.be.true;
+
+        await webView.switchBack();
+
+        const notifications = await workbench.getNotifications();
+        const notification = notifications[0];
+        expect(await notification.getMessage()).equals(
+          "Bad Request response. Please try again. customPrompt: custom prompt is invalid",
+        );
+
+        await workbench.executeCommand("View: Close All Editor Groups");
+      } else {
+        this.skip();
+      }
+    });
+
     after(async function () {
       if (process.env.TEST_LIGHTSPEED_URL) {
         settingsEditor = await workbench.openSettings();
@@ -757,6 +1096,16 @@ export function lightspeedUIAssetsTest(): void {
           settingsEditor,
           "ansible.lightspeed.URL",
           "https://c.ai.ansible.redhat.com",
+        );
+        await updateSettings(
+          settingsEditor,
+          "ansible.lightspeed.playbookGenerationCustomPrompt",
+          "",
+        );
+        await updateSettings(
+          settingsEditor,
+          "ansible.lightspeed.playbookExplanationCustomPrompt",
+          "",
         );
       }
     });


### PR DESCRIPTION
Support "custom prompts" for Playbook Generation and Explanation.

Corollary for https://github.com/ansible/ansible-ai-connect-service/pull/1322