### PR TITLE
Use . instead of source for sourcing scripts

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -110,7 +110,7 @@ tasks:
       - $(git rev-parse --is-shallow-repository) && git fetch --unshallow > /dev/null || true
       - git fetch --tags --force
       - npx ts-node packages/ansible-language-server/tools/settings-doc-generator.ts
-      - bash -c 'source "${VIRTUAL_ENV}/bin/activate" && mkdocs build --strict'
+      - bash -c '. "${VIRTUAL_ENV}/bin/activate" && mkdocs build --strict'
       - tools/dirty.sh
   lint:
     desc: Lint the project
@@ -154,7 +154,7 @@ tasks:
     cmds:
       - task: package
       - "{{.VIRTUAL_ENV}}/bin/python3 --version"
-      - '{{.XVFB}} bash -c ''source "{{.VIRTUAL_ENV}}/bin/activate" &&  COVERAGE=1 MOCK_LIGHTSPEED_API=1 TEST_TYPE=e2e ./tools/test-launcher.sh'''
+      - '{{.XVFB}} bash -c ''. "{{.VIRTUAL_ENV}}/bin/activate" &&  COVERAGE=1 MOCK_LIGHTSPEED_API=1 TEST_TYPE=e2e ./tools/test-launcher.sh'''
     interactive: true
   test-ui:
     desc: Run UI tests {{.XVFB}}
@@ -163,7 +163,7 @@ tasks:
       - yarn webpack-dev
       - "{{.VIRTUAL_ENV}}/bin/python3 --version"
       - bash -c 'rm -rf ./out/test-resources ./out/ext'
-      - ' {{.XVFB}} bash -c ''source "{{.VIRTUAL_ENV}}/bin/activate" && COVERAGE=1 MOCK_LIGHTSPEED_API=1 ./tools/test-launcher.sh'''
+      - ' {{.XVFB}} bash -c ''. "{{.VIRTUAL_ENV}}/bin/activate" && COVERAGE=1 MOCK_LIGHTSPEED_API=1 ./tools/test-launcher.sh'''
     interactive: true
   test-unit:
     desc: Run unit tests with coverage report

--- a/packages/ansible-language-server/Taskfile.yml
+++ b/packages/ansible-language-server/Taskfile.yml
@@ -58,7 +58,7 @@ tasks:
     dir: "{{ .TASKFILE_DIR }}"
     cmds:
       - task: build
-      - bash -c "source {{.VIRTUAL_ENV}}/bin/activate && command -v ansible-lint && npm run test"
+      - bash -c ". {{.VIRTUAL_ENV}}/bin/activate && command -v ansible-lint && npm run test"
     interactive: true
   test:
     desc: Run all tests using node (same version as vscode), will skip @ee tests if both SKIP_PODMAN=1 and SKIP_DOCKER=1.
@@ -84,7 +84,7 @@ tasks:
     cmds:
       - task: build
       - >
-        source {{.VIRTUAL_ENV}}/bin/activate &&
+        . {{.VIRTUAL_ENV}}/bin/activate &&
         bash -c 'npm run test-with-ee'
     interactive: true
   test-without-ee:
@@ -93,7 +93,7 @@ tasks:
     cmds:
       - task: build
       - >
-        source {{.VIRTUAL_ENV}}/bin/activate &&
+        .{{.VIRTUAL_ENV}}/bin/activate &&
         bash -c 'npm run test-without-ee'
     interactive: true
   package:

--- a/packages/ansible-language-server/src/utils/misc.ts
+++ b/packages/ansible-language-server/src/utils/misc.ts
@@ -58,7 +58,7 @@ export function withInterpreter(
   });
 
   if (activationScript) {
-    command = `sh -c 'source ${activationScript} && ${executable} ${args}'`;
+    command = `sh -c '. ${activationScript} && ${executable} ${args}'`;
     return { command: command, env: process.env };
   }
 

--- a/packages/ansible-language-server/test/utils/runCommand.test.ts
+++ b/packages/ansible-language-server/test/utils/runCommand.test.ts
@@ -26,6 +26,7 @@ describe("commandRunner", () => {
       stdout: `${pkgJSON["version"]}`,
       stderr: "",
       pythonInterpreterPath: "",
+      activationScript: "",
     },
     {
       args: ["ansible-config", "dump"],
@@ -33,6 +34,7 @@ describe("commandRunner", () => {
       stdout: "ANSIBLE_FORCE_COLOR",
       stderr: "",
       pythonInterpreterPath: "",
+      activationScript: "",
     },
     {
       args: ["ansible", "--version"],
@@ -40,6 +42,7 @@ describe("commandRunner", () => {
       stdout: "configured module search path",
       stderr: "",
       pythonInterpreterPath: "",
+      activationScript: "",
     },
     {
       args: ["ansible-lint", "--version"],
@@ -47,6 +50,7 @@ describe("commandRunner", () => {
       stdout: "using ansible",
       stderr: "",
       pythonInterpreterPath: "",
+      activationScript: "",
     },
     {
       args: ["ansible-playbook", "missing-file"],
@@ -54,6 +58,7 @@ describe("commandRunner", () => {
       stdout: "",
       stderr: "ERROR! the playbook: missing-file could not be found",
       pythonInterpreterPath: "",
+      activationScript: "",
     },
     {
       args: [
@@ -65,48 +70,66 @@ describe("commandRunner", () => {
       stdout: "path-before-python",
       stderr: "",
       pythonInterpreterPath: "path-before-python/bin/python",
+      activationScript: "",
+    },
+    {
+      args: ["echo", "123"],
+      rc: 0,
+      stdout: "123",
+      stderr: "",
+      pythonInterpreterPath: "path-before-python/bin/python",
+      activationScript: `${process.env.VIRTUAL_ENV}/bin/activate`,
     },
   ];
 
-  tests.forEach(({ args, rc, stdout, stderr, pythonInterpreterPath }) => {
-    it(`call ${args.join(" ")}`, async function () {
-      this.timeout(10000);
+  tests.forEach(
+    ({ args, rc, stdout, stderr, pythonInterpreterPath, activationScript }) => {
+      it(`call ${args.join(" ")}`, async function () {
+        this.timeout(10000);
 
-      // try to enforce ansible to output ANSI in order to check if we are
-      // still able to disable it at runtime in order to keep output parseable.
-      process.env.ANSIBLE_FORCE_COLOR = "1";
+        // try to enforce ansible to output ANSI in order to check if we are
+        // still able to disable it at runtime in order to keep output parseable.
+        process.env.ANSIBLE_FORCE_COLOR = "1";
 
-      process.argv.push("--node-ipc");
-      const connection = createConnection();
-      const workspaceManager = new WorkspaceManager(connection);
-      const textDoc = getDoc("yaml/ancestryBuilder.yml");
-      const context = workspaceManager.getContext(textDoc.uri);
-      if (context) {
-        const settings = await context.documentSettings.get(textDoc.uri);
-        if (pythonInterpreterPath) {
-          settings.python.interpreterPath = pythonInterpreterPath;
-        }
+        process.argv.push("--node-ipc");
+        const connection = createConnection();
+        const workspaceManager = new WorkspaceManager(connection);
+        const textDoc = getDoc("yaml/ancestryBuilder.yml");
+        const context = workspaceManager.getContext(textDoc.uri);
+        if (context) {
+          const settings = await context.documentSettings.get(textDoc.uri);
+          if (pythonInterpreterPath) {
+            settings.python.interpreterPath = pythonInterpreterPath;
+          }
+          if (activationScript) {
+            settings.python.activationScript = activationScript;
+          }
 
-        const commandRunner = new CommandRunner(connection, context, settings);
-        try {
-          const proc = await commandRunner.runCommand(
-            args[0],
-            args.slice(1).join(" "),
+          const commandRunner = new CommandRunner(
+            connection,
+            context,
+            settings,
           );
-          expect(proc.stdout, proc.stderr).contains(stdout);
-          expect(proc.stderr, proc.stdout).contains(stderr);
-        } catch (e) {
-          if (e instanceof AssertionError) {
-            throw e;
-          }
-          if (e instanceof Error) {
-            const err = e as ExecException;
-            expect(err.code).equals(rc);
-            expect(err.stdout).contains(stdout);
-            expect(err.stderr).contains(stderr);
+          try {
+            const proc = await commandRunner.runCommand(
+              args[0],
+              args.slice(1).join(" "),
+            );
+            expect(proc.stdout, proc.stderr).contains(stdout);
+            expect(proc.stderr, proc.stdout).contains(stderr);
+          } catch (e) {
+            if (e instanceof AssertionError) {
+              throw e;
+            }
+            if (e instanceof Error) {
+              const err = e as ExecException;
+              expect(err.code).equals(rc);
+              expect(err.stdout).contains(stdout);
+              expect(err.stderr).contains(stderr);
+            }
           }
         }
-      }
-    });
-  });
+      });
+    },
+  );
 });

--- a/packages/ansible-language-server/test/utils/withInterpreter.test.ts
+++ b/packages/ansible-language-server/test/utils/withInterpreter.test.ts
@@ -19,7 +19,7 @@ describe("withInterpreter", () => {
       interpreterPath: "",
       activationScript: "/path/to/venv/bin/activate",
       expectedCommand:
-        "sh -c 'source /path/to/venv/bin/activate && ansible-lint playbook.yml'",
+        "sh -c '. /path/to/venv/bin/activate && ansible-lint playbook.yml'",
       expectedEnv: {},
     },
     {

--- a/src/features/ansibleTox/runner.ts
+++ b/src/features/ansibleTox/runner.ts
@@ -28,7 +28,7 @@ export async function getToxEnvs(
   )) as string;
 
   if (activationScript) {
-    command = `sh -c 'source ${activationScript} && ${command}'`;
+    command = `sh -c '. ${activationScript} && ${command}'`;
   }
   if (interpreterPath && interpreterPath !== "") {
     const virtualEnv = path.resolve(interpreterPath, "../..");

--- a/src/features/utils/commandRunner.ts
+++ b/src/features/utils/commandRunner.ts
@@ -28,7 +28,7 @@ export function withInterpreter(
 
   const activationScript = settings.activationScript;
   if (activationScript) {
-    command = `sh -c 'source ${activationScript} && ${runExecutable} ${cmdArgs}'`;
+    command = `sh -c '. ${activationScript} && ${runExecutable} ${cmdArgs}'`;
     return { command: command, env: process.env };
   }
 


### PR DESCRIPTION
As not all shells supports 'source' command, we should always use
the '.' command which is more portable.

sh points to dash on Ubuntu and does not have source.

Fixes: #1830
Fixes: #1827
Closes: #1831
