### PR TITLE
Remove Lightspeed Enabled setting

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -221,7 +221,6 @@ any level (User, Remote, Workspace and/or Folder).
   completing module options.
 - `ansibleServer.trace.server`: Traces the communication between VS Code and the
   ansible language server.
-- `ansible.lightspeed.enabled`: Enable Ansible Lightspeed.
 - `ansible.lightspeed.URL`: URL for Ansible Lightspeed.
 - `ansible.lightspeed.suggestions.enabled`: Enable Ansible Lightspeed with
   watsonx Code Assistant inline suggestions.

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
         "steps": [
           {
             "id": "enable-lightspeed-playbook",
-            "title": "Enable Ansible Lightspeed",
+            "title": "Log in to Ansible Lightspeed",
             "description": "Use generative AI to assist in your automation content creation.\nAnsible Lightspeed is available to Ansible Automation Platform users.\nCheck availability by logging in with your Red Hat account.\n[Log in with Red Hat ↗](command:ansible.lightspeed.signInWithLightspeed)\n[Learn more ↗](https://www.redhat.com/en/technologies/management/ansible/ansible-lightspeed) ",
             "media": {
               "markdown": "media/walkthroughs/startAutomatingPlaybook/enable-lightspeed.md"
@@ -329,7 +329,7 @@
       },
       {
         "command": "ansible.create-playbook-options",
-        "title": "Ansible: Create an empty playbook or with Lightspeed (if enabled)"
+        "title": "Ansible: Create an empty playbook or with Lightspeed (if authenticated)"
       },
       {
         "command": "ansible.content-creator.menu",
@@ -656,39 +656,32 @@
       {
         "title": "Ansible Lightspeed",
         "properties": {
-          "ansible.lightspeed.enabled": {
-            "scope": "resource",
-            "type": "boolean",
-            "default": false,
-            "markdownDescription": "Enable Ansible Lightspeed.",
-            "order": 0
-          },
           "ansible.lightspeed.URL": {
             "scope": "resource",
             "type": "string",
             "default": "https://c.ai.ansible.redhat.com",
             "markdownDescription": "URL for Ansible Lightspeed.",
-            "order": 1
+            "order": 0
           },
           "ansible.lightspeed.suggestions.enabled": {
             "scope": "resource",
             "type": "boolean",
-            "default": false,
+            "default": true,
             "markdownDescription": "Enable Ansible Lightspeed with watsonx Code Assistant inline suggestions.",
-            "order": 2
+            "order": 1
           },
           "ansible.lightspeed.suggestions.waitWindow": {
             "scope": "resource",
             "type": "number",
             "default": 0,
             "markdownDescription": "Delay (in msecs) prior to sending an inline suggestion request to Ansible Lightspeed with watsonx Code Assistant.",
-            "order": 3
+            "order": 2
           },
           "ansible.lightspeed.modelIdOverride": {
             "scope": "resource",
             "type": "string",
             "markdownDescription": "Model ID to override your organization's default model. This setting is only applicable to commercial users with an Ansible Lightspeed seat assignment.",
-            "order": 4
+            "order": 3
           }
         }
       },
@@ -742,7 +735,7 @@
         "command": "ansible.lightspeed.inlineSuggest.trigger",
         "extensionName": "Ansible",
         "source": "extension",
-        "when": "config.ansible.lightspeed.enabled && config.ansible.lightspeed.suggestions.enabled && editorTextFocus && !editorHasSelection && !inlineSuggestionVisible && editorLangId == 'ansible'"
+        "when": "config.ansible.lightspeed.suggestions.enabled && editorTextFocus && !editorHasSelection && !inlineSuggestionVisible && editorLangId == 'ansible'"
       }
     ],
     "languages": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -794,9 +794,9 @@ export async function activate(context: ExtensionContext): Promise<void> {
     vscode.commands.registerCommand(
       "ansible.create-playbook-options",
       async () => {
-        if (
-          await workspace.getConfiguration("ansible").get("lightspeed.enabled")
-        ) {
+        const isAuthenticated =
+          await lightSpeedManager.lightspeedAuthenticatedUser.isAuthenticated();
+        if (isAuthenticated) {
           vscode.commands.executeCommand(
             "ansible.lightspeed.playbookGeneration",
           );
@@ -949,24 +949,9 @@ async function resyncAnsibleInventory(): Promise<void> {
   }
 }
 
-export async function isLightspeedEnabled(): Promise<boolean> {
-  if (
-    !(await workspace.getConfiguration("ansible").get("lightspeed.enabled"))
-  ) {
-    await window.showErrorMessage(
-      "Enable lightspeed services from settings to use the feature.",
-    );
-    return false;
-  }
-  return true;
-}
-
 async function lightspeedLogin(
   providerType: AuthProviderType | undefined,
 ): Promise<void> {
-  if (!(await isLightspeedEnabled())) {
-    return;
-  }
   lightSpeedManager.currentModelValue = undefined;
   const authenticatedUser =
     await lightSpeedManager.lightspeedAuthenticatedUser.getLightspeedUserDetails(

--- a/src/features/ansibleMetaData.ts
+++ b/src/features/ansibleMetaData.ts
@@ -19,7 +19,6 @@ interface ansibleMetadataEvent {
   pythonVersion?: string;
   ansibleLintVersion?: string;
   eeEnabled: boolean;
-  lightSpeedEnabled: boolean;
   lightSpeedCodeAssistEnabled: boolean;
 }
 
@@ -156,8 +155,6 @@ export class MetadataManager {
       ansibleVersion,
       pythonVersion,
       eeEnabled: this.extensionSettings.settings.executionEnvironment.enabled,
-      lightSpeedEnabled:
-        this.extensionSettings.settings.lightSpeedService.enabled,
       lightSpeedCodeAssistEnabled:
         this.extensionSettings.settings.lightSpeedService.suggestions.enabled,
     };

--- a/src/features/lightspeed/base.ts
+++ b/src/features/lightspeed/base.ts
@@ -58,9 +58,8 @@ export class LightSpeedManager {
         ANSIBLE_LIGHTSPEED_AUTH_ID,
         ANSIBLE_LIGHTSPEED_AUTH_NAME,
       );
-    if (this.settingsManager.settings.lightSpeedService.enabled) {
-      this.lightSpeedAuthenticationProvider.initialize();
-    }
+    this.lightSpeedAuthenticationProvider.initialize();
+
     this.lightspeedAuthenticatedUser = new LightspeedUser(
       this.context,
       this.settingsManager,
@@ -109,29 +108,21 @@ export class LightSpeedManager {
     const lightspeedSettings = <LightSpeedServiceSettings>(
       vscode.workspace.getConfiguration("ansible").get("lightspeed")
     );
-    const lightspeedEnabled = lightspeedSettings.enabled;
 
-    if (!lightspeedEnabled) {
-      this.resetContext();
-      await this.lightSpeedAuthenticationProvider.dispose();
-      this.statusBarProvider.statusBar.hide();
-      return;
-    } else {
-      this.lightSpeedAuthenticationProvider.initialize();
-      this.statusBarProvider.setLightSpeedStatusBarTooltip();
-      this.setContext();
-      if (lightspeedSettings.suggestions.enabled) {
-        const githubConfig = (<unknown>(
-          vscode.workspace.getConfiguration("github")
-        )) as {
-          copilot: { enable?: { ansible?: boolean } };
-        };
-        const copilotEnableForAnsible = githubConfig?.copilot?.enable?.ansible;
-        if (copilotEnableForAnsible) {
-          vscode.window.showInformationMessage(
-            "Please disable GitHub Copilot for Ansible Lightspeed file types to use Ansible Lightspeed.",
-          );
-        }
+    this.lightSpeedAuthenticationProvider.initialize();
+    this.statusBarProvider.setLightSpeedStatusBarTooltip();
+    this.setContext();
+    if (lightspeedSettings.suggestions.enabled) {
+      const githubConfig = (<unknown>(
+        vscode.workspace.getConfiguration("github")
+      )) as {
+        copilot: { enable?: { ansible?: boolean } };
+      };
+      const copilotEnableForAnsible = githubConfig?.copilot?.enable?.ansible;
+      if (copilotEnableForAnsible) {
+        vscode.window.showInformationMessage(
+          "Please disable GitHub Copilot for Ansible Lightspeed file types to use Ansible Lightspeed.",
+        );
       }
     }
 
@@ -165,10 +156,9 @@ export class LightSpeedManager {
     const lightspeedSettings = <LightSpeedServiceSettings>(
       vscode.workspace.getConfiguration("ansible").get("lightspeed")
     );
-    const lightspeedEnabled = lightspeedSettings?.enabled;
     const lightspeedSuggestionsEnabled =
       lightspeedSettings?.suggestions.enabled;
-    return lightspeedEnabled && lightspeedSuggestionsEnabled;
+    return lightspeedSuggestionsEnabled;
   }
 
   private setCustomWhenClauseContext(): void {

--- a/src/features/lightspeed/inlineSuggestions.ts
+++ b/src/features/lightspeed/inlineSuggestions.ts
@@ -167,7 +167,7 @@ function getCompletionState(
   if (isCancellationRequested) {
     return CompletionState.CancellationRequested;
   }
-  if (!lightSpeedSetting.enabled || !lightSpeedSetting.suggestions.enabled) {
+  if (!lightSpeedSetting.suggestions.enabled) {
     return CompletionState.LightspeedIsDisabled;
   }
 

--- a/src/features/lightspeed/lightspeedUser.ts
+++ b/src/features/lightspeed/lightspeedUser.ts
@@ -368,10 +368,6 @@ export class LightspeedUser {
     createIfNone: boolean,
     useProviderType: AuthProviderType | undefined = undefined,
   ) {
-    // Ensure we don't try to get a lightspeed auth session when the provider is not initialized
-    if (!this._settingsManager.settings.lightSpeedService.enabled) {
-      return undefined;
-    }
     if (
       this._userDetails &&
       (!useProviderType || useProviderType === this._userType)
@@ -388,10 +384,6 @@ export class LightspeedUser {
     createIfNone: boolean,
     useProviderType: AuthProviderType | undefined = undefined,
   ) {
-    // Ensure we don't try to get a lightspeed auth session when the provider is not initialized
-    if (!this._settingsManager.settings.lightSpeedService.enabled) {
-      return undefined;
-    }
     if (
       this._markdownUserDetails &&
       (!useProviderType || useProviderType === this._userType)
@@ -405,11 +397,6 @@ export class LightspeedUser {
   }
 
   public async getLightspeedUserContent() {
-    // Ensure we don't try to get a lightspeed auth session when the provider is not initialized
-    if (!this._settingsManager.settings.lightSpeedService.enabled) {
-      return undefined;
-    }
-
     const markdownUserDetails =
       await this.getMarkdownLightspeedUserDetails(false);
     const userDetails = await this.getLightspeedUserDetails(false);

--- a/src/features/lightspeed/playbookGeneration.ts
+++ b/src/features/lightspeed/playbookGeneration.ts
@@ -3,7 +3,7 @@ import { v4 as uuidv4 } from "uuid";
 import { Webview, Uri } from "vscode";
 import { getNonce } from "../utils/getNonce";
 import { getUri } from "../utils/getUri";
-import { isLightspeedEnabled, lightSpeedManager } from "../../extension";
+import { lightSpeedManager } from "../../extension";
 import { PlaybookGenerationResponseParams } from "../../interfaces/lightspeed";
 import {
   LightSpeedCommands,
@@ -96,8 +96,13 @@ async function generatePlaybook(
 }
 
 export async function showPlaybookGenerationPage(extensionUri: vscode.Uri) {
-  // Check if Lightspeed is enabled or not.  If it is not, return without opening the panel.
-  if (!(await isLightspeedEnabled())) {
+  const isAuthenticated =
+    await lightSpeedManager.lightspeedAuthenticatedUser.isAuthenticated();
+  if (!isAuthenticated) {
+    await vscode.window.showErrorMessage(
+      "Log in to Ansible Lightspeed to use this feature.",
+    );
+
     return;
   }
 

--- a/src/features/lightspeed/statusBar.ts
+++ b/src/features/lightspeed/statusBar.ts
@@ -80,10 +80,7 @@ export class LightspeedStatusBar {
       );
     }
 
-    if (
-      this.settingsManager.settings.lightSpeedService.enabled &&
-      this.settingsManager.settings.lightSpeedService.suggestions.enabled
-    ) {
+    if (this.settingsManager.settings.lightSpeedService.suggestions.enabled) {
       this.statusBar.backgroundColor = new vscode.ThemeColor(
         "statusBarItem.prominentForeground",
       );
@@ -97,10 +94,7 @@ export class LightspeedStatusBar {
   }
 
   public async updateLightSpeedStatusbar(): Promise<void> {
-    if (
-      vscode.window.activeTextEditor?.document.languageId !== "ansible" ||
-      !this.settingsManager.settings.lightSpeedService.enabled
-    ) {
+    if (vscode.window.activeTextEditor?.document.languageId !== "ansible") {
       this.statusBar.hide();
       return;
     }

--- a/src/interfaces/extensionSettings.ts
+++ b/src/interfaces/extensionSettings.ts
@@ -40,7 +40,6 @@ export interface UserResponse {
 
 // Settings appear on VS Code Settings UI
 export interface LightSpeedServiceSettings {
-  enabled: boolean;
   URL: string;
   suggestions: { enabled: boolean; waitWindow: number };
   model: string | undefined;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -40,10 +40,9 @@ export class SettingsManager {
         volumeMounts: eeSettings.get("volumeMounts", []),
       },
       lightSpeedService: {
-        enabled: lightSpeedSettings.get("enabled", false),
         URL: lightSpeedSettings.get("URL", "https://c.ai.ansible.redhat.com"),
         suggestions: {
-          enabled: lightSpeedSettings.get("suggestions.enabled", false),
+          enabled: lightSpeedSettings.get("suggestions.enabled", true),
           waitWindow: lightSpeedSettings.get("suggestions.waitWindow", 0),
         },
         model: lightSpeedSettings.get("modelIdOverride", undefined),

--- a/test/helper.ts
+++ b/test/helper.ts
@@ -134,7 +134,6 @@ export async function disableExecutionEnvironmentSettings(): Promise<void> {
 }
 
 export async function enableLightspeedSettings(): Promise<void> {
-  await updateSettings("lightspeed.enabled", true);
   await updateSettings("lightspeed.suggestions.enabled", true);
   await updateSettings("lightspeed.URL", process.env.TEST_LIGHTSPEED_URL);
 
@@ -152,7 +151,6 @@ export async function enableLightspeedSettings(): Promise<void> {
 }
 
 export async function disableLightspeedSettings(): Promise<void> {
-  await updateSettings("lightspeed.enabled", false);
   await updateSettings("lightspeed.suggestions.enabled", false);
   await updateSettings("lightspeed.URL", "");
 }

--- a/test/testFixtures/settings.json
+++ b/test/testFixtures/settings.json
@@ -18,7 +18,6 @@
   "ansible.python.activationScript": "",
   "ansible.python.interpreterPath": "python3",
   "ansibleServer.trace.server": "verbose",
-  "ansible.lightspeed.enabled": false,
   "ansible.lightspeed.suggestions.enabled": false,
   "ansible.lightspeed.URL": "https://c.ai.ansible.redhat.com",
 

--- a/test/ui-test/lightspeedAuthUiTest.ts
+++ b/test/ui-test/lightspeedAuthUiTest.ts
@@ -37,7 +37,6 @@ describe("Login to Lightspeed", () => {
     // Enable Lightspeed and open Ansible Light view on sidebar
     workbench = new Workbench();
     const settingsEditor = await workbench.openSettings();
-    await updateSettings(settingsEditor, "ansible.lightspeed.enabled", true);
     await updateSettings(
       settingsEditor,
       "ansible.lightspeed.URL",

--- a/test/ui-test/lightspeedOneClickTrialUITest.ts
+++ b/test/ui-test/lightspeedOneClickTrialUITest.ts
@@ -1,4 +1,4 @@
-// BEFORE: ansible.lightspeed.enabled: true
+// BEFORE: ansible.lightspeed.suggestions.enabled: true
 import {
   ActionsControl,
   ActivityBar,

--- a/test/ui-test/lightspeedRoleGenTest.ts
+++ b/test/ui-test/lightspeedRoleGenTest.ts
@@ -1,4 +1,4 @@
-// BEFORE: ansible.lightspeed.enabled: true
+// BEFORE: ansible.lightspeed.suggestions.enabled: true
 
 import { expect, config } from "chai";
 import fs from "fs";
@@ -9,6 +9,7 @@ import {
   getWebviewByLocator,
   workbenchExecuteCommand,
   dismissNotifications,
+  connectLightspeed,
 } from "./uiTestHelper";
 
 config.truncateThreshold = 0;
@@ -32,7 +33,7 @@ function cleanUpTmpfile() {
 }
 
 before(function () {
-  if (process.platform === "darwin") {
+  if (process.platform !== "darwin") {
     this.skip();
   }
 });
@@ -40,7 +41,7 @@ before(function () {
 describe("Verify Role generation feature works as expected", function () {
   let workbench: Workbench;
 
-  before(function () {
+  before(async function () {
     if (!process.env.TEST_LIGHTSPEED_URL) {
       this.skip();
     }
@@ -62,6 +63,8 @@ describe("Verify Role generation feature works as expected", function () {
     await workbenchExecuteCommand("View: Close All Editor Groups");
 
     await dismissNotifications(workbench);
+
+    await connectLightspeed();
   });
 
   after(async function () {

--- a/test/ui-test/lightspeedUiTestActiveBarTest.ts
+++ b/test/ui-test/lightspeedUiTestActiveBarTest.ts
@@ -7,12 +7,7 @@ import {
   WebView,
   ViewSection,
 } from "vscode-extension-tester";
-import {
-  sleep,
-  updateSettings,
-  getWebviewByLocator,
-  openSettings,
-} from "./uiTestHelper";
+import { sleep, getWebviewByLocator, openSettings } from "./uiTestHelper";
 
 config.truncateThreshold = 0;
 
@@ -23,9 +18,7 @@ describe("Verify the presence of lightspeed login button in the activity bar", (
   let webviewView: WebView;
 
   before(async function () {
-    const settingsEditor = await openSettings();
-    await updateSettings(settingsEditor, "ansible.lightspeed.enabled", true);
-
+    await openSettings();
     view = (await new ActivityBar().getViewControl("Ansible")) as ViewControl;
     sideBar = await view.openView();
 
@@ -47,8 +40,6 @@ describe("Verify the presence of lightspeed login button in the activity bar", (
     if (webviewView) {
       await webviewView.switchBack();
     }
-    const settingsEditor = await openSettings();
-    await updateSettings(settingsEditor, "ansible.lightspeed.enabled", false);
   });
 
   it("Ansible Lightspeed welcome message is present", async function () {

--- a/test/ui-test/lightspeedUiTestExplorerTest.ts
+++ b/test/ui-test/lightspeedUiTestExplorerTest.ts
@@ -1,4 +1,4 @@
-// BEFORE: ansible.lightspeed.enabled: true
+// BEFORE: ansible.lightspeed.suggestions.enabled: true
 
 import {
   ActionsControl,

--- a/test/ui-test/lightspeedUiTestPlaybookExpTest.ts
+++ b/test/ui-test/lightspeedUiTestPlaybookExpTest.ts
@@ -1,4 +1,4 @@
-// BEFORE: ansible.lightspeed.enabled: true
+// BEFORE: ansible.lightspeed.suggestions.enabled: true
 
 import { expect, config } from "chai";
 import { By, VSBrowser, EditorView, WebView } from "vscode-extension-tester";

--- a/test/ui-test/lightspeedUiTestPlaybookExpTestNoExpTest.ts
+++ b/test/ui-test/lightspeedUiTestPlaybookExpTestNoExpTest.ts
@@ -1,4 +1,4 @@
-// BEFORE: ansible.lightspeed.enabled: true
+// BEFORE: ansible.lightspeed.suggestions.enabled: true
 
 import { expect, config } from "chai";
 import { By, VSBrowser, EditorView } from "vscode-extension-tester";
@@ -24,6 +24,7 @@ describe.skip("Verify playbook explanation features when no explanation is retur
     if (!process.env.TEST_LIGHTSPEED_URL) {
       this.skip();
     }
+
     const folder = "lightspeed";
     const file = "playbook_explanation_none.yml";
     const filePath = getFixturePath(folder, file);
@@ -35,10 +36,12 @@ describe.skip("Verify playbook explanation features when no explanation is retur
     await workbenchExecuteCommand(
       "Explain the playbook with Ansible Lightspeed",
     );
+
     await sleep(5000);
 
     // Locate the playbook explanation webview
     await new EditorView().openEditor("Explanation", 1);
+
     const webView = await getWebviewByLocator(
       By.xpath("//div[contains(@class, 'playbookGeneration') ]"),
     );
@@ -49,10 +52,12 @@ describe.skip("Verify playbook explanation features when no explanation is retur
     );
     expect(mainDiv, "mainDiv should not be undefined").not.to.be.undefined;
     await sleep(5000);
+
     const text = await mainDiv.getText();
     expect(text.includes("No explanation provided")).to.be.true;
 
     await webView.switchBack();
+
     editorView = new EditorView();
     if (editorView) {
       await editorView.closeAllEditors();

--- a/test/ui-test/lightspeedUiTestPlaybookExpTestNoLSTest.ts
+++ b/test/ui-test/lightspeedUiTestPlaybookExpTestNoLSTest.ts
@@ -40,7 +40,7 @@ describe("Verify playbook generation page is not opened when Lightspeed is not e
     const notification = notifications[0];
     console.log(notification);
     expect(await notification.getMessage()).equals(
-      "Enable lightspeed services from settings to use the feature.",
+      "Log in to Ansible Lightspeed to use this feature.",
     );
   });
 });

--- a/test/ui-test/lightspeedUiTestPlaybookGenTest.ts
+++ b/test/ui-test/lightspeedUiTestPlaybookGenTest.ts
@@ -1,4 +1,4 @@
-// BEFORE: ansible.lightspeed.enabled: true
+// BEFORE: ansible.lightspeed.suggestions.enabled: true
 
 import { expect, config } from "chai";
 import {
@@ -9,6 +9,7 @@ import {
   until,
   WebView,
   ModalDialog,
+  WebviewView,
 } from "vscode-extension-tester";
 import {
   getFixturePath,
@@ -16,15 +17,22 @@ import {
   getWebviewByLocator,
   workbenchExecuteCommand,
   dismissNotifications,
+  connectLightspeed,
 } from "./uiTestHelper";
 import { WizardGenerationActionType } from "../../src/definitions/lightspeed";
 import { PlaybookGenerationActionEvent } from "../../src/interfaces/lightspeed";
+
+before(function () {
+  if (process.platform !== "darwin") {
+    this.skip();
+  }
+});
 
 config.truncateThreshold = 0;
 
 describe.skip("Verify playbook generation features work as expected", function () {
   let workbench: Workbench;
-  let webView: WebView;
+  let webView: WebviewView;
 
   beforeEach(function () {
     if (!process.env.TEST_LIGHTSPEED_URL) {
@@ -44,6 +52,8 @@ describe.skip("Verify playbook generation features work as expected", function (
     await workbenchExecuteCommand("View: Close All Editor Groups");
 
     await dismissNotifications(workbench);
+
+    await connectLightspeed();
   });
 
   async function setupPage1() {
@@ -85,14 +95,20 @@ describe.skip("Verify playbook generation features work as expected", function (
     );
     expect(outlineList, "An ordered list should exist.").to.be.not.undefined;
     let text = await outlineList.getText();
-    expect(text.includes("Create virtual network peering")).to.be.true;
+    expect(
+      text.includes("Create virtual network peering"),
+      "Ordered list should include Create virtual network peering",
+    ).to.be.true;
 
     // Verify the prompt is displayed as a static text
     const prompt = await webView.findWebElement(
       By.xpath("//span[@id='prompt']"),
     );
     text = await prompt.getText();
-    expect(text.includes("Create an azure network.")).to.be.true;
+    expect(
+      text.includes("Create an azure network."),
+      "Prompt should include Create an azure network.",
+    ).to.be.true;
 
     // Click Generate playbook button to invoke the generations API
     const generatePlaybookButton = await webView.findWebElement(
@@ -146,13 +162,22 @@ describe.skip("Verify playbook generation features work as expected", function (
 
       if (response.ok) {
         const data = await response.json();
-        expect(data.feedbacks.length).equals(expected.length);
+        expect(
+          data.feedbacks.length,
+          "feedback length should be the correct length",
+        ).equals(expected.length);
         for (let i = 0; i < expected.length; i++) {
           const evt: PlaybookGenerationActionEvent =
             data.feedbacks[i].playbookGenerationAction;
-          expect(evt.action).equals(expected[i][0]);
-          expect(evt.fromPage).equals(expected[i][1]);
-          expect(evt.toPage).equals(expected[i][2]);
+          expect(evt.action, "action matches expected value").equals(
+            expected[i][0],
+          );
+          expect(evt.fromPage, "fromPage matches expected value").equals(
+            expected[i][1],
+          );
+          expect(evt.toPage, "toPage matches expected value").equals(
+            expected[i][2],
+          );
         }
       } else {
         expect.fail(

--- a/test/ui-test/lightspeedUiTestPlaybookGenWebviewPart2Test.ts
+++ b/test/ui-test/lightspeedUiTestPlaybookGenWebviewPart2Test.ts
@@ -1,4 +1,4 @@
-// BEFORE: ansible.lightspeed.enabled: true
+// BEFORE: ansible.lightspeed.suggestions.enabled: true
 
 import { expect, config } from "chai";
 import {
@@ -16,9 +16,16 @@ import {
   getWebviewByLocator,
   workbenchExecuteCommand,
   dismissNotifications,
+  connectLightspeed,
 } from "./uiTestHelper";
 import { WizardGenerationActionType } from "../../src/definitions/lightspeed";
 import { PlaybookGenerationActionEvent } from "../../src/interfaces/lightspeed";
+
+before(function () {
+  if (process.platform !== "darwin") {
+    this.skip();
+  }
+});
 
 config.truncateThreshold = 0;
 
@@ -42,6 +49,8 @@ describe("Verify playbook generation features work as expected", function () {
     await workbenchExecuteCommand("View: Close All Editor Groups");
 
     await dismissNotifications(workbench);
+
+    await connectLightspeed();
   });
 
   it("Playbook generation webview works as expected (full path) - part 2", async function () {

--- a/test/ui-test/lightspeedUiTestStatusBarAndExplorerViewTest.ts
+++ b/test/ui-test/lightspeedUiTestStatusBarAndExplorerViewTest.ts
@@ -1,4 +1,4 @@
-// BEFORE: ansible.lightspeed.enabled: true
+// BEFORE: ansible.lightspeed.suggestions.enabled: true
 
 import { expect, config } from "chai";
 import { By, StatusBar, VSBrowser, EditorView } from "vscode-extension-tester";
@@ -20,7 +20,7 @@ describe("Verify the presence of lightspeed element in the status bar and the ex
     // open file in the editor
     await VSBrowser.instance.openResources(filePath);
   });
-  it("Ansible Lightspeed status bar item present when lightspeed and lightspeed suggestions are enabled (with normal color)", async () => {
+  it("Ansible Lightspeed status bar item present when lightspeed suggestions are enabled (with normal color)", async () => {
     const statusBar = new StatusBar();
     const editorView = new EditorView();
     await editorView.openEditor(file);
@@ -35,7 +35,7 @@ describe("Verify the presence of lightspeed element in the status bar and the ex
     );
     expect(lightspeedStatusBarItem).not.to.be.undefined;
   });
-  it.skip("Ansible Lightspeed status bar item present when only lightspeed is enabled (with warning color)", async () => {
+  it.skip("Ansible Lightspeed status bar item present when lightspeed suggestions are not enabled (with warning color)", async () => {
     const statusBar = new StatusBar();
     const editorView = new EditorView();
     const settingsEditor = await openSettings();

--- a/test/ui-test/walkthroughUiTest.ts
+++ b/test/ui-test/walkthroughUiTest.ts
@@ -3,17 +3,15 @@ import {
   By,
   EditorView,
   ModalDialog,
-  SettingsEditor,
   until,
   Workbench,
 } from "vscode-extension-tester";
-import { updateSettings, sleep } from "./uiTestHelper";
+import { sleep } from "./uiTestHelper";
 
 config.truncateThreshold = 0;
 
 let workbench: Workbench;
 let editorView: EditorView;
-let settingsEditor: SettingsEditor;
 
 before(async () => {
   workbench = new Workbench();
@@ -37,7 +35,7 @@ describe("Check walkthroughs, elements and associated commands", async () => {
     [
       "Start automating with your first Ansible playbook",
       [
-        "Enable Ansible Lightspeed",
+        "Log in to Ansible Lightspeed",
         "Create an Ansible playbook project",
         "Create an Ansible playbook",
         "Save your playbook to a playbook project",
@@ -83,10 +81,24 @@ describe("Check walkthroughs, elements and associated commands", async () => {
   });
 
   it("Check empty playbook command option", async function () {
-    settingsEditor = await workbench.openSettings();
-    await updateSettings(settingsEditor, "ansible.lightspeed.enabled", false);
+    await workbench.executeCommand("Ansible: Create an empty Ansible playbook");
+    await sleep(500);
+
+    const newFileEditor = await new EditorView().openEditor("Untitled-1");
+    const startingText = await newFileEditor.getText();
+    expect(
+      startingText.startsWith("---"),
+      "The playbook file should start with ---",
+    ).to.be.true;
+    await workbench.executeCommand("View: Close All Editor Groups");
+    const dialogBox = new ModalDialog();
+    await dialogBox.pushButton(`Don't Save`);
+    await dialogBox.getDriver().wait(until.stalenessOf(dialogBox), 2000);
+  });
+
+  it("Check unauthenticated playbook command option", async function () {
     await workbench.executeCommand(
-      "Ansible: Create an empty playbook or with Lightspeed (if enabled)",
+      "Ansible: Create an empty playbook or with Lightspeed (if authenticated)",
     );
     await sleep(500);
 

--- a/tools/test-launcher.sh
+++ b/tools/test-launcher.sh
@@ -55,10 +55,8 @@ function stop_server() {
 function refresh_settings() {
     test_file=$1
     cp test/testFixtures/settings.json out/settings.json
-    sed -i.bak 's/"ansible.lightspeed.enabled": .*/"ansible.lightspeed.enabled": false,/' out/settings.json
     sed -i.bak 's/"ansible.lightspeed.suggestions.enabled": .*/"ansible.lightspeed.suggestions.enabled": false,/' out/settings.json
-    if grep "// BEFORE: ansible.lightspeed.enabled: true" "${test_file}"; then
-        sed -i.bak 's/"ansible.lightspeed.enabled": .*/"ansible.lightspeed.enabled": true,/' out/settings.json
+    if grep "// BEFORE: ansible.lightspeed.suggestions.enabled: true" "${test_file}"; then
         sed -i.bak 's/"ansible.lightspeed.suggestions.enabled": .*/"ansible.lightspeed.suggestions.enabled": true,/' out/settings.json
     fi
 


### PR DESCRIPTION
Addresses https://issues.redhat.com/browse/AAP-31064

The scope of the changes has shifted a bit after initial investigation.  We realized that the "Lightspeed Enabled" checkbox was redundant with the user being logged in.  The only "automatic" action that Lightspeed takes is code completion (which has it's own checkbox to toggle on/off).  All other actions are manually initiated by the user by clicking buttons or executing commands.  The fact that they're opting in by taking the action tells us that they actually want to perform that action.  I've shifted some of the checks we used to have for "Lightspeed Enabled" to now check to make sure the user is actually logged in to Lightspeed before proceeding.  This should simplify the user experience and simply the onboarding of Lightspeed users.

The other change here is defaulting the Ansible > Lightspeed > Suggestions checkbox to "enabled."  The original intent behind the ticket was to programatically set this value to true whenever the user logged in to Lightspeed.  In reality though, we only want to make sure that this value is set to true _initially_.  Once the user turns it off, it should stay off.  The easiest way to achieve this was to simply default the value to true on install.  Of course, the suggestion completion won't trigger if the user is logged out of Lightspeed (see above).