### PR TITLE
Update name of ui test upload from unit to ui

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -359,7 +359,7 @@ jobs:
       - name: Upload ui test coverage data [3/4]
         uses: codecov/codecov-action@v5.1.1
         with:
-          name: unit
+          name: ui
           files: ./*/coverage/ui/lcov.info
           flags: ui
           disable_search: true


### PR DESCRIPTION
Speculative... I noticed when looking at the codecov interface that both the ui coverage and the unit coverage where both called "unit" - It's unclear to me if this is a bug or problematic in any way.  This could just be housekeeping.

<img width="502" alt="Screenshot 2024-12-09 at 11 58 27 AM" src="https://github.com/user-attachments/assets/d5ebf3c2-08d1-4bf6-a716-1015b398f2b7">
