### PR TITLE
AAP-16652: Lightspeed: support multi-line prompt for multitasks suggestions

### DIFF
--- a/src/features/lightspeed/utils/multiLinePromptForMultiTasks.ts
+++ b/src/features/lightspeed/utils/multiLinePromptForMultiTasks.ts
@@ -1,0 +1,77 @@
+export function shouldRequestForPromptPosition(
+  documentContent: string,
+  promptLine: number,
+): boolean {
+  const documentLines = documentContent.trim().split("\n");
+  if (documentLines.length > 0 && promptLine > 0) {
+    const promptLineText = documentLines[promptLine - 1].trim();
+    if (promptLineText.startsWith("# ") && promptLineText.endsWith(" &")) {
+      // should do not make request for prompt that ends with "&"
+      return false;
+    }
+  }
+  return true;
+}
+
+export function getContentWithMultiLinePromptForMultiTasksSuggestions(
+  promptContent: string,
+) {
+  const promptLines = promptContent.trim().split("\n");
+  const promptLine = promptLines.length;
+  if (
+    promptLine < 1 ||
+    !promptLines[promptLine - 1].trim().startsWith("#") ||
+    promptLines[promptLine - 1].trim().endsWith("&")
+  ) {
+    return promptContent;
+  }
+
+  const spacesBeforePromptStart =
+    promptLines[promptLine - 1].match(/^ +/)?.[0].length || 0;
+
+  const commentLines = [];
+  for (let lineIndex = promptLine - 1; lineIndex >= 0; lineIndex--) {
+    const spacesBeforeLinePromptStart =
+      promptLines[lineIndex].match(/^ +/)?.[0].length || 0;
+    let promptLineText = promptLines[lineIndex].trim();
+    if (
+      !promptLineText.startsWith("# ") ||
+      (!promptLineText.endsWith(" &") && commentLines.length !== 0) ||
+      spacesBeforeLinePromptStart !== spacesBeforePromptStart
+    ) {
+      break;
+    }
+
+    promptLineText = promptLineText.replace(/^# /g, "");
+    promptLineText = promptLineText.replace(/&$/g, "");
+    commentLines.push(promptLineText.trim());
+  }
+
+  if (commentLines.length > 1) {
+    // create a new prompt based on the non-empty collected comments and
+    // clear all other participating comments
+    // Notes: do not delete the comments lines to preserve document lines count
+
+    commentLines.reverse();
+    const newPromptLineText = " "
+      .repeat(spacesBeforePromptStart)
+      .concat("# ", commentLines.filter(Boolean).join(" & "));
+
+    for (
+      let commentIndex = 0;
+      commentIndex < commentLines.length;
+      commentIndex++
+    ) {
+      if (commentIndex === 0) {
+        promptLines[promptLine - 1] = newPromptLineText;
+      } else {
+        promptLines[promptLine - commentIndex - 1] = " "
+          .repeat(spacesBeforePromptStart)
+          .concat("# -");
+      }
+    }
+    return promptLines.join("\n");
+  }
+
+  return promptContent;
+}

--- a/test/units/lightspeed/utils/multiLinePromptForMultiTasks.test.ts
+++ b/test/units/lightspeed/utils/multiLinePromptForMultiTasks.test.ts
@@ -1,0 +1,151 @@
+import assert from "assert";
+import {
+  shouldRequestForPromptPosition,
+  getContentWithMultiLinePromptForMultiTasksSuggestions,
+} from "../../../../src/features/lightspeed/utils/multiLinePromptForMultiTasks";
+
+describe("Test getContentWithMultiLinePromptForMultiTasksSuggestions", () => {
+  const testsData = [
+    {
+      name: "should parse and generate new prompt for playbook",
+      promptContent: `---
+- name: Testing playbook
+hosts: all
+tasks:
+  # Create a key-pair called lightspeed-key-pair &
+  # create a vpc & create vpc_id var &
+  # create a security group that allows SSH & create subnet with 10.0.1.0/24 cidr &
+  # create an internet gateway & create a route table`,
+      expectedContent: `---
+- name: Testing playbook
+hosts: all
+tasks:
+  # -
+  # -
+  # -
+  # Create a key-pair called lightspeed-key-pair & create a vpc & create vpc_id var & create a security group that allows SSH & create subnet with 10.0.1.0/24 cidr & create an internet gateway & create a route table`,
+      promptChanges: true,
+    },
+    {
+      name: "should parse and generate new prompt for tasks",
+      promptContent: `---
+# Install postgresql server &
+# Do the initial postgresql server config &
+# Start the postgresql service &
+# Allow the firewall traffic`,
+      expectedContent: `---
+# -
+# -
+# -
+# Install postgresql server & Do the initial postgresql server config & Start the postgresql service & Allow the firewall traffic`,
+      promptChanges: true,
+    },
+    {
+      name: "should not include lines in new prompt when previous comment does not end with '&'",
+      promptContent: `---\n# A &\n# B\n# C &\n# D`,
+      expectedContent: `---\n# A &\n# B\n# -\n# C & D`,
+      promptChanges: true,
+    },
+    {
+      name: "should not include empty comments lines in the new prompt",
+      promptContent: `---\n# A &\n#     &\n# B`,
+      expectedContent: `---\n# -\n# -\n# A & B`,
+      promptChanges: true,
+    },
+    {
+      name: "should not make changes to prompt when the latest previous comment does not end with '&'",
+      promptContent: `---\n# A &\n# B\n# C`,
+      promptChanges: false,
+    },
+    {
+      name: "should not make changes to prompt when the latest previous comment does not start with '# '",
+      promptContent: `---\n#C &\n## A &\n# B`,
+      promptChanges: false,
+    },
+    {
+      name: "should not include lines in new prompt when previous line comment does not start with '# '",
+      promptContent: `---\n#C &\n## A &\n# B &\n# D`,
+      expectedContent: `---\n#C &\n## A &\n# -\n# B & D`,
+      promptChanges: true,
+    },
+    {
+      name: "should not include lines in new prompt when previous line comment does not have the same indentation",
+      promptContent: `---\n#A &\n  # B &\n# C &\n# D`,
+      expectedContent: `---\n#A &\n  # B &\n# -\n# C & D`,
+      promptChanges: true,
+    },
+    {
+      name: "should not generate new prompt when prompt line does not start with '# '",
+      promptContent: `---# A &\nB`,
+      expectedContent: `---# A &\nB`,
+      promptChanges: false,
+    },
+    {
+      name: "should not generate new prompt when prompt line ends with '&'",
+      promptContent: `---# A &\n# B &\n# C &`,
+      promptChanges: false,
+    },
+  ];
+
+  testsData.forEach(
+    ({ name, promptContent, promptChanges, expectedContent }) => {
+      it(name, () => {
+        const newContent =
+          getContentWithMultiLinePromptForMultiTasksSuggestions(promptContent);
+        if (promptChanges) {
+          assert.equal(newContent, expectedContent);
+        } else {
+          assert.equal(newContent, promptContent);
+        }
+      });
+    },
+  );
+});
+
+describe("Test shouldRequestForPromptPosition", () => {
+  it("should not make request when prompt line start with '# ' and end with ' &' for tasks", () => {
+    const promptContent = `---
+# Create a key-pair called lightspeed-key-pair &
+# create a vpc & create vpc_id var &
+# create a security group that allows SSH & create subnet with 10.0.1.0/24 cidr &
+# create an internet gateway & create a route table &`;
+    const shouldRequest = shouldRequestForPromptPosition(promptContent, 5);
+    assert.equal(shouldRequest, false);
+  });
+
+  it("should not make request when prompt line start with '# ' and end with ' &' for playbook", () => {
+    const promptContent = `---
+- name: Testing playbook
+  hosts: all
+  tasks:
+    # Create a key-pair called lightspeed-key-pair &
+    # create a vpc & create vpc_id var &
+    # create a security group that allows SSH & create subnet with 10.0.1.0/24 cidr &
+    # create an internet gateway & create a route table &`;
+    const shouldRequest = shouldRequestForPromptPosition(promptContent, 8);
+    assert.equal(shouldRequest, false);
+  });
+
+  it("should allow request when prompt line start with '# ' and does not end with ' &' for tasks", () => {
+    const promptContent = `---
+# Create a key-pair called lightspeed-key-pair &
+# create a vpc & create vpc_id var &
+# create a security group that allows SSH & create subnet with 10.0.1.0/24 cidr &
+# create an internet gateway & create a route table`;
+    const shouldRequest = shouldRequestForPromptPosition(promptContent, 5);
+    assert.equal(shouldRequest, true);
+  });
+
+  it("should allow request when prompt line start with '# ' and does not end with ' &' for playbook", () => {
+    const promptContent = `---
+- name: Testing playbook
+  hosts: all
+  tasks:
+    # Create a key-pair called lightspeed-key-pair &
+    # create a vpc & create vpc_id var &
+    # create a security group that allows SSH & create subnet with 10.0.1.0/24 cidr &
+    # create an internet gateway & create a route table`;
+    const shouldRequest = shouldRequestForPromptPosition(promptContent, 8);
+    assert.equal(shouldRequest, true);
+  });
+});


### PR DESCRIPTION
add a feature to allow multi line prompt for multitasks suggestion. 

REF: AAP-16652

prompt may be like:
```yaml
---
# Install postgresql-server &
# Do the initial postgresql-server config &
# Start the postgresql service &
# Allow the firewall traffic

...
``` 
suggestion resolution will be like:

```yaml
---
# Install postgresql-server &
# Do the initial postgresql-server config &
# Start the postgresql service &
# Allow the firewall traffic
- name: Install postgresql-server
  become: true
  ansible.builtin.package:
    name: postgresql-server
    state: present

- name: Do the initial postgresql-server config
  ansible.builtin.command: /usr/pgsql-12/bin/postgresql-setup initdb
  become: true
  become_user: postgres

- name: Start the postgresql service
  ansible.builtin.service:
    name: postgresql
    state: started
    enabled: true

- name: Allow the firewall traffic
  ansible.posix.firewalld:
    port: 5432/tcp
    permanent: true
    state: enabled
    immediate: true
    
...

```

https://github.com/user-attachments/assets/f57a810f-ee68-44ac-b4a7-74b5eff0b3e4



