### PR TITLE
Add a link to extension settings in the quick links bar

### DIFF
--- a/src/features/quickLinks/quickLinksView.ts
+++ b/src/features/quickLinks/quickLinksView.ts
@@ -73,6 +73,13 @@ export function getWebviewQuickLinks(webview: Webview, extensionUri: Uri) {
               </a>
             </h3>
           </div>
+          <div class="catalogue">
+            <h3>
+              <a href="command:ansible.extension-settings.open" title="Ansible extension settings">
+                <span class="codicon codicon-settings-gear"></span> Settings
+              </a>
+            </h3>
+          </div>
         <h3>INITIALIZE</h3>
         <p>Initialize a new Ansible project</p>
           <div class="catalogue">


### PR DESCRIPTION
Adds a link to the Ansible extension settings in the quick links sidebar for easy access to settings without using the VSCode command prompt. 