### PR TITLE
add a sonar-project.properties file

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,4 @@
+sonar.projectKey=vscode-ansible
+sonar.organization=ansible
+
+sonar.cpd.exclusions=src/features/lightspeed/playbookGeneration.ts,src/features/lightspeed/roleGeneration.ts,test/ui-test/*.ts


### PR DESCRIPTION
Main objective is to ignore the duplicated lines warnings between the role and playbook generations.
Those are normal.
