### PR TITLE
Automatically set lightspeed and inline suggestion checkboxes to enabled when user clicks Connect

### DIFF
--- a/src/features/lightspeed/statusBar.ts
+++ b/src/features/lightspeed/statusBar.ts
@@ -124,10 +124,17 @@ export class LightspeedStatusBar {
   }
 
   public async setLightSpeedStatusBarTooltip(): Promise<void> {
+    const userIsLoggedIn =
+      await this.lightspeedAuthenticatedUser.isAuthenticated();
+    if (!userIsLoggedIn) {
+      lightSpeedManager.statusBarProvider.statusBar.tooltip = undefined;
+      return;
+    }
     const userDetails =
       await this.lightspeedAuthenticatedUser.getLightspeedUserDetails(false);
     if (!userDetails) {
-      return undefined;
+      lightSpeedManager.statusBarProvider.statusBar.tooltip = undefined;
+      return;
     }
     const statusBarInfo = getLoggedInUserDetails(userDetails);
     const userType = statusBarInfo.userInfo?.userType;

--- a/test/ui-test/lightspeedAuthUiTest.ts
+++ b/test/ui-test/lightspeedAuthUiTest.ts
@@ -13,6 +13,7 @@ import {
 } from "vscode-extension-tester";
 import {
   getModalDialogAndMessage,
+  getSettingInUI,
   sleep,
   updateSettings,
 } from "./uiTestHelper";
@@ -119,6 +120,30 @@ describe("Login to Lightspeed", () => {
     const text = await div.getText();
     expect(text).contains("Logged in as:");
     await explorerView.switchBack();
+  });
+
+  it("Lightspeed enabled setting should be on", async () => {
+    const settingsEditor = await workbench.openSettings();
+    const settingInUI = await getSettingInUI(
+      settingsEditor,
+      "ansible.lightspeed.enabled",
+    );
+    const lightspeedEnabledValue = settingInUI
+      ? await settingInUI.getValue()
+      : undefined;
+    expect(lightspeedEnabledValue).to.be.true;
+  });
+
+  it("Lightspeed suggestions enabled setting should be on", async () => {
+    const settingsEditor = await workbench.openSettings();
+    const settingInUI = await getSettingInUI(
+      settingsEditor,
+      "ansible.lightspeed.suggestions.enabled",
+    );
+    const lightspeedSuggestionsEnabledValue = settingInUI
+      ? await settingInUI.getValue()
+      : undefined;
+    expect(lightspeedSuggestionsEnabledValue).to.be.true;
   });
 });
 

--- a/test/ui-test/uiTestHelper.ts
+++ b/test/ui-test/uiTestHelper.ts
@@ -23,10 +23,9 @@ export async function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-export async function updateSettings(
+export async function getSettingInUI(
   settingsEditor: SettingsEditor,
   setting: string,
-  value: any,
 ) {
   let settingArray = setting.split(".");
   settingArray = settingArray.map((item) => capitalizeFirstLetter(item));
@@ -37,6 +36,20 @@ export async function updateSettings(
   if (!title) return;
 
   const settingInUI = await settingsEditor.findSetting(title, ...categories);
+  return settingInUI;
+}
+
+export async function updateSettings(
+  settingsEditor: SettingsEditor,
+  setting: string,
+  value: any,
+) {
+  const settingInUI = await getSettingInUI(settingsEditor, setting);
+
+  if (!settingInUI) {
+    return;
+  }
+
   await settingInUI.setValue(value);
   await sleep(1000);
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-31064

The basic gist of this change is that when we catch the "connect" message and before we initiate the login flow, we update ansible.lightspeed.enabled and ansible.lightspeed.suggestions.enabled to be true (if they're not already true).  

I found that I needed to update the status bar logic since that gets triggered by the programatic settings update and the scenario where a user is not yet logged in wasn't explicitly handled.  Without this change, the modal never appears after clicking `Connect`

As far as the tests go, I extended what was already there in the ui tests to include two scenarios:

1. Clicking Connect when both checkboxes are already checked
2. Clicking Connect when both checkboxes are unchecked

In both cases the tests confirm that the checkboxes are checked after login