### PR TITLE
tools/helper --package: ensure out/log directory exists

### DIFF
--- a/tools/helper
+++ b/tools/helper
@@ -160,6 +160,7 @@ def cli() -> None:
             f" --readme-path docs/README.md {pre_release_arg} {version}"
         )
         # Using zipinfo instead of `npx vsce ls` due to https://github.com/microsoft/vscode-vsce/issues/517
+        run("mkdir -p out/log")
         run("zipinfo -1 ./*.vsix > out/log/package.log")
         run("tools/dirty.sh")
         print(f"Generated ansible-{version}")


### PR DESCRIPTION
This to avoid the following error:

```
subprocess.CalledProcessError: Command 'zipinfo -1 ./*.vsix > out/log/package.log' returned non-zero exit status 1.
```
