### PR TITLE
roleGen: show collection in final file path

### DIFF
--- a/src/features/lightspeed/roleGeneration.ts
+++ b/src/features/lightspeed/roleGeneration.ts
@@ -327,7 +327,7 @@ export async function showRoleGenerationPage(extensionUri: vscode.Uri) {
 
           const link = `command:vscode.open?${encodeURIComponent(JSON.stringify(linkUri))}`;
           addFile(
-            `<a href="${link}">tasks/${roleName}/${f.file_type}s/main.yml</a>`,
+            `<a href="${link}">collections/${fqcn.replace(".", "/")}/tasks/${roleName}/${f.file_type}s/main.yml</a>`,
           );
         });
         await Promise.all(promises);

--- a/test/ui-test/lightspeedRoleGenTest.ts
+++ b/test/ui-test/lightspeedRoleGenTest.ts
@@ -118,13 +118,13 @@ describe("Verify Role generation feature works as expected", function () {
     ).click();
 
     webView = await getWebviewByLocator(
-      By.xpath("//a[text()='tasks/install_nginx/tasks/main.yml']"),
+      By.xpath("//a[contains(text(), 'tasks/install_nginx/tasks/main.yml')]"),
     );
 
     await sleep(500);
     await (
       await webView.findWebElement(
-        By.xpath("//a[text()='tasks/install_nginx/tasks/main.yml']"),
+        By.xpath("//a[contains(text(), 'tasks/install_nginx/tasks/main.yml')]"),
       )
     ).click();
 


### PR DESCRIPTION
Include the collection name in the name of the final clickable file link.
