### PR TITLE
Increase node memory on GH runners

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -13,7 +13,7 @@ export VIRTUAL_ENV="${HOME}/.local/share/virtualenvs/vsa"
 # Reached heap limit Allocation failed - JavaScript heap out of memory
 # https://nodejs.org/api/cli.html#--max-old-space-sizesize-in-megabytes
 # default 16 MiB for 64-bit systems and 8 MiB for 32-bit systems
-export NODE_OPTIONS="--max-old-space-size=4096"
+export NODE_OPTIONS="--max-old-space-size=8192"
 
 # Activate virtualenv (creates it if needed)
 layout python3


### PR DESCRIPTION
Fixes the `JavaScript heap out of memory` error on CI