### PR TITLE
Pin to codecov version v4.5.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -350,7 +350,7 @@ jobs:
           path: .
 
       - name: Upload als test coverage data [1/4]
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v4.5.0
         with:
           name: als
           files: ./*/coverage/als/lcov.info
@@ -360,7 +360,7 @@ jobs:
           use_oidc: true # cspell:ignore oidc
 
       - name: Upload unit test coverage data [2/4]
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v4.5.0
         with:
           name: unit
           files: ./*/coverage/unit/lcov.info
@@ -370,7 +370,7 @@ jobs:
           use_oidc: true # cspell:ignore oidc
 
       - name: Upload ui test coverage data [3/4]
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v4.5.0
         with:
           name: unit
           files: ./*/coverage/ui/lcov.info
@@ -380,7 +380,7 @@ jobs:
           use_oidc: true # cspell:ignore oidc
 
       - name: Upload e2e test coverage data [4/4]
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v4.5.0
         with:
           name: e2e
           files: ./*/coverage/e2e/lcov.info


### PR DESCRIPTION
Changing our codecov version from `v4` to `v4.5.0`, since `v4.6.0` introduced a regression causing this error: 

`Error: Codecov: Failed to get OIDC token with url: https://codecov.io./ Error message: Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable`

Codecov issue: https://github.com/codecov/codecov-action/issues/1594
