### PR TITLE
lightspeedRoleGenTest: fix the tests

### DIFF
--- a/test/ui-test/lightspeedRoleGenTest.ts
+++ b/test/ui-test/lightspeedRoleGenTest.ts
@@ -117,14 +117,14 @@ describe("Verify Role generation feature works as expected", function () {
       )
     ).click();
 
+    await sleep(500);
     webView = await getWebviewByLocator(
-      By.xpath("//a[contains(text(), 'tasks/install_nginx/tasks/main.yml')]"),
+      By.xpath("//a[contains(text(), 'install_nginx/tasks/main.yml')]"),
     );
 
-    await sleep(500);
     await (
       await webView.findWebElement(
-        By.xpath("//a[contains(text(), 'tasks/install_nginx/tasks/main.yml')]"),
+        By.xpath("//a[contains(text(), 'install_nginx/tasks/main.yml')]"),
       )
     ).click();
 


### PR DESCRIPTION
Adjust the incorrect xpath (`//a[contains(text(), 'tasks/install_nginx/tasks/main.yml')]`) that was breaking the tests.
