### PR TITLE
Update pre-commit dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,14 +24,14 @@ exclude: >
 minimum_pre_commit_version: 4.0.0 # Related to https://github.com/ekalinin/nodeenv/issues/369
 repos:
   - repo: https://github.com/streetsidesoftware/cspell-cli
-    rev: v8.17.0
+    rev: v8.17.2
     hooks:
       - id: cspell
         args:
           -  --config=cspell.config.yaml
         # name: Spell check with cspell
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.3.0
+    rev: v2.4.1
     hooks:
       - id: codespell
         pass_filenames: false # we want to use its own config
@@ -48,7 +48,7 @@ repos:
           - -e
           - SC1091
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.6
+    rev: v0.9.4
     hooks:
       - id: ruff
         args:
@@ -58,7 +58,7 @@ repos:
       - id: ruff-format # must be after ruff
         types_or: [python, pyi]
   - repo: https://github.com/psf/black # must be after ruff
-    rev: 24.10.0
+    rev: 25.1.0
     hooks:
       - id: black
   - repo: local
@@ -189,7 +189,7 @@ repos:
             docs/als/settings.md
           )$
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.43.0
+    rev: v0.44.0
     hooks:
       - id: markdownlint
         exclude: >

--- a/syntaxes/plist2xml.py
+++ b/syntaxes/plist2xml.py
@@ -77,7 +77,7 @@ def generate_xml(parent: ET.Element, data: pp.ParseResults, level=0, indent=4):
         lines = string.split("\n")
         reindented_lines = [lines[0]]
         for line in lines[1:]:
-            m: Match = re.match(f"^[ ]{{{(level-1)*indent}}}", line)
+            m: Match = re.match(f"^[ ]{{{(level - 1) * indent}}}", line)
             if m:
                 # remove plist indent
                 line = line[len(m.group(0)) :]

--- a/syntaxes/xml2plist.py
+++ b/syntaxes/xml2plist.py
@@ -65,13 +65,16 @@ def convert_to_plist(element: ET.Element, level=0, indent=4, context: str = ""):
         while True:
             try:
                 key_element = next(dict_iter)
-                assert (
-                    key_element.tag == "key"
-                ), f"Got {key_element.tag}({key_element.text}) instead of key"
+                # Skipping black formatting due to https://github.com/astral-sh/ruff/issues/15927
+                # fmt: off
+                assert key_element.tag == "key", (
+                    f"Got {key_element.tag}({key_element.text}) instead of key"
+                )
                 value_element = next(dict_iter, None)
-                assert (
-                    value_element is not None
-                ), f"Got {key_element.tag}({key_element.text}) without value"
+                assert value_element is not None, (
+                    f"Got {key_element.tag}({key_element.text}) without value"
+                )
+                # fmt: on
                 item_str = (
                     f"{inner_indentation}{to_safe_string(key_element.text)} ="
                     f" {convert_to_plist(value_element, level + 1, indent, 'mapping')};"

--- a/syntaxes/xml2plist.py
+++ b/syntaxes/xml2plist.py
@@ -74,7 +74,7 @@ def convert_to_plist(element: ET.Element, level=0, indent=4, context: str = ""):
                 ), f"Got {key_element.tag}({key_element.text}) without value"
                 item_str = (
                     f"{inner_indentation}{to_safe_string(key_element.text)} ="
-                    f" {convert_to_plist(value_element, level+1, indent, 'mapping')};"
+                    f" {convert_to_plist(value_element, level + 1, indent, 'mapping')};"
                 )
                 dict_items.append(item_str)
             except StopIteration:


### PR DESCRIPTION
This updates pre-commit dependencies as detailed in #1801, and adds a block skip for black formatting - due to incompatibilities between ruff and black 25.1.0. 

See: https://github.com/astral-sh/ruff/issues/15927
