### PR TITLE
Close editors before running One Click Trial UI test

### DIFF
--- a/test/ui-test/lightspeedOneClickTrialUITest.ts
+++ b/test/ui-test/lightspeedOneClickTrialUITest.ts
@@ -50,6 +50,8 @@ export function lightspeedOneClickTrialUITest(): void {
         "ansible.lightspeed.suggestions.enabled",
         true,
       );
+      // Close settings and other open editors (if any)
+      await new EditorView().closeAllEditors();
 
       // Set "UI Test" and "One Click" options for mock server
       await axios.post(


### PR DESCRIPTION
We found One Click Trial UI test at `Invoke Playbook generation:` step in the test runs for #1475  ([link to test result](https://github.com/ansible/vscode-ansible/actions/runs/11046865797/job/30702174026)).  The step was for opening the Playbook Generation UI in the Editor pane and get the text area for input.

```
  1) VSCode Ansible - UI tests
       Test One Click Trial feature
         Invoke Playbook generation:
     NoSuchElementError: no such element: Unable to locate element: {"method":"xpath","selector":"//vscode-text-area"}
  (Session info: chrome=122.0.6261.156)
      at Object.throwDecodedError (node_modules/selenium-webdriver/lib/error.js:521:15)
      at parseHttpResponse (node_modules/selenium-webdriver/lib/http.js:514:13)
      at Executor.execute (node_modules/selenium-webdriver/lib/http.js:446:28)
      at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
      at async Driver.execute (node_modules/selenium-webdriver/lib/webdriver.js:742:17)
      at async WebViewBase.findWebElement (node_modules/@redhat-developer/page-objects/out/components/WebviewMixin.js:42:20)
      at async Context.<anonymous> (out/client/test/ui-test/lightspeedOneClickTrialUITest.js:108:30)
```

I tried several changes and found it could be fixed if all editors are closed after required settings are configured at the beginning of the test case. This PR is for that change on the One Click Trial UI test case.
