### PR TITLE
Check ansible-creator version when initializing a collection project

### DIFF
--- a/src/definitions/constants.ts
+++ b/src/definitions/constants.ts
@@ -44,6 +44,8 @@ export const ANSIBLE_LIGHTSPEED_API_TIMEOUT = 28000;
 
 export const ANSIBLE_CREATOR_VERSION_MIN = "24.10.1";
 
+export const ANSIBLE_CREATOR_COLLECTION_VERSION_MIN = "24.7.1";
+
 export const DevfileImages = {
   Upstream: "ghcr.io/ansible/ansible-workspace-env-reference:latest",
 };

--- a/src/features/contentCreator/utils.ts
+++ b/src/features/contentCreator/utils.ts
@@ -19,6 +19,14 @@ export async function getBinDetail(cmd: string, arg: string) {
   }
 }
 
+export async function getCreatorVersion(): Promise<string> {
+  const creatorVersion = (
+    await getBinDetail("ansible-creator", "--version")
+  ).toString();
+  console.log("ansible-creator version: ", creatorVersion);
+  return creatorVersion;
+}
+
 export async function runCommand(
   command: string,
   runEnv: NodeJS.ProcessEnv | undefined,


### PR DESCRIPTION
This PR resolves #1722 by only using the new ansible-creator collection init command for creator versions `>=24.7.1`. 

This PR also resolves a bug where `--no-overwrite` was not set by default for versions of ansible-creator `>=24.10.1`, which resulted in EOF errors when ansible-creator was waiting for user input. 

