### PR TITLE
Update vscode-extension-tester to 8.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -972,7 +972,7 @@
     "ts-node": "^10.9.2",
     "typescript": "^5.6.3",
     "typescript-eslint": "^8.13.0",
-    "vscode-extension-tester": "^8.3.0",
+    "vscode-extension-tester": "^8.9.0",
     "warnings-to-errors-webpack-plugin": "^2.3.0",
     "webpack": "^5.96.1",
     "webpack-cli": "^5.1.4",

--- a/test/ui-test/contentCreatorUiTest.ts
+++ b/test/ui-test/contentCreatorUiTest.ts
@@ -1,11 +1,5 @@
-import {
-  By,
-  EditorView,
-  WebElement,
-  WebView,
-  Workbench,
-} from "vscode-extension-tester";
-import { sleep } from "./uiTestHelper";
+import { By, EditorView, WebElement, Workbench } from "vscode-extension-tester";
+import { getWebviewByLocator, sleep } from "./uiTestHelper";
 import { config, expect } from "chai";
 
 config.truncateThreshold = 0;
@@ -27,17 +21,10 @@ export function contentCreatorUiTest(): void {
       await workbench.executeCommand("Ansible: Create New Playbook Project");
       await sleep(4000);
 
-      const playbookProject = (await new EditorView().openEditor(
-        "Create Ansible project",
-      )) as WebView;
-
-      expect(playbookProject, "webView should not be undefined").not.to.be
-        .undefined;
-      await playbookProject.switchToFrame(5000);
-      expect(
-        playbookProject,
-        "webView should not be undefined after switching to its frame",
-      ).not.to.be.undefined;
+      await new EditorView().openEditor("Create Ansible project");
+      const playbookProject = await getWebviewByLocator(
+        By.xpath("//vscode-text-field[@id='namespace-name']"),
+      );
 
       const namespaceTextField = await playbookProject.findWebElement(
         By.xpath("//vscode-text-field[@id='namespace-name']"),

--- a/test/ui-test/lightspeedOneClickTrialUITest.ts
+++ b/test/ui-test/lightspeedOneClickTrialUITest.ts
@@ -19,6 +19,7 @@ import {
   expectNotification,
   getFixturePath,
   getModalDialogAndMessage,
+  getWebviewByLocator,
   sleep,
   updateSettings,
 } from "./uiTestHelper";
@@ -174,14 +175,9 @@ export function lightspeedOneClickTrialUITest(): void {
     it("Invoke Playbook generation", async () => {
       await workbench.executeCommand("Ansible Lightspeed: Playbook generation");
       await sleep(2000);
-      playbookGeneration = await new WebView();
-      expect(playbookGeneration, "webView should not be undefined").not.to.be
-        .undefined;
-      await playbookGeneration.switchToFrame(5000);
-      expect(
-        playbookGeneration,
-        "webView should not be undefined after switching to its frame",
-      ).not.to.be.undefined;
+      playbookGeneration = await getWebviewByLocator(
+        By.xpath("//*[text()='Create a playbook with Ansible Lightspeed']"),
+      );
 
       // Set input text and invoke summaries API
       const textArea = await playbookGeneration.findWebElement(

--- a/test/ui-test/uiTestHelper.ts
+++ b/test/ui-test/uiTestHelper.ts
@@ -3,9 +3,11 @@ import { expect } from "chai";
 import path from "path";
 import {
   By,
+  Locator,
   ModalDialog,
   SettingsEditor,
   Workbench,
+  WebView,
 } from "vscode-extension-tester";
 
 // Returns testFixtures/ path by default, and can
@@ -84,4 +86,70 @@ export async function expectNotification(
       notification.dismiss();
     }
   }
+}
+
+export async function getWebviewByLocator(locator: Locator): Promise<WebView> {
+  const wv = await new WebView();
+  const driver = wv.getDriver();
+
+  driver.switchTo().defaultContent();
+
+  const iframes = await wv.findElements(
+    By.xpath("//iframe[@class='webview ready']"),
+  );
+
+  for (let i = iframes.length - 1; i >= 0; i--) {
+    await driver.switchTo().defaultContent();
+    await driver.switchTo().frame(iframes[i]);
+
+    const iframeName = await driver.executeScript("return self.name");
+
+    const activeFrame = await driver.findElement(By.id("active-frame"));
+    await driver.switchTo().frame(activeFrame);
+
+    const elements = await driver.findElements(locator);
+    // console.log(`Switched to active-frame of iframe ${iframeName}`);
+    // console.log(elements);
+    if (elements.length === 0) {
+      console.log(`locator=${locator} not found :-(`);
+      continue;
+    }
+    console.log(`locator=${locator} found in iframe ${iframeName}!`);
+
+    return wv;
+  }
+  // debugger;
+  throw new Error("Cannot find any matching view");
+}
+
+export async function workbenchExecuteCommand(command: string) {
+  const workbench = new Workbench();
+  workbench.getDriver().switchTo().defaultContent();
+  for (let i = 0; i < 5; i++) {
+    try {
+      return await workbench.executeCommand(command);
+    } catch (e) {
+      console.log(`workbenchExecuteCommand: i=${i} exception ${e}`);
+      if (i > 3) {
+        throw e;
+      }
+    }
+  }
+}
+
+export async function openSettings() {
+  const workbench = new Workbench();
+
+  for (let i = 0; i < 5; i++) {
+    try {
+      return await workbench.openSettings();
+    } catch (e) {
+      console.log(`openSettings: i=${i} exception ${e}`);
+      if (i > 3) {
+        throw e;
+      }
+    }
+  }
+
+  throw new Error("Something bad happened");
 }

--- a/test/ui-test/walkthroughUiTest.ts
+++ b/test/ui-test/walkthroughUiTest.ts
@@ -60,7 +60,9 @@ export function walkthroughUiTest(): void {
         await sleep(1000);
 
         // Select the editor window
-        const welcomeTab = await editorView.getTabByTitle("Welcome");
+        const welcomeTab = await editorView.getTabByTitle(
+          "Walkthrough: Ansible",
+        );
         expect(welcomeTab).is.not.undefined;
 
         // Locate walkthrough title text

--- a/test/ui-test/welcomePageUITest.ts
+++ b/test/ui-test/welcomePageUITest.ts
@@ -5,11 +5,13 @@ import {
   SideBarView,
   ViewControl,
   ViewSection,
-  WebView,
   WebviewView,
-  Workbench,
 } from "vscode-extension-tester";
-import { sleep } from "./uiTestHelper";
+import {
+  sleep,
+  getWebviewByLocator,
+  workbenchExecuteCommand,
+} from "./uiTestHelper";
 
 config.truncateThreshold = 0;
 export function welcomePageUITest(): void {
@@ -17,12 +19,10 @@ export function welcomePageUITest(): void {
     let view: ViewControl;
     let sideBar: SideBarView;
     let webviewView: InstanceType<typeof WebviewView>;
-    let workbench: Workbench;
     let adtSection: ViewSection;
 
     before(async () => {
       // Open Ansible Development Tools by clicking the Getting started button on the side bar
-      workbench = new Workbench();
       view = (await new ActivityBar().getViewControl("Ansible")) as ViewControl;
       sideBar = await view.openView();
       await sleep(2000);
@@ -37,7 +37,7 @@ export function welcomePageUITest(): void {
     it("check for title and get started button", async function () {
       const title = await adtSection.getTitle();
 
-      await workbench.executeCommand(
+      await workbenchExecuteCommand(
         "Ansible: Focus on Ansible Development Tools View",
       );
 
@@ -67,17 +67,12 @@ export function welcomePageUITest(): void {
     });
 
     it("check for header and subtitle", async function () {
-      const welcomePageWebView = await new WebView();
-      expect(welcomePageWebView, "welcomePageWebView should not be undefined")
-        .not.to.be.undefined;
-      await welcomePageWebView.switchToFrame(3000);
-      expect(
-        welcomePageWebView,
-        "welcomePageWebView should not be undefined after switching to its frame",
-      ).not.to.be.undefined;
+      const welcomePageWebView = await getWebviewByLocator(
+        By.xpath("//h1[text()='Ansible Development Tools']"),
+      );
 
       const adtHeaderTitle = await welcomePageWebView.findWebElement(
-        By.className("title caption"),
+        By.xpath("//h1[text()='Ansible Development Tools']"),
       );
       expect(adtHeaderTitle).not.to.be.undefined;
       expect(await adtHeaderTitle.getText()).to.equals(
@@ -96,25 +91,15 @@ export function welcomePageUITest(): void {
     });
 
     it("Check if start and walkthrough list section is visible", async () => {
-      const welcomePageWebView = await new WebView();
-      expect(welcomePageWebView, "welcomePageWebView should not be undefined")
-        .not.to.be.undefined;
-      await welcomePageWebView.switchToFrame(3000);
-      expect(
-        welcomePageWebView,
-        "welcomePageWebView should not be undefined after switching to its frame",
-      ).not.to.be.undefined;
+      const welcomePageWebView = await getWebviewByLocator(
+        By.className("index-list start-container"),
+      );
 
       const startSection = await welcomePageWebView.findWebElement(
         By.className("index-list start-container"),
       );
 
-      const walkthroughSection = await welcomePageWebView.findWebElement(
-        By.className("index-list getting-started"),
-      );
-
       expect(startSection).not.to.be.undefined;
-      expect(walkthroughSection).not.to.be.undefined;
 
       const playbookWithLightspeedOption = await startSection.findElement(
         By.css("h3"),
@@ -124,12 +109,17 @@ export function welcomePageUITest(): void {
         "Playbook with Ansible Lightspeed",
       );
 
-      const walkthroughItems = await walkthroughSection.findElements(
-        By.className("walkthrough-item"),
+      const walkthroughSection = await getWebviewByLocator(
+        By.xpath("//button[@class='walkthrough-item']"),
+      );
+      const walkthroughItems = await walkthroughSection.findWebElements(
+        By.xpath("//button[@class='walkthrough-item']"),
       );
       expect(walkthroughItems.length).to.greaterThanOrEqual(2);
 
-      const firstWalkthrough = walkthroughItems[0].findElement(By.css("h3"));
+      const firstWalkthrough = await walkthroughSection.findWebElement(
+        By.xpath("//h3[contains(text(), 'Create an Ansible environment')]"),
+      );
       expect(await firstWalkthrough.getText()).to.equal(
         "Create an Ansible environment",
       );

--- a/yarn.lock
+++ b/yarn.lock
@@ -834,28 +834,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@redhat-developer/locators@npm:^1.1.2":
-  version: 1.1.2
-  resolution: "@redhat-developer/locators@npm:1.1.2"
+"@redhat-developer/locators@npm:^1.7.0":
+  version: 1.7.0
+  resolution: "@redhat-developer/locators@npm:1.7.0"
   peerDependencies:
     "@redhat-developer/page-objects": ">=1.0.0"
     selenium-webdriver: ">=4.6.1"
-  checksum: 10/d597cf640c2714fbb697bf15fc5b406e7248bb092be05e65853753c3f990ec3b6b0aabce9ee420e387d0948559628e5c408b7021ff2551f9d4da8a4d069f0d3b
+  checksum: 10/660e365d665ef9904831293e366c9d5b85c216cef00a374b1fc3d298fc676fe8405607a0f66f140392de4545c7c0f967966f51d4a2012189d353203a7eba28ad
   languageName: node
   linkType: hard
 
-"@redhat-developer/page-objects@npm:^1.1.2":
-  version: 1.1.2
-  resolution: "@redhat-developer/page-objects@npm:1.1.2"
+"@redhat-developer/page-objects@npm:^1.7.0":
+  version: 1.7.0
+  resolution: "@redhat-developer/page-objects@npm:1.7.0"
   dependencies:
     clipboardy: "npm:^4.0.0"
     clone-deep: "npm:^4.0.1"
-    compare-versions: "npm:^6.1.0"
+    compare-versions: "npm:^6.1.1"
     fs-extra: "npm:^11.2.0"
+    type-fest: "npm:^4.26.1"
   peerDependencies:
     selenium-webdriver: ">=4.6.1"
     typescript: ">=4.6.2"
-  checksum: 10/94b28c9fb46727ac533eafee217578b120b63439bab5ebc00eecada817891cc7312b2e813aeb37682bea152e1c91e96fee09cb996dd61cf177e0d2a27ac67563
+  checksum: 10/9f854132dc3ca17a428a82d800fa1e828d7f3c56c5fbe1f1bdf785f2eb96efcbc009caee9ee9e33ef0a9c71a75e57327a423e181253e4615b4465c4973856ef7
   languageName: node
   linkType: hard
 
@@ -872,6 +873,13 @@ __metadata:
     ua-parser-js: "npm:1.0.39"
     uuid: "npm:^10.0.0"
   checksum: 10/f9fdff3e37bf91a5e7c4f6ef82bf910400b3a5eefdaf7a71522882d1c4618de24a723ebe1f9e91902424733ad979c8e2d7c9ef70249a1643e305ebc08d4cd333
+  languageName: node
+  linkType: hard
+
+"@sec-ant/readable-stream@npm:^0.4.1":
+  version: 0.4.1
+  resolution: "@sec-ant/readable-stream@npm:0.4.1"
+  checksum: 10/aac89581652ac85debe7c5303451c2ebf8bf25ca25db680e4b9b73168f6940616d9a4bbe3348981827b1159b14e2f2e6af4b7bd5735cac898c12d5c51909c102
   languageName: node
   linkType: hard
 
@@ -963,10 +971,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sindresorhus/is@npm:^5.2.0":
-  version: 5.6.0
-  resolution: "@sindresorhus/is@npm:5.6.0"
-  checksum: 10/b077c325acec98e30f7d86df158aaba2e7af2acb9bb6a00fda4b91578539fbff4ecebe9b934e24fec0e6950de3089d89d79ec02d9062476b20ce185be0e01bd6
+"@sindresorhus/is@npm:^7.0.1":
+  version: 7.0.1
+  resolution: "@sindresorhus/is@npm:7.0.1"
+  checksum: 10/d096d98268400c698633e620616b56dec822fd4fc55299caaf6c985e9242215c2c99f81da5701b783295c3019f6298a8299535eb9c2fcb69684fb9b5882aaedd
   languageName: node
   linkType: hard
 
@@ -1149,7 +1157,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/http-cache-semantics@npm:^4.0.2":
+"@types/http-cache-semantics@npm:^4.0.4":
   version: 4.0.4
   resolution: "@types/http-cache-semantics@npm:4.0.4"
   checksum: 10/a59566cff646025a5de396d6b3f44a39ab6a74f2ed8150692e0f31cc52f3661a68b04afe3166ebe0d566bd3259cb18522f46e949576d5204781cd6452b7fe0c5
@@ -1303,7 +1311,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/selenium-webdriver@npm:^4.1.22, @types/selenium-webdriver@npm:^4.1.27":
+"@types/selenium-webdriver@npm:^4.1.27":
   version: 4.1.27
   resolution: "@types/selenium-webdriver@npm:4.1.27"
   dependencies:
@@ -1670,44 +1678,6 @@ __metadata:
     "@vscode/vsce-sign-win32-x64":
       optional: true
   checksum: 10/b1aaf2e7e3d8744f79a0b470b382d168bf0fc4ea71d039991408ca06dd754f1ec4ae3b2ce5613cb86c9311d745c82374e0fbdfdcb97077d0dabd321491fb2aaa
-  languageName: node
-  linkType: hard
-
-"@vscode/vsce@npm:^2.27.0":
-  version: 2.31.1
-  resolution: "@vscode/vsce@npm:2.31.1"
-  dependencies:
-    "@azure/identity": "npm:^4.1.0"
-    "@vscode/vsce-sign": "npm:^2.0.0"
-    azure-devops-node-api: "npm:^12.5.0"
-    chalk: "npm:^2.4.2"
-    cheerio: "npm:^1.0.0-rc.9"
-    cockatiel: "npm:^3.1.2"
-    commander: "npm:^6.2.1"
-    form-data: "npm:^4.0.0"
-    glob: "npm:^11.0.0"
-    hosted-git-info: "npm:^4.0.2"
-    jsonc-parser: "npm:^3.2.0"
-    keytar: "npm:^7.7.0"
-    leven: "npm:^3.1.0"
-    markdown-it: "npm:^12.3.2"
-    mime: "npm:^1.3.4"
-    minimatch: "npm:^3.0.3"
-    parse-semver: "npm:^1.1.1"
-    read: "npm:^1.0.7"
-    semver: "npm:^7.5.2"
-    tmp: "npm:^0.2.3"
-    typed-rest-client: "npm:^1.8.4"
-    url-join: "npm:^4.0.1"
-    xml2js: "npm:^0.5.0"
-    yauzl: "npm:^2.3.1"
-    yazl: "npm:^2.2.2"
-  dependenciesMeta:
-    keytar:
-      optional: true
-  bin:
-    vsce: vsce
-  checksum: 10/e9c2516e83c3a2091d6842e37eee10a58597e2256b6e519defb69a011021ada85edd4c8880e1b381ccc28cff6c107e67a1d4870f13525efc50a7d54509fb1db1
   languageName: node
   linkType: hard
 
@@ -2232,7 +2202,7 @@ __metadata:
     typescript: "npm:^5.6.3"
     typescript-eslint: "npm:^8.13.0"
     uuid: "npm:^11.0.3"
-    vscode-extension-tester: "npm:^8.3.0"
+    vscode-extension-tester: "npm:^8.9.0"
     vscode-languageclient: "npm:^9.0.1"
     vscode-uri: "npm:^3.0.8"
     warnings-to-errors-webpack-plugin: "npm:^2.3.0"
@@ -2465,6 +2435,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"bluebird@npm:~3.7.2":
+  version: 3.7.2
+  resolution: "bluebird@npm:3.7.2"
+  checksum: 10/007c7bad22c5d799c8dd49c85b47d012a1fe3045be57447721e6afbd1d5be43237af1db62e26cb9b0d9ba812d2e4ca3bac82f6d7e016b6b88de06ee25ceb96e7
+  languageName: node
+  linkType: hard
+
 "body-parser@npm:^2.0.1":
   version: 2.0.2
   resolution: "body-parser@npm:2.0.2"
@@ -2611,7 +2588,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"c8@npm:^10.1.1":
+"c8@npm:^10.1.2":
   version: 10.1.2
   resolution: "c8@npm:10.1.2"
   dependencies:
@@ -2664,18 +2641,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cacheable-request@npm:^10.2.8":
-  version: 10.2.14
-  resolution: "cacheable-request@npm:10.2.14"
+"cacheable-request@npm:^12.0.1":
+  version: 12.0.1
+  resolution: "cacheable-request@npm:12.0.1"
   dependencies:
-    "@types/http-cache-semantics": "npm:^4.0.2"
-    get-stream: "npm:^6.0.1"
+    "@types/http-cache-semantics": "npm:^4.0.4"
+    get-stream: "npm:^9.0.1"
     http-cache-semantics: "npm:^4.1.1"
-    keyv: "npm:^4.5.3"
+    keyv: "npm:^4.5.4"
     mimic-response: "npm:^4.0.0"
-    normalize-url: "npm:^8.0.0"
+    normalize-url: "npm:^8.0.1"
     responselike: "npm:^3.0.0"
-  checksum: 10/102f454ac68eb66f99a709c5cf65e90ed89f1b9269752578d5a08590b3986c3ea47a5d9dff208fe7b65855a29da129a2f23321b88490106898e0ba70b807c912
+  checksum: 10/91ca6f3cdcbec3309032b96ba8e94e9d3978ab2e9ee048d75b32acf8a0f06c4cd4739317a39ce621469130f838b06713c1333d35b212e87633c4812d7f18b17f
   languageName: node
   linkType: hard
 
@@ -3114,10 +3091,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"compare-versions@npm:^6.1.0":
-  version: 6.1.0
-  resolution: "compare-versions@npm:6.1.0"
-  checksum: 10/20f349e7f8ad784704c68265f4e660e2abbe2c3d5c75793184fccb85f0c5c0263260e01fdd4488376f6b74b0f069e16c9684463f7316b075716fb1581eb36b77
+"compare-versions@npm:^6.1.1":
+  version: 6.1.1
+  resolution: "compare-versions@npm:6.1.1"
+  checksum: 10/9325c0fadfba81afa0ec17e6fc2ef823ba785c693089698b8d9374e5460509f1916a88591644d4cb4045c9a58e47fafbcc0724fe8bf446d2a875a3d6eeddf165
   languageName: node
   linkType: hard
 
@@ -3567,6 +3544,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"duplexer2@npm:~0.1.4":
+  version: 0.1.4
+  resolution: "duplexer2@npm:0.1.4"
+  dependencies:
+    readable-stream: "npm:^2.0.2"
+  checksum: 10/f60ff8b8955f992fd9524516e82faa5662d7aca5b99ee71c50bbbe1a3c970fafacb35d526d8b05cef8c08be56eed3663c096c50626c3c3651a52af36c408bf4d
+  languageName: node
+  linkType: hard
+
 "each-parallel-async@npm:^1.0.0":
   version: 1.0.0
   resolution: "each-parallel-async@npm:1.0.0"
@@ -3678,13 +3664,6 @@ __metadata:
   version: 4.5.0
   resolution: "entities@npm:4.5.0"
   checksum: 10/ede2a35c9bce1aeccd055a1b445d41c75a14a2bb1cd22e242f20cf04d236cdcd7f9c859eb83f76885327bfae0c25bf03303665ee1ce3d47c5927b98b0e3e3d48
-  languageName: node
-  linkType: hard
-
-"entities@npm:~2.1.0":
-  version: 2.1.0
-  resolution: "entities@npm:2.1.0"
-  checksum: 10/fe71642e42e108540b0324dea03e00f3dbad93617c601bfcf292c3f852c236af3e58469219c4653f6f05df781a446f3b82105b8d26b936d0fa246b0103f2f951
   languageName: node
   linkType: hard
 
@@ -4384,10 +4363,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"form-data-encoder@npm:^2.1.2":
-  version: 2.1.4
-  resolution: "form-data-encoder@npm:2.1.4"
-  checksum: 10/3778e7db3c21457296e6fdbc4200642a6c01e8be9297256e845ee275f9ddaecb5f49bfb0364690ad216898c114ec59bf85f01ec823a70670b8067273415d62f6
+"form-data-encoder@npm:^4.0.2":
+  version: 4.0.2
+  resolution: "form-data-encoder@npm:4.0.2"
+  checksum: 10/71a00a1e954267f8b87d4301936dda7177cfe18714a92930c87ebc132acb8b19ed12e9b9f8ad47af52c1cc582fd45c1771f66f850a6d319147731160f6b9b3fa
   languageName: node
   linkType: hard
 
@@ -4574,17 +4553,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-stream@npm:^6.0.1":
-  version: 6.0.1
-  resolution: "get-stream@npm:6.0.1"
-  checksum: 10/781266d29725f35c59f1d214aedc92b0ae855800a980800e2923b3fbc4e56b3cb6e462c42e09a1cf1a00c64e056a78fa407cbe06c7c92b7e5cd49b4b85c2a497
-  languageName: node
-  linkType: hard
-
 "get-stream@npm:^8.0.1":
   version: 8.0.1
   resolution: "get-stream@npm:8.0.1"
   checksum: 10/dde5511e2e65a48e9af80fea64aff11b4921b14b6e874c6f8294c50975095af08f41bfb0b680c887f28b566dd6ec2cb2f960f9d36a323359be324ce98b766e9e
+  languageName: node
+  linkType: hard
+
+"get-stream@npm:^9.0.1":
+  version: 9.0.1
+  resolution: "get-stream@npm:9.0.1"
+  dependencies:
+    "@sec-ant/readable-stream": "npm:^0.4.1"
+    is-stream: "npm:^4.0.1"
+  checksum: 10/ce56e6db6bcd29ca9027b0546af035c3e93dcd154ca456b54c298901eb0e5b2ce799c5d727341a100c99e14c523f267f1205f46f153f7b75b1f4da6d98a21c5e
   languageName: node
   linkType: hard
 
@@ -4742,26 +4724,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"got@npm:^13.0.0":
-  version: 13.0.0
-  resolution: "got@npm:13.0.0"
+"got@npm:^14.4.3":
+  version: 14.4.4
+  resolution: "got@npm:14.4.4"
   dependencies:
-    "@sindresorhus/is": "npm:^5.2.0"
+    "@sindresorhus/is": "npm:^7.0.1"
     "@szmarczak/http-timer": "npm:^5.0.1"
     cacheable-lookup: "npm:^7.0.0"
-    cacheable-request: "npm:^10.2.8"
+    cacheable-request: "npm:^12.0.1"
     decompress-response: "npm:^6.0.0"
-    form-data-encoder: "npm:^2.1.2"
-    get-stream: "npm:^6.0.1"
-    http2-wrapper: "npm:^2.1.10"
+    form-data-encoder: "npm:^4.0.2"
+    http2-wrapper: "npm:^2.2.1"
     lowercase-keys: "npm:^3.0.0"
-    p-cancelable: "npm:^3.0.0"
+    p-cancelable: "npm:^4.0.1"
     responselike: "npm:^3.0.0"
-  checksum: 10/35ac9fe37daca3d0a4f90305d8e64626268ef5a42584f5bcb42eea3cb9bbeb691cf9041d5ea72133a7295d1291684789a3148ff89a95f3d3ce3d0ebb6fb2f680
+    type-fest: "npm:^4.26.1"
+  checksum: 10/18502a1b6abbf92d6ad80dd7d6baf68967df4c0b15662b9065490b7c910fd3e236f3ba81cc6d2af2fe055fe5ab75c08b0b8c97ad7721e202b1826b69a0910f57
   languageName: node
   linkType: hard
 
-"graceful-fs@npm:^4.1.15, graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.11, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6":
+"graceful-fs@npm:^4.1.15, graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.11, graceful-fs@npm:^4.2.2, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6":
   version: 4.2.11
   resolution: "graceful-fs@npm:4.2.11"
   checksum: 10/bf152d0ed1dc159239db1ba1f74fdbc40cb02f626770dcd5815c427ce0688c2635a06ed69af364396da4636d0408fcf7d4afdf7881724c3307e46aff30ca49e2
@@ -4976,7 +4958,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"http2-wrapper@npm:^2.1.10":
+"http2-wrapper@npm:^2.2.1":
   version: 2.2.1
   resolution: "http2-wrapper@npm:2.2.1"
   dependencies:
@@ -5311,6 +5293,13 @@ __metadata:
   version: 3.0.0
   resolution: "is-stream@npm:3.0.0"
   checksum: 10/172093fe99119ffd07611ab6d1bcccfe8bc4aa80d864b15f43e63e54b7abc71e779acd69afdb854c4e2a67fdc16ae710e370eda40088d1cfc956a50ed82d8f16
+  languageName: node
+  linkType: hard
+
+"is-stream@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "is-stream@npm:4.0.1"
+  checksum: 10/cbea3f1fc271b21ceb228819d0c12a0965a02b57f39423925f99530b4eb86935235f258f06310b67cd02b2d10b49e9a0998f5ececf110ab7d3760bae4055ad23
   languageName: node
   linkType: hard
 
@@ -5764,7 +5753,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"keyv@npm:^4.5.3, keyv@npm:^4.5.4":
+"keyv@npm:^4.5.4":
   version: 4.5.4
   resolution: "keyv@npm:4.5.4"
   dependencies:
@@ -5826,15 +5815,6 @@ __metadata:
   version: 1.2.4
   resolution: "lines-and-columns@npm:1.2.4"
   checksum: 10/0c37f9f7fa212b38912b7145e1cd16a5f3cd34d782441c3e6ca653485d326f58b3caccda66efce1c5812bde4961bbde3374fae4b0d11bf1226152337f3894aa5
-  languageName: node
-  linkType: hard
-
-"linkify-it@npm:^3.0.1":
-  version: 3.0.3
-  resolution: "linkify-it@npm:3.0.3"
-  dependencies:
-    uc.micro: "npm:^1.0.1"
-  checksum: 10/1ed466b02ad361bb5e5b94a81232fc126890751038bf3e61f648f4ccb01e5e096bba66c3eff3d21ed5e3da738de0dc29783afedf0255733669889aa09d49e47e
   languageName: node
   linkType: hard
 
@@ -6151,21 +6131,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"markdown-it@npm:^12.3.2":
-  version: 12.3.2
-  resolution: "markdown-it@npm:12.3.2"
-  dependencies:
-    argparse: "npm:^2.0.1"
-    entities: "npm:~2.1.0"
-    linkify-it: "npm:^3.0.1"
-    mdurl: "npm:^1.0.1"
-    uc.micro: "npm:^1.0.5"
-  bin:
-    markdown-it: bin/markdown-it.js
-  checksum: 10/d83d794bfb9f5e05750b25db401d9c1f9b97c6bbabb6cfd78988bb98652c62c24417435487238e2b91fd4e495547ae8c9429fb4c69e9f5bf49bd0dd292d53f24
-  languageName: node
-  linkType: hard
-
 "markdown-it@npm:^14.1.0":
   version: 14.1.0
   resolution: "markdown-it@npm:14.1.0"
@@ -6205,13 +6170,6 @@ __metadata:
     unist-util-visit: "npm:^5.0.0"
     vfile: "npm:^6.0.0"
   checksum: 10/b17ee338f843af31a1c7a2ebf0df6f0b41c9380b7119a63ab521d271df665456578e1234bb7617883e8d860fe878038dcf2b76ab2f21e0f7451215a096d26cce
-  languageName: node
-  linkType: hard
-
-"mdurl@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "mdurl@npm:1.0.1"
-  checksum: 10/ada367d01c9e81d07328101f187d5bd8641b71f33eab075df4caed935a24fa679e625f07108801d8250a5e4a99e5cd4be7679957a11424a3aa3e740d2bb2d5cb
   languageName: node
   linkType: hard
 
@@ -6806,6 +6764,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"node-int64@npm:^0.4.0":
+  version: 0.4.0
+  resolution: "node-int64@npm:0.4.0"
+  checksum: 10/b7afc2b65e56f7035b1a2eec57ae0fbdee7d742b1cdcd0f4387562b6527a011ab1cbe9f64cc8b3cca61e3297c9637c8bf61cec2e6b8d3a711d4b5267dfafbe02
+  languageName: node
+  linkType: hard
+
 "node-preload@npm:^0.2.1":
   version: 0.2.1
   resolution: "node-preload@npm:0.2.1"
@@ -6840,10 +6805,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"normalize-url@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "normalize-url@npm:8.0.0"
-  checksum: 10/4347d6ee39d9e1e7138c9e7c0b459c1e07304d9cd7c62d92c1ca01ed1f0c5397b292079fe7cfa953f469722ae150eec82e14b97e2175af39ede0b58f99ef8cac
+"normalize-url@npm:^8.0.1":
+  version: 8.0.1
+  resolution: "normalize-url@npm:8.0.1"
+  checksum: 10/ae392037584fc5935b663ae4af475351930a1fc39e107956cfac44f42d5127eec2d77d9b7b12ded4696ca78103bafac5b6206a0ea8673c7bffecbe13544fcc5a
   languageName: node
   linkType: hard
 
@@ -7099,10 +7064,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"p-cancelable@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "p-cancelable@npm:3.0.0"
-  checksum: 10/a5eab7cf5ac5de83222a014eccdbfde65ecfb22005ee9bc242041f0b4441e07fac7629432c82f48868aa0f8413fe0df6c6067c16f76bf9217cd8dc651923c93d
+"p-cancelable@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "p-cancelable@npm:4.0.1"
+  checksum: 10/64de7b0be4c8bacc006488e0e90aa66fbcceb4da4f6fb84584573145f015f9650fe6ac26470897b3e82a3b528f6c60ea276b84cc315e35c45e9f12dec062a295
   languageName: node
   linkType: hard
 
@@ -7674,7 +7639,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"readable-stream@npm:^2.3.0, readable-stream@npm:^2.3.5, readable-stream@npm:~2.3.6":
+"readable-stream@npm:^2.0.2, readable-stream@npm:^2.3.0, readable-stream@npm:^2.3.5, readable-stream@npm:~2.3.6":
   version: 2.3.8
   resolution: "readable-stream@npm:2.3.8"
   dependencies:
@@ -7979,7 +7944,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"selenium-webdriver@npm:^4.21.0, selenium-webdriver@npm:^4.26.0":
+"selenium-webdriver@npm:^4.26.0":
   version: 4.26.0
   resolution: "selenium-webdriver@npm:4.26.0"
   dependencies:
@@ -8957,6 +8922,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"type-fest@npm:^4.26.1":
+  version: 4.26.1
+  resolution: "type-fest@npm:4.26.1"
+  checksum: 10/b82676194f80af228cb852e320d2ea8381c89d667d2e4d9f2bdfc8f254bccc039c7741a90c53617a4de0c9fdca8265ed18eb0888cd628f391c5c381c33a9f94b
+  languageName: node
+  linkType: hard
+
 "type-is@npm:^2.0.0":
   version: 2.0.0
   resolution: "type-is@npm:2.0.0"
@@ -9038,13 +9010,6 @@ __metadata:
   bin:
     ua-parser-js: script/cli.js
   checksum: 10/dd4026b6ece8a34a0d39b6de5542154c4506077d8def8647a300a29e1b3ffa0e23f5c8eeeb8101df6162b7b3eb3597d0b4adb031ae6104cbdb730d6ebc07f3c0
-  languageName: node
-  linkType: hard
-
-"uc.micro@npm:^1.0.1, uc.micro@npm:^1.0.5":
-  version: 1.0.6
-  resolution: "uc.micro@npm:1.0.6"
-  checksum: 10/6898bb556319a38e9cf175e3628689347bd26fec15fc6b29fa38e0045af63075ff3fea4cf1fdba9db46c9f0cbf07f2348cd8844889dd31ebd288c29fe0d27e7a
   languageName: node
   linkType: hard
 
@@ -9162,6 +9127,19 @@ __metadata:
   version: 1.0.0
   resolution: "unpipe@npm:1.0.0"
   checksum: 10/4fa18d8d8d977c55cb09715385c203197105e10a6d220087ec819f50cb68870f02942244f1017565484237f1f8c5d3cd413631b1ae104d3096f24fdfde1b4aa2
+  languageName: node
+  linkType: hard
+
+"unzipper@npm:^0.12.3":
+  version: 0.12.3
+  resolution: "unzipper@npm:0.12.3"
+  dependencies:
+    bluebird: "npm:~3.7.2"
+    duplexer2: "npm:~0.1.4"
+    fs-extra: "npm:^11.2.0"
+    graceful-fs: "npm:^4.2.2"
+    node-int64: "npm:^0.4.0"
+  checksum: 10/b210c421308e1913e01b54faad4ae79e758c674311892414a0697acacba9f82fa0051b677faa77e62fab422eef928c858f2d5cda9ddb47a2f3db95b0e9b36359
   languageName: node
   linkType: hard
 
@@ -9295,32 +9273,33 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vscode-extension-tester@npm:^8.3.0":
-  version: 8.3.0
-  resolution: "vscode-extension-tester@npm:8.3.0"
+"vscode-extension-tester@npm:^8.9.0":
+  version: 8.9.0
+  resolution: "vscode-extension-tester@npm:8.9.0"
   dependencies:
-    "@redhat-developer/locators": "npm:^1.1.2"
-    "@redhat-developer/page-objects": "npm:^1.1.2"
-    "@types/selenium-webdriver": "npm:^4.1.22"
-    "@vscode/vsce": "npm:^2.27.0"
-    c8: "npm:^10.1.1"
+    "@redhat-developer/locators": "npm:^1.7.0"
+    "@redhat-developer/page-objects": "npm:^1.7.0"
+    "@types/selenium-webdriver": "npm:^4.1.27"
+    "@vscode/vsce": "npm:^3.2.1"
+    c8: "npm:^10.1.2"
     commander: "npm:^12.1.0"
-    compare-versions: "npm:^6.1.0"
+    compare-versions: "npm:^6.1.1"
     find-up: "npm:7.0.0"
     fs-extra: "npm:^11.2.0"
-    glob: "npm:^10.4.1"
-    got: "npm:^13.0.0"
+    glob: "npm:^11.0.0"
+    got: "npm:^14.4.3"
     hpagent: "npm:^1.2.0"
     js-yaml: "npm:^4.1.0"
     sanitize-filename: "npm:^1.6.3"
-    selenium-webdriver: "npm:^4.21.0"
+    selenium-webdriver: "npm:^4.26.0"
     targz: "npm:^1.0.1"
+    unzipper: "npm:^0.12.3"
   peerDependencies:
     mocha: ">=5.2.0"
     typescript: ">=4.6.2"
   bin:
     extest: out/cli.js
-  checksum: 10/f9fb7e2092bc9f3d2ac8a30e6c8e25d23ecca8284e4de696aab67648d20e653943440f1c9b20d655df52db28613f1c83cb2b919f6b9521fa83d8e305cf77b38a
+  checksum: 10/552bd2d0dba7ed1d3891d142ffa59b06bc8e12669e95d74de1439f8edd3169cef7f61f11353b084462d9e094415af723abe33dde826e87445febec0c98c163c5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This also trigger some adjustments in the test-suite to address some known issues with vscode-extension-tester.

- `getWebviewByLocator(locator: Locator): Promise<Webview>`: returns the first Webview where `locator` is found.
- `workbenchExecuteCommand()`: Run `workbench.executeCommand(command);` but retry on failure.
- `openSettings()`: Run `workbench.openSettings();` but retry on failure.

Closes: https://github.com/ansible/vscode-ansible/issues/1464