### PR TITLE
Autofill devfile project name into the webview text field

### DIFF
--- a/src/features/contentCreator/createDevfilePage.ts
+++ b/src/features/contentCreator/createDevfilePage.ts
@@ -88,6 +88,12 @@ export class CreateDevfile {
     const nonce = getNonce();
 
     const workspaceDir = this.getWorkspaceFolder();
+    let projectName = "";
+
+    if (workspaceDir !== "") {
+      const projectNameSplit = workspaceDir.split("/");
+      projectName = projectNameSplit[projectNameSplit.length - 1];
+    }
 
     const webviewUri = getUri(webview, extensionUri, [
       "out",
@@ -132,7 +138,7 @@ export class CreateDevfile {
                 </vscode-text-field>
 
                 <div class="devfile-name-div">
-                <vscode-text-field id="devfile-name" form="devfile-form" placeholder="Enter Ansible project name" size="512">Ansible project name *</vscode-text-field>
+                <vscode-text-field id="devfile-name" form="devfile-form" placeholder="${projectName}" size="512">Ansible project name *</vscode-text-field>
                 </div>
 
                 <div id="full-devfile-path" class="full-devfile-path">

--- a/src/webview/apps/contentCreator/createDevfilePageApp.ts
+++ b/src/webview/apps/contentCreator/createDevfilePageApp.ts
@@ -95,6 +95,8 @@ function main() {
 
   destinationPathUrlTextField.value = destinationPathUrlTextField.placeholder;
 
+  devfileNameTextField.value = devfileNameTextField.placeholder;
+
   devfilePathDiv?.appendChild(devfilePathElement);
 }
 


### PR DESCRIPTION
Autofills the assumed project name into the devfile webview's "Ansible Project name" text field. 

![image](https://github.com/user-attachments/assets/1ba8b0f2-f898-4238-808e-26b20a06bd98)
