### PR TITLE
Invoke contentmatch immediately after user accepted a suggestion

### DIFF
--- a/src/features/lightspeed/inlineSuggestions.ts
+++ b/src/features/lightspeed/inlineSuggestions.ts
@@ -850,11 +850,13 @@ export async function inlineSuggestionCommitHandler() {
   vscode.commands.executeCommand("editor.action.inlineSuggest.commit");
 
   // If the suggestion does not seem to be ours, exit early.
-  if (!inlineSuggestionData["suggestionId"]) {
+  const suggestionId = inlineSuggestionData["suggestionId"];
+  if (!suggestionId) {
     return;
   }
 
   console.log("[inline-suggestions] User accepted the inline suggestion.");
+  acceptSuggestion(suggestionId);
 }
 
 export async function inlineSuggestionHideHandler(
@@ -978,6 +980,14 @@ export async function ignorePendingSuggestion() {
   }
 }
 
+async function acceptSuggestion(suggestionId: string) {
+  await inlineSuggestionUserActionHandler(suggestionId, UserAction.ACCEPTED);
+  // Show training matches for the accepted suggestion.
+  vscode.commands.executeCommand(
+    LightSpeedCommands.LIGHTSPEED_FETCH_TRAINING_MATCHES,
+  );
+}
+
 export async function inlineSuggestionTextDocumentChangeHandler(
   e: vscode.TextDocumentChangeEvent,
 ) {
@@ -999,14 +1009,7 @@ export async function inlineSuggestionTextDocumentChangeHandler(
         console.log(
           "[inline-suggestions] Detected a text change that matches to the current suggestion.",
         );
-        await inlineSuggestionUserActionHandler(
-          suggestionId,
-          UserAction.ACCEPTED,
-        );
-        // Show training matches for the accepted suggestion.
-        vscode.commands.executeCommand(
-          LightSpeedCommands.LIGHTSPEED_FETCH_TRAINING_MATCHES,
-        );
+        acceptSuggestion(suggestionId);
       }
     });
   }


### PR DESCRIPTION
This PR contains the same change as the one included in PR #1581.

I was thinking that I would add a test case before merging this change to the main branch.  However, the test case would be similar to the one that #1458 temporary disabled, which was causing instabilities in CI until it was disabled.  I re-thought adding such a test was not a good idea.

A .vsix file that contained PR #1581 fix was sent to a customer and they found it worked. With that manual verification with the customer, I think it is safe to merge this fix to the main branch.