### PR TITLE
roleGen: reset the outline if use go back on first page

### DIFF
--- a/webviews/lightspeed/role-generation/src/App.vue
+++ b/webviews/lightspeed/role-generation/src/App.vue
@@ -55,10 +55,16 @@ vscodeApi.on('generateRole', (data: any) => {
   page.value++;
 });
 
+
+
 // Reset some stats before the page transition
-watch(page, () => {
+watch(page, (newPage) => {
   errorMessages.value = [];
   filesWereSaved.value = false;
+  if (newPage === 1) {
+    roleName.value = "";
+    outline.value = "";
+  }
 })
 
 watch(prompt, (newPrompt) => {


### PR DESCRIPTION
When the user goes back to the first page, we need to ignore the `outline` used
previously or we will mess up the next role generation request.
