### PR TITLE
Disable flaky lightspeed ui tests

### DIFF
--- a/.mocharc.yml
+++ b/.mocharc.yml
@@ -1,7 +1,7 @@
 extension: ["ts"]
 require: ts-node/register
 package: "./package.json"
-timeout: 40003 # default is 2000
+timeout: 30003 # default is 2000
 # most UI tests are >22s due to our current wait times and we do not want
 # red slow marker to distract us until we sort that part yet. Red is expected
 # to appear on unexpected long tests, not on an expected duration.

--- a/test/ui-test/lightspeedUiTestPlaybookExpTestNoExpTest.ts
+++ b/test/ui-test/lightspeedUiTestPlaybookExpTestNoExpTest.ts
@@ -11,7 +11,7 @@ import {
 
 config.truncateThreshold = 0;
 
-describe("Verify playbook explanation features when no explanation is returned", function () {
+describe.skip("Verify playbook explanation features when no explanation is returned", function () {
   let editorView: EditorView;
 
   beforeEach(function () {

--- a/test/ui-test/lightspeedUiTestPlaybookGenTest.ts
+++ b/test/ui-test/lightspeedUiTestPlaybookGenTest.ts
@@ -22,7 +22,7 @@ import { PlaybookGenerationActionEvent } from "../../src/interfaces/lightspeed";
 
 config.truncateThreshold = 0;
 
-describe("Verify playbook generation features work as expected", function () {
+describe.skip("Verify playbook generation features work as expected", function () {
   let workbench: Workbench;
   let webView: WebView;
 

--- a/test/ui-test/lightspeedUiTestStatusBarAndExplorerViewTest.ts
+++ b/test/ui-test/lightspeedUiTestStatusBarAndExplorerViewTest.ts
@@ -35,7 +35,7 @@ describe("Verify the presence of lightspeed element in the status bar and the ex
     );
     expect(lightspeedStatusBarItem).not.to.be.undefined;
   });
-  it("Ansible Lightspeed status bar item present when only lightspeed is enabled (with warning color)", async () => {
+  it.skip("Ansible Lightspeed status bar item present when only lightspeed is enabled (with warning color)", async () => {
     const statusBar = new StatusBar();
     const editorView = new EditorView();
     const settingsEditor = await openSettings();


### PR DESCRIPTION
Also rolls back the mocha timeout bump to go back to 30s

These are the three suites/cases that I see failing most consistently (although still inconsistent)

Next steps will be handled with https://issues.redhat.com/browse/AAP-40154