### PR TITLE
Swap workbench command to close editor with closeAllEditors from the EditorView

### DIFF
--- a/test/ui-test/lightspeedUiTestPlaybookExpTestNoExpTest.ts
+++ b/test/ui-test/lightspeedUiTestPlaybookExpTestNoExpTest.ts
@@ -12,6 +12,8 @@ import {
 config.truncateThreshold = 0;
 
 describe("Verify playbook explanation features when no explanation is returned", function () {
+  let editorView: EditorView;
+
   beforeEach(function () {
     if (!process.env.TEST_LIGHTSPEED_URL) {
       this.skip();
@@ -51,6 +53,9 @@ describe("Verify playbook explanation features when no explanation is returned",
     expect(text.includes("No explanation provided")).to.be.true;
 
     await webView.switchBack();
-    await workbenchExecuteCommand("View: Close All Editor Groups");
+    editorView = new EditorView();
+    if (editorView) {
+      await editorView.closeAllEditors();
+    }
   });
 });


### PR DESCRIPTION
We're seeing this error intermittently:

```
  1) Verify playbook explanation features when no explanation is returned
       Playbook explanation webview works as expected, no explanation:
     Error: Timeout of 30003ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/Users/runner/work/vscode-ansible/vscode-ansible/out/client/test/ui-test/lightspeedUiTestPlaybookExpTestNoExpTest.js)
      at listOnTimeout (node:internal/timers:581:17)
      at process.processTimers (node:internal/timers:519:7)
```

I believe that's coming from `await workbenchExecuteCommand("View: Close All Editor Groups");` not resolving from time to time.  Opening up this PR to test out whether it improves stability.