### PR TITLE
Add mkdocs.configuration key to .readthedocs.yml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,6 +9,7 @@ version: 2
 
 mkdocs:
   fail_on_warning: true
+  configuration: mkdocs.yml
 
 # Optionally build your docs in additional formats
 # such as PDF and ePub


### PR DESCRIPTION
Per new readthedocs requirements, there must be an mkdocs.configuration key in the .readthedocs.yml file or builds will not succeed. 

See the [readthedocs announcement](https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/) for details. 