### PR TITLE
Correct devcontainer webview description

### DIFF
--- a/src/features/contentCreator/createDevcontainerPage.ts
+++ b/src/features/contentCreator/createDevcontainerPage.ts
@@ -119,10 +119,10 @@ export class CreateDevcontainer {
         <body>
             <div class="title-description-div">
               <h1>Create a devcontainer</h1>
-              <p class="subtitle">Leverage Red Hat Openshift Dev Spaces</p>
+              <p class="subtitle">Build containerized development environments</p>
             </div>
             <div class="description-div">
-              <h3>Devcontainers are json files used for development environment customization.<br><br>Enter your project details below to utilize a devcontainer template designed for Red Hat OpenShift Dev Spaces.</h3>
+              <h3>Devcontainers are json files used for building containerized development environments.<br><br>Enter your project details below to utilize a devcontainer template designed for the Dev Containers extension.</h3>
             </div>
 
             <form id="devcontainer-form">

--- a/src/features/quickLinks/quickLinksView.ts
+++ b/src/features/quickLinks/quickLinksView.ts
@@ -124,7 +124,7 @@ export function getWebviewQuickLinks(webview: Webview, extensionUri: Uri) {
           </div>
           <div class="catalogue">
             <h3>
-              <a href="command:ansible.content-creator.create-execution-env-file" title="Create an Execution Environment file.">
+              <a href="command:ansible.content-creator.create-execution-env-file" title="Create an Execution Environment file">
                 <span class="codicon codicon-new-file"></span> Execution environment template
                 <span class="new-badge">NEW</span>
               </a>


### PR DESCRIPTION
Updates the devcontainer webview subheading to one that accurately describes the form. 

Also removes a `.` from the quick links EE link hover description. 