### PR TITLE
Bump @shikijs/core from 1.26.2 to 2.1.0 and add RegExp engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -921,7 +921,7 @@
   "dependencies": {
     "@ansible/ansible-language-server": "workspace:^",
     "@redhat-developer/vscode-redhat-telemetry": "^0.9.1",
-    "@shikijs/core": "^1.26.2",
+    "@shikijs/core": "2.1.0",
     "@types/ini": "^4.1.1",
     "@vscode-elements/elements": "^1.10.0",
     "@vscode/webview-ui-toolkit": "^1.4.0",

--- a/src/features/utils/syntaxHighlighter.ts
+++ b/src/features/utils/syntaxHighlighter.ts
@@ -1,4 +1,5 @@
 import { getSingletonHighlighterCore, HighlighterCore } from "@shikijs/core";
+import { createOnigurumaEngine } from "shiki/engine/oniguruma";
 import darkPlus from "shiki/themes/dark-plus.mjs";
 import lightPlus from "shiki/themes/light-plus.mjs";
 import { default as yamlLang } from "shiki/langs/yaml.mjs";
@@ -12,6 +13,7 @@ export async function codeToHtml(code: string, theme: string, lang: string) {
       themes: [darkPlus, lightPlus],
       langs: [yamlLang],
       loadWasm: getWasm,
+      engine: createOnigurumaEngine(import("shiki/wasm")),
     });
   }
 

--- a/src/webview/apps/lightspeed/roleGeneration/main.ts
+++ b/src/webview/apps/lightspeed/roleGeneration/main.ts
@@ -11,7 +11,7 @@ import {
   Dropdown,
 } from "@vscode/webview-ui-toolkit";
 import { EditableList } from "../../common/editableList";
-
+import { createOnigurumaEngine } from "shiki/engine/oniguruma";
 import { getSingletonHighlighterCore, HighlighterCore } from "@shikijs/core";
 import darkPlus from "shiki/themes/dark-plus.mjs";
 import lightPlus from "shiki/themes/light-plus.mjs";
@@ -50,6 +50,7 @@ export async function codeToHtml(code: string) {
       themes: [darkPlus, lightPlus],
       langs: [yamlLang],
       loadWasm: getWasm,
+      engine: createOnigurumaEngine(import("shiki/wasm")),
     });
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -936,28 +936,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@shikijs/core@npm:^1.26.2":
-  version: 1.26.2
-  resolution: "@shikijs/core@npm:1.26.2"
+"@shikijs/core@npm:2.1.0":
+  version: 2.1.0
+  resolution: "@shikijs/core@npm:2.1.0"
   dependencies:
-    "@shikijs/engine-javascript": "npm:1.26.2"
-    "@shikijs/engine-oniguruma": "npm:1.26.2"
-    "@shikijs/types": "npm:1.26.2"
+    "@shikijs/engine-javascript": "npm:2.1.0"
+    "@shikijs/engine-oniguruma": "npm:2.1.0"
+    "@shikijs/types": "npm:2.1.0"
     "@shikijs/vscode-textmate": "npm:^10.0.1"
     "@types/hast": "npm:^3.0.4"
     hast-util-to-html: "npm:^9.0.4"
-  checksum: 10/800b42edf0eb45489a6e8b2bb8c5d1f984b9a0dcf6f3c5c5aae2e5e43050d07acb26039d276e16130372f4e693a6907263a559cf18d3fdfb8e350de4cb1108d3
-  languageName: node
-  linkType: hard
-
-"@shikijs/engine-javascript@npm:1.26.2":
-  version: 1.26.2
-  resolution: "@shikijs/engine-javascript@npm:1.26.2"
-  dependencies:
-    "@shikijs/types": "npm:1.26.2"
-    "@shikijs/vscode-textmate": "npm:^10.0.1"
-    oniguruma-to-es: "npm:^1.0.0"
-  checksum: 10/e67d0fe3ddbb6173b019f615df4e19150c5272909a65deb9a90ec1f1f1f5b776990713f3b3de597ad5bae85734ebaa683a463cb6b4bb4866b378ca885d1ad981
+  checksum: 10/b802753155294e0d6d92ee5602c136aa6a230afc63e4b32bb940c461a857d3f566da51fc6dac6b723d721648fd1484bfe4a53b128d0c686846da277883014aca
   languageName: node
   linkType: hard
 
@@ -972,13 +961,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@shikijs/engine-oniguruma@npm:1.26.2":
-  version: 1.26.2
-  resolution: "@shikijs/engine-oniguruma@npm:1.26.2"
+"@shikijs/engine-javascript@npm:2.1.0":
+  version: 2.1.0
+  resolution: "@shikijs/engine-javascript@npm:2.1.0"
   dependencies:
-    "@shikijs/types": "npm:1.26.2"
+    "@shikijs/types": "npm:2.1.0"
     "@shikijs/vscode-textmate": "npm:^10.0.1"
-  checksum: 10/6b422c672ba05f2004138271a779215cf2a3b5b0b22e04d9c6081fad74ebd1bfad75c579762c16c708e9a3c2e8d84f6011844cc9504cb8d9b4536503d4d40207
+    oniguruma-to-es: "npm:^2.3.0"
+  checksum: 10/cb045273962f3704f87c723532df543f9a1f8b41c26b5a6dc6bbfca14951acfff629ba7976e5e9f92e9086709eb9427b703ce0d814ee18292e3929d62ef737b7
   languageName: node
   linkType: hard
 
@@ -989,6 +979,16 @@ __metadata:
     "@shikijs/types": "npm:2.0.3"
     "@shikijs/vscode-textmate": "npm:^10.0.1"
   checksum: 10/ee9c588d532496748f43d833756f7aa72e23bee57ac2b73d9caca585816b1a7ed035a5069e3eae06fa117fda1ff991e77b6366a885918b6fa64b1bd01013e323
+  languageName: node
+  linkType: hard
+
+"@shikijs/engine-oniguruma@npm:2.1.0":
+  version: 2.1.0
+  resolution: "@shikijs/engine-oniguruma@npm:2.1.0"
+  dependencies:
+    "@shikijs/types": "npm:2.1.0"
+    "@shikijs/vscode-textmate": "npm:^10.0.1"
+  checksum: 10/3e6a6198033e60323a3cc0f1b6945e7b62bc241278e6b8e15bf7fe74231ed4c5051ac44450a59fc2db9491dd53abae25fe3b19ad5bf7501c382f394149a8bddf
   languageName: node
   linkType: hard
 
@@ -1010,16 +1010,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@shikijs/types@npm:1.26.2":
-  version: 1.26.2
-  resolution: "@shikijs/types@npm:1.26.2"
-  dependencies:
-    "@shikijs/vscode-textmate": "npm:^10.0.1"
-    "@types/hast": "npm:^3.0.4"
-  checksum: 10/f50f2a220b365f0bc53bb4e7dda1b39e7a827d08d7ff865dd4a44b251f49b49692c95b4afe5ebfe27fe01bfeca69997a75e145a34afeff6bcf8bbb5d039a6de2
-  languageName: node
-  linkType: hard
-
 "@shikijs/types@npm:2.0.3":
   version: 2.0.3
   resolution: "@shikijs/types@npm:2.0.3"
@@ -1027,6 +1017,16 @@ __metadata:
     "@shikijs/vscode-textmate": "npm:^10.0.1"
     "@types/hast": "npm:^3.0.4"
   checksum: 10/3f3d450625e3ff35b25be9314cc116d1d86dcc7a88f36f64cb73e0b38bc43cd0463670500db3d22163890c21bf3f4878332235cf2119b61d4cf8b92024b1a273
+  languageName: node
+  linkType: hard
+
+"@shikijs/types@npm:2.1.0":
+  version: 2.1.0
+  resolution: "@shikijs/types@npm:2.1.0"
+  dependencies:
+    "@shikijs/vscode-textmate": "npm:^10.0.1"
+    "@types/hast": "npm:^3.0.4"
+  checksum: 10/f36898f1ecd5db14d2b8a26bdd71cc9c586cf1de2582d7b1cef4d264d124cf3a567d3c7693e1cd56da66bd30e88cfc5d17f15108833a13d1ccf438e3d9acb921
   languageName: node
   linkType: hard
 
@@ -2250,7 +2250,7 @@ __metadata:
     "@ansible/ansible-language-server": "workspace:^"
     "@eslint/js": "npm:^9.18.0"
     "@redhat-developer/vscode-redhat-telemetry": "npm:^0.9.1"
-    "@shikijs/core": "npm:^1.26.2"
+    "@shikijs/core": "npm:2.1.0"
     "@types/chai": "npm:^4.3.20"
     "@types/express": "npm:^5.0.0"
     "@types/glob": "npm:^8.1.0"
@@ -7019,18 +7019,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"oniguruma-to-es@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "oniguruma-to-es@npm:1.0.0"
-  dependencies:
-    emoji-regex-xs: "npm:^1.0.0"
-    regex: "npm:^5.1.1"
-    regex-recursion: "npm:^5.1.1"
-  checksum: 10/cc3120041d72c778da12e15ebfcf7d1b1445266a7d1ac275917c8fd5c8af33fe23e75acb26828723f6747e3c111ea35f1c9ab5c79a995748d7130ffbee33efc0
-  languageName: node
-  linkType: hard
-
-"oniguruma-to-es@npm:^2.2.0":
+"oniguruma-to-es@npm:^2.2.0, oniguruma-to-es@npm:^2.3.0":
   version: 2.3.0
   resolution: "oniguruma-to-es@npm:2.3.0"
   dependencies:


### PR DESCRIPTION
After the `shikijs:2.0.2` release, the `engine` option is required for the HighlighterCoreOptions interface. 

This PR bumps the `shikijs/core` dep to `2.1.0` and adds the engine option as needed. The default engine - "Oniguruma Engine" - is used. 