### PR TITLE
Add Webview to scaffold sample execution-environment.yml file using creator add subcommand

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,4 +1,6 @@
 sonar.cpd.exclusions=\
     src/features/lightspeed/playbookGeneration.ts, \
     src/features/lightspeed/roleGeneration.ts, \
+    src/features/contentCreator/createSampleExecutionEnvPage.ts, \
+    src/webview/apps/contentCreator/createSampleExecutionEnvPageApp.ts, \
     test/ui-test/*.ts

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -24,6 +24,7 @@
 !media/contentCreator/createAnsibleCollectionPageStyle.css
 !media/contentCreator/createAnsibleProjectPageStyle.css
 !media/contentCreator/createDevfilePageStyle.css
+!media/contentCreator/createSampleExecutionEnvPageStyle.css
 !media/contentCreator/welcomePageStyle.css
 !media/lightspeedExplorerView/style.css
 !media/quickLinks/lightspeed.png
@@ -44,6 +45,7 @@
 !out/client/webview/apps/contentCreator/createAnsibleCollectionPageApp.js
 !out/client/webview/apps/contentCreator/createAnsibleProjectPageApp.js
 !out/client/webview/apps/contentCreator/createDevfilePageApp.js
+!out/client/webview/apps/contentCreator/createSampleExecutionEnvPageApp.js
 !out/client/webview/apps/quickLinks/quickLinksApp.js
 !out/client/webview/apps/welcomePage/welcomePageApp.js
 !out/server/src/server.js

--- a/codecov.yml
+++ b/codecov.yml
@@ -19,5 +19,6 @@ ignore:
   - src/webview/apps/contentCreator/createAnsibleCollectionPageApp.ts
   - src/webview/apps/contentCreator/createAnsibleProjectPageApp.ts
   - src/webview/apps/contentCreator/createDevfilePageApp.ts
+  - src/webview/apps/contentCreator/createSampleExecutionEnvPageApp.ts
   - src/webview/apps/welcomePage/welcomePageApp.ts
   - src/webview/apps/quickLinks/quickLinksApp.ts

--- a/media/contentCreator/createSampleExecutionEnvPageStyle.css
+++ b/media/contentCreator/createSampleExecutionEnvPageStyle.css
@@ -84,16 +84,3 @@ vscode-checkbox i {
     line-height: normal;
     margin-bottom: 2px;
 }
-
-#log-to-file-options-div {
-    display: none;
-    flex-direction: column;
-    border-style: dotted;
-    border-color: var(--focus-border);
-    border-width: 0.5px;
-    padding: 8px;
-}
-
-.log-level-div {
-    margin: 4px 0px;
-}

--- a/media/contentCreator/createSampleExecutionEnvPageStyle.css
+++ b/media/contentCreator/createSampleExecutionEnvPageStyle.css
@@ -1,0 +1,99 @@
+@import url(../baseStyles/baseFormStyle.css);
+
+.container {
+    display: flex;
+    flex-direction: column;
+}
+
+.element {
+    margin-bottom: 14px;
+}
+
+vscode-text-field {
+    margin-top: 6px;
+    margin-bottom: 6px;
+}
+
+vscode-text-area {
+    margin-top: 6px;
+    margin-bottom: 6px;
+}
+
+.checkbox-div {
+    display: flex; /* Use flexbox */
+    flex-direction: column; /* Arrange child elements vertically */
+    margin-top: 22px;
+    margin-bottom: 10px;
+    width: 100%;
+}
+
+.verbose-div {
+    display: flex; /* Use flexbox */
+    flex-direction: row; /* Arrange child elements vertically */
+    margin-top: 12px;
+    margin-bottom: 30px;
+    width: 100%;
+}
+
+vscode-dropdown {
+    width: 200px;
+}
+
+.full-destination-path {
+    display: flex; /* Use flexbox */
+    flex-direction: row; /* Arrange child elements vertically */
+    color: var(--vscode-descriptionForeground);
+}
+
+.group-buttons {
+    display: flex; /* Use flexbox */
+    flex-direction: row; /* Arrange child elements vertically */
+}
+
+.p-collection-name {
+    font-style: italic;
+}
+
+vscode-button {
+    margin: 0px 3px;
+}
+
+vscode-checkbox i {
+    color: var(--vscode-descriptionForeground);
+    font-size: small;
+}
+
+#ade-docs-link {
+    margin-left: 30px;
+    font-style: italic;
+}
+
+.dropdown-container {
+    box-sizing: border-box;
+    display: flex;
+    flex-flow: column nowrap;
+    align-items: flex-start;
+    justify-content: flex-start;
+}
+
+.dropdown-container label {
+    display: block;
+    color: var(--vscode-foreground);
+    cursor: pointer;
+    font-size: var(--vscode-font-size);
+    line-height: normal;
+    margin-bottom: 2px;
+}
+
+#log-to-file-options-div {
+    display: none;
+    flex-direction: column;
+    border-style: dotted;
+    border-color: var(--focus-border);
+    border-width: 0.5px;
+    padding: 8px;
+}
+
+.log-level-div {
+    margin: 4px 0px;
+}

--- a/package.json
+++ b/package.json
@@ -351,6 +351,10 @@
         "title": "Ansible: Create a Devfile"
       },
       {
+        "command": "ansible.content-creator.create-sample-execution-env-file",
+        "title": "Ansible: Create a Sample Execution Environment file"
+      },
+      {
         "command": "ansible.content-creator.create",
         "title": "Ansible Content Creator: Create"
       },

--- a/src/definitions/constants.ts
+++ b/src/definitions/constants.ts
@@ -46,6 +46,8 @@ export const ANSIBLE_CREATOR_VERSION_MIN = "24.10.1";
 
 export const ANSIBLE_CREATOR_COLLECTION_VERSION_MIN = "24.7.1";
 
+export const ANSIBLE_CREATOR_EE_VERSION_MIN = "25.1.0";
+
 export const DevfileImages = {
   Upstream: "ghcr.io/ansible/ansible-workspace-env-reference:latest",
 };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -72,6 +72,7 @@ import {
 } from "./features/lightspeed/lightspeedUser";
 import { PlaybookFeedbackEvent } from "./interfaces/lightspeed";
 import { CreateDevfile } from "./features/contentCreator/createDevfilePage";
+import { CreateSampleExecutionEnv } from "./features/contentCreator/createSampleExecutionEnvPage";
 
 export let client: LanguageClient;
 export let lightSpeedManager: LightSpeedManager;
@@ -546,6 +547,16 @@ export async function activate(context: ExtensionContext): Promise<void> {
       "ansible.content-creator.create-devfile",
       () => {
         CreateDevfile.render(context.extensionUri);
+      },
+    ),
+  );
+
+  // open web-view for creating sample Execution Environment file
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "ansible.content-creator.create-sample-execution-env-file",
+      () => {
+        CreateSampleExecutionEnv.render(context.extensionUri);
       },
     ),
   );

--- a/src/features/contentCreator/createSampleExecutionEnvPage.ts
+++ b/src/features/contentCreator/createSampleExecutionEnvPage.ts
@@ -8,7 +8,7 @@ import { getNonce } from "../utils/getNonce";
 import { AnsibleSampleExecutionEnvInterface, PostMessageEvent } from "./types";
 import { withInterpreter } from "../utils/commandRunner";
 import { SettingsManager } from "../../settings";
-import { expandPath, getBinDetail, runCommand } from "./utils";
+import { expandPath, runCommand, getCreatorVersion } from "./utils";
 import { ANSIBLE_CREATOR_EE_VERSION_MIN } from "../../definitions/constants";
 
 export class CreateSampleExecutionEnv {
@@ -276,14 +276,6 @@ export class CreateSampleExecutionEnv {
     );
   }
 
-  private async getCreatorVersion(): Promise<string> {
-    const creatorVersion = (
-      await getBinDetail("ansible-creator", "--version")
-    ).toString();
-    console.log("ansible-creator version: ", creatorVersion);
-    return creatorVersion;
-  }
-
   public async getCreatorCommand(url: string): Promise<string> {
     let command = "";
 
@@ -395,7 +387,7 @@ export class CreateSampleExecutionEnv {
     let commandResult: string;
 
     commandOutput += `------------------------------------ ansible-creator logs ------------------------------------\n`;
-    const creatorVersion = await this.getCreatorVersion();
+    const creatorVersion = await getCreatorVersion();
     if (semver.gte(creatorVersion, ANSIBLE_CREATOR_EE_VERSION_MIN)) {
       // execute ansible-creator command
       const ansibleCreatorExecutionResult = await runCommand(command, env);

--- a/src/features/contentCreator/createSampleExecutionEnvPage.ts
+++ b/src/features/contentCreator/createSampleExecutionEnvPage.ts
@@ -1,0 +1,472 @@
+/* eslint-disable  @typescript-eslint/no-explicit-any */
+
+import * as vscode from "vscode";
+import * as os from "os";
+import * as semver from "semver";
+import { getUri } from "../utils/getUri";
+import { getNonce } from "../utils/getNonce";
+import { AnsibleSampleExecutionEnvInterface, PostMessageEvent } from "./types";
+import { withInterpreter } from "../utils/commandRunner";
+import { SettingsManager } from "../../settings";
+import { expandPath, getBinDetail, runCommand } from "./utils";
+import { ANSIBLE_CREATOR_EE_VERSION_MIN } from "../../definitions/constants";
+
+export class CreateSampleExecutionEnv {
+  public static currentPanel: CreateSampleExecutionEnv | undefined;
+  private readonly _panel: vscode.WebviewPanel;
+  private _disposables: vscode.Disposable[] = [];
+
+  private constructor(panel: vscode.WebviewPanel, extensionUri: vscode.Uri) {
+    this._panel = panel;
+    this._panel.webview.html = this._getWebviewContent(
+      this._panel.webview,
+      extensionUri,
+    );
+    this._setWebviewMessageListener(this._panel.webview);
+    this._panel.onDidDispose(
+      () => {
+        this.dispose();
+      },
+      null,
+      this._disposables,
+    );
+  }
+
+  public static render(extensionUri: vscode.Uri) {
+    if (CreateSampleExecutionEnv.currentPanel) {
+      CreateSampleExecutionEnv.currentPanel._panel.reveal(
+        vscode.ViewColumn.One,
+      );
+    } else {
+      const panel = vscode.window.createWebviewPanel(
+        "create-sample-execution-env",
+        "Create Sample Ansible Execution Environment",
+        vscode.ViewColumn.One,
+        {
+          enableScripts: true,
+          localResourceRoots: [
+            vscode.Uri.joinPath(extensionUri, "out"),
+            vscode.Uri.joinPath(extensionUri, "media"),
+          ],
+          enableCommandUris: true,
+          retainContextWhenHidden: true,
+        },
+      );
+
+      CreateSampleExecutionEnv.currentPanel = new CreateSampleExecutionEnv(
+        panel,
+        extensionUri,
+      );
+    }
+  }
+
+  public dispose() {
+    CreateSampleExecutionEnv.currentPanel = undefined;
+
+    this._panel.dispose();
+
+    while (this._disposables.length) {
+      const disposable = this._disposables.pop();
+      if (disposable) {
+        disposable.dispose();
+      }
+    }
+  }
+
+  private _getWebviewContent(
+    webview: vscode.Webview,
+    extensionUri: vscode.Uri,
+  ) {
+    const webviewUri = getUri(webview, extensionUri, [
+      "out",
+      "client",
+      "webview",
+      "apps",
+      "contentCreator",
+      "createSampleExecutionEnvPageApp.js",
+    ]);
+
+    const nonce = getNonce();
+    const styleUri = getUri(webview, extensionUri, [
+      "media",
+      "contentCreator",
+      "createSampleExecutionEnvPageStyle.css",
+    ]);
+
+    const codiconsUri = getUri(webview, extensionUri, [
+      "media",
+      "codicons",
+      "codicon.css",
+    ]);
+
+    const workspaceDir = this.getWorkspaceFolder();
+    const tempDir = os.tmpdir();
+
+    return /*html*/ `
+      <html>
+
+        <head>
+          <meta charset="UTF-8" />
+          <meta name="viewport" content="width=device-width, initial-scale=1.0">
+          <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'nonce-${nonce}'; style-src ${webview.cspSource}; font-src ${webview.cspSource};">
+          <title>AAA</title>
+          <link rel="stylesheet" href="${styleUri}">
+          <link rel="stylesheet" href="${codiconsUri}">
+        </head>
+
+        <body>
+            <div class="title-div">
+              <h1>Create a sample Ansible Execution Environment file</h1>
+              <p class="subtitle">Streamlining automation</p>
+            </div>
+
+            <form id="init-form">
+              <section class="component-container">
+
+                <vscode-text-field id="path-url" class="required" form="init-form" placeholder="${workspaceDir}"
+                  size="512">Destination path
+                  <section slot="end" class="explorer-icon">
+                    <vscode-button id="folder-explorer" appearance="icon">
+                      <span class="codicon codicon-folder-opened"></span>
+                    </vscode-button>
+                  </section>
+                </vscode-text-field>
+
+                <div id="full-destination-path" class="full-destination-path">
+                  <p>Default Destination path:&nbsp</p>
+                </div>
+
+                <div class="verbose-div">
+                  <div class="dropdown-container">
+                    <label for="verbosity-dropdown">Output Verbosity</label>
+                    <vscode-dropdown id="verbosity-dropdown">
+                      <vscode-option>Off</vscode-option>
+                      <vscode-option>Low</vscode-option>
+                      <vscode-option>Medium</vscode-option>
+                      <vscode-option>High</vscode-option>
+                    </vscode-dropdown>
+                  </div>
+                </div>
+
+                <div class="checkbox-div">
+                  <vscode-checkbox id="log-to-file-checkbox" form="init-form">Log output to a file <br><i>Default path:
+                      ${tempDir}/ansible-creator.log.</i></vscode-checkbox>
+                </div>
+
+                <div id="log-to-file-options-div">
+                  <vscode-text-field id="log-file-path" class="required" form="init-form" placeholder="${tempDir}/ansible-creator.log"
+                    size="512">Log file path
+                    <section slot="end" class="explorer-icon">
+                    <vscode-button id="file-explorer" appearance="icon">
+                      <span class="codicon codicon-file"></span>
+                    </vscode-button>
+                  </section>
+                  </vscode-text-field>
+
+                  <vscode-checkbox id="log-file-append-checkbox" form="init-form">Append</i></vscode-checkbox>
+
+                  <div class="log-level-div">
+                    <div class="dropdown-container">
+                      <label for="log-level-dropdown">Log level</label>
+                      <vscode-dropdown id="log-level-dropdown" position="below">
+                        <vscode-option>Debug</vscode-option>
+                        <vscode-option>Info</vscode-option>
+                        <vscode-option>Warning</vscode-option>
+                        <vscode-option>Error</vscode-option>
+                        <vscode-option>Critical</vscode-option>
+                      </vscode-dropdown>
+                    </div>
+                  </div>
+
+                </div>
+
+                <div class="checkbox-div">
+                  <vscode-checkbox id="overwrite-checkbox" form="init-form">Overwrite <br><i>Overwrite the existing execution-environment.yml file.</i></vscode-checkbox>
+                </div>
+
+                <div class="group-buttons">
+                  <vscode-button id="clear-button" form="init-form" appearance="secondary">
+                    <span class="codicon codicon-clear-all"></span>
+                    &nbsp; Clear All
+                  </vscode-button>
+                  <vscode-button id="create-button" form="init-form">
+                    <span class="codicon codicon-run-all"></span>
+                    &nbsp; Create
+                  </vscode-button>
+                </div>
+
+                <br>
+                <vscode-divider></vscode-divider>
+                <br>
+                <vscode-text-area id="log-text-area" cols="512" rows="10" placeholder="Output of the command execution"
+                  resize="vertical" readonly>Logs</vscode-text-area>
+
+                <div class="group-buttons">
+                  <vscode-button id="clear-logs-button" form="init-form" appearance="secondary">
+                    <span class="codicon codicon-clear-all"></span>
+                    &nbsp; Clear Logs
+                  </vscode-button>
+                  <vscode-button id="copy-logs-button" form="init-form" appearance="secondary">
+                    <span class="codicon codicon-copy"></span>
+                    &nbsp; Copy Logs
+                  </vscode-button>
+                  <vscode-button id="open-log-file-button" form="init-form" appearance="secondary" disabled>
+                    <span class="codicon codicon-open-preview"></span>
+                    &nbsp; Open Log File
+                  </vscode-button>
+                  <vscode-button id="open-file-button" form="init-form" disabled>
+                    <span class="codicon codicon-go-to-file"></span>
+                    &nbsp; Open Execution Environment file
+                  </vscode-button>
+                </div>
+              </section>
+            </form>
+
+          <!-- Component registration code -->
+          <script type="module" nonce="${nonce}" src="${webviewUri}"></script>
+        </body>
+      </html>
+    `;
+  }
+
+  private _setWebviewMessageListener(webview: vscode.Webview) {
+    webview.onDidReceiveMessage(
+      async (message: any) => {
+        const command = message.command;
+        let payload;
+
+        switch (command) {
+          case "open-explorer": {
+            payload = message.payload;
+            const selectedUri = await this.openExplorerDialog(
+              payload.selectOption,
+            );
+            webview.postMessage({
+              command: "file-uri",
+              arguments: { selectedUri: selectedUri },
+            } as PostMessageEvent);
+            return;
+          }
+          case "init-create":
+            payload = message.payload as AnsibleSampleExecutionEnvInterface;
+            await this.runInitCommand(payload, webview);
+            return;
+
+          case "init-copy-logs":
+            payload = message.payload;
+            vscode.env.clipboard.writeText(payload.initExecutionLogs);
+            await vscode.window.showInformationMessage(
+              "Logs copied to clipboard",
+            );
+            return;
+
+          case "init-open-log-file":
+            payload = message.payload;
+            await this.openLogFile(payload.logFileUrl);
+            return;
+
+          case "init-open-scaffolded-file":
+            payload = message.payload;
+            this.openFileInWorkspace(payload.projectUrl);
+            return;
+        }
+      },
+      undefined,
+      this._disposables,
+    );
+  }
+
+  private async getCreatorVersion(): Promise<string> {
+    const creatorVersion = (
+      await getBinDetail("ansible-creator", "--version")
+    ).toString();
+    console.log("ansible-creator version: ", creatorVersion);
+    return creatorVersion;
+  }
+
+  public async getCreatorCommand(url: string): Promise<string> {
+    let command = "";
+
+    command = `ansible-creator add resource execution-environment ${url} --no-ansi`;
+    return command;
+  }
+
+  public async openExplorerDialog(
+    selectOption: string,
+  ): Promise<string | undefined> {
+    const options: vscode.OpenDialogOptions = {
+      canSelectMany: false,
+      openLabel: "Select",
+      canSelectFiles: selectOption === "file",
+      canSelectFolders: selectOption === "folder",
+      defaultUri: vscode.Uri.parse(os.homedir()),
+    };
+
+    let selectedUri: string | undefined;
+    await vscode.window.showOpenDialog(options).then((fileUri) => {
+      if (fileUri && fileUri[0]) {
+        selectedUri = fileUri[0].fsPath;
+      }
+    });
+
+    return selectedUri;
+  }
+
+  public getWorkspaceFolder() {
+    let folder: string = "";
+    if (vscode.workspace.workspaceFolders) {
+      folder = vscode.workspace.workspaceFolders[0].uri.path;
+    }
+    return folder;
+  }
+
+  public async runInitCommand(
+    payload: AnsibleSampleExecutionEnvInterface,
+    webView: vscode.Webview,
+  ) {
+    const {
+      destinationPath,
+      logToFile,
+      logFilePath,
+      logFileAppend,
+      logLevel,
+      verbosity,
+      isOverwritten,
+    } = payload;
+
+    const destinationPathUrl = destinationPath
+      ? destinationPath
+      : this.getWorkspaceFolder();
+
+    let ansibleCreatorSampleEECommand =
+      await this.getCreatorCommand(destinationPathUrl);
+
+    if (isOverwritten) {
+      ansibleCreatorSampleEECommand += " --overwrite";
+    }
+
+    switch (verbosity) {
+      case "Off":
+        ansibleCreatorSampleEECommand += "";
+        break;
+      case "Low":
+        ansibleCreatorSampleEECommand += " -v";
+        break;
+      case "Medium":
+        ansibleCreatorSampleEECommand += " -vv";
+        break;
+      case "High":
+        ansibleCreatorSampleEECommand += " -vvv";
+        break;
+    }
+
+    let logFilePathUrl = "";
+
+    if (logToFile) {
+      if (logFilePath) {
+        logFilePathUrl = logFilePath;
+      } else {
+        logFilePathUrl = `${os.tmpdir()}/ansible-creator.log`;
+      }
+
+      ansibleCreatorSampleEECommand += ` --lf=${logFilePathUrl}`;
+
+      ansibleCreatorSampleEECommand += ` --ll=${logLevel.toLowerCase()}`;
+
+      if (logFileAppend) {
+        ansibleCreatorSampleEECommand += ` --la=true`;
+      } else {
+        ansibleCreatorSampleEECommand += ` --la=false`;
+      }
+    }
+
+    console.debug("[ansible-creator] command: ", ansibleCreatorSampleEECommand);
+
+    const extSettings = new SettingsManager();
+    await extSettings.initialize();
+
+    const { command, env } = withInterpreter(
+      extSettings.settings,
+      ansibleCreatorSampleEECommand,
+      "",
+    );
+
+    let commandOutput = "";
+    let commandResult: string;
+
+    commandOutput += `------------------------------------ ansible-creator logs ------------------------------------\n`;
+    const creatorVersion = await this.getCreatorVersion();
+    if (semver.gte(creatorVersion, ANSIBLE_CREATOR_EE_VERSION_MIN)) {
+      // execute ansible-creator command
+      const ansibleCreatorExecutionResult = await runCommand(command, env);
+      commandOutput += ansibleCreatorExecutionResult.output;
+      commandResult = ansibleCreatorExecutionResult.status;
+    } else {
+      commandOutput += ansibleCreatorSampleEECommand;
+      commandOutput += `\nMinimum ansible-creator version needed to scaffold an execution-environment.yml file is 25.1.0\n`;
+      commandOutput += `Please upgrade ansible-creator to minimum required version and try again.`;
+      commandResult = "failed";
+    }
+
+    await webView.postMessage({
+      command: "execution-log",
+      arguments: {
+        commandOutput: commandOutput,
+        logFileUrl: logFilePathUrl,
+        projectUrl: destinationPathUrl,
+        status: commandResult,
+      },
+    } as PostMessageEvent);
+
+    if (commandResult === "passed") {
+      const selection = await vscode.window.showInformationMessage(
+        `Ansible Sample Execution Environment file created at: ${destinationPathUrl}`,
+        `Open Sample Execution Environment file ↗`,
+      );
+      if (selection === "Open Sample Execution Environment file ↗") {
+        this.openFileInWorkspace(destinationPathUrl);
+      }
+    }
+  }
+
+  public async openLogFile(fileUrl: string) {
+    const logFileUrl = vscode.Uri.file(expandPath(fileUrl)).fsPath;
+    console.log(`[ansible-creator] New Log file url: ${logFileUrl}`);
+    const parsedUrl = vscode.Uri.parse(`vscode://file${logFileUrl}`);
+    console.log(`[ansible-creator] Parsed log file url: ${parsedUrl}`);
+    this.openFileInEditor(parsedUrl.toString());
+  }
+
+  public async openFileInWorkspace(fileUrl: string) {
+    const fileUri = vscode.Uri.parse(expandPath(fileUrl));
+
+    if (vscode.workspace.workspaceFolders?.length === 0) {
+      vscode.workspace.updateWorkspaceFolders(0, null, { uri: fileUri });
+    } else {
+      await vscode.commands.executeCommand("vscode.openFolder", fileUri, {
+        forceNewWindow: true,
+      });
+    }
+
+    // open the sample execution environment file in the editor
+    const eeFileUrl = vscode.Uri.joinPath(
+      vscode.Uri.parse(fileUrl),
+      "execution-environment.yml",
+    ).fsPath;
+    console.log(
+      `[ansible-creator] Execution Environment file url: ${eeFileUrl}`,
+    );
+    const parsedUrl = vscode.Uri.parse(`vscode://file${eeFileUrl}`);
+    console.log(
+      `[ansible-creator] Parsed Execution Environment file url: ${parsedUrl}`,
+    );
+    this.openFileInEditor(parsedUrl.toString());
+  }
+
+  public openFileInEditor(fileUrl: string) {
+    const updatedUrl = expandPath(fileUrl);
+    console.log(`[ansible-creator] Updated url: ${updatedUrl}`);
+
+    vscode.commands.executeCommand("vscode.open", vscode.Uri.parse(updatedUrl));
+  }
+}

--- a/src/features/contentCreator/types.ts
+++ b/src/features/contentCreator/types.ts
@@ -33,10 +33,6 @@ export type DevfileFormInterface = {
 export type AnsibleSampleExecutionEnvInterface = {
   destinationPath: string;
   verbosity: string;
-  logToFile: boolean;
-  logFilePath: string;
-  logFileAppend: boolean;
-  logLevel: string;
   isOverwritten: boolean;
 };
 

--- a/src/features/contentCreator/types.ts
+++ b/src/features/contentCreator/types.ts
@@ -30,6 +30,16 @@ export type DevfileFormInterface = {
   isOverwritten: boolean;
 };
 
+export type AnsibleSampleExecutionEnvInterface = {
+  destinationPath: string;
+  verbosity: string;
+  logToFile: boolean;
+  logFilePath: string;
+  logFileAppend: boolean;
+  logLevel: string;
+  isOverwritten: boolean;
+};
+
 export type PostMessageEvent =
   | {
       command: "ADEPresence";

--- a/src/features/quickLinks/quickLinksView.ts
+++ b/src/features/quickLinks/quickLinksView.ts
@@ -121,6 +121,14 @@ export function getWebviewQuickLinks(webview: Webview, extensionUri: Uri) {
               </a>
             </h3>
           </div>
+          <div class="catalogue">
+            <h3>
+              <a href="command:ansible.content-creator.create-sample-execution-env-file" title="Create a sample Execution Environment file.">
+                <span class="codicon codicon-new-file"></span> Execution Environment template
+                <span class="new-badge">NEW</span>
+              </a>
+            </h3>
+          </div>
     </div>
     <!-- Component registration code -->
     <script type="module" nonce="${nonce}" src="${webviewUri}"></script>

--- a/src/webview/apps/contentCreator/createSampleExecutionEnvPageApp.ts
+++ b/src/webview/apps/contentCreator/createSampleExecutionEnvPageApp.ts
@@ -1,0 +1,275 @@
+/* eslint-disable  @typescript-eslint/no-explicit-any */
+
+import {
+  allComponents,
+  Button,
+  Checkbox,
+  TextArea,
+  TextField,
+  provideVSCodeDesignSystem,
+  Dropdown,
+} from "@vscode/webview-ui-toolkit";
+import {
+  AnsibleSampleExecutionEnvInterface,
+  PostMessageEvent,
+} from "../../../features/contentCreator/types";
+
+provideVSCodeDesignSystem().register(allComponents);
+
+const vscode = acquireVsCodeApi();
+window.addEventListener("load", main);
+
+let destinationPathUrlTextField: TextField;
+let folderExplorerButton: Button;
+
+let initCreateButton: Button;
+let initClearButton: Button;
+
+let overwriteCheckbox: Checkbox;
+
+let logToFileCheckbox: Checkbox;
+let logToFileOptionsDiv: HTMLElement | null;
+let logFilePath: TextField;
+let fileExplorerButton: Button;
+let logFileAppendCheckbox: Checkbox;
+let logLevelDropdown: Dropdown;
+
+let verboseDropdown: Dropdown;
+
+let initDestinationPathDiv: HTMLElement | null;
+let initDestinationPathElement: HTMLElement;
+
+let initLogsTextArea: TextArea;
+let initClearLogsButton: Button;
+let initOpenLogFileButton: Button;
+let initCopyLogsButton: Button;
+let initOpenScaffoldedFileButton: Button;
+
+let logFileUrl = "";
+let projectUrl = "";
+
+function main() {
+  destinationPathUrlTextField = document.getElementById(
+    "path-url",
+  ) as TextField;
+  folderExplorerButton = document.getElementById("folder-explorer") as Button;
+
+  overwriteCheckbox = document.getElementById("overwrite-checkbox") as Checkbox;
+
+  logToFileCheckbox = document.getElementById(
+    "log-to-file-checkbox",
+  ) as Checkbox;
+  logToFileCheckbox.addEventListener("change", toggleLogToFileOptions);
+
+  logToFileOptionsDiv = document.getElementById("log-to-file-options-div");
+
+  logFilePath = document.getElementById("log-file-path") as TextField;
+  fileExplorerButton = document.getElementById("file-explorer") as Button;
+  logFileAppendCheckbox = document.getElementById(
+    "log-file-append-checkbox",
+  ) as Checkbox;
+  logLevelDropdown = document.getElementById("log-level-dropdown") as Dropdown;
+
+  verboseDropdown = document.getElementById("verbosity-dropdown") as Dropdown;
+  initCreateButton = document.getElementById("create-button") as Button;
+  initClearButton = document.getElementById("clear-button") as Button;
+
+  initLogsTextArea = document.getElementById("log-text-area") as TextArea;
+  initClearLogsButton = document.getElementById("clear-logs-button") as Button;
+  initOpenLogFileButton = document.getElementById(
+    "open-log-file-button",
+  ) as Button;
+  initCopyLogsButton = document.getElementById("copy-logs-button") as Button;
+  initOpenScaffoldedFileButton = document.getElementById(
+    "open-file-button",
+  ) as Button;
+
+  destinationPathUrlTextField.addEventListener("input", toggleCreateButton);
+
+  folderExplorerButton.addEventListener("click", openExplorer);
+  fileExplorerButton.addEventListener("click", openExplorer);
+
+  initCreateButton.addEventListener("click", handleInitCreateClick);
+  initCreateButton.disabled = false;
+
+  initClearButton.addEventListener("click", handleInitClearClick);
+
+  initClearLogsButton.addEventListener("click", handleInitClearLogsClick);
+  initOpenLogFileButton.addEventListener("click", handleInitOpenLogFileClick);
+  initCopyLogsButton.addEventListener("click", handleInitCopyLogsClick);
+  initOpenScaffoldedFileButton.addEventListener(
+    "click",
+    handleInitOpenScaffoldedFileClick,
+  );
+
+  initDestinationPathDiv = document.getElementById("full-destination-path");
+
+  initDestinationPathElement = document.createElement("p");
+  initDestinationPathElement.innerHTML =
+    destinationPathUrlTextField.placeholder;
+  initDestinationPathDiv?.appendChild(initDestinationPathElement);
+}
+
+function openExplorer(event: any) {
+  const source = event.target.parentNode.id;
+
+  let selectOption;
+
+  if (source === "folder-explorer") {
+    selectOption = "folder";
+  } else {
+    selectOption = "file";
+  }
+
+  vscode.postMessage({
+    command: "open-explorer",
+    payload: {
+      selectOption: selectOption,
+    },
+  });
+
+  window.addEventListener(
+    "message",
+    (event: MessageEvent<PostMessageEvent>) => {
+      const message = event.data;
+
+      if (message.command === "file-uri") {
+        const selectedUri = message.arguments.selectedUri;
+
+        if (selectedUri) {
+          if (source === "folder-explorer") {
+            destinationPathUrlTextField.value = selectedUri;
+            initDestinationPathElement.innerHTML = selectedUri;
+          } else {
+            logFilePath.value = selectedUri;
+          }
+        }
+      }
+    },
+  );
+}
+
+function handleInitClearClick() {
+  destinationPathUrlTextField.value = "";
+
+  initDestinationPathElement.innerHTML =
+    destinationPathUrlTextField.placeholder;
+
+  overwriteCheckbox.checked = false;
+  verboseDropdown.currentValue = "Off";
+
+  initCreateButton.disabled = false;
+
+  logToFileCheckbox.checked = false;
+  logFilePath.value = "";
+  logFileAppendCheckbox.checked = false;
+  logLevelDropdown.currentValue = "Debug";
+  initOpenScaffoldedFileButton.disabled = true;
+}
+
+function toggleCreateButton() {
+  //   update destination path <p> tag
+  initDestinationPathElement.innerHTML =
+    destinationPathUrlTextField.value.trim();
+
+  initCreateButton.disabled = false;
+}
+
+function toggleLogToFileOptions() {
+  if (logToFileCheckbox.checked) {
+    if (
+      logToFileOptionsDiv?.style.display === "" ||
+      logToFileOptionsDiv?.style.display === "none"
+    ) {
+      logToFileOptionsDiv.style.display = "flex";
+    }
+  } else {
+    if (logToFileOptionsDiv?.style.display === "flex") {
+      logToFileOptionsDiv.style.display = "none";
+    }
+  }
+}
+
+function handleInitCreateClick() {
+  initCreateButton.disabled = false;
+
+  vscode.postMessage({
+    command: "init-create",
+    payload: {
+      destinationPath: destinationPathUrlTextField.value.trim(),
+      verbosity: verboseDropdown.currentValue.trim(),
+      logToFile: logToFileCheckbox.checked,
+      logFilePath: logFilePath.value.trim(),
+      logFileAppend: logFileAppendCheckbox.checked,
+      logLevel: logLevelDropdown.currentValue.trim(),
+      isOverwritten: overwriteCheckbox.checked,
+    } as AnsibleSampleExecutionEnvInterface,
+  });
+
+  window.addEventListener(
+    "message",
+    async (event: MessageEvent<PostMessageEvent>) => {
+      const message = event.data;
+
+      switch (message.command) {
+        case "execution-log":
+          initLogsTextArea.value = message.arguments.commandOutput;
+          logFileUrl = message.arguments.logFileUrl;
+
+          if (logFileUrl) {
+            initOpenLogFileButton.disabled = false;
+          } else {
+            initOpenLogFileButton.disabled = true;
+          }
+
+          if (
+            message.arguments.status &&
+            message.arguments.status === "passed"
+          ) {
+            initOpenScaffoldedFileButton.disabled = false;
+          } else {
+            initOpenScaffoldedFileButton.disabled = true;
+          }
+
+          projectUrl = message.arguments.projectUrl
+            ? message.arguments.projectUrl
+            : "";
+
+          initCreateButton.disabled = false;
+
+          return;
+      }
+    },
+  );
+}
+
+function handleInitClearLogsClick() {
+  initLogsTextArea.value = "";
+}
+
+function handleInitOpenLogFileClick() {
+  vscode.postMessage({
+    command: "init-open-log-file",
+    payload: {
+      logFileUrl: logFileUrl,
+    },
+  });
+}
+
+function handleInitCopyLogsClick() {
+  vscode.postMessage({
+    command: "init-copy-logs",
+    payload: {
+      initExecutionLogs: initLogsTextArea.value,
+    },
+  });
+}
+
+function handleInitOpenScaffoldedFileClick() {
+  vscode.postMessage({
+    command: "init-open-scaffolded-file",
+    payload: {
+      projectUrl: projectUrl,
+    },
+  });
+}

--- a/src/webview/apps/contentCreator/createSampleExecutionEnvPageApp.ts
+++ b/src/webview/apps/contentCreator/createSampleExecutionEnvPageApp.ts
@@ -27,13 +27,6 @@ let initClearButton: Button;
 
 let overwriteCheckbox: Checkbox;
 
-let logToFileCheckbox: Checkbox;
-let logToFileOptionsDiv: HTMLElement | null;
-let logFilePath: TextField;
-let fileExplorerButton: Button;
-let logFileAppendCheckbox: Checkbox;
-let logLevelDropdown: Dropdown;
-
 let verboseDropdown: Dropdown;
 
 let initDestinationPathDiv: HTMLElement | null;
@@ -41,11 +34,8 @@ let initDestinationPathElement: HTMLElement;
 
 let initLogsTextArea: TextArea;
 let initClearLogsButton: Button;
-let initOpenLogFileButton: Button;
-let initCopyLogsButton: Button;
 let initOpenScaffoldedFileButton: Button;
 
-let logFileUrl = "";
 let projectUrl = "";
 
 function main() {
@@ -56,30 +46,12 @@ function main() {
 
   overwriteCheckbox = document.getElementById("overwrite-checkbox") as Checkbox;
 
-  logToFileCheckbox = document.getElementById(
-    "log-to-file-checkbox",
-  ) as Checkbox;
-  logToFileCheckbox.addEventListener("change", toggleLogToFileOptions);
-
-  logToFileOptionsDiv = document.getElementById("log-to-file-options-div");
-
-  logFilePath = document.getElementById("log-file-path") as TextField;
-  fileExplorerButton = document.getElementById("file-explorer") as Button;
-  logFileAppendCheckbox = document.getElementById(
-    "log-file-append-checkbox",
-  ) as Checkbox;
-  logLevelDropdown = document.getElementById("log-level-dropdown") as Dropdown;
-
   verboseDropdown = document.getElementById("verbosity-dropdown") as Dropdown;
   initCreateButton = document.getElementById("create-button") as Button;
   initClearButton = document.getElementById("clear-button") as Button;
 
   initLogsTextArea = document.getElementById("log-text-area") as TextArea;
   initClearLogsButton = document.getElementById("clear-logs-button") as Button;
-  initOpenLogFileButton = document.getElementById(
-    "open-log-file-button",
-  ) as Button;
-  initCopyLogsButton = document.getElementById("copy-logs-button") as Button;
   initOpenScaffoldedFileButton = document.getElementById(
     "open-file-button",
   ) as Button;
@@ -87,7 +59,6 @@ function main() {
   destinationPathUrlTextField.addEventListener("input", toggleCreateButton);
 
   folderExplorerButton.addEventListener("click", openExplorer);
-  fileExplorerButton.addEventListener("click", openExplorer);
 
   initCreateButton.addEventListener("click", handleInitCreateClick);
   initCreateButton.disabled = false;
@@ -95,8 +66,6 @@ function main() {
   initClearButton.addEventListener("click", handleInitClearClick);
 
   initClearLogsButton.addEventListener("click", handleInitClearLogsClick);
-  initOpenLogFileButton.addEventListener("click", handleInitOpenLogFileClick);
-  initCopyLogsButton.addEventListener("click", handleInitCopyLogsClick);
   initOpenScaffoldedFileButton.addEventListener(
     "click",
     handleInitOpenScaffoldedFileClick,
@@ -140,8 +109,6 @@ function openExplorer(event: any) {
           if (source === "folder-explorer") {
             destinationPathUrlTextField.value = selectedUri;
             initDestinationPathElement.innerHTML = selectedUri;
-          } else {
-            logFilePath.value = selectedUri;
           }
         }
       }
@@ -160,10 +127,6 @@ function handleInitClearClick() {
 
   initCreateButton.disabled = false;
 
-  logToFileCheckbox.checked = false;
-  logFilePath.value = "";
-  logFileAppendCheckbox.checked = false;
-  logLevelDropdown.currentValue = "Debug";
   initOpenScaffoldedFileButton.disabled = true;
 }
 
@@ -175,21 +138,6 @@ function toggleCreateButton() {
   initCreateButton.disabled = false;
 }
 
-function toggleLogToFileOptions() {
-  if (logToFileCheckbox.checked) {
-    if (
-      logToFileOptionsDiv?.style.display === "" ||
-      logToFileOptionsDiv?.style.display === "none"
-    ) {
-      logToFileOptionsDiv.style.display = "flex";
-    }
-  } else {
-    if (logToFileOptionsDiv?.style.display === "flex") {
-      logToFileOptionsDiv.style.display = "none";
-    }
-  }
-}
-
 function handleInitCreateClick() {
   initCreateButton.disabled = false;
 
@@ -198,10 +146,6 @@ function handleInitCreateClick() {
     payload: {
       destinationPath: destinationPathUrlTextField.value.trim(),
       verbosity: verboseDropdown.currentValue.trim(),
-      logToFile: logToFileCheckbox.checked,
-      logFilePath: logFilePath.value.trim(),
-      logFileAppend: logFileAppendCheckbox.checked,
-      logLevel: logLevelDropdown.currentValue.trim(),
       isOverwritten: overwriteCheckbox.checked,
     } as AnsibleSampleExecutionEnvInterface,
   });
@@ -214,13 +158,6 @@ function handleInitCreateClick() {
       switch (message.command) {
         case "execution-log":
           initLogsTextArea.value = message.arguments.commandOutput;
-          logFileUrl = message.arguments.logFileUrl;
-
-          if (logFileUrl) {
-            initOpenLogFileButton.disabled = false;
-          } else {
-            initOpenLogFileButton.disabled = true;
-          }
 
           if (
             message.arguments.status &&
@@ -245,24 +182,6 @@ function handleInitCreateClick() {
 
 function handleInitClearLogsClick() {
   initLogsTextArea.value = "";
-}
-
-function handleInitOpenLogFileClick() {
-  vscode.postMessage({
-    command: "init-open-log-file",
-    payload: {
-      logFileUrl: logFileUrl,
-    },
-  });
-}
-
-function handleInitCopyLogsClick() {
-  vscode.postMessage({
-    command: "init-copy-logs",
-    payload: {
-      initExecutionLogs: initLogsTextArea.value,
-    },
-  });
 }
 
 function handleInitOpenScaffoldedFileClick() {

--- a/test/ui-test/contentCreatorUiTest.ts
+++ b/test/ui-test/contentCreatorUiTest.ts
@@ -84,3 +84,57 @@ describe("Test Ansible playbook project scaffolding", () => {
     );
   });
 });
+
+describe("Test Ansible sample execution environment file scaffolding", () => {
+  let createEEButton: WebElement;
+  let editorView: EditorView;
+
+  async function testWebViewElements(command: string, editorTitle: string) {
+    await workbenchExecuteCommand(command);
+    await sleep(4000);
+
+    await new EditorView().openEditor(editorTitle);
+    const eeWebview = await getWebviewByLocator(
+      By.xpath("//vscode-text-field[@id='path-url']"),
+    );
+
+    const eeDestination = await eeWebview.findWebElement(
+      By.xpath("//vscode-text-field[@id='path-url']"),
+    );
+    expect(eeDestination, "eeDestination should not be undefined").not.to.be
+      .undefined;
+    await eeDestination.sendKeys("~");
+
+    const overwriteCheckbox = await eeWebview.findWebElement(
+      By.xpath("//vscode-checkbox[@id='overwrite-checkbox']"),
+    );
+    expect(overwriteCheckbox, "overwriteCheckbox should not be undefined").not
+      .to.be.undefined;
+    await overwriteCheckbox.click();
+
+    createEEButton = await eeWebview.findWebElement(
+      By.xpath("//vscode-button[@id='create-button']"),
+    );
+    expect(createEEButton, "createEEButton should not be undefined").not.to.be
+      .undefined;
+
+    expect(
+      await createEEButton.isEnabled(),
+      "createEEbutton should be enabled now",
+    ).to.be.true;
+
+    await createEEButton.click();
+    await eeWebview.switchBack();
+    editorView = new EditorView();
+    if (editorView) {
+      await editorView.closeAllEditors();
+    }
+  }
+
+  it("Check create-sample-execution-env-file webview elements", async () => {
+    await testWebViewElements(
+      "Ansible: Create a sample Ansible Execution Environment file",
+      "Create Sample Ansible Execution Environment",
+    );
+  });
+});

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -237,6 +237,20 @@ const createDevfileWebviewConfig = {
   },
 };
 
+const createSampleExecutionEnvWebviewConfig = {
+  ...config,
+  target: ["web", "es2020"],
+  entry: "./src/webview/apps/contentCreator/createSampleExecutionEnvPageApp.ts",
+  experiments: { outputModule: true },
+  output: {
+    path: path.resolve(__dirname, "out"),
+    filename:
+      "./client/webview/apps/contentCreator/createSampleExecutionEnvPageApp.js",
+    libraryTarget: "module",
+    chunkFormat: "module",
+  },
+};
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 module.exports = (_env: any, argv: { mode: string }) => {
   // Use non-bundled js for client/server in dev environment
@@ -256,5 +270,6 @@ module.exports = (_env: any, argv: { mode: string }) => {
     createAnsibleProjectWebviewConfig,
     createDevfileWebviewConfig,
     quickLinksWebviewConfig,
+    createSampleExecutionEnvWebviewConfig,
   ];
 };


### PR DESCRIPTION
### Summary

This PR adds a new webview for adding a sample execution-environment.yml file to an existing destination path.

#### Available fields:
- `Destination Path`: The path where the sample execution-environment.yml file gets added. If the destination path does not exist, an error message comes up.

### Webview

![Screenshot 2024-12-18 at 8 05 25 PM](https://github.com/user-attachments/assets/fc4a864f-0572-4548-b779-f6de703a9e0b)

#### Related JIRA: [AAP-36883](https://issues.redhat.com/browse/AAP-36883)