### PR TITLE
[r11]: Add support for HTTP422 response

### DIFF
--- a/src/features/lightspeed/errors.ts
+++ b/src/features/lightspeed/errors.ts
@@ -184,6 +184,20 @@ ERRORS.addError(
   ),
 );
 ERRORS.addError(400, new Error("error__feedback_validation"));
+ERRORS.addError(
+  400,
+  new Error(
+    "error__wca_inference_failure",
+    "IBM watsonx Code Assistant inference failed. Please check your input and try again.",
+  ),
+);
+ERRORS.addError(
+  400,
+  new Error(
+    "error__wca_validation_failure",
+    "IBM watsonx Code Assistant failed to validate the response from the model. Please check your input and try again.",
+  ),
+);
 
 ERRORS.addError(
   403,

--- a/test/units/lightspeed/utils/handleApiError.test.ts
+++ b/test/units/lightspeed/utils/handleApiError.test.ts
@@ -150,6 +150,34 @@ describe("testing the error handling", () => {
     );
     assert.equal(error.message, "A field was invalid.");
   });
+
+  it("err WCA inference failure", () => {
+    const error = mapError(
+      createError(400, {
+        code: "error__wca_inference_failure",
+        message:
+          "IBM watsonx Code Assistant inference failed. Please check your input and try again.",
+      }),
+    );
+    assert.equal(
+      error.message,
+      "IBM watsonx Code Assistant inference failed. Please check your input and try again.",
+    );
+  });
+
+  it("err WCA validation failure", () => {
+    const error = mapError(
+      createError(400, {
+        code: "error__wca_validation_failure",
+        detail: { reason: "error 1" },
+      }),
+    );
+    assert.equal(
+      error.message,
+      "IBM watsonx Code Assistant failed to validate the response from the model. Please check your input and try again.",
+    );
+    assert.equal(error.detail, "reason: error 1");
+  });
   // =================================
 
   // =================================


### PR DESCRIPTION
Add support for HTTP422 errors received in the underlying Lightspeed service from WCA.

These are propagated to VSCode as HTTP400's.

This PR adds a _friendly_ message for Users for such exceptions.