### PR TITLE
Playbook Generation: Add "Are you sure?" Confirmation for Reset Button

### DIFF
--- a/src/features/lightspeed/playbookGeneration.ts
+++ b/src/features/lightspeed/playbookGeneration.ts
@@ -238,6 +238,25 @@ export async function showPlaybookGenerationPage(extensionUri: vscode.Uri) {
         panel.dispose();
         break;
       }
+      case "resetOutline": {
+        vscode.window
+          .showInformationMessage(
+            "Are you sure?",
+            {
+              modal: true,
+              detail: "Resetting the outline will loose your changes.",
+            },
+            "Ok",
+          )
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          .then((value: any) => {
+            if (value === "Ok") {
+              panel.webview.postMessage({
+                command: "resetOutline",
+              });
+            }
+          });
+      }
     }
   });
 

--- a/src/webview/apps/lightspeed/playbookGeneration/main.ts
+++ b/src/webview/apps/lightspeed/playbookGeneration/main.ts
@@ -114,6 +114,11 @@ window.addEventListener("message", async (event) => {
       }
       break;
     }
+    case "resetOutline": {
+      setButtonEnabled("reset-button", false);
+      outline.reset();
+      outline.focus();
+    }
   }
 });
 
@@ -179,8 +184,9 @@ async function submitInput() {
 }
 
 function reset() {
-  outline.reset();
-  outline.focus();
+  vscode.postMessage({
+    command: "resetOutline",
+  });
 }
 
 function backToPage1() {

--- a/test/ui-test/lightspeedUiTest.ts
+++ b/test/ui-test/lightspeedUiTest.ts
@@ -168,6 +168,7 @@ export function lightspeedUIAssetsTest(): void {
     let outlineList: WebElement;
     let resetButton: WebElement;
     let adtView: ViewSection;
+    let webView: WebView;
     let webviewView: InstanceType<typeof WebviewView>;
 
     before(async function () {
@@ -197,6 +198,23 @@ export function lightspeedUIAssetsTest(): void {
         // await sleep(500); // Needed?
       }
     });
+
+    async function handleResetOutlineDialog(title: string = "Ok") {
+      await webView.switchBack();
+      const resetOutlineDialog = new ModalDialog();
+      await resetOutlineDialog.pushButton(title);
+      await sleep(250);
+      // Sadly we need to switch context and so we must reload the WebView elements
+      webView = await getWebviewByLocator(
+        By.xpath("//*[text()='Create a playbook with Ansible Lightspeed']"),
+      );
+      outlineList = await webView.findWebElement(
+        By.xpath("//ol[@id='outline-list']"),
+      );
+      resetButton = await webView.findWebElement(
+        By.xpath("//vscode-button[@id='reset-button']"),
+      );
+    }
 
     it("Playbook generation webview works as expected (full path) - part 1", async function () {
       // Open Ansible Development Tools by clicking the Getting started button on the side bar
@@ -246,7 +264,7 @@ export function lightspeedUIAssetsTest(): void {
       await sleep(2000);
 
       // Start operations on Playbook Generation UI
-      const webView = await getWebviewByLocator(
+      webView = await getWebviewByLocator(
         By.xpath("//*[text()='Create a playbook with Ansible Lightspeed']"),
       );
 
@@ -300,6 +318,10 @@ export function lightspeedUIAssetsTest(): void {
         .undefined;
       await resetButton.click();
       await sleep(500);
+
+      // Confirm reset of Outline
+      await handleResetOutlineDialog();
+
       text = await outlineList.getText();
       expect(!text.includes("# COMMENT\n"));
 
@@ -362,6 +384,10 @@ export function lightspeedUIAssetsTest(): void {
       // Click reset button and make sure the string "(status=400)" is removed
       await resetButton.click();
       await sleep(500);
+
+      // Confirm reset of Outline
+      await handleResetOutlineDialog();
+
       text = await outlineList.getText();
       expect(!text.includes("(status=400)"));
 
@@ -576,6 +602,80 @@ export function lightspeedUIAssetsTest(): void {
         expect(evt.fromPage).equals(expected[i][1]);
         expect(evt.toPage).equals(expected[i][2]);
       }
+    });
+
+    it("Playbook generation (outline reset)", async function () {
+      // Execute only when TEST_LIGHTSPEED_URL environment variable is defined.
+      if (!process.env.TEST_LIGHTSPEED_URL) {
+        this.skip();
+      }
+
+      // Open playbook generation webview.
+      await workbenchExecuteCommand("Ansible Lightspeed: Playbook generation");
+      await sleep(2000);
+      const webView = await getWebviewByLocator(
+        By.xpath("//*[text()='Create a playbook with Ansible Lightspeed']"),
+      );
+
+      // Set input text and invoke summaries API
+      const textArea = await webView.findWebElement(
+        By.xpath("//vscode-text-area"),
+      );
+      expect(textArea, "textArea should not be undefined").not.to.be.undefined;
+      const submitButton = await webView.findWebElement(
+        By.xpath("//vscode-button[@id='submit-button']"),
+      );
+      expect(submitButton, "submitButton should not be undefined").not.to.be
+        .undefined;
+      //
+      // Note: Following line should succeed, but fails for some unknown reasons.
+      //
+      // expect((await submitButton.isEnabled()), "submit button should be disabled by default").is.false;
+      await textArea.sendKeys("Create an azure network.");
+      expect(
+        await submitButton.isEnabled(),
+        "submit button should be enabled now",
+      ).to.be.true;
+      await submitButton.click();
+      await sleep(1000);
+
+      // Verify outline output and text edit
+      const outlineList = await webView.findWebElement(
+        By.xpath("//ol[@id='outline-list']"),
+      );
+      expect(outlineList, "An ordered list should exist.").to.be.not.undefined;
+      let text = await outlineList.getText();
+      expect(text.includes("Create virtual network peering")).to.be.true;
+
+      // Test Reset button
+      await outlineList.sendKeys("# COMMENT\n");
+      text = await outlineList.getText();
+      expect(text.includes("# COMMENT\n"));
+
+      resetButton = await webView.findWebElement(
+        By.xpath("//vscode-button[@id='reset-button']"),
+      );
+      expect(resetButton, "resetButton should not be undefined").not.to.be
+        .undefined;
+      expect(
+        await resetButton.isEnabled(),
+        "submit button should be enabled now",
+      ).to.be.true;
+
+      await resetButton.click();
+      await sleep(500);
+
+      // Cancel reset of Outline
+      await handleResetOutlineDialog("Cancel");
+
+      text = await outlineList.getText();
+      expect(text.includes("# COMMENT\n"));
+      expect(
+        await resetButton.isEnabled(),
+        "submit button should be enabled now",
+      ).to.be.true;
+
+      await workbenchExecuteCommand("View: Close All Editor Groups");
     });
 
     it("Playbook generation webview works as expected (feature unavailable)", async function () {


### PR DESCRIPTION
Add a prompt for Users to confirm reset of Outline in Playbook Generation.

Example screen shot:

![AAP-34643](https://github.com/user-attachments/assets/30d09186-e636-4070-b3eb-c408f1a692ba)
