### PR TITLE
Run CI nightly on the main branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,6 +11,8 @@ on:
       - "v*.*"
   pull_request:
     branches: ["main", "devel/*"]
+  schedule:
+    - cron: "0 0 * * *"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.ref }}-${{ github.event.pull_request.number || github.sha }}


### PR DESCRIPTION
Adds a scheduled job for running CI on the extension, nightly at 0:00 UTC. 

(Related: https://issues.redhat.com/browse/AAP-33817)