### PR TITLE
Remove use of creator 'no-overwrite' param 

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,4 +1,6 @@
 sonar.cpd.exclusions=\
     src/features/lightspeed/playbookGeneration.ts, \
     src/features/lightspeed/roleGeneration.ts, \
+    src/features/contentCreator/createAnsibleCollectionPage.ts, \
+    src/features/contentCreator/createAnsibleProjectPage.ts, \
     test/ui-test/*.ts

--- a/src/features/contentCreator/createAnsibleCollectionPage.ts
+++ b/src/features/contentCreator/createAnsibleCollectionPage.ts
@@ -416,9 +416,14 @@ export class CreateAnsibleCollection {
       ansibleCreatorInitCommand += " --overwrite";
     } else if (!exceedMinVersion && isOverwritten) {
       ansibleCreatorInitCommand += " --force";
-    } else if (exceedMinVersion && !isOverwritten) {
-      ansibleCreatorInitCommand += " --no-overwrite";
     }
+    // TODO: Uncomment the below code once the following bugs are resolved
+    // https://github.com/ansible/vscode-ansible/issues/1730
+    // https://github.com/ansible/ansible-creator/issues/343
+
+    // else if (exceedMinVersion && !isOverwritten) {
+    //   ansibleCreatorInitCommand += " --no-overwrite";
+    // }
 
     switch (verbosity) {
       case "Off":
@@ -475,7 +480,19 @@ export class CreateAnsibleCollection {
     // execute ansible-creator command
     const ansibleCreatorExecutionResult = await runCommand(command, env);
     commandOutput += `------------------------------------ ansible-creator logs ------------------------------------\n`;
-    commandOutput += ansibleCreatorExecutionResult.output;
+
+    // TODO: Refactor to remove conditional below once the following bugs are resolved
+    // https://github.com/ansible/vscode-ansible/issues/1730
+    // https://github.com/ansible/ansible-creator/issues/343
+    const result = ansibleCreatorExecutionResult.output;
+
+    if (result.includes("Do you want to proceed?")) {
+      commandOutput += `The destination directory contains files that will be overwritten, but the "Overwrite" option was not selected.\n`;
+      commandOutput += `Please select the "Overwrite" option and try again.`;
+    } else {
+      commandOutput += result;
+    }
+
     const ansibleCreatorCommandPassed = ansibleCreatorExecutionResult.status;
 
     if (isEditableModeInstall) {

--- a/src/features/contentCreator/createAnsibleProjectPage.ts
+++ b/src/features/contentCreator/createAnsibleProjectPage.ts
@@ -353,9 +353,15 @@ export class CreateAnsibleProject {
       ansibleCreatorInitCommand += " --overwrite";
     } else if (!exceedMinVersion && isOverwritten) {
       ansibleCreatorInitCommand += " --force";
-    } else if (exceedMinVersion && !isOverwritten) {
-      ansibleCreatorInitCommand += " --no-overwrite";
     }
+
+    // TODO: Uncomment the below code once the following bugs are resolved
+    // https://github.com/ansible/vscode-ansible/issues/1730
+    // https://github.com/ansible/ansible-creator/issues/343
+
+    // else if (exceedMinVersion && !isOverwritten) {
+    //   ansibleCreatorInitCommand += " --no-overwrite";
+    // }
 
     switch (verbosity) {
       case "Off":
@@ -408,7 +414,19 @@ export class CreateAnsibleProject {
     // execute ansible-creator command
     const ansibleCreatorExecutionResult = await runCommand(command, env);
     commandOutput += `------------------------------------ ansible-creator logs ------------------------------------\n`;
-    commandOutput += ansibleCreatorExecutionResult.output;
+
+    // TODO: Refactor to remove conditional below once the following bugs are resolved
+    // https://github.com/ansible/vscode-ansible/issues/1730
+    // https://github.com/ansible/ansible-creator/issues/343
+    const result = ansibleCreatorExecutionResult.output;
+
+    if (result.includes("Do you want to proceed?")) {
+      commandOutput += `The destination directory contains files that will be overwritten, but the "Overwrite" option was not selected.\n`;
+      commandOutput += `Please select the "Overwrite" option and try again.`;
+    } else {
+      commandOutput += result;
+    }
+
     const commandPassed = ansibleCreatorExecutionResult.status;
 
     await webView.postMessage({

--- a/src/features/contentCreator/createAnsibleProjectPage.ts
+++ b/src/features/contentCreator/createAnsibleProjectPage.ts
@@ -438,16 +438,6 @@ export class CreateAnsibleProject {
         status: commandPassed,
       },
     } as PostMessageEvent);
-
-    if (commandPassed === "passed") {
-      const selection = await vscode.window.showInformationMessage(
-        `Ansible playbook project created at: ${destinationPathUrl}`,
-        `Open playbook project ↗`,
-      );
-      if (selection === "Open playbook project ↗") {
-        this.openFolderInWorkspace(destinationPathUrl);
-      }
-    }
   }
 
   public async openLogFile(fileUrl: string) {

--- a/test/ui-test/contentCreatorUiTest.ts
+++ b/test/ui-test/contentCreatorUiTest.ts
@@ -13,6 +13,12 @@ describe("Test Ansible playbook project scaffolding", () => {
   let editorView: EditorView;
   let output: WebElement;
 
+  before(async () => {
+    // Install ansible-creator
+    await workbenchExecuteCommand("Install Ansible Content Creator");
+    await sleep(2000);
+  });
+
   async function testWebViewElements(
     command: string,
     editorTitle: string,
@@ -20,7 +26,7 @@ describe("Test Ansible playbook project scaffolding", () => {
     collectionName: string,
   ) {
     await workbenchExecuteCommand(command);
-    await sleep(4000);
+    await sleep(5000);
 
     await new EditorView().openEditor(editorTitle);
     const webview = await getWebviewByLocator(
@@ -60,11 +66,12 @@ describe("Test Ansible playbook project scaffolding", () => {
     ).to.be.true;
 
     await createButton.click();
-    await sleep(1000);
+    await sleep(500);
 
     output = await webview.findWebElement(
       By.xpath("//vscode-text-area[@id='log-text-area']"),
     );
+
     expect(
       await output.getAttribute("current-value"),
       "Creator output should contain success message",
@@ -74,7 +81,7 @@ describe("Test Ansible playbook project scaffolding", () => {
     await overwriteCheckbox.click();
 
     await createButton.click();
-    await sleep(1000);
+    await sleep(500);
 
     output = await webview.findWebElement(
       By.xpath("//vscode-text-area[@id='log-text-area']"),

--- a/test/ui-test/contentCreatorUiTest.ts
+++ b/test/ui-test/contentCreatorUiTest.ts
@@ -11,6 +11,7 @@ config.truncateThreshold = 0;
 describe("Test Ansible playbook project scaffolding", () => {
   let createButton: WebElement;
   let editorView: EditorView;
+  let output: WebElement;
 
   async function testWebViewElements(
     command: string,
@@ -59,6 +60,33 @@ describe("Test Ansible playbook project scaffolding", () => {
     ).to.be.true;
 
     await createButton.click();
+    await sleep(500);
+
+    output = await webview.findWebElement(
+      By.xpath("//vscode-text-area[@id='log-text-area']"),
+    );
+    expect(
+      await output.getAttribute("current-value"),
+      "Creator output should contain success message",
+    ).contains("project created at");
+
+    // retry without overwrite selected
+    await overwriteCheckbox.click();
+
+    await createButton.click();
+    await sleep(500);
+
+    output = await webview.findWebElement(
+      By.xpath("//vscode-text-area[@id='log-text-area']"),
+    );
+    expect(
+      await output.getAttribute("current-value"),
+      "Creator output should contain overwrite failure message",
+    ).contains(
+      "The destination directory contains files that will be overwritten",
+    );
+    await sleep(500);
+
     await webview.switchBack();
     editorView = new EditorView();
     if (editorView) {

--- a/test/ui-test/contentCreatorUiTest.ts
+++ b/test/ui-test/contentCreatorUiTest.ts
@@ -60,7 +60,7 @@ describe("Test Ansible playbook project scaffolding", () => {
     ).to.be.true;
 
     await createButton.click();
-    await sleep(500);
+    await sleep(1000);
 
     output = await webview.findWebElement(
       By.xpath("//vscode-text-area[@id='log-text-area']"),
@@ -74,7 +74,7 @@ describe("Test Ansible playbook project scaffolding", () => {
     await overwriteCheckbox.click();
 
     await createButton.click();
-    await sleep(500);
+    await sleep(1000);
 
     output = await webview.findWebElement(
       By.xpath("//vscode-text-area[@id='log-text-area']"),


### PR DESCRIPTION
This PR introduces a workaround for https://github.com/ansible/ansible-creator/issues/343 and resolves #1730. 

A "TODO" is introduced in these files to complete once the ansible-creator issue is resolved. 

This PR also extends tests to check the creator output for the views. 

Adds to #1722.