### PR TITLE
lightpseed: only show the "Explain with Lightspeed" when needed

### DIFF
--- a/package.json
+++ b/package.json
@@ -777,7 +777,8 @@
         },
         {
           "group": "2_main@1",
-          "command": "ansible.lightspeed.playbookExplanation"
+          "command": "ansible.lightspeed.playbookExplanation",
+          "when": "redhat.ansible.lightspeedSuggestionsEnabled && editorLangId == ansible"
         }
       ],
       "explorer/context": [


### PR DESCRIPTION
Only show the "Explain the playbook with Ansible Lightspeed" when:

- The Lightspeed feature is enabled
- The file has the Ansible file type
