### PR TITLE
Rework EE volume mount setting so default value will populate

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -202,7 +202,7 @@ any level (User, Remote, Workspace and/or Folder).
   the image and setting tag will always pull if the image tag is 'latest',
   otherwise pull if not locally available.
 - `ansible.executionEnvironment.volumeMounts`: The setting contains volume mount
-  information for each entry in the list. Individual entry consist of a
+  information for each dict entry in the list. Individual entry consists of
   - `src`: The name of the local volume or path to be mounted within execution
     environment.
   - `dest`: The path where the file or directory are mounted in the container.

--- a/docs/als/settings.md
+++ b/docs/als/settings.md
@@ -49,6 +49,11 @@ Specify any additional parameters that should be added to the pull command when 
 . Default value:
 ``""``
 
+## [`ansible.executionEnvironment.volumeMounts`](#executionEnvironment.volumeMounts) { #executionEnvironment.volumeMounts data-toc-label=executionEnvironment.volumeMounts }
+Add a dictionary entry to the array with the volume mount source path (key: &#x27;src&#x27;), destination (key: &#x27;dest&#x27;), and options (key: &#x27;options&#x27;)
+. Default value:
+``""``
+
 ## [`ansible.executionEnvironment.containerOptions`](#executionEnvironment.containerOptions) { #executionEnvironment.containerOptions data-toc-label=executionEnvironment.containerOptions }
 Extra parameters passed to the container engine command example: &#x27;--net&#x3D;host&#x27;
 . Default value:
@@ -83,12 +88,4 @@ Path to the ansible-lint executable
 Optional command line arguments to be appended to ansible-lint invocation
 . Default value:
 ``""``
-
-## [`ansible.executionEnvironment.volumeMounts`](#executionEnvironment.volumeMounts) { #executionEnvironment.volumeMounts data-toc-label=executionEnvironment.volumeMounts }
-  - **src**: The name of the local volume or path to be mounted within execution environment.. Default value:
-`""`
-  - **dest**: The path where the file or directory are mounted in the container.. Default value:
-`""`
-  - **options**: The field is optional, and is a comma-separated list of options, such as ro,Z. Default value:
-`""`
 

--- a/package.json
+++ b/package.json
@@ -620,26 +620,9 @@
           "ansible.executionEnvironment.volumeMounts": {
             "scope": "resource",
             "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "src": {
-                  "type": "string",
-                  "markdownDescription": "The name of the local volume or path to be mounted within execution environment.",
-                  "order": 6
-                },
-                "dest": {
-                  "type": "string",
-                  "markdownDescription": "The path where the file or directory are mounted in the container.",
-                  "order": 7
-                },
-                "options": {
-                  "type": "string",
-                  "markdownDescription": "The field is optional, and is a comma-separated list of options, such as `ro,Z.`",
-                  "order": 8
-                }
-              }
-            }
+            "default": [],
+            "markdownDescription": "Add a dictionary entry to the array with the volume mount source path (key: 'src'), destination (key: 'dest'), and options (key: 'options')",
+            "order": 6
           }
         }
       },

--- a/packages/ansible-language-server/src/interfaces/extensionSettings.ts
+++ b/packages/ansible-language-server/src/interfaces/extensionSettings.ts
@@ -72,11 +72,7 @@ interface ExecutionEnvironmentSettingsWithDescription extends SettingsEntry {
     policy: { default: IPullPolicy; description: string };
     arguments: { default: string; description: string };
   };
-  volumeMounts: Array<{
-    src: { default: string; description: string };
-    dest: { default: string; description: string };
-    options: { default: string; description: string };
-  }>;
+  volumeMounts: { default: Array<IVolumeMounts>; description: string };
   containerOptions: { default: string; description: string };
 }
 
@@ -98,11 +94,7 @@ export interface SettingsEntry {
     | SettingsEntry
     | string
     | boolean
-    | Array<{
-        src: { default: string; description: string };
-        dest: { default: string; description: string };
-        options: { default: string; description: string };
-      }>;
+    | Array<IVolumeMounts>;
 }
 
 interface AnsibleSettingsWithDescription extends SettingsEntry {

--- a/packages/ansible-language-server/src/services/executionEnvironment.ts
+++ b/packages/ansible-language-server/src/services/executionEnvironment.ts
@@ -215,13 +215,9 @@ export class ExecutionEnvironment {
       ...["-v", `${workspaceFolderPath}:${workspaceFolderPath}`],
     );
 
-    // TODO: add condition to check file path exists or not
     for (const mountPath of mountPaths || []) {
-      // push to array only if mount path is valid
-      if (mountPath === "" || !fs.existsSync(mountPath)) {
-        this.connection.console.error(
-          `Volume mount source path '${mountPath}' does not exist. Ignoring this volume mount entry.`,
-        );
+      // push to array only if mount path isn't an empty string, then let podman produce errors as needed
+      if (mountPath === "") {
         continue;
       }
 
@@ -399,18 +395,6 @@ export class ExecutionEnvironment {
       const fsSrcPath = volumeMounts.src;
       const fsDestPath = volumeMounts.dest;
       const options = volumeMounts.options;
-      if (fsSrcPath === "" || !fs.existsSync(fsSrcPath)) {
-        this.connection.console.error(
-          `Volume mount source path '${fsSrcPath}' does not exist. Ignoring this volume mount entry.`,
-        );
-        continue;
-      }
-      if (fsDestPath === "") {
-        this.connection.console.error(
-          `Volume mount destination path '${fsDestPath}' not provided. Ignoring this volume mount entry.`,
-        );
-        continue;
-      }
 
       let mountPath = `${fsSrcPath}:${fsDestPath}`;
       if (options && options !== "") {

--- a/packages/ansible-language-server/src/services/settingsManager.ts
+++ b/packages/ansible-language-server/src/services/settingsManager.ts
@@ -68,25 +68,11 @@ export class SettingsManager {
             "Specify any additional parameters that should be added to the pull command when pulling an execution environment from a container registry. e.g. '-–tls-verify=false'",
         },
       },
-      volumeMounts: [
-        {
-          src: {
-            default: "",
-            description:
-              "The name of the local volume or path to be mounted within execution environment.",
-          },
-          dest: {
-            default: "",
-            description:
-              "The path where the file or directory are mounted in the container.",
-          },
-          options: {
-            default: "",
-            description:
-              "The field is optional, and is a comma-separated list of options, such as ro,Z",
-          },
-        },
-      ],
+      volumeMounts: {
+        default: [],
+        description:
+          "Add a dictionary entry to the array with the volume mount source path (key: 'src'), destination (key: 'dest'), and options (key: 'options')",
+      },
       containerOptions: {
         default: "",
         description:

--- a/packages/ansible-language-server/test/helper.ts
+++ b/packages/ansible-language-server/test/helper.ts
@@ -21,6 +21,7 @@ export const ANSIBLE_COLLECTIONS_FIXTURES_BASE_PATH = path.resolve(
   "collections",
 );
 export const ANSIBLE_ADJACENT_COLLECTIONS__PATH = path.resolve(
+  FIXTURES_BASE_PATH,
   "playbook_adjacent_collection",
   "collections",
 );

--- a/packages/ansible-language-server/tools/settings-doc-generator.ts
+++ b/packages/ansible-language-server/tools/settings-doc-generator.ts
@@ -111,6 +111,8 @@ export function toDotNotation(
     if (value && typeof value === "object") {
       if (_.isArray(value) && value[0]) {
         toDotNotation(value[0], res, `${newKey}._array`); // it's an array object, so do it again (to identify array '._array' is added)
+      } else if (_.isArray(value) && !value[0]) {
+        res[newKey] = value; // empty array
       } else {
         toDotNotation(
           value as ExtensionSettingsWithDescriptionBase,


### PR DESCRIPTION
This PR reworks the EE volume mount setting so a default value of `[]` for the volume mounts array is assigned correctly. 

Reason for the change:

Our EE volume mount settings didn't set default values of `""` to the `src`, `dest`, and `options` fields due to apparent lack of vscode detection for settings default values at that nested depth. 

This means the `src`, `dest`, and `options` values were set to their dictionary object values, for example:

```
          src: {
            default: "",
            description:
              "The name of the local volume or path to be mounted within execution environment.",
          },
```
The type would be `object`, and podman would either throw an error or the error would be output into the log (even if the setting was not used at all). 

This PR also removes custom error handling so that podman can throw errors more accurately and display them through toast notifications rather than the log. 

There is also a change to update the `ANSIBLE_ADJACENT_COLLECTIONS__PATH` value in ALS tests, since this path was being skipped previously in tests because the path didn't exist. 

This also updates the docs generation script for ALS so empty arrays as default settings values aren't skipped. 

Fixes #1524.