### PR TITLE
roleGen: properly reset the outline when they are changed manually

### DIFF
--- a/webviews/lightspeed/role-generation/src/App.vue
+++ b/webviews/lightspeed/role-generation/src/App.vue
@@ -46,7 +46,7 @@ async function nextPage() {
 vscodeApi.on('generateRole', (data: any) => {
   response.value = undefined; // To disable the watchers
   roleName.value = data["role"];
-  outline.value = data["outline"];
+  outline.value = data["outline"] || outline.value;
   if (Array.isArray(data["warnings"])) {
     errorMessages.value.push(...data["warnings"]);
   }
@@ -55,16 +55,22 @@ vscodeApi.on('generateRole', (data: any) => {
   page.value++;
 });
 
+
+
 // Reset some stats before the page transition
-watch(page, () => {
+watch(page, (newPage) => {
   errorMessages.value = [];
   filesWereSaved.value = false;
+  if (newPage === 1) {
+    roleName.value = "";
+  }
 })
 
 watch(prompt, (newPrompt) => {
   if (response.value !== undefined) {
     console.log(`New prompt is ${newPrompt}`)
     response.value = undefined;
+    outline.value = "";
   }
 })
 
@@ -128,7 +134,8 @@ watch(outline, (newOutline) => {
       Role name: <vscode-text-field v-model="roleName" />
     </div>
 
-    <OutlineReview :outline @outline-update="(newOutline) => outline = newOutline" />
+    <OutlineReview :outline
+      @outline-update="(newOutline: string) => { console.log(`new outline: ${newOutline}`); outline = newOutline; }" />
 
     <div>
       <vscode-button @click.once="nextPage">

--- a/webviews/lightspeed/role-generation/src/components/OutlineReview.vue
+++ b/webviews/lightspeed/role-generation/src/components/OutlineReview.vue
@@ -6,21 +6,21 @@ const emit = defineEmits<{ outlineUpdate: [outline: string] }>();
 
 function outlineWithLineNumber() {
   let textField = document.querySelector("#outline-field") as HTMLTextAreaElement;
-  const originalPosition = textField?.selectionStart;
 
+  const originalPosition = textField?.selectionStart || 0;
   textField.value = textField.value.split("\n").map((l) => l.replace(/\d+\.\s/, '')).map((l, idx) => { return `${idx + 1}. ${l}` }).join("\n");
+
   const newPosition = textField.value[originalPosition - 1] === '\n' ? originalPosition + 3 : originalPosition;
   textField.setSelectionRange(newPosition, newPosition)
   emit("outlineUpdate", textField.value);
-
 }
 </script>
 
 <template>
   <div>
     <h4>Review the suggested steps for your role and modify as needed.</h4>
-    <textarea id="outline-field" :rows="outline.split('\n').length + 2" :cols="outline.split('\n')[0].length + 5"
-      :value="outline.toString()" @input="outlineWithLineNumber" />
+    <textarea id="outline-field" :rows="outline.split('\n').length + 2" :cols="70" :value="outline.toString()"
+      @input="outlineWithLineNumber" />
   </div>
 </template>
 


### PR DESCRIPTION
When the user goes back to the first page, we need to ignore the `outline` used
previously or we will mess up the next role generation request.

- reset the request if the outline get changed
- don't reset the outline if the user get back on page one
  - the outline and request will be reset only if the user changes the prompt
- keep the prompt if the WCA answer has not prompt set
- finally, if `selectionStart()` returns `undefined`, we default on `0`
