### PR TITLE
Disable explanation thumbs up and thumbs down buttons after selection

### DIFF
--- a/src/webview/apps/lightspeed/playbookExplanation/main.ts
+++ b/src/webview/apps/lightspeed/playbookExplanation/main.ts
@@ -38,7 +38,9 @@ function sendThumbsup() {
     "thumbsdown-button",
   ) as Button;
   thumbsUpButton.setAttribute("class", "iconButtonSelected");
+  thumbsUpButton.setAttribute("disabled", "true");
   thumbsDownButton.setAttribute("class", "iconButton");
+  thumbsDownButton.setAttribute("disabled", "true");
   vscode.postMessage({
     command: "thumbsUp",
     action: ThumbsUpDownAction.UP,
@@ -51,7 +53,9 @@ function sendThumbsdown() {
     "thumbsdown-button",
   ) as Button;
   thumbsUpButton.setAttribute("class", "iconButton");
+  thumbsUpButton.setAttribute("disabled", "true");
   thumbsDownButton.setAttribute("class", "iconButtonSelected");
+  thumbsDownButton.setAttribute("disabled", "true");
   vscode.postMessage({
     command: "thumbsDown",
     action: ThumbsUpDownAction.DOWN,

--- a/test/ui-test/lightspeedUiTestPlaybookExpTest.ts
+++ b/test/ui-test/lightspeedUiTestPlaybookExpTest.ts
@@ -11,6 +11,64 @@ import {
 
 config.truncateThreshold = 0;
 
+async function testThumbsButtonInteraction(buttonToClick: string) {
+  const folder = "lightspeed";
+  const filePath = getFixturePath(folder, "playbook_1.yml");
+
+  // Open file in the editor
+  await VSBrowser.instance.openResources(filePath);
+
+  // Open playbook explanation webview.
+  await workbenchExecuteCommand("Explain the playbook with Ansible Lightspeed");
+  await sleep(2000);
+
+  await new EditorView().openEditor("Explanation", 1);
+  // Locate the playbook explanation webview
+  const webView = await getWebviewByLocator(
+    By.xpath("//div[contains(@class, 'playbookGeneration') ]"),
+  );
+  const thumbsUpButton = await webView.findWebElement(
+    By.xpath("//vscode-button[@id='thumbsup-button']"),
+  );
+  expect(thumbsUpButton, "thumbsUpButton should not be undefined").not.to.be
+    .undefined;
+
+  const thumbsDownButton = await webView.findWebElement(
+    By.xpath("//vscode-button[@id='thumbsdown-button']"),
+  );
+  expect(thumbsDownButton, "thumbsDownButton should not be undefined").not.to.be
+    .undefined;
+
+  expect(
+    await thumbsUpButton.isEnabled(),
+    `Thumbs up button should be enabled now`,
+  ).to.be.true;
+
+  expect(
+    await thumbsDownButton.isEnabled(),
+    `Thumbs down button should be enabled now`,
+  ).to.be.true;
+
+  const button =
+    buttonToClick === "thumbsup" ? thumbsUpButton : thumbsDownButton;
+  await button.click();
+
+  await sleep(2000);
+
+  expect(
+    await thumbsUpButton.getAttribute("disabled"),
+    "Thumbs up button should be disabled now",
+  ).equals("true");
+
+  expect(
+    await thumbsDownButton.getAttribute("disabled"),
+    "Thumbs down button should be disabled now",
+  ).equals("true");
+
+  await webView.switchBack();
+  await workbenchExecuteCommand("View: Close All Editor Groups");
+}
+
 describe("Verify playbook explanation features work as expected", function () {
   beforeEach(function () {
     if (!process.env.TEST_LIGHTSPEED_URL) {
@@ -55,6 +113,20 @@ describe("Verify playbook explanation features work as expected", function () {
 
     await webView.switchBack();
     await workbenchExecuteCommand("View: Close All Editor Groups");
+  });
+
+  it("Playbook explanation thumbs up/down button disabled after thumbs up", async function () {
+    if (!process.env.TEST_LIGHTSPEED_URL) {
+      this.skip();
+    }
+    await testThumbsButtonInteraction("thumbsup");
+  });
+
+  it("Playbook explanation thumbs up/down button disabled after thumbs down", async function () {
+    if (!process.env.TEST_LIGHTSPEED_URL) {
+      this.skip();
+    }
+    await testThumbsButtonInteraction("thumbsdown");
   });
 });
 


### PR DESCRIPTION
The ask here was to disable the thumbs up and thumbs down buttons after a user interacts with one of them in the playbook explanation panel.  Inside the same function(s) that update the button class, I went ahead and set the `disabled` attribute which the button component seems to handle correctly.

![disabled_thumbs_up_down](https://github.com/user-attachments/assets/c00bc9d1-a07c-4ff8-a89d-a39e100032e1)
