### PR TITLE
Pin codecov action to v4.5.0 and update dependabot.yml to ignore v4.6.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,6 +29,8 @@ updates:
       # @types/vscode should be manually bumped when we also update
       # engines.vscode inside package.json
       - dependency-name: "@types/vscode"
+      - dependency-name: "codecov/codecov-action"
+        versions: ["4.6.0"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -350,7 +350,7 @@ jobs:
           path: .
 
       - name: Upload als test coverage data [1/4]
-        uses: codecov/codecov-action@v4.6.0
+        uses: codecov/codecov-action@v4.5.0
         with:
           name: als
           files: ./*/coverage/als/lcov.info
@@ -360,7 +360,7 @@ jobs:
           use_oidc: true # cspell:ignore oidc
 
       - name: Upload unit test coverage data [2/4]
-        uses: codecov/codecov-action@v4.6.0
+        uses: codecov/codecov-action@v4.5.0
         with:
           name: unit
           files: ./*/coverage/unit/lcov.info
@@ -370,7 +370,7 @@ jobs:
           use_oidc: true # cspell:ignore oidc
 
       - name: Upload ui test coverage data [3/4]
-        uses: codecov/codecov-action@v4.6.0
+        uses: codecov/codecov-action@v4.5.0
         with:
           name: unit
           files: ./*/coverage/ui/lcov.info
@@ -380,7 +380,7 @@ jobs:
           use_oidc: true # cspell:ignore oidc
 
       - name: Upload e2e test coverage data [4/4]
-        uses: codecov/codecov-action@v4.6.0
+        uses: codecov/codecov-action@v4.5.0
         with:
           name: e2e
           files: ./*/coverage/e2e/lcov.info


### PR DESCRIPTION
Same changes as #1562 but also adds the dependabot.yml ignore for codecov v4.6.0. 