### PR TITLE
AAP-37422: Empty line at the top of the file break completion

### DIFF
--- a/src/features/lightspeed/utils/multiLinePromptForMultiTasks.ts
+++ b/src/features/lightspeed/utils/multiLinePromptForMultiTasks.ts
@@ -2,9 +2,9 @@ export function shouldRequestForPromptPosition(
   documentContent: string,
   promptLine: number,
 ): boolean {
-  const documentLines = documentContent.trim().split("\n");
+  const documentLines = documentContent.split("\n").map((l) => l.trim());
   if (documentLines.length > 0 && promptLine > 0) {
-    const promptLineText = documentLines[promptLine - 1].trim();
+    const promptLineText = documentLines[promptLine - 1];
     if (promptLineText.startsWith("# ") && promptLineText.endsWith(" &")) {
       // should do not make request for prompt that ends with "&"
       return false;

--- a/test/units/lightspeed/utils/multiLinePromptForMultiTasks.test.ts
+++ b/test/units/lightspeed/utils/multiLinePromptForMultiTasks.test.ts
@@ -103,6 +103,15 @@ tasks:
 });
 
 describe("Test shouldRequestForPromptPosition", () => {
+  it("should trigger request even when document starts with empty line", () => {
+    const promptContent = `
+---
+# Create a key-pair called lightspeed-key-pair &
+# create a vpc & create vpc_id var     `;
+    const shouldRequest = shouldRequestForPromptPosition(promptContent, 4);
+    assert.equal(shouldRequest, true);
+  });
+
   it("should not make request when prompt line start with '# ' and end with ' &' for tasks", () => {
     const promptContent = `---
 # Create a key-pair called lightspeed-key-pair &


### PR DESCRIPTION
When the first line of the document is empty, the line is removed from the `documentLines`
array because of the early `trim()` call.
As a consequence, the `promptLine` value is incorrect and not completion is never triggered.
This PR address the problem.

See: c5b208d0985228110864dde9774c85cc68b09fe6
