### PR TITLE
Prevent Feedback Panel from Opening on Status Bar Click

### DIFF
--- a/src/features/lightspeed/statusBar.ts
+++ b/src/features/lightspeed/statusBar.ts
@@ -116,9 +116,7 @@ export class LightspeedStatusBar {
   }
 
   public async lightSpeedStatusBarClickHandler() {
-    if (await this.lightspeedAuthenticatedUser.isAuthenticated()) {
-      vscode.commands.executeCommand(LightSpeedCommands.LIGHTSPEED_FEEDBACK);
-    } else {
+    if (!(await this.lightspeedAuthenticatedUser.isAuthenticated())) {
       vscode.commands.executeCommand(
         LightSpeedCommands.LIGHTSPEED_AUTH_REQUEST,
       );


### PR DESCRIPTION
Remove the code that launches the Feedback view when already logged in.