### PR TITLE
Bump mocha timeout to 40s as some tests occasionally run longer than 30

### DIFF
--- a/.mocharc.yml
+++ b/.mocharc.yml
@@ -1,7 +1,7 @@
 extension: ["ts"]
 require: ts-node/register
 package: "./package.json"
-timeout: 30003 # default is 2000
+timeout: 40003 # default is 2000
 # most UI tests are >22s due to our current wait times and we do not want
 # red slow marker to distract us until we sort that part yet. Red is expected
 # to appear on unexpected long tests, not on an expected duration.


### PR DESCRIPTION
`lightspeedUiTestPlaybookExpTestNoExpTest.ts` is periodically taking longer than 30 seconds to run and is resulting in failures.  This is not ideal but is a mitigation for now until we can spend some time improving the performance of our tests.