### PR TITLE
Label images in the devfile webview

### DIFF
--- a/media/contentCreator/createDevfilePageStyle.css
+++ b/media/contentCreator/createDevfilePageStyle.css
@@ -68,7 +68,7 @@ vscode-text-area {
 }
 
 vscode-dropdown {
-    width: 400px;
+    width: 500px;
 }
 
 .full-devfile-path {

--- a/src/definitions/constants.ts
+++ b/src/definitions/constants.ts
@@ -43,3 +43,7 @@ export const IncludeVarValidTaskName = [
 export const ANSIBLE_LIGHTSPEED_API_TIMEOUT = 28000;
 
 export const ANSIBLE_CREATOR_VERSION_MIN = "24.10.1";
+
+export const DevfileImages = {
+  Upstream: "ghcr.io/ansible/ansible-workspace-env-reference:latest",
+};

--- a/src/features/contentCreator/createDevfilePage.ts
+++ b/src/features/contentCreator/createDevfilePage.ts
@@ -9,6 +9,7 @@ import * as fs from "fs";
 import { SettingsManager } from "../../settings";
 import { expandPath } from "./utils";
 import { randomUUID } from "crypto";
+import { DevfileImages } from "../../definitions/constants";
 
 export class CreateDevfile {
   public static currentPanel: CreateDevfile | undefined;
@@ -142,7 +143,7 @@ export class CreateDevfile {
                   <div class="dropdown-container">
                     <label for="image-dropdown">Container image</label>
                     <vscode-dropdown id="image-dropdown">
-                      <vscode-option>ghcr.io/ansible/ansible-workspace-env-reference:latest</vscode-option>
+                      <vscode-option>Upstream (ghcr.io/ansible/ansible-workspace-env-reference:latest)</vscode-option>
                     </vscode-dropdown>
                   </div>
                 </div>
@@ -253,6 +254,11 @@ export class CreateDevfile {
     return folder;
   }
 
+  public getContainerImage(dropdownImage: string) {
+    const image = dropdownImage.split(" ")[0]; // Splits on the space after the name (e.g "Upstream (image)")
+    return DevfileImages[image as keyof typeof DevfileImages];
+  }
+
   public async runDevfileCreateProcess(
     payload: DevfileFormInterface,
     webView: vscode.Webview,
@@ -269,6 +275,8 @@ export class CreateDevfile {
 
     const devfileExists = fs.existsSync(expandPath(destinationPathUrl));
 
+    const imageURL = this.getContainerImage(image);
+
     if (devfileExists && !isOverwritten) {
       message = `Error: Devfile already exists at ${destinationPathUrl} and was not overwritten. Use the 'Overwrite' option to overwrite the existing file.`;
       commandResult = "failed";
@@ -276,7 +284,7 @@ export class CreateDevfile {
       commandResult = this.createDevfile(
         destinationPathUrl,
         name,
-        image,
+        imageURL,
         extensionUri,
       );
       if (commandResult === "failed") {

--- a/src/webview/apps/contentCreator/createDevfilePageApp.ts
+++ b/src/webview/apps/contentCreator/createDevfilePageApp.ts
@@ -166,7 +166,7 @@ function handleResetClick() {
 
   overwriteCheckbox.checked = false;
   imageDropdown.currentValue =
-    "ghcr.io/ansible/ansible-workspace-env-reference:latest";
+    "Upstream (ghcr.io/ansible/ansible-workspace-env-reference:latest)";
 
   devfileCreateButton.disabled = true;
 }


### PR DESCRIPTION
Labels the devfile image with an "Upstream" descriptor. This pattern will be followed for the downstream image when it is added in the future. 

Creates a constant in `src/definitions/constants.ts` that defines devfile images. 

Adds a function to get the devfile image based on the webview dropdown input. 