### PR TITLE
test-launcher.sh: reset the VSCode settings between tests

### DIFF
--- a/tools/test-launcher.sh
+++ b/tools/test-launcher.sh
@@ -63,6 +63,9 @@ function refresh_settings() {
     if [ "${TEST_LIGHTSPEED_URL}" != "" ]; then
         sed -i.bak "s,https://c.ai.ansible.redhat.com,$TEST_LIGHTSPEED_URL," out/settings.json
     fi
+    rm -rf out/test-resources/settings/
+
+    jq < out/settings.json
 }
 
 


### PR DESCRIPTION
The goal is to avoid the situation where a test open an account session
that breaks the following test.
