### PR TITLE
fix deprecation warning for ANSIBLE_COLLECTIONS_PATH

### DIFF
--- a/packages/ansible-language-server/test/helper.ts
+++ b/packages/ansible-language-server/test/helper.ts
@@ -39,15 +39,15 @@ export function deleteAlsCache(): void {
 
 export function setFixtureAnsibleCollectionPathEnv(prePendPath?: string): void {
   if (prePendPath) {
-    process.env.ANSIBLE_COLLECTIONS_PATHS = `${prePendPath}:${ANSIBLE_COLLECTIONS_FIXTURES_BASE_PATH}`;
+    process.env.ANSIBLE_COLLECTIONS_PATH = `${prePendPath}:${ANSIBLE_COLLECTIONS_FIXTURES_BASE_PATH}`;
   } else {
-    process.env.ANSIBLE_COLLECTIONS_PATHS =
+    process.env.ANSIBLE_COLLECTIONS_PATH =
       ANSIBLE_COLLECTIONS_FIXTURES_BASE_PATH;
   }
 }
 
 export function unSetFixtureAnsibleCollectionPathEnv(): void {
-  process.env.ANSIBLE_COLLECTIONS_PATHS = undefined;
+  process.env.ANSIBLE_COLLECTIONS_PATH = undefined;
 }
 
 export function setAnsibleConfigEnv(): void {

--- a/test/helper.ts
+++ b/test/helper.ts
@@ -246,6 +246,10 @@ export async function testDiagnostics(
   if (actualDiagnostics.length && expectedDiagnostics.length) {
     expectedDiagnostics.forEach((expectedDiagnostic, i) => {
       const actualDiagnostic = actualDiagnostics[i];
+      if (docUri.toString().includes("yaml/invalid_yaml.yml")) {
+        console.log("actualDiagnostic.message: ", actualDiagnostic.message);
+        console.log("expectedDiagnostic.message: ", expectedDiagnostic.message);
+      }
       assert.include(actualDiagnostic.message, expectedDiagnostic.message); // subset of expected message
       assert.deepEqual(actualDiagnostic.range, expectedDiagnostic.range);
       assert.strictEqual(

--- a/test/helper.ts
+++ b/test/helper.ts
@@ -104,15 +104,15 @@ export function setFixtureAnsibleCollectionPathEnv(
   prePendPath: string | undefined = undefined,
 ): void {
   if (prePendPath) {
-    process.env.ANSIBLE_COLLECTIONS_PATHS = `${prePendPath}:${ANSIBLE_COLLECTIONS_FIXTURES_BASE_PATH}`;
+    process.env.ANSIBLE_COLLECTIONS_PATH = `${prePendPath}:${ANSIBLE_COLLECTIONS_FIXTURES_BASE_PATH}`;
   } else {
-    process.env.ANSIBLE_COLLECTIONS_PATHS =
+    process.env.ANSIBLE_COLLECTIONS_PATH =
       ANSIBLE_COLLECTIONS_FIXTURES_BASE_PATH;
   }
 }
 
 export function unSetFixtureAnsibleCollectionPathEnv(): void {
-  process.env.ANSIBLE_COLLECTIONS_PATHS = undefined;
+  process.env.ANSIBLE_COLLECTIONS_PATH = undefined;
 }
 
 export async function enableExecutionEnvironmentSettings(): Promise<void> {

--- a/test/helper.ts
+++ b/test/helper.ts
@@ -246,10 +246,6 @@ export async function testDiagnostics(
   if (actualDiagnostics.length && expectedDiagnostics.length) {
     expectedDiagnostics.forEach((expectedDiagnostic, i) => {
       const actualDiagnostic = actualDiagnostics[i];
-      if (docUri.toString().includes("yaml/invalid_yaml.yml")) {
-        console.log("actualDiagnostic.message: ", actualDiagnostic.message);
-        console.log("expectedDiagnostic.message: ", expectedDiagnostic.message);
-      }
       assert.include(actualDiagnostic.message, expectedDiagnostic.message); // subset of expected message
       assert.deepEqual(actualDiagnostic.range, expectedDiagnostic.range);
       assert.strictEqual(

--- a/test/testScripts/diagnostics/testYamlWithoutEE.test.ts
+++ b/test/testScripts/diagnostics/testYamlWithoutEE.test.ts
@@ -93,7 +93,7 @@ export function testDiagnosticsYAMLWithoutEE(): void {
             severity: 0,
             message:
               "Syntax Error while loading YAML.\n" +
-              "  mapping values are not allowed in this context\n",
+              "  mapping values are not allowed in this context",
             range: new vscode.Range(
               new vscode.Position(6, 21),
               new vscode.Position(6, integer.MAX_VALUE),


### PR DESCRIPTION
This PR fixes the deprecation warning message for using `ANSIBLE_COLLECTIONS_PATHS` when running `e2e` yaml diagnostic tests.
```
[DEPRECATION WARNING]: ANSIBLE_COLLECTIONS_PATHS option, does not fit var 
naming standard, use the singular form ANSIBLE_COLLECTIONS_PATH instead. This 
feature will be removed from ansible-core in version 2.19. Deprecation warnings
 can be disabled by setting deprecation_warnings=False in ansible.cfg.
```
Updated to use the singular form `ANSIBLE_COLLECTIONS_PATH`.

Related: #1561,  #1573, #1575 and #1576.
