### PR TITLE
AAP-33750: UI screens for role generation

### DIFF
--- a/media/roleGeneration/style.css
+++ b/media/roleGeneration/style.css
@@ -1,0 +1,328 @@
+a:link {
+  text-decoration: none;
+}
+
+a:visited {
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: none;
+}
+
+a:active {
+  text-decoration: none;
+}
+
+.backAnchor {
+  cursor: pointer;
+}
+
+.playbookGeneration {
+  right: 0px;
+  bottom: 0px;
+}
+
+.pageNumber {
+  text-align: left;
+  margin: 0.2em;
+  color: var(--vscode-descriptionForeground);
+}
+
+.playbookGeneration h2 {
+  color: var(--vscode-foreground);
+  text-align: left;
+  margin-block-end: 0.2em;
+  font-weight: 400;
+}
+
+.playbookGeneration h4 {
+  color: var(--vscode-foreground);
+  margin-block-end: 0.2em;
+  font-weight: bold;
+}
+
+.examplesContainer h4 {
+  color: var(--vscode-descriptionForeground);
+  font-weight: 400;
+}
+
+.mainContainer {
+  position: relative;
+}
+
+.editArea {
+  position: relative;
+  border-style: none;
+}
+
+.editArea>vscode-text-area {
+  width: 100%;
+  border-style: none;
+}
+
+.editArea>button {
+  float: right;
+}
+
+.inputSection {
+  margin-top: 2em;
+}
+
+.inputArea {
+  margin-top: 1em;
+  width: 100%
+}
+
+.inputArea>vscode-text-field {
+  width: 100%
+}
+
+.bigIconButtonContainer {
+  position: relative;
+  margin-top: 1em;
+  margin-bottom: 0.5em;
+  width: 100%;
+  height: 48px;
+  display: block;
+}
+
+.biggerButton {
+  padding: 3px;
+}
+
+/* override the default .codicon class */
+.codicon[class*='codicon-'] {
+  font: normal normal normal 16px/1 codicon;
+  display: inline-block;
+  text-decoration: none;
+  text-rendering: auto;
+  text-align: center;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  user-select: none;
+  -webkit-user-select: none;
+  -ms-user-select: none;
+  position: relative;
+  font-size: 24px;
+  width: calc(var(--design-unit) * 6px);
+  height: calc(var(--design-unit) * 6px);
+}
+
+.spinnerContainer {
+  background-color: var(--vscode-editor-background, #ffffff80);
+  border-style: solid;
+  border-radius: 12px;
+  border-width: thin;
+  border-color: var(--vscode-widget-border);
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  display: none;
+  text-align: center;
+  padding: 12px;
+  margin: auto;
+  z-index: 100;
+  opacity: 0.7;
+}
+
+.codicon-spinner {
+  font: normal normal normal 16px/1 codicon;
+  display: inline-block;
+  text-decoration: none;
+  text-rendering: auto;
+  text-align: center;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  user-select: none;
+  -webkit-user-select: none;
+  -ms-user-select: none;
+  position: relative;
+  font-size: 48px;
+  width: calc(var(--design-unit) * 12px);
+  height: calc(var(--design-unit) * 12px);
+}
+
+.resetFeedbackContainer {
+  margin: 0.25em;
+  position: relative;
+  width: 100%;
+  height: 36px;
+  display: none;
+}
+
+.resetContainer {
+  position: absolute;
+  left: 0px;
+  bottom: 5px;
+  display: flow;
+}
+
+.playbookExplanationSpacer {
+  height: 30px;
+}
+
+.stickyFeedbackContainer {
+  position: sticky;
+  bottom: 0px;
+}
+
+.feedbackContainer {
+  background-color: var(--vscode-editor-background, #ffffff80);
+  position: absolute;
+  right: 0px;
+  bottom: 0px;
+  display: flex;
+  opacity: 0.8;
+}
+
+.generatePlaybookContainer {
+  margin-top: 2em;
+  display: none;
+}
+
+.openEditorContainer {
+  margin-top: 3em;
+  display: none;
+}
+
+.promptContainer {
+  margin: 1em;
+  display: none;
+  color: var(--vscode-descriptionForeground);
+}
+
+.examplesContainer {
+  margin-top: 1em;
+}
+
+.exampleTextContainer {
+  margin: 0.5em;
+  padding-top: 0px;
+  padding-bottom: 0px;
+  padding-left: 8px;
+  padding-right: 8px;
+  border-style: solid;
+  border-width: thin;
+  border-radius: 8px;
+  width: fit-content;
+  max-width: 90%;
+  color: var(--vscode-descriptionForeground);
+}
+
+.continueButtonContainer {
+  margin-top: 1em;
+  display: none;
+}
+
+.buttonBorder {
+  border-style: solid;
+  border-width: thin;
+}
+
+.textFieldFullWidth {
+  width: 100%;
+}
+
+.firstMessage {
+  display: block;
+}
+
+.secondMessage {
+  display: none;
+}
+
+.thirdMessage {
+  display: none;
+}
+
+.iconButton {
+  width: 36px;
+  height: 36px;
+  margin: 0.2em;
+  background: var(--button-icon-background);
+  border-radius: var(--button-icon-corner-radius);
+  color: var(--foreground);
+  opacity: 1.0;
+}
+
+.iconButtonSelected {
+  width: 36px;
+  height: 36px;
+  margin: 0.2em;
+  background: var(--button-primary-background);
+  color: var(--button-primary-foreground);
+  opacity: 1.0;
+}
+
+.outlineContainer {
+  display: none;
+  width: 100%;
+  height: 12em;
+  color: var(--input-foreground);
+  background: var(--input-background);
+  overflow-x: auto;
+  overflow-y: auto;
+  border-style: solid;
+  border-width: thin;
+  border-color: var(--vscode-widget-border);
+  resize: vertical;
+}
+
+.outlineContainer ol {
+  margin-block-start: 0.3em;
+  margin-block-end: 0.3em;
+  margin-inline-start: 0.3em;
+  margin-inline-end: 0.3em;
+  padding-inline-start: 20px;
+}
+
+.outlineContainer ol:focus {
+  outline-style: solid;
+  outline-width: thin;
+  outline-color: var(--vscode-focusBorder);
+}
+
+#formattedOutput {
+  display: none;
+}
+
+.formattedPlaybook {
+  width: 100%;
+  height: 25em;
+  border-style: solid;
+  border-width: thin;
+  border-color: var(--vscode-widget-border);
+  overflow-x: auto;
+  overflow-y: auto;
+  resize: vertical;
+}
+
+.formattedPlaybook code {
+  background-color: var(--input-background);
+}
+
+.formattedPlaybook pre {
+  margin: 0em;
+  background-color: var(--input-background);
+}
+
+/*
+.dropdown-container {
+  box-sizing: border-box;
+  display: flex;
+  flex-flow: column nowrap;
+  align-items: flex-start;
+  justify-content: flex-start;
+}
+
+.dropdown-container label {
+  display: block;
+  color: var(--vscode-foreground);
+  cursor: pointer;
+  font-size: var(--vscode-font-size);
+  line-height: normal;
+  margin-bottom: 2px;
+}
+ */

--- a/package.json
+++ b/package.json
@@ -401,6 +401,11 @@
         "title": "Ansible Lightspeed: Playbook generation"
       },
       {
+        "command": "ansible.lightspeed.roleGeneration",
+        "enablement": "redhat.ansible.lightspeedExperimentalEnabled",
+        "title": "Ansible Lightspeed: Role generation"
+      },
+      {
         "command": "ansible.lightspeed.thumbsUpDown",
         "title": "Send Lightspeed Thumbs Up/Down Feedback"
       },

--- a/src/definitions/lightspeed.ts
+++ b/src/definitions/lightspeed.ts
@@ -53,6 +53,7 @@ export namespace LightSpeedCommands {
     "ansible.lightspeed.playbookExplanation";
   export const LIGHTSPEED_PLAYBOOK_GENERATION =
     "ansible.lightspeed.playbookGeneration";
+  export const LIGHTSPEED_ROLE_GENERATION = "ansible.lightspeed.roleGeneration";
   export const LIGHTSPEED_SIGN_IN_WITH_REDHAT =
     "ansible.lightspeed.signInWithRedHat";
   export const LIGHTSPEED_SIGN_IN_WITH_LIGHTSPEED =
@@ -65,6 +66,7 @@ export namespace LightSpeedCommands {
 export const LIGHTSPEED_API_VERSION = "v0";
 export const LIGHTSPEED_PLAYBOOK_EXPLANATION_URL = `${LIGHTSPEED_API_VERSION}/ai/explanations/`;
 export const LIGHTSPEED_PLAYBOOK_GENERATION_URL = `${LIGHTSPEED_API_VERSION}/ai/generations/`;
+export const LIGHTSPEED_ROLE_GENERATION_URL = `${LIGHTSPEED_API_VERSION}/ai/generations/role`;
 export const LIGHTSPEED_SUGGESTION_COMPLETION_URL = `${LIGHTSPEED_API_VERSION}/ai/completions/`;
 export const LIGHTSPEED_SUGGESTION_FEEDBACK_URL = `${LIGHTSPEED_API_VERSION}/ai/feedback/`;
 export const LIGHTSPEED_SUGGESTION_CONTENT_MATCHES_URL = `${LIGHTSPEED_API_VERSION}/ai/contentmatches/`;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -61,6 +61,7 @@ import { CreateAnsibleCollection } from "./features/contentCreator/createAnsible
 import { withInterpreter } from "./features/utils/commandRunner";
 import { IFileSystemWatchers } from "./interfaces/watchers";
 import { showPlaybookGenerationPage } from "./features/lightspeed/playbookGeneration";
+import { showRoleGenerationPage } from "./features/lightspeed/roleGeneration";
 import { ExecException, execSync } from "child_process";
 import { CreateAnsibleProject } from "./features/contentCreator/createAnsibleProjectPage";
 // import { LightspeedExplorerWebviewViewProvider } from "./features/lightspeed/explorerWebviewViewProvider";
@@ -540,15 +541,20 @@ export async function activate(context: ExtensionContext): Promise<void> {
     }),
   );
 
-  // Command to render a webview-based note view
   context.subscriptions.push(
     vscode.commands.registerCommand(
       LightSpeedCommands.LIGHTSPEED_PLAYBOOK_GENERATION,
       async () => {
-        await showPlaybookGenerationPage(
-          context.extensionUri,
-          lightSpeedManager.lightspeedAuthenticatedUser,
-        );
+        await showPlaybookGenerationPage(context.extensionUri);
+      },
+    ),
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      LightSpeedCommands.LIGHTSPEED_ROLE_GENERATION,
+      async () => {
+        await showRoleGenerationPage(context.extensionUri);
       },
     ),
   );

--- a/src/features/contentCreator/createAnsibleProjectPage.ts
+++ b/src/features/contentCreator/createAnsibleProjectPage.ts
@@ -143,7 +143,7 @@ export class CreateAnsibleProject {
                 <div class="verbose-div">
                   <div class="dropdown-container">
                     <label for="verbosity-dropdown">Output Verbosity</label>
-                    <vscode-dropdown id="verbosity-dropdown" position="below">
+                    <vscode-dropdown id="verbosity-dropdown">
                       <vscode-option>Off</vscode-option>
                       <vscode-option>Low</vscode-option>
                       <vscode-option>Medium</vscode-option>

--- a/src/webview/apps/lightspeed/roleGeneration/main.ts
+++ b/src/webview/apps/lightspeed/roleGeneration/main.ts
@@ -1,0 +1,347 @@
+import { v4 as uuidv4 } from "uuid";
+import {
+  provideVSCodeDesignSystem,
+  Button,
+  vsCodeButton,
+  vsCodeDropdown,
+  vsCodeOption,
+  vsCodeTag,
+  vsCodeTextArea,
+  vsCodeTextField,
+  TextArea,
+  Dropdown,
+} from "@vscode/webview-ui-toolkit";
+import { EditableList } from "../../common/editableList";
+
+provideVSCodeDesignSystem().register(
+  vsCodeButton(),
+  vsCodeDropdown(),
+  vsCodeOption(),
+  vsCodeTag(),
+  vsCodeTextArea(),
+  vsCodeTextField(),
+);
+
+const TEXTAREA_MAX_HEIGHT = 500;
+const TOTAL_PAGES = 3;
+
+let savedText: string;
+let savedPlaybook: string | undefined;
+let generationId: string | undefined;
+let darkMode = true;
+let textArea: TextArea;
+let currentPage = 1;
+
+let outline: EditableList;
+
+const vscode = acquireVsCodeApi();
+
+window.addEventListener("load", () => {
+  setListener("submit-button", submitInput);
+  setListener("generateButton", generateCode);
+  setListener("reset-button", reset);
+  setListener("backAnchorPrompt", backToPage1);
+  setListener("backAnchorCollectionName", backToPage1);
+  setListener("backButton", backToPage1);
+  setListener("backToPage2Button", backToPage2);
+  setListener("openEditorButton", openEditor);
+
+  textArea = document.getElementById("playbook-text-area") as TextArea;
+  setListenerOnTextArea();
+  savedText = "";
+
+  outline = new EditableList("outline-list");
+  outline.element.addEventListener("input", () => {
+    setButtonEnabled("reset-button", outline.isChanged());
+    setButtonEnabled("generateButton", !outline.isEmpty());
+  });
+
+  // Detect whether a dark or a light color theme is used.
+  const element = document.getElementById("main-header");
+  if (element) {
+    const style = window.getComputedStyle(element);
+    const color = style.getPropertyValue("color");
+    const re = /rgb.?\((\d+), (\d+), (\d+)/;
+    const found = color.match(re);
+    if (found) {
+      const r = parseInt(found[1]);
+      const g = parseInt(found[2]);
+      const b = parseInt(found[3]);
+      darkMode = r > 128 && g > 128 && b > 128;
+    }
+  }
+});
+
+window.addEventListener("message", async (event) => {
+  const message = event.data;
+
+  switch (message.command) {
+    case "init": {
+      textArea.focus();
+      break;
+    }
+    case "outline": {
+      setupPage(2);
+
+      outline.update(message.outline.outline);
+      savedPlaybook = message.outline.playbook;
+      generationId = message.outline.generationId;
+
+      const prompt = document.getElementById("prompt") as HTMLSpanElement;
+      prompt.textContent = savedText;
+
+      outline.focus();
+      break;
+    }
+    case "playbook": {
+      setupPage(3);
+      savedPlaybook = message.playbook.playbook;
+      generationId = message.playbook.generationId;
+      outline.save();
+
+      const formattedTasksCode = document.getElementById(
+        "formattedTasksCode",
+      ) as Element;
+      formattedTasksCode.innerHTML = message.playbook.html;
+      const formattedDefaultsCode = document.getElementById(
+        "formattedDefaultsCode",
+      ) as Element;
+      formattedDefaultsCode.innerHTML = message.playbook.html;
+
+      const pre = document.getElementsByTagName("pre")[0];
+      pre.style.backgroundColor = "";
+      break;
+    }
+    case "startSpinner": {
+      changeDisplay("spinnerContainer", "block");
+      break;
+    }
+    case "stopSpinner": {
+      changeDisplay("spinnerContainer", "none");
+      if (currentPage === 1) {
+        setButtonEnabled("submit-button", true);
+      } else if (currentPage === 2) {
+        setButtonEnabled("generateButton", true);
+        setButtonEnabled("backButton", true);
+        setButtonEnabled("reset-button", true);
+      }
+      break;
+    }
+  }
+});
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function setListener(id: string, func: any) {
+  const button = document.getElementById(id) as Button;
+  if (button) {
+    button.addEventListener("click", async () => {
+      await func();
+    });
+  }
+}
+
+function setListenerOnTextArea() {
+  textArea.addEventListener("input", async () => {
+    const input = textArea.value;
+    setButtonEnabled("submit-button", input.length > 0);
+    adjustTextAreaHeight();
+  });
+}
+
+function changeDisplay(className: string, displayState: string) {
+  const elements = document.getElementsByClassName(className);
+  for (let i = 0; i < elements.length; i++) {
+    const element = elements[i] as HTMLElement;
+    element.style.display = displayState;
+  }
+}
+
+function showBlockElement(id: string) {
+  const element = document.getElementById(id);
+  if (element) {
+    element.style.display = "block";
+  }
+}
+
+function hideBlockElement(id: string) {
+  const element = document.getElementById(id);
+  if (element) {
+    element.style.display = "none";
+  }
+}
+
+async function submitInput() {
+  const selectedCollectionName = document.getElementById(
+    "selectedCollectionName",
+  ) as Dropdown;
+  const collectionName = document.getElementById("collectionName");
+  if (collectionName && selectedCollectionName) {
+    collectionName.textContent = selectedCollectionName.value;
+  }
+  // If the saved text is not the current one, clear saved values and assign a new generationId
+  if (savedText !== textArea.value) {
+    savedText = textArea.value;
+    outline.update("");
+    savedPlaybook = undefined;
+    generationId = uuidv4();
+  }
+
+  setButtonEnabled("submit-button", false);
+
+  vscode.postMessage({
+    command: "outline",
+    text: savedText,
+    playbook: savedPlaybook,
+    outline: outline.getSavedValueAsString(),
+    generationId,
+  });
+  textArea.focus();
+}
+
+function reset() {
+  outline.reset();
+  outline.focus();
+}
+
+function backToPage1() {
+  setupPage(1);
+  textArea.focus();
+}
+
+function backToPage2() {
+  setupPage(2);
+  outline.focus();
+}
+
+async function generateCode() {
+  const text = savedText;
+  let playbook: string | undefined;
+
+  // If user made any changes to the generated outline, generate a playbook with a new generationId.
+  // Otherwise, just use the generated playbook.
+  if (outline.isChanged()) {
+    generationId = uuidv4();
+  } else {
+    playbook = savedPlaybook;
+  }
+
+  setButtonEnabled("generateButton", false);
+  setButtonEnabled("backButton", false);
+  setButtonEnabled("reset-button", false);
+
+  vscode.postMessage({
+    command: "generateCode",
+    text,
+    outline: EditableList.listToString(outline.getFromUI()),
+    playbook,
+    generationId,
+    darkMode,
+  });
+}
+
+async function openEditor() {
+  vscode.postMessage({
+    command: "openEditor",
+    playbook: savedPlaybook,
+  });
+}
+
+function getTextAreaInShadowDOM() {
+  const shadowRoot = document.querySelector("vscode-text-area")?.shadowRoot;
+  return shadowRoot?.querySelector("textarea");
+}
+
+function adjustTextAreaHeight() {
+  const textarea = getTextAreaInShadowDOM();
+  if (textarea?.scrollHeight) {
+    const scrollHeight = textarea.scrollHeight;
+    if (scrollHeight < TEXTAREA_MAX_HEIGHT) {
+      if (textarea.style.height) {
+        const height = parseInt(textarea.style.height);
+        if (height >= scrollHeight) {
+          return;
+        }
+      }
+      // +2 was needed to eliminate scrollbar...
+      textarea.style.height = `${scrollHeight + 2}px`;
+    }
+  }
+}
+
+function setPageNumber(pageNumber: number) {
+  const span = document.getElementById("page-number") as Element;
+  span.textContent = `${pageNumber} of ${TOTAL_PAGES}`;
+  currentPage = pageNumber;
+
+  vscode.postMessage({
+    command: "transition",
+    toPage: pageNumber,
+  });
+}
+
+function setButtonEnabled(id: string, enabled: boolean) {
+  const element = document.getElementById(id) as Button;
+  element.disabled = !enabled;
+}
+
+function setupPage(pageNumber: number) {
+  switch (pageNumber) {
+    case 1:
+      setPageNumber(1);
+      showBlockElement("roleInfo");
+      showBlockElement("collection_selector");
+      showBlockElement("playbook-text-area");
+      changeDisplay("outlineContainer", "none");
+      changeDisplay("bigIconButtonContainer", "block");
+      changeDisplay("examplesContainer", "block");
+      changeDisplay("resetFeedbackContainer", "none");
+      changeDisplay("firstMessage", "block");
+      changeDisplay("secondMessage", "none");
+      changeDisplay("thirdMessage", "none");
+      changeDisplay("generatePlaybookContainer", "none");
+      changeDisplay("promptContainer", "none");
+      changeDisplay("openEditorContainer", "none");
+      setButtonEnabled("submit-button", true);
+      hideBlockElement("formattedOutput");
+      break;
+    case 2:
+      setPageNumber(2);
+      hideBlockElement("roleInfo");
+      hideBlockElement("collection_selector");
+      hideBlockElement("playbook-text-area");
+      changeDisplay("outlineContainer", "block");
+      changeDisplay("bigIconButtonContainer", "none");
+      changeDisplay("examplesContainer", "none");
+      changeDisplay("resetFeedbackContainer", "block");
+      changeDisplay("resetContainer", "block");
+      changeDisplay("feedbackContainer", "none");
+      changeDisplay("firstMessage", "none");
+      changeDisplay("secondMessage", "block");
+      changeDisplay("thirdMessage", "none");
+      changeDisplay("generatePlaybookContainer", "block");
+      changeDisplay("promptContainer", "block");
+      changeDisplay("openEditorContainer", "none");
+      setButtonEnabled("reset-button", false);
+      setButtonEnabled("backButton", true);
+      setButtonEnabled("generateButton", true);
+      hideBlockElement("formattedOutput");
+      break;
+    case 3:
+      setPageNumber(3);
+      hideBlockElement("roleInfo");
+      hideBlockElement("collection_selector");
+      hideBlockElement("playbook-text-area");
+      changeDisplay("outlineContainer", "none");
+      changeDisplay("bigIconButtonContainer", "none");
+      changeDisplay("examplesContainer", "none");
+      changeDisplay("resetFeedbackContainer", "none");
+      changeDisplay("firstMessage", "none");
+      changeDisplay("secondMessage", "none");
+      changeDisplay("thirdMessage", "block");
+      changeDisplay("generatePlaybookContainer", "none");
+      changeDisplay("openEditorContainer", "block");
+      showBlockElement("formattedOutput");
+
+      break;
+  }
+}

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -170,6 +170,19 @@ const playbookExplanationWebviewConfig = {
   },
 };
 
+const roleGenerationWebviewConfig = {
+  ...config,
+  target: ["web", "es2020"],
+  entry: "./src/webview/apps/lightspeed/roleGeneration/main.ts",
+  experiments: { outputModule: true },
+  output: {
+    path: path.resolve(__dirname, "out"),
+    filename: "./client/webview/apps/lightspeed/roleGeneration/main.js",
+    libraryTarget: "module",
+    chunkFormat: "module",
+  },
+};
+
 const createAnsibleCollectionWebviewConfig = {
   ...config,
   target: ["web", "es2020"],
@@ -213,6 +226,7 @@ module.exports = (_env: any, argv: { mode: string }) => {
     playbookExplorerWebviewConfig,
     playbookGenerationWebviewConfig,
     playbookExplanationWebviewConfig,
+    roleGenerationWebviewConfig,
     createAnsibleProjectWebviewConfig,
   ];
 };


### PR DESCRIPTION
New views for the role generation. They are not enabled by default and currently
require the `redhat.ansible.lightspeedExperimentalEnabled`.

The views are directly based on the Playbook Generation and they still reuse some
of the variable names. This will be adjusted during the coming iterations.
