### PR TITLE
Start using uv instead of pip during testing

### DIFF
--- a/.config/requirements.in
+++ b/.config/requirements.in
@@ -5,7 +5,8 @@ ansible-navigator
 mypy # used by vscode
 pip>=22.3.1
 pip-tools>=6.12.1
-pre-commit>=2.20
+pre-commit>=4.0.1
+pre-commit-uv>=4.1.4
 # docs
 argparse-manpage
 cairosvg
@@ -23,3 +24,4 @@ mkdocstrings-python
 pillow
 pymdown-extensions
 slugify
+uv>=0.4.29

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,7 @@ repos:
           - -e
           - SC1091
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.7.0
+    rev: v0.7.1
     hooks:
       - id: ruff
         args:

--- a/tools/test-setup.sh
+++ b/tools/test-setup.sh
@@ -277,9 +277,9 @@ if [[ "$(which python3)" != ${VIRTUAL_ENV}/bin/python3 ]]; then
         exit 99
     fi
 fi
-log notice "Upgrading pip ..."
+log notice "Upgrading pip and uv ..."
 
-python3 -m pip install -q -U pip
+python3 -m pip install -q -U pip uv
 # Fail fast if user has broken dependencies
 python3 -m pip check || {
         log error "pip check failed with exit code $?"
@@ -294,7 +294,7 @@ if [[ $(uname || true) != MINGW* ]]; then # if we are not on pure Windows
     # We used the already tested constraints file from community-ansible-dev-tools EE in order
     # to avoid surprises. This ensures venv and community-ansible-dev-tools EE have exactly same
     # versions.
-    python3 -m pip install -q \
+    python3 -m uv pip install -q \
         -r .config/requirements.in
 fi
 


### PR DESCRIPTION
This should bring a notable speed increase in installing python dependencies.