### PR TITLE
Upload all coverage reports to codecov

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -375,11 +375,17 @@ jobs:
           fail_ci_if_error: true
           use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }} # cspell:ignore oidc
 
+      - name: Find and upload UI test coverage data [3/4]
+        run: |
+          COVERAGE_FILES=$(find ./*/coverage/ui/ -name 'lcov.*.info' -print0 | xargs -0 | tr ' ' ',')
+          echo "Found coverage files: $COVERAGE_FILES"
+          echo "COVERAGE_FILES=$COVERAGE_FILES" >> $GITHUB_ENV
+
       - name: Upload ui test coverage data [3/4]
         uses: codecov/codecov-action@v5.1.2
         with:
           name: ui
-          files: ./*/coverage/ui/lcov.*.info
+          files: ${{ env.COVERAGE_FILES }}
           flags: ui
           disable_search: true
           fail_ci_if_error: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -196,7 +196,6 @@ jobs:
           asdf exec direnv export gha >> "$GITHUB_ENV"
           asdf exec direnv exec . bash -c 'echo "${VIRTUAL_ENV}/bin"' >> "$GITHUB_PATH"
 
-
       - name: Ensure .env file is automatically loaded (direnv)
         if: ${{ !contains(matrix.shell, 'wsl') }}
         run: |
@@ -246,7 +245,7 @@ jobs:
       - name: task package
         id: package
         run: |
-            task package ${{ matrix.env.TASKFILE_ARGS }}
+          task package ${{ matrix.env.TASKFILE_ARGS }}
 
       - name: task ${{ matrix.task-name }}
         if: "${{ !contains(matrix.name, 'test') }}"
@@ -380,7 +379,7 @@ jobs:
         uses: codecov/codecov-action@v5.1.2
         with:
           name: ui
-          files: ./*/coverage/ui/lcov.info
+          files: ./*/coverage/ui/lcov.*.info
           flags: ui
           disable_search: true
           fail_ci_if_error: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -389,7 +389,7 @@ jobs:
           fail_ci_if_error: true
           use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }} # cspell:ignore oidc
 
-      - name: Find and upload UI test coverage data [3/4]
+      - name: Find all the UI test coverage data
         run: |
           COVERAGE_FILES=$(find ./*/coverage/ui/ -name 'lcov.*.info' -print0 | xargs -0 | tr ' ' ',')
           echo "Found coverage files: $COVERAGE_FILES"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -288,6 +288,13 @@ jobs:
           if-no-files-found: error
           retention-days: 90
 
+      - name: Remove invalid files
+        if: ${{ always() }}
+        run: |
+          find out -name '*\?*' -exec rm -r {} \; || true
+          find out -name '*"*' -exec rm -r {} \; || true
+          find out -name '*:*' -exec rm -r {} \; || true
+
       - name: Upload test logs and reports
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
@@ -354,6 +361,13 @@ jobs:
         with:
           name: logs.zip
           path: .
+
+      - name: Remove invalid files
+        if: ${{ always() }}
+        run: |
+          find . -name '*\?*' -exec rm -r {} \; || true
+          find . -name '*"*' -exec rm -r {} \; || true
+          find . -name '*:*' -exec rm -r {} \; || true
 
       - name: Upload als test coverage data [1/4]
         uses: codecov/codecov-action@v5.1.2

--- a/tools/test-launcher.sh
+++ b/tools/test-launcher.sh
@@ -126,7 +126,7 @@ if [[ "${TEST_TYPE}" == "ui" ]]; then
         fi
         refresh_settings "${test_file}"
 
-        TEST_COVERAGE_FILE=./out/coverage/ui/lcov.$(basename "${test_file}").info
+        TEST_COVERAGE_FILE=./out/coverage/ui/lcov.${test_file##*/}.info
         ${EXTEST} run-tests "${COVERAGE_ARG}" -s out/test-resources -e out/ext --code_settings out/settings.json "${test_file}"
 
         if [[ -f ./out/coverage/ui/lcov.info ]]; then

--- a/tools/test-launcher.sh
+++ b/tools/test-launcher.sh
@@ -126,7 +126,13 @@ if [[ "${TEST_TYPE}" == "ui" ]]; then
         fi
         refresh_settings "${test_file}"
 
+        TEST_COVERAGE_FILE=./out/coverage/ui/lcov.$(basename "${test_file}").info
         ${EXTEST} run-tests "${COVERAGE_ARG}" -s out/test-resources -e out/ext --code_settings out/settings.json "${test_file}"
+
+        if [[ -f ./out/coverage/ui/lcov.info ]]; then
+            mv ./out/coverage/ui/lcov.info "$TEST_COVERAGE_FILE"
+        fi
+
         stop_server
     done
 fi


### PR DESCRIPTION
- Add some filters to remove the Webpack generated files that should not be part of the final coverage anyway.
- Generate and upload one .info file per UI test

Related JIRAs: [AAP-37628](https://issues.redhat.com/browse/AAP-37628), [AAP-38977](https://issues.redhat.com/browse/AAP-38977)