### PR TITLE
Add a webview to generate a devfile without ansible-creator

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -3,6 +3,8 @@ Ansible
 Anson
 CFLAGS
 Containerfile
+Devfile
+Devfiles
 Dockal
 Dpkg
 Elio
@@ -13,6 +15,7 @@ Ganesh
 HORIZONTALLINE
 IAM
 Jenkinsfile
+KUBEDOCK
 Launay
 Maciążek
 Nalawade

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,7 @@ ci:
     - codecov
     - depcheck
     - eslint
+    - compare-devfile
 exclude: >
   (?x)^(
     .config/requirements.in|
@@ -104,6 +105,12 @@ repos:
         language: system
         files: "codecov.yml"
         pass_filenames: false
+
+      - id: compare-devfile
+        name: Compare extension devfile with ansible-creator
+        entry: tools/compare_devfile.sh
+        language: script
+
   - repo: https://github.com/ScribeMD/pre-commit-hooks
     rev: 0.16.3
     hooks:

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -23,6 +23,7 @@
 !media/contentCreator/icons/ansible-logo-red.png
 !media/contentCreator/createAnsibleCollectionPageStyle.css
 !media/contentCreator/createAnsibleProjectPageStyle.css
+!media/contentCreator/createDevfilePageStyle.css
 !media/contentCreator/welcomePageStyle.css
 !media/lightspeedExplorerView/style.css
 !media/welcomePage/lightspeed.png
@@ -39,6 +40,7 @@
 !out/client/webview/apps/contentCreator/welcomePageApp.js
 !out/client/webview/apps/contentCreator/createAnsibleCollectionPageApp.js
 !out/client/webview/apps/contentCreator/createAnsibleProjectPageApp.js
+!out/client/webview/apps/contentCreator/createDevfilePageApp.js
 !out/client/webview/apps/quickLinks/quickLinksApp.js
 !out/server/src/server.js
 !package.json
@@ -73,3 +75,6 @@
 !media/walkthroughs/startAutomatingPlaybook/learning.png
 !media/walkthroughs/startAutomatingPlaybook/open-folder.png
 !media/walkthroughs/startAutomatingPlaybook/playbook-project.md
+
+# resources
+!resources/contentCreator/createDevfile/devfile-template.txt

--- a/media/baseStyles/baseFormStyle.css
+++ b/media/baseStyles/baseFormStyle.css
@@ -18,6 +18,16 @@ body {
     margin: 25px 0px 50px;
 }
 
+.title-description-div {
+    box-sizing: border-box;
+    display: flex;
+    flex-flow: column nowrap;
+    width: 100%;
+    max-width: 650px;
+    text-align: left;
+    margin: 25px 0px 40px;
+}
+
 h1 {
     border: none;
     font-size: 2.7em;

--- a/media/contentCreator/createDevfilePageStyle.css
+++ b/media/contentCreator/createDevfilePageStyle.css
@@ -1,0 +1,131 @@
+@import url(../baseStyles/baseFormStyle.css);
+
+.container {
+    display: flex;
+    flex-direction: column;
+}
+
+.element {
+    margin-bottom: 14px;
+}
+
+h3 {
+    border: none;
+    font-size: 1.1em;
+    font-style: normal;
+    font-weight: normal;
+    margin: 0;
+    color: var(--vscode-foreground);
+    white-space: wrap;
+}
+
+.description-div {
+    box-sizing: border-box;
+    display: flex;
+    flex-flow: column nowrap;
+    width: 100%;
+    max-width: 650px;
+    text-align: left;
+    margin: 0px 0px 40px;
+}
+
+vscode-text-field {
+    margin-top: 6px;
+    margin-bottom: 6px;
+}
+
+vscode-text-area {
+    margin-top: 6px;
+    margin-bottom: 6px;
+}
+
+.devfile-name-div {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+}
+
+#devfile-name {
+    width:49%;
+    display:inline-block;
+}
+
+.checkbox-div {
+    display: flex; /* Use flexbox */
+    flex-direction: column; /* Arrange child elements vertically */
+    margin-top: 22px;
+    margin-bottom: 10px;
+    width: 100%;
+}
+
+.image-div {
+    display: flex; /* Use flexbox */
+    flex-direction: row; /* Arrange child elements vertically */
+    margin-top: 12px;
+    margin-bottom: 30px;
+    width: 100%;
+}
+
+vscode-dropdown {
+    width: 400px;
+}
+
+.full-devfile-path {
+    display: flex; /* Use flexbox */
+    flex-direction: row; /* Arrange child elements vertically */
+    color: var(--vscode-descriptionForeground);
+}
+
+.group-buttons {
+    display: flex; /* Use flexbox */
+    flex-direction: row; /* Arrange child elements vertically */
+}
+
+.p-collection-name {
+    font-style: italic;
+}
+
+vscode-button {
+    margin: 0px 3px;
+}
+
+vscode-checkbox i {
+    color: var(--vscode-descriptionForeground);
+    font-size: small;
+}
+
+#ade-docs-link {
+    margin-left: 30px;
+    font-style: italic;
+}
+
+.dropdown-container {
+    box-sizing: border-box;
+    display: flex;
+    flex-flow: column nowrap;
+    align-items: flex-start;
+    justify-content: flex-start;
+}
+
+.dropdown-container label {
+    display: block;
+    color: var(--vscode-foreground);
+    cursor: pointer;
+    font-size: var(--vscode-font-size);
+    line-height: normal;
+    margin-bottom: 2px;
+}
+
+#log-to-file-options-div {
+    display: none;
+    flex-direction: column;
+    border-style: dotted;
+    border-color: var(--focus-border);
+    border-width: 0.5px;
+    padding: 8px;
+}
+
+.log-level-div {
+    margin: 4px 0px;
+}

--- a/package.json
+++ b/package.json
@@ -347,6 +347,10 @@
         "title": "Ansible: Create New Playbook Project"
       },
       {
+        "command": "ansible.content-creator.create-devfile",
+        "title": "Ansible: Create a Devfile"
+      },
+      {
         "command": "ansible.content-creator.create",
         "title": "Ansible Content Creator: Create"
       },

--- a/resources/contentCreator/createDevfile/devfile-template.txt
+++ b/resources/contentCreator/createDevfile/devfile-template.txt
@@ -1,0 +1,15 @@
+schemaVersion: 2.2.2
+metadata:
+  name: {{ dev_file_name }}
+components:
+  - name: tooling-container
+    container:
+      image: {{ dev_file_image }}
+      memoryRequest: 256M
+      memoryLimit: 6Gi
+      cpuRequest: 250m
+      cpuLimit: 2000m
+      args: ["tail", "-f", "/dev/null"]
+      env:
+        - name: KUBEDOCK_ENABLED
+          value: "true"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -71,6 +71,7 @@ import {
   AuthProviderType,
 } from "./features/lightspeed/lightspeedUser";
 import { PlaybookFeedbackEvent } from "./interfaces/lightspeed";
+import { CreateDevfile } from "./features/contentCreator/createDevfilePage";
 
 export let client: LanguageClient;
 export let lightSpeedManager: LightSpeedManager;
@@ -535,6 +536,16 @@ export async function activate(context: ExtensionContext): Promise<void> {
       "ansible.content-creator.create-ansible-project",
       () => {
         CreateAnsibleProject.render(context.extensionUri);
+      },
+    ),
+  );
+
+  // open web-view for creating devfile
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "ansible.content-creator.create-devfile",
+      () => {
+        CreateDevfile.render(context.extensionUri);
       },
     ),
   );

--- a/src/features/contentCreator/createDevfilePage.ts
+++ b/src/features/contentCreator/createDevfilePage.ts
@@ -301,15 +301,15 @@ export class CreateDevfile {
       },
     } as PostMessageEvent);
 
-    if (commandResult === "passed") {
-      const selection = await vscode.window.showInformationMessage(
-        `Devfile created at: ${destinationPathUrl}`,
-        `Open devfile ↗`,
-      );
-      if (selection === "Open devfile ↗") {
-        this.openDevfile(destinationPathUrl);
-      }
-    }
+    // if (commandResult === "passed") {
+    //   const selection = await vscode.window.showInformationMessage(
+    //     `Devfile created at: ${destinationPathUrl}`,
+    //     `Open devfile ↗`,
+    //   );
+    //   if (selection === "Open devfile ↗") {
+    //     this.openDevfile(destinationPathUrl);
+    //   }
+    // }
   }
 
   public createDevfile(

--- a/src/features/contentCreator/createDevfilePage.ts
+++ b/src/features/contentCreator/createDevfilePage.ts
@@ -1,0 +1,353 @@
+/* eslint-disable  @typescript-eslint/no-explicit-any */
+
+import * as vscode from "vscode";
+import * as os from "os";
+import { getUri } from "../utils/getUri";
+import { getNonce } from "../utils/getNonce";
+import { DevfileFormInterface, PostMessageEvent } from "./types";
+import * as fs from "fs";
+import { SettingsManager } from "../../settings";
+import { expandPath } from "./utils";
+import { randomUUID } from "crypto";
+
+export class CreateDevfile {
+  public static currentPanel: CreateDevfile | undefined;
+  private readonly _panel: vscode.WebviewPanel;
+  private _disposables: vscode.Disposable[] = [];
+  public static readonly viewType = "CreateProject";
+
+  private constructor(panel: vscode.WebviewPanel, extensionUri: vscode.Uri) {
+    this._panel = panel;
+    this._panel.webview.html = this._getWebviewContent(
+      this._panel.webview,
+      extensionUri,
+    );
+    this._setWebviewMessageListener(this._panel.webview, extensionUri);
+    this._panel.onDidDispose(
+      () => {
+        this.dispose();
+      },
+      null,
+      this._disposables,
+    );
+  }
+
+  public dispose() {
+    CreateDevfile.currentPanel = undefined;
+
+    this._panel.dispose();
+
+    while (this._disposables.length) {
+      const disposable = this._disposables.pop();
+      if (disposable) {
+        disposable.dispose();
+      }
+    }
+  }
+
+  public static render(extensionUri: vscode.Uri) {
+    if (CreateDevfile.currentPanel) {
+      CreateDevfile.currentPanel._panel.reveal(vscode.ViewColumn.One);
+    } else {
+      const panel = vscode.window.createWebviewPanel(
+        "create-devfile",
+        "Create Devfile",
+        vscode.ViewColumn.One,
+        {
+          enableScripts: true,
+          localResourceRoots: [
+            vscode.Uri.joinPath(extensionUri, "out"),
+            vscode.Uri.joinPath(extensionUri, "media"),
+          ],
+          enableCommandUris: true,
+          retainContextWhenHidden: true,
+        },
+      );
+
+      CreateDevfile.currentPanel = new CreateDevfile(panel, extensionUri);
+    }
+  }
+
+  private _getWebviewContent(
+    webview: vscode.Webview,
+    extensionUri: vscode.Uri,
+  ) {
+    const codiconsUri = getUri(webview, extensionUri, [
+      "media",
+      "codicons",
+      "codicon.css",
+    ]);
+
+    const styleUri = getUri(webview, extensionUri, [
+      "media",
+      "contentCreator",
+      "createDevfilePageStyle.css",
+    ]);
+
+    const nonce = getNonce();
+
+    const workspaceDir = this.getWorkspaceFolder();
+
+    const webviewUri = getUri(webview, extensionUri, [
+      "out",
+      "client",
+      "webview",
+      "apps",
+      "contentCreator",
+      "createDevfilePageApp.js",
+    ]);
+
+    return /*html*/ `
+      <html>
+
+        <head>
+          <meta charset="UTF-8" />
+          <meta name="viewport" content="width=device-width, initial-scale=1.0">
+          <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'nonce-${nonce}'; style-src ${webview.cspSource}; font-src ${webview.cspSource};">
+          <title>AAA</title>
+          <link rel="stylesheet" href="${styleUri}">
+          <link rel="stylesheet" href="${codiconsUri}">
+        </head>
+
+        <body>
+            <div class="title-description-div">
+              <h1>Create a devfile</h1>
+              <p class="subtitle">Leverage Red Hat Openshift Dev Spaces</p>
+            </div>
+            <div class="description-div">
+              <h3>Devfiles are yaml files used for development environment customization.<br><br>Enter your project details below to utilize a devfile template designed for Red Hat OpenShift Dev Spaces.</h3>
+            </div>
+
+            <form id="devfile-form">
+              <section class="component-container">
+
+                <vscode-text-field id="path-url" class="required" form="devfile-form" placeholder="${workspaceDir}"
+                  size="512">Destination directory *
+                  <section slot="end" class="explorer-icon">
+                    <vscode-button id="folder-explorer" appearance="icon">
+                      <span class="codicon codicon-folder-opened"></span>
+                    </vscode-button>
+                  </section>
+                </vscode-text-field>
+
+                <div class="devfile-name-div">
+                <vscode-text-field id="devfile-name" form="devfile-form" placeholder="Enter Ansible project name" size="512">Ansible project name *</vscode-text-field>
+                </div>
+
+                <div id="full-devfile-path" class="full-devfile-path">
+                  <p>Devfile path:&nbsp</p>
+                </div>
+
+                <div class="image-div">
+                  <div class="dropdown-container">
+                    <label for="image-dropdown">Container image</label>
+                    <vscode-dropdown id="image-dropdown">
+                      <vscode-option>ghcr.io/ansible/ansible-workspace-env-reference:latest</vscode-option>
+                    </vscode-dropdown>
+                  </div>
+                </div>
+
+                <div class="checkbox-div">
+                  <vscode-checkbox id="overwrite-checkbox" form="devfile-form">Overwrite <br><i>Overwrite an existing devfile.</i></vscode-checkbox>
+                </div>
+
+                <div class="group-buttons">
+                  <vscode-button id="reset-button" form="devfile-form" appearance="secondary">
+                    <span class="codicon codicon-clear-all"></span>
+                    &nbsp; Reset All
+                  </vscode-button>
+                  <vscode-button id="create-button" form="devfile-form">
+                    <span class="codicon codicon-run-all"></span>
+                    &nbsp; Create
+                  </vscode-button>
+                </div>
+
+                <br>
+                <vscode-divider></vscode-divider>
+                <br>
+                <vscode-text-area id="log-text-area" cols="512" rows="10" placeholder="Output of the command execution"
+                  resize="vertical" readonly>Logs</vscode-text-area>
+
+                <div class="group-buttons">
+                  <vscode-button id="clear-logs-button" form="devfile-form" appearance="secondary">
+                    <span class="codicon codicon-clear-all"></span>
+                    &nbsp; Clear Logs
+                  </vscode-button>
+                  <vscode-button id="open-file-button" form="devfile-form" disabled>
+                    <span class="codicon codicon-go-to-file"></span>
+                    &nbsp; Open Devfile
+                  </vscode-button>
+                </div>
+              </section>
+            </form>
+
+          <!-- Component registration code -->
+          <script type="module" nonce="${nonce}" src="${webviewUri}"></script>
+        </body>
+      </html>
+    `;
+  }
+
+  private _setWebviewMessageListener(
+    webview: vscode.Webview,
+    extensionUri: vscode.Uri,
+  ) {
+    webview.onDidReceiveMessage(
+      async (message: any) => {
+        const command = message.command;
+        let payload;
+
+        switch (command) {
+          case "open-explorer": {
+            payload = message.payload;
+            const selectedUri = await this.openExplorerDialog(
+              payload.selectOption,
+            );
+            webview.postMessage({
+              command: "file-uri",
+              arguments: { selectedUri: selectedUri },
+            } as PostMessageEvent);
+            return;
+          }
+          case "devfile-create":
+            payload = message.payload as DevfileFormInterface;
+            await this.runDevfileCreateProcess(payload, webview, extensionUri);
+            return;
+
+          case "open-devfile":
+            payload = message.payload;
+            this.openDevfile(payload.projectUrl);
+            return;
+        }
+      },
+      undefined,
+      this._disposables,
+    );
+  }
+
+  public async openExplorerDialog(
+    selectOption: string,
+  ): Promise<string | undefined> {
+    const options: vscode.OpenDialogOptions = {
+      canSelectMany: false,
+      openLabel: "Select",
+      canSelectFolders: selectOption === "folder",
+      defaultUri: vscode.Uri.parse(os.homedir()),
+    };
+
+    let selectedUri: string | undefined;
+    await vscode.window.showOpenDialog(options).then((fileUri) => {
+      if (fileUri?.[0]) {
+        selectedUri = fileUri[0].fsPath;
+      }
+    });
+
+    return selectedUri;
+  }
+
+  public getWorkspaceFolder() {
+    let folder: string = "";
+    if (vscode.workspace.workspaceFolders) {
+      folder = vscode.workspace.workspaceFolders[0].uri.path;
+    }
+    return folder;
+  }
+
+  public async runDevfileCreateProcess(
+    payload: DevfileFormInterface,
+    webView: vscode.Webview,
+    extensionUri: vscode.Uri,
+  ) {
+    const { destinationPath, name, image, isOverwritten } = payload;
+    let commandResult: string;
+    let message: string;
+    let commandOutput = "";
+
+    commandOutput += `------------------------------------ devfile generation logs ------------------------------------\n`;
+
+    const destinationPathUrl = `${destinationPath}/devfile.yaml`;
+
+    const devfileExists = fs.existsSync(expandPath(destinationPathUrl));
+
+    if (devfileExists && !isOverwritten) {
+      message = `Error: Devfile already exists at ${destinationPathUrl} and was not overwritten. Use the 'Overwrite' option to overwrite the existing file.`;
+      commandResult = "failed";
+    } else {
+      commandResult = this.createDevfile(
+        destinationPathUrl,
+        name,
+        image,
+        extensionUri,
+      );
+      if (commandResult === "failed") {
+        message =
+          "ERROR: Could not create devfile. Please check that your destination path exists and write permissions are configured for it.";
+      } else {
+        message = `Creating new devfile at ${destinationPathUrl}`;
+      }
+    }
+    commandOutput += message;
+    console.debug(message);
+
+    const extSettings = new SettingsManager();
+    await extSettings.initialize();
+
+    await webView.postMessage({
+      command: "execution-log",
+      arguments: {
+        commandOutput: commandOutput,
+        projectUrl: destinationPathUrl,
+        status: commandResult,
+      },
+    } as PostMessageEvent);
+
+    if (commandResult === "passed") {
+      const selection = await vscode.window.showInformationMessage(
+        `Devfile created at: ${destinationPathUrl}`,
+        `Open devfile ↗`,
+      );
+      if (selection === "Open devfile ↗") {
+        this.openDevfile(destinationPathUrl);
+      }
+    }
+  }
+
+  public createDevfile(
+    destinationUrl: string,
+    devfileName: string,
+    devfileImage: string,
+    extensionUri: vscode.Uri,
+  ) {
+    let devfile: string;
+    const relativeTemplatePath =
+      "resources/contentCreator/createDevfile/devfile-template.txt";
+
+    const expandedDestUrl = expandPath(destinationUrl);
+
+    const uuid = randomUUID().slice(0, 8);
+    const fullDevfileName = `${devfileName}-${uuid}`;
+
+    const absoluteTemplatePath = vscode.Uri.joinPath(
+      extensionUri,
+      relativeTemplatePath,
+    )
+      .toString()
+      .replace("file://", "");
+
+    try {
+      devfile = fs.readFileSync(absoluteTemplatePath, "utf8");
+      devfile = devfile.replace("{{ dev_file_name }}", fullDevfileName);
+      devfile = devfile.replace("{{ dev_file_image }}", devfileImage);
+      fs.writeFileSync(expandedDestUrl, devfile);
+      return "passed";
+    } catch (err) {
+      console.error("Devfile could not be created. Error: ", err);
+      return "failed";
+    }
+  }
+
+  public openDevfile(fileUrl: string) {
+    const updatedUrl = expandPath(fileUrl);
+    vscode.commands.executeCommand("vscode.open", vscode.Uri.parse(updatedUrl));
+  }
+}

--- a/src/features/contentCreator/types.ts
+++ b/src/features/contentCreator/types.ts
@@ -23,6 +23,13 @@ export type AnsibleProjectFormInterface = {
   isOverwritten: boolean;
 };
 
+export type DevfileFormInterface = {
+  destinationPath: string;
+  name: string;
+  image: string;
+  isOverwritten: boolean;
+};
+
 export type PostMessageEvent =
   | {
       command: "ADEPresence";

--- a/src/features/quickLinks/quickLinksView.ts
+++ b/src/features/quickLinks/quickLinksView.ts
@@ -106,6 +106,13 @@ export function getWebviewQuickLinks(webview: Webview, extensionUri: Uri) {
               </a>
             </h3>
           </div>
+          <div class="catalogue">
+            <h3>
+              <a href="command:ansible.content-creator.create-devfile" title="Create a devfile and add it to an existing Ansible project">
+                <span class="codicon codicon-new-file"></span> Devfile
+              </a>
+            </h3>
+          </div>
     </div>
     <!-- Component registration code -->
     <script type="module" nonce="${nonce}" src="${webviewUri}"></script>

--- a/src/webview/apps/contentCreator/createDevfilePageApp.ts
+++ b/src/webview/apps/contentCreator/createDevfilePageApp.ts
@@ -1,0 +1,234 @@
+/* eslint-disable  @typescript-eslint/no-explicit-any */
+
+import {
+  allComponents,
+  Button,
+  Checkbox,
+  TextArea,
+  TextField,
+  provideVSCodeDesignSystem,
+  Dropdown,
+} from "@vscode/webview-ui-toolkit";
+import {
+  DevfileFormInterface,
+  PostMessageEvent,
+} from "../../../features/contentCreator/types";
+
+provideVSCodeDesignSystem().register(allComponents);
+
+const vscode = acquireVsCodeApi();
+window.addEventListener("load", main);
+
+let destinationPathUrlTextField: TextField;
+let folderExplorerButton: Button;
+
+let devfileNameTextField: TextField;
+
+let devfileCreateButton: Button;
+let devfileClearButton: Button;
+
+let devfileClearLogsButton: Button;
+
+let overwriteCheckbox: Checkbox;
+
+let imageDropdown: Dropdown;
+
+let devfilePathDiv: HTMLElement | null;
+let devfilePathElement: HTMLElement;
+
+let devfileLogsTextArea: TextArea;
+let devfileOpenScaffoldedFolderButton: Button;
+
+let projectUrl = "";
+
+function main() {
+  destinationPathUrlTextField = document.getElementById(
+    "path-url",
+  ) as TextField;
+  folderExplorerButton = document.getElementById("folder-explorer") as Button;
+
+  devfileNameTextField = document.getElementById("devfile-name") as TextField;
+
+  overwriteCheckbox = document.getElementById("overwrite-checkbox") as Checkbox;
+
+  imageDropdown = document.getElementById("image-dropdown") as Dropdown;
+  devfileCreateButton = document.getElementById("create-button") as Button;
+  devfileClearButton = document.getElementById("reset-button") as Button;
+
+  devfileLogsTextArea = document.getElementById("log-text-area") as TextArea;
+
+  devfileClearLogsButton = document.getElementById(
+    "clear-logs-button",
+  ) as Button;
+
+  devfileOpenScaffoldedFolderButton = document.getElementById(
+    "open-file-button",
+  ) as Button;
+
+  destinationPathUrlTextField.addEventListener("input", toggleCreateButton);
+  devfileNameTextField.addEventListener("input", toggleCreateButton);
+
+  folderExplorerButton.addEventListener("click", openFolderExplorer);
+
+  devfileCreateButton.addEventListener("click", handleCreateClick);
+  devfileCreateButton.disabled = true;
+
+  devfileClearButton.addEventListener("click", handleResetClick);
+
+  devfileOpenScaffoldedFolderButton.addEventListener(
+    "click",
+    handleOpenDevfileClick,
+  );
+
+  devfileClearLogsButton.addEventListener("click", handleDevfileLogsClick);
+
+  devfilePathDiv = document.getElementById("full-devfile-path");
+
+  devfilePathElement = document.createElement("p");
+
+  if (destinationPathUrlTextField.placeholder !== "") {
+    devfilePathElement.innerHTML = `${destinationPathUrlTextField.placeholder}/devfile.yaml`;
+  } else {
+    devfilePathElement.innerHTML =
+      "No folders are open in the workspace - Enter a destination directory.";
+  }
+
+  destinationPathUrlTextField.value = destinationPathUrlTextField.placeholder;
+
+  devfilePathDiv?.appendChild(devfilePathElement);
+}
+
+function openFolderExplorer(event: any) {
+  const source = event.target.parentNode.id;
+
+  const typeOption = "folder";
+
+  vscode.postMessage({
+    command: "open-explorer",
+    payload: {
+      selectOption: typeOption,
+    },
+  });
+
+  window.addEventListener(
+    "message",
+    (event: MessageEvent<PostMessageEvent>) => {
+      const message = event.data;
+
+      if (message.command === "file-uri") {
+        const selectedUri = message.arguments.selectedUri;
+
+        if (selectedUri) {
+          if (source === "folder-explorer") {
+            destinationPathUrlTextField.value = selectedUri;
+            devfilePathElement.innerHTML = selectedUri;
+          }
+        }
+      }
+    },
+  );
+}
+
+function toggleCreateButton() {
+  //   update <p> tag text
+  if (!destinationPathUrlTextField.value.trim()) {
+    if (destinationPathUrlTextField.placeholder !== "") {
+      devfilePathElement.innerHTML = `${destinationPathUrlTextField.placeholder}/devfile.yaml`;
+    } else {
+      devfilePathElement.innerHTML =
+        "No folders are open in the workspace - Enter a destination directory.";
+    }
+  } else {
+    devfilePathElement.innerHTML = `${destinationPathUrlTextField.value.trim()}/devfile.yaml`;
+  }
+
+  if (
+    devfileNameTextField.value.trim() &&
+    (destinationPathUrlTextField.value.trim() ||
+      destinationPathUrlTextField.placeholder !== "")
+  ) {
+    devfileCreateButton.disabled = false;
+  } else {
+    devfileCreateButton.disabled = true;
+  }
+}
+
+function handleResetClick() {
+  destinationPathUrlTextField.value = destinationPathUrlTextField.placeholder;
+  devfileNameTextField.value = "";
+
+  if (destinationPathUrlTextField.placeholder !== "") {
+    devfilePathElement.innerHTML = `${destinationPathUrlTextField.placeholder}/devfile.yaml`;
+  } else {
+    devfilePathElement.innerHTML =
+      "No folders are open in the workspace - Enter a destination directory.";
+  }
+
+  overwriteCheckbox.checked = false;
+  imageDropdown.currentValue =
+    "ghcr.io/ansible/ansible-workspace-env-reference:latest";
+
+  devfileCreateButton.disabled = true;
+}
+
+function handleCreateClick() {
+  let path: string;
+  devfileCreateButton.disabled = true;
+  if (destinationPathUrlTextField.value === "") {
+    path = destinationPathUrlTextField.placeholder;
+  } else {
+    path = destinationPathUrlTextField.value.trim();
+  }
+
+  vscode.postMessage({
+    command: "devfile-create",
+    payload: {
+      destinationPath: path,
+      name: devfileNameTextField.value.trim(),
+      image: imageDropdown.currentValue.trim(),
+      isOverwritten: overwriteCheckbox.checked,
+    } as DevfileFormInterface,
+  });
+
+  window.addEventListener(
+    "message",
+    async (event: MessageEvent<PostMessageEvent>) => {
+      const message = event.data;
+
+      switch (message.command) {
+        case "execution-log":
+          devfileLogsTextArea.value = message.arguments.commandOutput;
+
+          if (
+            message.arguments.status &&
+            message.arguments.status === "passed"
+          ) {
+            devfileOpenScaffoldedFolderButton.disabled = false;
+          } else {
+            devfileOpenScaffoldedFolderButton.disabled = true;
+          }
+
+          projectUrl = message.arguments.projectUrl
+            ? message.arguments.projectUrl
+            : "";
+
+          devfileCreateButton.disabled = false;
+
+          return;
+      }
+    },
+  );
+}
+
+function handleOpenDevfileClick() {
+  vscode.postMessage({
+    command: "open-devfile",
+    payload: {
+      projectUrl: projectUrl,
+    },
+  });
+}
+
+function handleDevfileLogsClick() {
+  devfileLogsTextArea.value = "";
+}

--- a/test/ui-test/contentCreatorUiTest.ts
+++ b/test/ui-test/contentCreatorUiTest.ts
@@ -89,4 +89,115 @@ export function contentCreatorUiTest(): void {
       );
     });
   });
+  describe("Test devfile generation webview (without creator)", () => {
+    let workbench: Workbench;
+    let createDevfileButton: WebElement;
+    let editorView: EditorView;
+
+    before(async () => {
+      workbench = new Workbench();
+    });
+    it("Check create-devfile webview elements", async () => {
+      await workbench.executeCommand("Ansible: Create a Devfile");
+      await sleep(2000);
+
+      await new EditorView().openEditor("Create Devfile");
+      const devfileWebview = await getWebviewByLocator(
+        By.xpath("//vscode-text-field[@id='path-url']"),
+      );
+
+      const descriptionText = await (
+        await devfileWebview.findWebElement(
+          By.xpath("//div[@class='description-div']"),
+        )
+      ).getText();
+
+      expect(
+        descriptionText,
+        "descriptionText should contain 'Devfiles are yaml files'",
+      ).to.contain("Devfiles are yaml files");
+
+      const devfileDestination = await devfileWebview.findWebElement(
+        By.xpath("//vscode-text-field[@id='path-url']"),
+      );
+
+      expect(devfileDestination, "devfileDestination should not be undefined")
+        .not.to.be.undefined;
+
+      await devfileDestination.sendKeys("~");
+
+      const devfileNameTextField = await devfileWebview.findWebElement(
+        By.xpath("//vscode-text-field[@id='devfile-name']"),
+      );
+
+      expect(
+        devfileNameTextField,
+        "devfileNameTextField should not be undefined",
+      ).not.to.be.undefined;
+
+      await devfileNameTextField.sendKeys("test");
+
+      createDevfileButton = await devfileWebview.findWebElement(
+        By.xpath("//vscode-button[@id='create-button']"),
+      );
+      expect(createDevfileButton, "createDevfileButton should not be undefined")
+        .not.to.be.undefined;
+
+      expect(
+        await createDevfileButton.isEnabled(),
+        "createDevfileButton button should be enabled now",
+      ).to.be.true;
+
+      const overwriteDevfileCheckbox = await devfileWebview.findWebElement(
+        By.xpath("//vscode-checkbox[@id='overwrite-checkbox']"),
+      );
+      await overwriteDevfileCheckbox.click();
+      await createDevfileButton.click();
+      await sleep(500);
+
+      await createDevfileButton.click();
+
+      await sleep(1000);
+
+      const devfileClearLogsButton = await devfileWebview.findWebElement(
+        By.xpath("//vscode-button[@id='clear-logs-button']"),
+      );
+
+      expect(
+        devfileClearLogsButton,
+        "devfileClearLogsButton should not be undefined",
+      ).not.to.be.undefined;
+
+      await devfileClearLogsButton.click();
+
+      const resetButton = await devfileWebview.findWebElement(
+        By.xpath("//vscode-button[@id='reset-button']"),
+      );
+
+      expect(resetButton, "resetButton should not be undefined").not.to.be
+        .undefined;
+
+      await resetButton.click();
+
+      // Check that the devfile can't be generated if the dir doesn't exist
+      await devfileDestination.sendKeys("~/test");
+      await devfileNameTextField.sendKeys("test");
+      await createDevfileButton.click();
+      await resetButton.click();
+      await sleep(1000);
+
+      // Check that the devfile can't be generated if it already exists
+      await devfileDestination.sendKeys("~");
+      await devfileNameTextField.sendKeys("test");
+      await createDevfileButton.click();
+      await sleep(1000);
+
+      await devfileWebview.switchBack();
+
+      editorView = new EditorView();
+      if (editorView) {
+        await editorView.closeAllEditors();
+      }
+    });
+  });
 }

--- a/test/ui-test/contentCreatorUiTest.ts
+++ b/test/ui-test/contentCreatorUiTest.ts
@@ -153,9 +153,7 @@ export function contentCreatorUiTest(): void {
       );
       await overwriteDevfileCheckbox.click();
       await createDevfileButton.click();
-      await sleep(500);
-
-      await createDevfileButton.click();
+      await sleep(1000);
 
       await sleep(1000);
 

--- a/test/ui-test/contentCreatorUiTest.ts
+++ b/test/ui-test/contentCreatorUiTest.ts
@@ -155,8 +155,6 @@ export function contentCreatorUiTest(): void {
       await createDevfileButton.click();
       await sleep(1000);
 
-      await sleep(1000);
-
       const devfileClearLogsButton = await devfileWebview.findWebElement(
         By.xpath("//vscode-button[@id='clear-logs-button']"),
       );

--- a/tools/compare_devfile.sh
+++ b/tools/compare_devfile.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Pull devfile template from ansible-creator
+CREATOR_REPO="https://github.com/ansible/ansible-creator.git"
+CREATOR_DEVFILE_TEMPLATE="src/ansible_creator/resources/common/devfile/devfile.yaml.j2"
+EXTENSION_DEVFILE_TEMPLATE="resources/contentCreator/createDevfile/devfile-template.txt"
+
+# Clone ansible-creator repo
+
+TEMP_DIR=$(mktemp -d)
+git clone --depth 1 --branch main "$CREATOR_REPO" "$TEMP_DIR"
+
+# Compare the files
+if diff "$TEMP_DIR/$CREATOR_DEVFILE_TEMPLATE" "$EXTENSION_DEVFILE_TEMPLATE" > /dev/null; then
+    echo "Devfile template matches ansible-creator devfile template."
+    rm -rf "$TEMP_DIR"
+    exit 0
+else
+    echo "Devfile template under resources/ does not match the template ansible-creator is using."
+    rm -rf "$TEMP_DIR"
+    exit 1
+fi

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -224,6 +224,19 @@ const createAnsibleProjectWebviewConfig = {
   },
 };
 
+const createDevfileWebviewConfig = {
+  ...config,
+  target: ["web", "es2020"],
+  entry: "./src/webview/apps/contentCreator/createDevfilePageApp.ts",
+  experiments: { outputModule: true },
+  output: {
+    path: path.resolve(__dirname, "out"),
+    filename: "./client/webview/apps/contentCreator/createDevfilePageApp.js",
+    libraryTarget: "module",
+    chunkFormat: "module",
+  },
+};
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 module.exports = (_env: any, argv: { mode: string }) => {
   // Use non-bundled js for client/server in dev environment
@@ -241,6 +254,7 @@ module.exports = (_env: any, argv: { mode: string }) => {
     playbookExplanationWebviewConfig,
     roleGenerationWebviewConfig,
     createAnsibleProjectWebviewConfig,
+    createDevfileWebviewConfig,
     quickLinksWebviewConfig,
   ];
 };


### PR DESCRIPTION
This PR adds a new webview for generating a devfile from a template, designed for Red Hat OpenShift Dev Spaces. 

 ### New `Create Devfile` Webview
Adds a view where devfiles can be generated. The options are: `Destination Path`, `Ansible Project Name`, `Container Image`, and `Override`. 
- Destination Path: defaults to the first folder open in the current workspace, or an empty path. If the path is empty, a path must be entered into the text box before the devfile can be generated. 
- Ansible Project Name: Ansible project the devfile is being added to
- Container Image: Image to use in the devfile
- Override: If a file named `devfile.yaml` already exists at the destination path, create a new one with the form details. 

### Logging
Adds log output to the webview form showing that the devfile was created or that an error occurred. 

### Open file options
Shows a toast notification if the devfile was created successfully, and highlights an option to open it in the editor. '

### Testing
Adds tests for checking the webview elements and the create functionality. 
Adds a pre-commit hook (local) to check if the extension devfile template matches the ansible-creator devfile template. 

### Webview

![image](https://github.com/user-attachments/assets/02f0344b-c1a7-49c1-ae09-04697284ddf3)

![image](https://github.com/user-attachments/assets/288b2681-56a6-456e-abd7-3b876b371c39)
