### PR TITLE
Add support to scaffold `action` plugins in the plugin webview

### DIFF
--- a/src/features/contentCreator/addPluginPage.ts
+++ b/src/features/contentCreator/addPluginPage.ts
@@ -131,6 +131,7 @@ export class AddPlugin {
                     <vscode-dropdown id="plugin-dropdown">
                       <vscode-option>filter</vscode-option>
                       <vscode-option>lookup</vscode-option>
+                      <vscode-option>action</vscode-option>
                     </vscode-dropdown>
                   </div>
                 </div>

--- a/src/features/contentCreator/createDevcontainerPage.ts
+++ b/src/features/contentCreator/createDevcontainerPage.ts
@@ -177,7 +177,7 @@ export class CreateDevcontainer {
                   </vscode-button>
                   <vscode-button id="open-file-button" form="devcontainer-form" disabled>
                     <span class="codicon codicon-go-to-file"></span>
-                    &nbsp; Explore Devcontainer
+                    &nbsp; Open Devcontainer
                   </vscode-button>
                 </div>
               </section>

--- a/src/features/contentCreator/createSampleExecutionEnvPage.ts
+++ b/src/features/contentCreator/createSampleExecutionEnvPage.ts
@@ -115,7 +115,7 @@ export class CreateSampleExecutionEnv {
 
         <body>
             <div class="title-div">
-              <h1>Create a sample Ansible Execution Environment file</h1>
+              <h1>Create a sample Ansible execution environment file</h1>
               <p class="subtitle">Streamlining automation</p>
             </div>
 
@@ -175,7 +175,7 @@ export class CreateSampleExecutionEnv {
                   </vscode-button>
                   <vscode-button id="open-file-button" form="init-form" disabled>
                     <span class="codicon codicon-go-to-file"></span>
-                    &nbsp; Open Execution Environment file
+                    &nbsp; Open Execution environment file
                   </vscode-button>
                 </div>
               </section>

--- a/src/features/quickLinks/quickLinksView.ts
+++ b/src/features/quickLinks/quickLinksView.ts
@@ -125,7 +125,7 @@ export function getWebviewQuickLinks(webview: Webview, extensionUri: Uri) {
           <div class="catalogue">
             <h3>
               <a href="command:ansible.content-creator.create-sample-execution-env-file" title="Create a sample Execution Environment file.">
-                <span class="codicon codicon-new-file"></span> Execution environment template
+                <span class="codicon codicon-new-file"></span> Execution environment
                 <span class="new-badge">NEW</span>
               </a>
             </h3>

--- a/test/ui-test/contentCreatorUiTest.ts
+++ b/test/ui-test/contentCreatorUiTest.ts
@@ -182,7 +182,7 @@ describe("Test Ansible sample execution environment file scaffolding", () => {
 
   it("Check create-sample-execution-env-file webview elements", async () => {
     await testWebViewElements(
-      "Ansible: Create a sample Ansible Execution Environment file",
+      "Ansible: Create a sample Ansible execution environment file",
       "Create Sample Ansible Execution Environment",
     );
   });

--- a/test/ui-test/contentCreatorUiTest.ts
+++ b/test/ui-test/contentCreatorUiTest.ts
@@ -300,12 +300,20 @@ describe("Test collection plugins scaffolding", () => {
     }
   }
 
-  it("Check add-plugin webview elements", async () => {
+  it("Check add-plugin webview elements for lookup plugin", async () => {
     await testWebViewElements(
       "Ansible: Add a Plugin",
       "Add Plugin",
       "test_plugin_name",
       "lookup",
+    );
+  });
+  it("Check add-plugin webview elements for action plugin", async () => {
+    await testWebViewElements(
+      "Ansible: Add a Plugin",
+      "Add Plugin",
+      "test_plugin_name",
+      "action",
     );
   });
 });


### PR DESCRIPTION
### SUMMARY

- This PR updates the existing plugin webview to add support for action plugin scaffolding by simply adding `action` in the existing plugin-type dropdown.
- Related JIRA: [AAP-36650](https://issues.redhat.com/browse/AAP-36650)

### Additional updates

- Updated the devcontainer webview to rename the button that says **Explore Devcontainer** -> **Open Devcontainer** instead.
- Updated the EE webview to make its wordings lowercase where required. Also, in the quicklinksView entry of EE webview rename **Execution environment template** -> **Execution environment**

### Updated Plugin Webview

![image](https://github.com/user-attachments/assets/ae516b8a-4f66-43b0-8c9f-c4de56cbb9b9)