### PR TITLE
Refactor vscode-elements textfield value workaround

### DIFF
--- a/package.json
+++ b/package.json
@@ -938,7 +938,7 @@
     "@redhat-developer/vscode-redhat-telemetry": "^0.9.1",
     "@shikijs/core": "2.2.0",
     "@types/ini": "^4.1.1",
-    "@vscode-elements/elements": "^1.11.0",
+    "@vscode-elements/elements": "^1.12.0",
     "@vscode/webview-ui-toolkit": "^1.4.0",
     "ini": "^5.0.0",
     "marked": "^15.0.6",

--- a/src/features/contentCreator/createAnsibleCollectionPage.ts
+++ b/src/features/contentCreator/createAnsibleCollectionPage.ts
@@ -169,7 +169,7 @@ export class CreateAnsibleCollection {
                 </vscode-form-group>
 
                 <div id="full-collection-path" class="full-collection-name">
-                  <p>Default collection path:&nbsp</p>
+                  <p>Project path:&nbsp</p>
                 </div>
 
                 <div class="verbose-div">

--- a/src/webview/apps/contentCreator/addPluginPageApp.ts
+++ b/src/webview/apps/contentCreator/addPluginPageApp.ts
@@ -20,8 +20,6 @@ window.addEventListener("load", main);
 let pluginNameTextField: VscodeTextfield;
 let pluginTypeDropdown: VscodeSingleSelect;
 
-let pluginNameInputField: HTMLInputElement;
-
 let collectionPathUrlTextField: VscodeTextfield;
 let folderExplorerIcon: VscodeIcon;
 
@@ -72,11 +70,6 @@ function main() {
   initOpenScaffoldedFolderButton = document.getElementById(
     "open-folder-button",
   ) as VscodeButton;
-
-  // Workaround for vscode-elements .value limitations for text fields
-  pluginNameInputField = pluginNameTextField.shadowRoot?.querySelector(
-    "#input",
-  ) as HTMLInputElement;
 
   pluginNameTextField.addEventListener("input", toggleCreateButton);
   collectionPathUrlTextField.addEventListener("input", toggleCreateButton);
@@ -140,7 +133,7 @@ function openExplorer(event: any) {
 }
 
 function handleInitClearClick() {
-  pluginNameInputField.value = "";
+  pluginNameTextField.value = "";
   pluginTypeDropdown.value = "filter";
   collectionPathUrlTextField.value = "";
 

--- a/src/webview/apps/contentCreator/createAnsibleCollectionPageApp.ts
+++ b/src/webview/apps/contentCreator/createAnsibleCollectionPageApp.ts
@@ -170,6 +170,7 @@ function openExplorer(event: any) {
         if (selectedUri) {
           if (source === "folder-explorer") {
             initPathUrlTextField.value = selectedUri;
+            initCollectionPathElement.innerHTML = selectedUri;
           } else {
             logFilePath.value = selectedUri;
           }
@@ -180,14 +181,26 @@ function openExplorer(event: any) {
 }
 
 function toggleCreateButton() {
-  //   update collection name <p> tag
-  if (
-    !initNamespaceNameTextField.value.trim() &&
-    !initCollectionNameTextField.value.trim()
-  ) {
+  //   update collection name and project path <p> tags
+
+  const namespaceName = initNamespaceNameTextField.value.trim();
+  const collectionName = initCollectionNameTextField.value.trim();
+  const pathUrl = initPathUrlTextField.value.trim();
+  const placeholderPath = initPathUrlTextField.placeholder as string;
+
+  const namespaceOrCollectionHasValue = namespaceName || collectionName;
+
+  if (!namespaceOrCollectionHasValue) {
     initCollectionNameElement.innerHTML = "namespace.collection";
+    initCollectionPathElement.innerHTML = pathUrl || placeholderPath;
+  } else if (!pathUrl) {
+    initCollectionNameElement.innerHTML = `${namespaceName}.${collectionName}`;
+    initCollectionPathElement.innerHTML = `${
+      placeholderPath
+    }/${namespaceName}/${collectionName}`;
   } else {
-    initCollectionNameElement.innerHTML = `${initNamespaceNameTextField.value.trim()}.${initCollectionNameTextField.value.trim()}`;
+    initCollectionPathElement.innerHTML = pathUrl;
+    initCollectionNameElement.innerHTML = `${namespaceName}.${collectionName}`;
   }
 
   if (

--- a/src/webview/apps/contentCreator/createAnsibleCollectionPageApp.ts
+++ b/src/webview/apps/contentCreator/createAnsibleCollectionPageApp.ts
@@ -20,11 +20,6 @@ window.addEventListener("load", main);
 let initNamespaceNameTextField: VscodeTextfield;
 let initCollectionNameTextField: VscodeTextfield;
 
-let namespaceInputField: HTMLInputElement;
-let collectionInputField: HTMLInputElement;
-let logFilePathInputField: HTMLInputElement;
-let initPathUrlInputField: HTMLInputElement;
-
 let initPathUrlTextField: VscodeTextfield;
 let folderExplorerIcon: VscodeIcon;
 
@@ -111,20 +106,6 @@ function main() {
     "open-folder-button",
   ) as VscodeButton;
 
-  // Workaround for vscode-elements .value limitations for text fields
-  namespaceInputField = initNamespaceNameTextField.shadowRoot?.querySelector(
-    "#input",
-  ) as HTMLInputElement;
-  collectionInputField = initCollectionNameTextField.shadowRoot?.querySelector(
-    "#input",
-  ) as HTMLInputElement;
-  logFilePathInputField = logFilePath.shadowRoot?.querySelector(
-    "#input",
-  ) as HTMLInputElement;
-  initPathUrlInputField = initPathUrlTextField.shadowRoot?.querySelector(
-    "#input",
-  ) as HTMLInputElement;
-
   initNamespaceNameTextField.addEventListener("input", toggleCreateButton);
   initCollectionNameTextField.addEventListener("input", toggleCreateButton);
   initPathUrlTextField.addEventListener("input", toggleCreateButton);
@@ -188,9 +169,9 @@ function openExplorer(event: any) {
 
         if (selectedUri) {
           if (source === "folder-explorer") {
-            initPathUrlInputField.value = selectedUri;
+            initPathUrlTextField.value = selectedUri;
           } else {
-            logFilePathInputField.value = selectedUri;
+            logFilePath.value = selectedUri;
           }
         }
       }
@@ -241,11 +222,10 @@ function toggleEditableModeInstallCheckBox() {
 }
 
 function handleInitClearClick() {
-  namespaceInputField.value = "";
-  collectionInputField.value = "";
-
-  initPathUrlInputField.value = "";
-  logFilePathInputField.value = "";
+  initNamespaceNameTextField.value = "";
+  initCollectionNameTextField.value = "";
+  logFilePath.value = "";
+  initPathUrlTextField.value = "";
 
   initCollectionNameElement.innerHTML = "namespace.collection";
 

--- a/src/webview/apps/contentCreator/createAnsibleProjectPageApp.ts
+++ b/src/webview/apps/contentCreator/createAnsibleProjectPageApp.ts
@@ -23,11 +23,6 @@ let folderExplorerIcon: VscodeIcon;
 let namespaceNameTextField: VscodeTextfield;
 let collectionNameTextField: VscodeTextfield;
 
-let namespaceInputField: HTMLInputElement;
-let collectionInputField: HTMLInputElement;
-let destPathUrlInputField: HTMLInputElement;
-let logFilePathInputField: HTMLInputElement;
-
 let initCreateButton: VscodeButton;
 let initClearButton: VscodeButton;
 
@@ -108,21 +103,6 @@ function main() {
     "open-folder-button",
   ) as VscodeButton;
 
-  // Workaround for vscode-elements .value limitations for text fields
-  namespaceInputField = namespaceNameTextField.shadowRoot?.querySelector(
-    "#input",
-  ) as HTMLInputElement;
-  collectionInputField = collectionNameTextField.shadowRoot?.querySelector(
-    "#input",
-  ) as HTMLInputElement;
-  destPathUrlInputField = destinationPathUrlTextField.shadowRoot?.querySelector(
-    "#input",
-  ) as HTMLInputElement;
-  logFilePathInputField = logFilePath.shadowRoot?.querySelector(
-    "#input",
-  ) as HTMLInputElement;
-
-  // projectNameTextField?.addEventListener("input", toggleCreateButton);
   destinationPathUrlTextField.addEventListener("input", toggleCreateButton);
   namespaceNameTextField.addEventListener("input", toggleCreateButton);
   collectionNameTextField.addEventListener("input", toggleCreateButton);
@@ -179,10 +159,10 @@ function openExplorer(event: any) {
 
         if (selectedUri) {
           if (source === "folder-explorer") {
-            destPathUrlInputField.value = selectedUri;
+            destinationPathUrlTextField.value = selectedUri;
             initCollectionPathElement.innerHTML = selectedUri;
           } else {
-            logFilePathInputField.value = selectedUri;
+            logFilePath.value = selectedUri;
           }
         }
       }
@@ -220,10 +200,10 @@ function toggleCreateButton() {
 }
 
 function handleInitClearClick() {
-  namespaceInputField.value = "";
-  collectionInputField.value = "";
-  destPathUrlInputField.value = "";
-  logFilePathInputField.value = "";
+  namespaceNameTextField.value = "";
+  collectionNameTextField.value = "";
+  destinationPathUrlTextField.value = "";
+  logFilePath.value = "";
 
   initCollectionPathElement.innerHTML =
     destinationPathUrlTextField.placeholder as string;

--- a/src/webview/apps/contentCreator/createExecutionEnvPageApp.ts
+++ b/src/webview/apps/contentCreator/createExecutionEnvPageApp.ts
@@ -46,13 +46,6 @@ let initLogsTextArea: VscodeTextarea;
 let initClearLogsButton: VscodeButton;
 let initOpenScaffoldedFileButton: VscodeButton;
 
-let destinationPathUrlInputField: HTMLInputElement;
-let customBaseImageInputField: HTMLInputElement;
-let systemPackagesInputField: HTMLInputElement;
-let collectionsInputField: HTMLInputElement;
-let pythonPackagesInputField: HTMLInputElement;
-let tagInputField: HTMLInputElement;
-
 let projectUrl = "";
 
 function main() {
@@ -105,27 +98,6 @@ function main() {
   initOpenScaffoldedFileButton = document.getElementById(
     "open-file-button",
   ) as VscodeButton;
-
-  // Workaround for vscode-elements .value limitations for text fields
-  systemPackagesInputField = systemPackagesTextField.shadowRoot?.querySelector(
-    "#input",
-  ) as HTMLInputElement;
-  collectionsInputField = collectionsTextField.shadowRoot?.querySelector(
-    "#input",
-  ) as HTMLInputElement;
-  pythonPackagesInputField = pythonPackagesTextField.shadowRoot?.querySelector(
-    "#input",
-  ) as HTMLInputElement;
-  destinationPathUrlInputField =
-    destinationPathUrlTextField.shadowRoot?.querySelector(
-      "#input",
-    ) as HTMLInputElement;
-  tagInputField = tagTextField.shadowRoot?.querySelector(
-    "#input",
-  ) as HTMLInputElement;
-  customBaseImageInputField = customBaseImageField.shadowRoot?.querySelector(
-    "#input",
-  ) as HTMLInputElement;
 
   destinationPathUrlTextField.addEventListener("input", toggleCreateButton);
 
@@ -208,7 +180,6 @@ function openExplorer(event: any) {
         if (selectedUri) {
           if (source === "folder-explorer") {
             destinationPathUrlTextField.value = selectedUri;
-            destinationPathUrlInputField.value = selectedUri;
             initDestinationPathElement.innerHTML = selectedUri;
           }
         }
@@ -251,26 +222,18 @@ function validateBaseImage() {
 
 function handleInitClearClick() {
   destinationPathUrlTextField.value = "";
-
-  destinationPathUrlInputField.value = "";
-  collectionsInputField.value = "";
-  systemPackagesInputField.value = "";
-  pythonPackagesInputField.value = "";
-  tagInputField.value = "";
-  customBaseImageInputField.value = "";
+  collectionsTextField.value = "";
+  systemPackagesTextField.value = "";
+  pythonPackagesTextField.value = "";
+  tagTextField.value = "";
+  customBaseImageField.value = "";
 
   baseImageDropdown.value = "";
-  customBaseImageField.value = "";
 
   createContextCheckbox.checked = false;
   createContextCheckbox.disabled = false;
 
   buildImageCheckbox.checked = false;
-
-  collectionsTextField.value = "";
-  systemPackagesTextField.value = "";
-  pythonPackagesTextField.value = "";
-  tagTextField.value = "";
 
   suggestedCollectionsCheckboxes.forEach((checkbox) => {
     checkbox.checked = false;

--- a/src/webview/apps/quickLinks/quickLinksApp.ts
+++ b/src/webview/apps/quickLinks/quickLinksApp.ts
@@ -1,10 +1,3 @@
-import {
-  allComponents,
-  provideVSCodeDesignSystem,
-} from "@vscode/webview-ui-toolkit";
-
-provideVSCodeDesignSystem().register(allComponents);
-
 const vscode = acquireVsCodeApi();
 window.addEventListener("load", main);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1586,12 +1586,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vscode-elements/elements@npm:^1.11.0":
-  version: 1.11.0
-  resolution: "@vscode-elements/elements@npm:1.11.0"
+"@vscode-elements/elements@npm:^1.12.0":
+  version: 1.12.0
+  resolution: "@vscode-elements/elements@npm:1.12.0"
   dependencies:
     lit: "npm:^3.2.1"
-  checksum: 10/7d033fa4a779f42d064280cf903a1a0a05c40f60b51f286bb482a880686d14b1c6216361db3367a2e4a3c991ab21331ecd2483596f896c65491ae479a6a386df
+  checksum: 10/44946a286718ad57e6b44fedc255abf5f20df15b7115305a285978bd672fdaabdc5867d7951bb11a978ee28c53c4b37d4e7d63b2e194a12a4e3d527678329e7a
   languageName: node
   linkType: hard
 
@@ -2225,7 +2225,7 @@ __metadata:
     "@types/yargs": "npm:^17.0.33"
     "@typescript-eslint/eslint-plugin": "npm:^8.22.0"
     "@typescript-eslint/parser": "npm:^8.22.0"
-    "@vscode-elements/elements": "npm:^1.11.0"
+    "@vscode-elements/elements": "npm:^1.12.0"
     "@vscode/test-electron": "npm:^2.4.1"
     "@vscode/vsce": "npm:^3.2.2"
     "@vscode/webview-ui-toolkit": "npm:^1.4.0"


### PR DESCRIPTION
This PR removes workarounds related to https://github.com/vscode-elements/elements/issues/271, as that was resolved in vscode-elements 1.12.0. 

Now the VSCodeTextField `.value` attribute can be accessed and utilized correctly to update the inner <input> element. 

This PR also resolves a small issue related to this workaround in the Collection and Playbook Project webviews, where when selecting a folder for the init path, the init path would not be updated. 

An import for webview-ui-toolkit in the Quick Links webview is also removed in this change, since none of those elements are utilized in that webview. 

The collection project webview also now displays the correct init collection path rather than only showing the default path. 