### PR TITLE
Add a `new` badge to items in the quick links view

### DIFF
--- a/media/quickLinks/quickLinksStyle.css
+++ b/media/quickLinks/quickLinksStyle.css
@@ -54,3 +54,15 @@
 img.category-icon {
     max-height: 20px;
 }
+
+.new-badge {
+    height: 15px;
+    width: 35px;
+    border: 1px solid gray;
+    border-radius: 30px;
+    text-align: center;
+    color: gray;
+    font-size: 9px;
+    line-height: 15px;
+    float: right;
+}

--- a/src/features/quickLinks/quickLinksView.ts
+++ b/src/features/quickLinks/quickLinksView.ts
@@ -117,6 +117,7 @@ export function getWebviewQuickLinks(webview: Webview, extensionUri: Uri) {
             <h3>
               <a href="command:ansible.content-creator.create-devfile" title="Create a devfile and add it to an existing Ansible project">
                 <span class="codicon codicon-new-file"></span> Devfile
+                <span class="new-badge">NEW</span>
               </a>
             </h3>
           </div>


### PR DESCRIPTION
Adds a `new` badge to assign to items in the quick links sidebar webview. This is for use by any new additions in the quick links list. 
Currently only the "Devfile" option is labeled as "new". 

![image](https://github.com/user-attachments/assets/40775967-6496-463b-b9ea-3efbb5fcbc2b)
