### PR TITLE
Invoke contentmatch immediately after user accepted a suggestion

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -231,6 +231,10 @@ any level (User, Remote, Workspace and/or Folder).
 - `ansible.lightspeed.modelIdOverride`: Model ID to override your organization's
   default model. This setting is only applicable to commercial users with an
   Ansible Lightspeed seat assignment.
+- `ansible.lightspeed.includeModelIdOverrideInPlaybookGenExpRequests`:
+  (experimental) When set to `true`, the overridden model ID is included in
+  playbook generation and explanation requests in addition to inline suggestion
+  requests. Otherwise, it is included in inline suggestion requests only.
 - `ansible.playbook.arguments`: Specify additional arguments to append to
   ansible-playbook invocation. e.g. `--syntax-check`
 

--- a/media/playbookGeneration/playbookGeneration.css
+++ b/media/playbookGeneration/playbookGeneration.css
@@ -41,6 +41,10 @@ a .codicon {
 	color: green;
 }
 
+.codicon.codicon-warning {
+	margin: 10px;
+	color: orange;
+}
 
 #system-readiness-error {
 	display: flex;

--- a/media/playbookGeneration/style.css
+++ b/media/playbookGeneration/style.css
@@ -284,6 +284,13 @@ a:active {
   outline-color: var(--vscode-focusBorder);
 }
 
+.warningsContainer {
+  display: none;
+  width: 100%;
+  color: var(--input-foreground);
+  background: var(--input-background);
+}
+
 .formattedPlaybook {
   display: none;
   width: 100%;

--- a/package.json
+++ b/package.json
@@ -645,13 +645,20 @@
             "markdownDescription": "Model ID to override your organization's default model. This setting is only applicable to commercial users with an Ansible Lightspeed seat assignment.",
             "order": 4
           },
+          "ansible.lightspeed.includeModelIdOverrideInPlaybookGenExpRequests": {
+            "scope": "resource",
+            "type": "boolean",
+            "default": false,
+            "markdownDescription": "Include the overridden model ID in playbook generation/explanation requests",
+            "order": 5
+          },
           "ansible.lightspeed.playbookGenerationCustomPrompt": {
             "scope": "resource",
             "type": "string",
             "markdownDescription": "Custom Prompt for Playbook generation.",
             "pattern": "^$|^.*{goal}.*{outline}.*|.*{outline}.*{goal}.*$",
             "patternErrorMessage": "The prompt must contain placeholders for both '{goal}' and '{outline}'.",
-            "order": 5
+            "order": 6
           },
           "ansible.lightspeed.playbookExplanationCustomPrompt": {
             "scope": "resource",
@@ -659,7 +666,7 @@
             "markdownDescription": "Custom Prompt for Playbook explanation.",
             "pattern": "^$|^.*{playbook}.*$",
             "patternErrorMessage": "The prompt must contain a placeholder for '{playbook}'.",
-            "order": 6
+            "order": 7
           }
         }
       },

--- a/src/features/lightspeed/api.ts
+++ b/src/features/lightspeed/api.ts
@@ -297,7 +297,11 @@ export class LightSpeedAPI {
       return {} as ExplanationResponseParams;
     }
     // If a Model ID Override is specified, send it to Lightspeed with the request.
-    if (lightSpeedManager.settingsManager.settings.lightSpeedService.model) {
+    if (
+      lightSpeedManager.settingsManager.settings.lightSpeedService.model &&
+      lightSpeedManager.settingsManager.settings.lightSpeedService
+        .includeModelInPlaybookAPIs
+    ) {
       inputData.model =
         lightSpeedManager.settingsManager.settings.lightSpeedService.model;
     }
@@ -348,7 +352,11 @@ export class LightSpeedAPI {
     }
     try {
       // If a Model ID Override is specified, send it to Lightspeed with the request.
-      if (lightSpeedManager.settingsManager.settings.lightSpeedService.model) {
+      if (
+        lightSpeedManager.settingsManager.settings.lightSpeedService.model &&
+        lightSpeedManager.settingsManager.settings.lightSpeedService
+          .includeModelInPlaybookAPIs
+      ) {
         inputData.model =
           lightSpeedManager.settingsManager.settings.lightSpeedService.model;
       }

--- a/src/features/lightspeed/api.ts
+++ b/src/features/lightspeed/api.ts
@@ -296,6 +296,11 @@ export class LightSpeedAPI {
       console.error("Ansible Lightspeed instance is not initialized.");
       return {} as ExplanationResponseParams;
     }
+    // If a Model ID Override is specified, send it to Lightspeed with the request.
+    if (lightSpeedManager.settingsManager.settings.lightSpeedService.model) {
+      inputData.model =
+        lightSpeedManager.settingsManager.settings.lightSpeedService.model;
+    }
     try {
       const customPrompt =
         lightSpeedManager.settingsManager.settings.lightSpeedService
@@ -342,6 +347,11 @@ export class LightSpeedAPI {
       return {} as GenerationResponseParams;
     }
     try {
+      // If a Model ID Override is specified, send it to Lightspeed with the request.
+      if (lightSpeedManager.settingsManager.settings.lightSpeedService.model) {
+        inputData.model =
+          lightSpeedManager.settingsManager.settings.lightSpeedService.model;
+      }
       const customPrompt =
         lightSpeedManager.settingsManager.settings.lightSpeedService
           .playbookGenerationCustomPrompt;

--- a/src/features/lightspeed/inlineSuggestions.ts
+++ b/src/features/lightspeed/inlineSuggestions.ts
@@ -850,11 +850,13 @@ export async function inlineSuggestionCommitHandler() {
   vscode.commands.executeCommand("editor.action.inlineSuggest.commit");
 
   // If the suggestion does not seem to be ours, exit early.
-  if (!inlineSuggestionData["suggestionId"]) {
+  const suggestionId = inlineSuggestionData["suggestionId"];
+  if (!suggestionId) {
     return;
   }
 
   console.log("[inline-suggestions] User accepted the inline suggestion.");
+  acceptSuggestion(suggestionId);
 }
 
 export async function inlineSuggestionHideHandler(
@@ -978,6 +980,14 @@ export async function ignorePendingSuggestion() {
   }
 }
 
+async function acceptSuggestion(suggestionId: string) {
+  await inlineSuggestionUserActionHandler(suggestionId, UserAction.ACCEPTED);
+  // Show training matches for the accepted suggestion.
+  vscode.commands.executeCommand(
+    LightSpeedCommands.LIGHTSPEED_FETCH_TRAINING_MATCHES,
+  );
+}
+
 export async function inlineSuggestionTextDocumentChangeHandler(
   e: vscode.TextDocumentChangeEvent,
 ) {
@@ -999,14 +1009,7 @@ export async function inlineSuggestionTextDocumentChangeHandler(
         console.log(
           "[inline-suggestions] Detected a text change that matches to the current suggestion.",
         );
-        await inlineSuggestionUserActionHandler(
-          suggestionId,
-          UserAction.ACCEPTED,
-        );
-        // Show training matches for the accepted suggestion.
-        vscode.commands.executeCommand(
-          LightSpeedCommands.LIGHTSPEED_FETCH_TRAINING_MATCHES,
-        );
+        acceptSuggestion(suggestionId);
       }
     });
   }

--- a/src/features/lightspeed/playbookGeneration.ts
+++ b/src/features/lightspeed/playbookGeneration.ts
@@ -172,6 +172,7 @@ export async function showPlaybookGenerationPage(
               outline: {
                 playbook: message.playbook,
                 outline: message.outline,
+                warnings: message.warnings,
                 generationId: message.generationId,
               },
             });
@@ -281,6 +282,11 @@ export function getWebviewContent(webview: Webview, extensionUri: Uri) {
     "playbookGeneration",
     "style.css",
   ]);
+  const playbookGenerationUri = getUri(webview, extensionUri, [
+    "media",
+    "playbookGeneration",
+    "playbookGeneration.css",
+  ]);
   const codiconsUri = getUri(webview, extensionUri, [
     "media",
     "codicons",
@@ -299,6 +305,7 @@ export function getWebviewContent(webview: Webview, extensionUri: Uri) {
         content="default-src 'none'; script-src 'nonce-${nonce}'; style-src ${webview.cspSource} 'unsafe-inline'; font-src ${webview.cspSource};'">
     <link rel="stylesheet" href="${codiconsUri}">
     <link rel="stylesheet" href="${styleUri}">
+    <link rel="stylesheet" href="${playbookGenerationUri}">
     <title>Playbook</title>
 </head>
 
@@ -331,6 +338,23 @@ export function getWebviewContent(webview: Webview, extensionUri: Uri) {
               <ol id="outline-list" contentEditable="true">
                 <li></li>
               </ol>
+            </div>
+            <div class="warningsContainer">
+              <div class="playbookGenerationCategoriesContainer">
+                <div class="header">
+                  <div id="system-readiness" class="statusDisplay">
+                    <section>
+                      <span class="codicon codicon-warning"></span>
+                    </section>
+                    <section>
+                      <p class="system-description">
+                        <b>Warnings were produced for your request. Your custom prompt may need review.</b>
+                      </p>
+                      <ul id="warnings-list" id="warnings"></ul>
+                    </section>
+                  </div>
+                </div>
+              </div>
             </div>
             <div class="spinnerContainer">
               <span class="codicon-spinner codicon-loading codicon-modifier-spin" id="loading"></span>

--- a/src/interfaces/extensionSettings.ts
+++ b/src/interfaces/extensionSettings.ts
@@ -44,6 +44,7 @@ export interface LightSpeedServiceSettings {
   URL: string;
   suggestions: { enabled: boolean; waitWindow: number };
   model: string | undefined;
+  includeModelInPlaybookAPIs: boolean | undefined;
   playbookGenerationCustomPrompt: string | undefined;
   playbookExplanationCustomPrompt: string | undefined;
 }

--- a/src/interfaces/lightspeed.ts
+++ b/src/interfaces/lightspeed.ts
@@ -147,6 +147,7 @@ export interface GenerationRequestParams {
   generationId: string;
   createOutline: boolean;
   wizardId?: string;
+  model?: string;
 }
 
 export interface GenerationResponseParams {
@@ -159,6 +160,7 @@ export interface ExplanationRequestParams {
   content: string;
   customPrompt?: string;
   explanationId: string;
+  model?: string;
 }
 
 export interface ExplanationResponseParams {

--- a/src/interfaces/lightspeed.ts
+++ b/src/interfaces/lightspeed.ts
@@ -150,9 +150,16 @@ export interface GenerationRequestParams {
   model?: string;
 }
 
+export interface GenerationResponseWarning {
+  id: string;
+  message: string;
+  details: string;
+}
+
 export interface GenerationResponseParams {
   playbook: string;
   outline?: string;
+  warnings?: GenerationResponseWarning[];
   generationId: string;
 }
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -47,6 +47,10 @@ export class SettingsManager {
           waitWindow: lightSpeedSettings.get("suggestions.waitWindow", 0),
         },
         model: lightSpeedSettings.get("modelIdOverride", undefined),
+        includeModelInPlaybookAPIs: lightSpeedSettings.get(
+          "includeModelIdOverrideInPlaybookGenExpRequests",
+          false,
+        ),
         playbookGenerationCustomPrompt: lightSpeedSettings.get(
           "playbookGenerationCustomPrompt",
           undefined,

--- a/test/mockLightspeedServer/explanations.ts
+++ b/test/mockLightspeedServer/explanations.ts
@@ -13,6 +13,7 @@ export function explanations(
   const explanationId = req.body.explanationId
     ? req.body.explanationId
     : uuidv4();
+  const model = req.body?.model;
   const format = "markdown";
   logger.info(`content: ${playbook}`);
 
@@ -96,6 +97,10 @@ the following parameters:
 
   if (customPrompt) {
     content += "\nCustom prompt explanation.";
+  }
+
+  if (model) {
+    content += `\nmodel=${model}`;
   }
 
   return res.send({

--- a/test/mockLightspeedServer/generations.ts
+++ b/test/mockLightspeedServer/generations.ts
@@ -1,5 +1,6 @@
 import { v4 as uuidv4 } from "uuid";
 import { logger, options, permissionDeniedCanApplyForTrial } from "./server";
+import { GenerationResponseWarning } from "../../src/interfaces/lightspeed";
 
 export function generations(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -118,9 +119,17 @@ export function generations(
     outline += `\n6. model=${model}`;
   }
 
+  let warnings: GenerationResponseWarning[] = [];
+  if (text === "Create a playbook with warnings") {
+    warnings = [
+      { id: "id-1", message: "Warning message", details: "Warning details" },
+    ];
+  }
+
   return res.send({
     playbook,
     outline,
+    warnings,
     generationId,
   });
 }

--- a/test/mockLightspeedServer/generations.ts
+++ b/test/mockLightspeedServer/generations.ts
@@ -12,6 +12,7 @@ export function generations(
   const createOutline = req.body.createOutline;
   const generationId = req.body.generationId ? req.body.generationId : uuidv4();
   const wizardId = req.body.wizardId;
+  const model = req.body?.model;
   logger.info(`text: ${text}`);
   logger.info(`outline: ${req.body.outline}`);
   logger.info(`wizardId: ${wizardId}`);
@@ -111,6 +112,10 @@ export function generations(
 
   if (customPrompt) {
     outline += "\n5. Custom prompt step.";
+  }
+
+  if (model) {
+    outline += `\n6. model=${model}`;
   }
 
   return res.send({

--- a/test/ui-test/allTestsSuite.ts
+++ b/test/ui-test/allTestsSuite.ts
@@ -5,7 +5,7 @@ import { lightspeedUIAssetsTest } from "./lightspeedUiTest";
 import { terminalUITests } from "./terminalUiTest";
 
 describe("VSCode Ansible - UI tests", function () {
-  this.timeout(30000);
+  this.timeout(40000);
   extensionUIAssetsTest();
   lightspeedUIAssetsTest();
   terminalUITests();

--- a/test/ui-test/lightspeedUiTest.ts
+++ b/test/ui-test/lightspeedUiTest.ts
@@ -630,7 +630,7 @@ export function lightspeedUIAssetsTest(): void {
       }
     });
 
-    it("Playbook generation webview works as expected (fast path, custom prompt)", async function () {
+    it("Playbook generation webview works as expected (fast path, custom prompt, model override)", async function () {
       // Execute only when TEST_LIGHTSPEED_URL environment variable is defined.
       if (process.env.TEST_LIGHTSPEED_URL) {
         // Set Playbook generation custom prompt
@@ -639,6 +639,16 @@ export function lightspeedUIAssetsTest(): void {
           settingsEditor,
           "ansible.lightspeed.playbookGenerationCustomPrompt",
           "custom prompt {goal}, {outline}",
+        );
+        await updateSettings(
+          settingsEditor,
+          "ansible.lightspeed.modelIdOverride",
+          "my_model",
+        );
+        await updateSettings(
+          settingsEditor,
+          "ansible.lightspeed.includeModelIdOverrideInPlaybookGenExpRequests",
+          true,
         );
         await workbench.executeCommand("View: Close All Editor Groups");
 
@@ -686,6 +696,7 @@ export function lightspeedUIAssetsTest(): void {
           .undefined;
         const text = await outlineList.getText();
         expect(text.includes("Custom prompt step")).to.be.true;
+        expect(text.includes("model=my_model")).to.be.true;
 
         await webView.switchBack();
         await workbench.executeCommand("View: Close All Editor Groups");
@@ -908,7 +919,7 @@ export function lightspeedUIAssetsTest(): void {
       }
     });
 
-    it("Playbook explanation webview works as expected, custom prompt", async function () {
+    it("Playbook explanation webview works as expected, custom prompt, model override", async function () {
       if (process.env.TEST_LIGHTSPEED_URL) {
         const folder = "lightspeed";
         const file = "playbook_4.yml";
@@ -920,6 +931,16 @@ export function lightspeedUIAssetsTest(): void {
           settingsEditor,
           "ansible.lightspeed.playbookExplanationCustomPrompt",
           "custom prompt {playbook}",
+        );
+        await updateSettings(
+          settingsEditor,
+          "ansible.lightspeed.modelIdOverride",
+          "my_model",
+        );
+        await updateSettings(
+          settingsEditor,
+          "ansible.lightspeed.includeModelIdOverrideInPlaybookGenExpRequests",
+          true,
         );
         await workbench.executeCommand("View: Close All Editor Groups");
 
@@ -952,6 +973,7 @@ export function lightspeedUIAssetsTest(): void {
         const text = await mainDiv.getText();
         expect(text.includes("Playbook Overview and Structure")).to.be.true;
         expect(text.includes("Custom prompt explanation")).to.be.true;
+        expect(text.includes("model=my_model")).to.be.true;
 
         await webView.switchBack();
         await workbench.executeCommand("View: Close All Editor Groups");


### PR DESCRIPTION
**NOTE: This PR is to be merged into the "custom_propmpts" branch, not into the main branch.**

A customer reported an issue that content match is not invoked occasionally after a task suggestion is accepted.
Their log shows a REJECTED user response is sent after a task suggestion is accepted.  The REJECTED user response can be sent by a text change, which was not caused by accepting a suggestion. Usually, when a text suggestion is accepted, the extension receives the text change caused by the acceptance, but there seem some cases that cause this error.

This PR will immediately after user accepted a suggestion within the `inlineSuggestionCommitHandler`, which is called when a user hit the TAB key.