### PR TITLE
AAP-35216: lightspeed: Rename PlaybookGenerationActionType

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,0 +1,4 @@
+sonar.cpd.exclusions=\
+    src/features/lightspeed/playbookGeneration.ts, \
+    src/features/lightspeed/roleGeneration.ts, \
+    test/ui-test/*.ts

--- a/src/definitions/lightspeed.ts
+++ b/src/definitions/lightspeed.ts
@@ -24,7 +24,7 @@ export enum ThumbsUpDownAction {
   DOWN = 1, //Thumbs Down
 }
 
-export enum PlaybookGenerationActionType {
+export enum WizardGenerationActionType {
   OPEN = 0, // Open wizard
   CLOSE_CANCEL = 1, // Close wizard without accepting the generated playbook
   TRANSITION = 2, // Page transition

--- a/src/features/lightspeed/playbookGeneration.ts
+++ b/src/features/lightspeed/playbookGeneration.ts
@@ -8,7 +8,7 @@ import { IError } from "./utils/errors";
 import { GenerationResponseParams } from "../../interfaces/lightspeed";
 import {
   LightSpeedCommands,
-  PlaybookGenerationActionType,
+  WizardGenerationActionType,
 } from "../../definitions/lightspeed";
 import { isError, UNKNOWN_ERROR } from "./utils/errors";
 import { getOneClickTrialProvider } from "./utils/oneClickTrial";
@@ -42,7 +42,7 @@ function contentMatch(generationId: string, playbook: string) {
 }
 
 async function sendActionEvent(
-  action: PlaybookGenerationActionType,
+  action: WizardGenerationActionType,
   toPage?: number,
 ) {
   if (wizardId) {
@@ -116,7 +116,7 @@ export async function showPlaybookGenerationPage(extensionUri: vscode.Uri) {
   );
 
   panel.onDidDispose(async () => {
-    await sendActionEvent(PlaybookGenerationActionType.CLOSE_CANCEL, undefined);
+    await sendActionEvent(WizardGenerationActionType.CLOSE_CANCEL, undefined);
     wizardId = undefined;
   });
 
@@ -223,14 +223,14 @@ export async function showPlaybookGenerationPage(extensionUri: vscode.Uri) {
       }
       case "transition": {
         const { toPage } = message;
-        await sendActionEvent(PlaybookGenerationActionType.TRANSITION, toPage);
+        await sendActionEvent(WizardGenerationActionType.TRANSITION, toPage);
         break;
       }
       case "openEditor": {
         const { playbook } = message;
         await openNewPlaybookEditor(playbook);
         await sendActionEvent(
-          PlaybookGenerationActionType.CLOSE_ACCEPT,
+          WizardGenerationActionType.CLOSE_ACCEPT,
           undefined,
         );
         // Clear wizardId to suppress another CLOSE event at dispose()
@@ -245,7 +245,7 @@ export async function showPlaybookGenerationPage(extensionUri: vscode.Uri) {
   panel.webview.html = getWebviewContent(panel.webview, extensionUri);
   panel.webview.postMessage({ command: "init" });
 
-  await sendActionEvent(PlaybookGenerationActionType.OPEN, 1);
+  await sendActionEvent(WizardGenerationActionType.OPEN, 1);
 }
 
 export function getWebviewContent(webview: Webview, extensionUri: Uri) {

--- a/src/features/lightspeed/roleGeneration.ts
+++ b/src/features/lightspeed/roleGeneration.ts
@@ -9,7 +9,7 @@ import { IError } from "./utils/errors";
 import { GenerationResponseParams } from "../../interfaces/lightspeed";
 import {
   LightSpeedCommands,
-  PlaybookGenerationActionType,
+  WizardGenerationActionType,
 } from "../../definitions/lightspeed";
 import { isError, UNKNOWN_ERROR } from "./utils/errors";
 import { getOneClickTrialProvider } from "./utils/oneClickTrial";
@@ -44,7 +44,7 @@ function contentMatch(generationId: string, playbook: string) {
 }
 
 async function sendActionEvent(
-  action: PlaybookGenerationActionType,
+  action: WizardGenerationActionType,
   toPage?: number,
 ) {
   if (currentPanel && wizardId) {
@@ -139,7 +139,7 @@ export async function showRoleGenerationPage(extensionUri: vscode.Uri) {
   );
 
   panel.onDidDispose(async () => {
-    await sendActionEvent(PlaybookGenerationActionType.CLOSE_CANCEL, undefined);
+    await sendActionEvent(WizardGenerationActionType.CLOSE_CANCEL, undefined);
     currentPanel = undefined;
     wizardId = undefined;
   });
@@ -248,13 +248,13 @@ export async function showRoleGenerationPage(extensionUri: vscode.Uri) {
       }
       case "transition": {
         const { toPage } = message;
-        await sendActionEvent(PlaybookGenerationActionType.TRANSITION, toPage);
+        await sendActionEvent(WizardGenerationActionType.TRANSITION, toPage);
         break;
       }
       case "openEditor": {
         const { playbook } = message;
         await sendActionEvent(
-          PlaybookGenerationActionType.CLOSE_ACCEPT,
+          WizardGenerationActionType.CLOSE_ACCEPT,
           undefined,
         );
         await openNewPlaybookEditor(playbook);
@@ -271,7 +271,7 @@ export async function showRoleGenerationPage(extensionUri: vscode.Uri) {
   panel.webview.html = await getWebviewContent(panel.webview, extensionUri);
   panel.webview.postMessage({ command: "init" });
 
-  await sendActionEvent(PlaybookGenerationActionType.OPEN, 1);
+  await sendActionEvent(WizardGenerationActionType.OPEN, 1);
 }
 
 export async function getWebviewContent(webview: Webview, extensionUri: Uri) {

--- a/src/interfaces/lightspeed.ts
+++ b/src/interfaces/lightspeed.ts
@@ -1,7 +1,7 @@
 import { AuthenticationSession } from "vscode";
 import {
   LIGHTSPEED_USER_TYPE,
-  PlaybookGenerationActionType,
+  WizardGenerationActionType,
   ThumbsUpDownAction,
   UserAction,
 } from "../definitions/lightspeed";
@@ -84,7 +84,7 @@ export interface PlaybookFeedbackEvent {
 
 export interface PlaybookGenerationActionEvent {
   wizardId: string;
-  action: PlaybookGenerationActionType;
+  action: WizardGenerationActionType;
   fromPage?: number;
   toPage?: number;
 }

--- a/test/ui-test/lightspeedUiTest.ts
+++ b/test/ui-test/lightspeedUiTest.ts
@@ -24,7 +24,7 @@ import {
   workbenchExecuteCommand,
   openSettings,
 } from "./uiTestHelper";
-import { PlaybookGenerationActionType } from "../../src/definitions/lightspeed";
+import { WizardGenerationActionType } from "../../src/definitions/lightspeed";
 import { PlaybookGenerationActionEvent } from "../../src/interfaces/lightspeed";
 
 config.truncateThreshold = 0;
@@ -433,18 +433,18 @@ export function lightspeedUIAssetsTest(): void {
 
       /* verify generated events */
       const expected = [
-        [PlaybookGenerationActionType.OPEN, undefined, 1],
-        [PlaybookGenerationActionType.TRANSITION, 1, 2],
-        [PlaybookGenerationActionType.TRANSITION, 2, 1],
-        [PlaybookGenerationActionType.TRANSITION, 1, 2],
-        [PlaybookGenerationActionType.TRANSITION, 2, 1],
-        [PlaybookGenerationActionType.TRANSITION, 1, 2],
-        [PlaybookGenerationActionType.TRANSITION, 2, 3],
-        [PlaybookGenerationActionType.TRANSITION, 3, 2],
-        [PlaybookGenerationActionType.TRANSITION, 2, 3],
-        [PlaybookGenerationActionType.TRANSITION, 3, 2],
-        [PlaybookGenerationActionType.TRANSITION, 2, 3],
-        [PlaybookGenerationActionType.CLOSE_ACCEPT, 3, undefined],
+        [WizardGenerationActionType.OPEN, undefined, 1],
+        [WizardGenerationActionType.TRANSITION, 1, 2],
+        [WizardGenerationActionType.TRANSITION, 2, 1],
+        [WizardGenerationActionType.TRANSITION, 1, 2],
+        [WizardGenerationActionType.TRANSITION, 2, 1],
+        [WizardGenerationActionType.TRANSITION, 1, 2],
+        [WizardGenerationActionType.TRANSITION, 2, 3],
+        [WizardGenerationActionType.TRANSITION, 3, 2],
+        [WizardGenerationActionType.TRANSITION, 2, 3],
+        [WizardGenerationActionType.TRANSITION, 3, 2],
+        [WizardGenerationActionType.TRANSITION, 2, 3],
+        [WizardGenerationActionType.CLOSE_ACCEPT, 3, undefined],
       ];
       const res = await axios.get(
         `${process.env.TEST_LIGHTSPEED_URL}/__debug__/feedbacks`,
@@ -560,10 +560,10 @@ export function lightspeedUIAssetsTest(): void {
 
       /* verify generated events */
       const expected = [
-        [PlaybookGenerationActionType.OPEN, undefined, 1],
-        [PlaybookGenerationActionType.TRANSITION, 1, 2],
-        [PlaybookGenerationActionType.TRANSITION, 2, 3],
-        [PlaybookGenerationActionType.CLOSE_ACCEPT, 3, undefined],
+        [WizardGenerationActionType.OPEN, undefined, 1],
+        [WizardGenerationActionType.TRANSITION, 1, 2],
+        [WizardGenerationActionType.TRANSITION, 2, 3],
+        [WizardGenerationActionType.CLOSE_ACCEPT, 3, undefined],
       ];
       const res = await axios.get(
         `${process.env.TEST_LIGHTSPEED_URL}/__debug__/feedbacks`,


### PR DESCRIPTION
Rename `PlaybookGenerationActionType` as `WizardGenerationActionType` since the
interface will also be used for the role generation.
