### PR TITLE
lightspeed: move down the default timeout to 28s

### DIFF
--- a/src/definitions/constants.ts
+++ b/src/definitions/constants.ts
@@ -39,6 +39,7 @@ export const IncludeVarValidTaskName = [
   "ansible.legacy.include_vars",
 ];
 
-export const ANSIBLE_LIGHTSPEED_API_TIMEOUT = 50000;
+/* Slightly lower than CloudFront's timeout which is 30s. */
+export const ANSIBLE_LIGHTSPEED_API_TIMEOUT = 28000;
 
 export const ANSIBLE_CREATOR_VERSION_MIN = "24.10.1";

--- a/src/features/lightspeed/api.ts
+++ b/src/features/lightspeed/api.ts
@@ -312,9 +312,7 @@ export class LightSpeedAPI {
         requestData,
         {
           timeout: ANSIBLE_LIGHTSPEED_API_TIMEOUT,
-          // This is coming from our former LSP implementation, it may be a good
-          // idea to generalize the use of a <28s timeout to be below CloudFront's 30s
-          signal: AbortSignal.timeout(28000),
+          signal: AbortSignal.timeout(ANSIBLE_LIGHTSPEED_API_TIMEOUT),
         },
       );
       return response.data;
@@ -351,9 +349,7 @@ export class LightSpeedAPI {
         requestData,
         {
           timeout: ANSIBLE_LIGHTSPEED_API_TIMEOUT,
-          // This is coming from our former LSP implementation, it may be a good
-          // idea to generalize the use of a <28s timeout to be below CloudFront's 30s
-          signal: AbortSignal.timeout(28000),
+          signal: AbortSignal.timeout(ANSIBLE_LIGHTSPEED_API_TIMEOUT),
         },
       );
       return response.data;


### PR DESCRIPTION
Our API calls go throught CloudFront where we have 30s timeout. By having a timeout
slightly lower, we can properly trigger them from the client side, avoid the dead closed
connection and handle them elegantly.
