### PR TITLE
Add support for lightspeed role explanation

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -13,4 +13,6 @@ sonar.cpd.exclusions=\
     test/units/lightspeed/utils/handleApiError.test.ts, \
     src/features/lightspeed/vue/views/playbookGenPanel.ts, \
     webviews/lightspeed/src/playbook-generation.ts, \
-    src/features/lightspeed/vue/views/helper.ts
+    src/features/lightspeed/vue/views/helper.ts, \
+    src/webview/apps/lightspeed/roleExplanation/main.ts, \
+    src/features/lightspeed/roleExplanation.ts

--- a/media/roleExplanation/style.css
+++ b/media/roleExplanation/style.css
@@ -1,0 +1,78 @@
+a:link {
+    text-decoration: none;
+  }
+
+  a:visited {
+    text-decoration: none;
+  }
+
+  a:hover {
+    text-decoration: none;
+  }
+
+  a:active {
+    text-decoration: none;
+  }
+
+  .roleGeneration {
+    right: 0px;
+    bottom: 0px;
+  }
+
+  .roleGeneration h2 {
+    color: var(--vscode-foreground);
+    text-align: left;
+    margin-block-end: 0.2em;
+    font-weight: 400;
+  }
+
+  .roleGeneration h4 {
+    color: var(--vscode-foreground);
+    margin-block-end: 0.2em;
+    font-weight: bold;
+  }
+
+  /* override the default .codicon class */
+  .codicon[class*='codicon-'] {
+    position: relative;
+    font-size: 24px;
+    width: calc(var(--design-unit) * 6px);
+    height: calc(var(--design-unit) * 6px);
+  }
+
+  .roleExplanationSpacer {
+    height: 30px;
+  }
+
+  .stickyFeedbackContainer {
+    position: sticky;
+    bottom: 0px;
+  }
+
+  .feedbackContainer {
+    background-color: var(--vscode-editor-background, #ffffff80);
+    position: absolute;
+    right: 0px;
+    bottom: 0px;
+    display: flex;
+    opacity: 0.8;
+  }
+
+  .iconButton {
+    width: 36px;
+    height: 36px;
+    margin: 0.2em;
+    background: var(--button-icon-background);
+    border-radius: var(--button-icon-corner-radius);
+    color: var(--foreground);
+    opacity: 1.0;
+  }
+
+  .iconButtonSelected {
+    width: 36px;
+    height: 36px;
+    margin: 0.2em;
+    background: var(--button-primary-background);
+    color: var(--button-primary-foreground);
+    opacity: 1.0;
+  }

--- a/package.json
+++ b/package.json
@@ -414,11 +414,20 @@
       },
       {
         "command": "ansible.lightspeed.thumbsUpDown",
-        "title": "Send Lightspeed Thumbs Up/Down Feedback"
+        "title": "Send Lightspeed Thumbs Up/Down Feedback on playbook explanation"
+      },
+      {
+        "command": "ansible.lightspeed.roleThumbsUpDown",
+        "title": "Send Lightspeed Thumbs Up/Down Feedback on role explanation"
       },
       {
         "command": "ansible.lightspeed.playbookExplanation",
         "title": "Explain the playbook with Ansible Lightspeed"
+      },
+      {
+        "command": "ansible.lightspeed.roleExplanation",
+        "enablement": "redhat.ansible.lightspeedExperimentalEnabled",
+        "title": "Explain the role with Ansible Lightspeed"
       },
       {
         "command": "ansible.lightspeed.openTrialPage",
@@ -793,6 +802,11 @@
           "group": "2_main@1",
           "command": "ansible.lightspeed.playbookExplanation",
           "when": "redhat.ansible.lightspeedSuggestionsEnabled && editorLangId == ansible"
+        },
+        {
+          "group": "2_main@1",
+          "command": "ansible.lightspeed.roleExplanation",
+          "when": "redhat.ansible.lightspeedExperimentalEnabled"
         },
         {
           "when": "resourceFilename == 'execution-environment.yml' || resourceFilename == 'execution-environment.yaml'",

--- a/src/definitions/lightspeed.ts
+++ b/src/definitions/lightspeed.ts
@@ -54,6 +54,8 @@ export namespace LightSpeedCommands {
   export const LIGHTSPEED_PLAYBOOK_GENERATION =
     "ansible.lightspeed.playbookGeneration";
   export const LIGHTSPEED_ROLE_GENERATION = "ansible.lightspeed.roleGeneration";
+  export const LIGHTSPEED_ROLE_EXPLANATION =
+    "ansible.lightspeed.roleExplanation";
   export const LIGHTSPEED_SIGN_IN_WITH_REDHAT =
     "ansible.lightspeed.signInWithRedHat";
   export const LIGHTSPEED_SIGN_IN_WITH_LIGHTSPEED =
@@ -68,6 +70,7 @@ export const LIGHTSPEED_API_VERSION_V1 = "v1";
 export const LIGHTSPEED_PLAYBOOK_EXPLANATION_URL = `${LIGHTSPEED_API_VERSION}/ai/explanations/`;
 export const LIGHTSPEED_PLAYBOOK_GENERATION_URL = `${LIGHTSPEED_API_VERSION}/ai/generations/`;
 export const LIGHTSPEED_ROLE_GENERATION_URL = `${LIGHTSPEED_API_VERSION_V1}/ai/generations/role/`;
+export const LIGHTSPEED_ROLE_EXPLANATION_URL = `${LIGHTSPEED_API_VERSION_V1}/ai/explanations/role/`;
 export const LIGHTSPEED_SUGGESTION_COMPLETION_URL = `${LIGHTSPEED_API_VERSION}/ai/completions/`;
 export const LIGHTSPEED_SUGGESTION_FEEDBACK_URL = `${LIGHTSPEED_API_VERSION}/ai/feedback/`;
 export const LIGHTSPEED_SUGGESTION_CONTENT_MATCHES_URL = `${LIGHTSPEED_API_VERSION}/ai/contentmatches/`;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -45,6 +45,7 @@ import {
   setDocumentChanged,
 } from "./features/lightspeed/inlineSuggestions";
 import { playbookExplanation } from "./features/lightspeed/playbookExplanation";
+import { roleExplanation } from "./features/lightspeed/roleExplanation";
 import { ContentMatchesWebview } from "./features/lightspeed/contentMatchesWebview";
 import {
   setPythonInterpreter,
@@ -69,7 +70,10 @@ import {
   LightspeedUser,
   AuthProviderType,
 } from "./features/lightspeed/lightspeedUser";
-import { PlaybookFeedbackEvent } from "./interfaces/lightspeed";
+import {
+  PlaybookFeedbackEvent,
+  RoleFeedbackEvent,
+} from "./interfaces/lightspeed";
 import { CreateDevfile } from "./features/contentCreator/createDevfilePage";
 import { CreateExecutionEnv } from "./features/contentCreator/createExecutionEnvPage";
 import { CreateDevcontainer } from "./features/contentCreator/createDevcontainerPage";
@@ -615,6 +619,15 @@ export async function activate(context: ExtensionContext): Promise<void> {
   );
 
   context.subscriptions.push(
+    vscode.commands.registerTextEditorCommand(
+      LightSpeedCommands.LIGHTSPEED_ROLE_EXPLANATION,
+      async () => {
+        await roleExplanation(context.extensionUri);
+      },
+    ),
+  );
+
+  context.subscriptions.push(
     vscode.commands.registerCommand(
       "ansible.lightspeed.thumbsUpDown",
       async (param: PlaybookFeedbackEvent) => {
@@ -631,6 +644,19 @@ export async function activate(context: ExtensionContext): Promise<void> {
             true,
           );
         }
+      },
+    ),
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "ansible.lightspeed.roleThumbsUpDown",
+      async (param: RoleFeedbackEvent) => {
+        lightSpeedManager.apiInstance.feedbackRequest(
+          { roleExplanationFeedback: param },
+          true,
+          true,
+        );
       },
     ),
   );

--- a/src/features/lightspeed/api.ts
+++ b/src/features/lightspeed/api.ts
@@ -12,11 +12,13 @@ import {
   GenerationRequestParams,
   PlaybookGenerationResponseParams,
   RoleGenerationResponseParams,
+  RoleExplanationRequestParams,
 } from "../../interfaces/lightspeed";
 import {
   LIGHTSPEED_PLAYBOOK_EXPLANATION_URL,
   LIGHTSPEED_PLAYBOOK_GENERATION_URL,
   LIGHTSPEED_ROLE_GENERATION_URL,
+  LIGHTSPEED_ROLE_EXPLANATION_URL,
   LIGHTSPEED_SUGGESTION_COMPLETION_URL,
   LIGHTSPEED_SUGGESTION_CONTENT_MATCHES_URL,
   LIGHTSPEED_SUGGESTION_FEEDBACK_URL,
@@ -364,6 +366,39 @@ export class LightSpeedAPI {
       );
       const response = await this.lightspeedPost(
         LIGHTSPEED_ROLE_GENERATION_URL,
+        JSON.stringify(requestData),
+      );
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        throw new HTTPError(response, response.status, data);
+      }
+
+      return data;
+    } catch (error) {
+      const mappedError: IError = mapError(error as Error);
+      return mappedError;
+    }
+  }
+
+  public async roleExplanationRequest(
+    inputData: RoleExplanationRequestParams,
+  ): Promise<ExplanationResponseParams | IError> {
+    try {
+      const requestData = {
+        ...inputData,
+        metadata: { ansibleExtensionVersion: this._extensionVersion },
+      };
+
+      console.log(
+        `[ansible-lightspeed] Role explanation request sent to lightspeed: ${JSON.stringify(
+          requestData,
+        )}`,
+      );
+
+      const response = await this.lightspeedPost(
+        LIGHTSPEED_ROLE_EXPLANATION_URL,
         JSON.stringify(requestData),
       );
 

--- a/src/features/lightspeed/explorerWebviewViewProvider.ts
+++ b/src/features/lightspeed/explorerWebviewViewProvider.ts
@@ -15,6 +15,7 @@ import {
 import { LightspeedUser } from "./lightspeedUser";
 
 import { isPlaybook } from "./playbookExplanation";
+import { isDocumentInRole } from "./roleExplanation";
 
 export class LightspeedExplorerWebviewViewProvider
   implements WebviewViewProvider
@@ -77,6 +78,7 @@ export class LightspeedExplorerWebviewViewProvider
         extensionUri,
         String(content),
         this.hasPlaybookOpened(),
+        await this.hasRoleOpened(),
       );
     } else {
       return getWebviewContentWithLoginForm(webview, extensionUri);
@@ -88,6 +90,18 @@ export class LightspeedExplorerWebviewViewProvider
     if (document !== undefined && document.languageId === "ansible") {
       try {
         return isPlaybook(document.getText());
+      } catch {
+        return false;
+      }
+    }
+    return false;
+  }
+
+  private async hasRoleOpened() {
+    const document = window.activeTextEditor?.document;
+    if (document !== undefined) {
+      try {
+        return await isDocumentInRole(document);
       } catch {
         return false;
       }

--- a/src/features/lightspeed/inlineSuggestion/additionalContext.ts
+++ b/src/features/lightspeed/inlineSuggestion/additionalContext.ts
@@ -11,9 +11,9 @@ import {
 import {
   getVarsFilesContext,
   getRelativePath,
-  getRolePathFromPathWithinRole,
   getIncludeVarsContext,
 } from "../utils/data";
+import { getRoleNamePathFromFilePath } from "../utils/getRoleNamePathFromFilePath";
 import { lightSpeedManager } from "../../../extension";
 import { getCustomRolePaths } from "../../utils/ansible";
 import { watchRolesDirectory } from "../utils/watchers";
@@ -71,7 +71,7 @@ export function getAdditionalContext(
     playbookContext["roles"] = rolesCache;
   } else if (ansibleFileType === "tasks_in_role") {
     const roleCache = lightSpeedManager.ansibleRolesCache;
-    const absRolePath = getRolePathFromPathWithinRole(documentFilePath);
+    const absRolePath = getRoleNamePathFromFilePath(documentFilePath);
     if (
       workSpaceRoot &&
       workSpaceRoot in roleCache &&

--- a/src/features/lightspeed/roleExplanation.ts
+++ b/src/features/lightspeed/roleExplanation.ts
@@ -1,0 +1,264 @@
+import * as vscode from "vscode";
+import { getNonce } from "../utils/getNonce";
+import { getUri } from "../utils/getUri";
+import { isError, IError, UNKNOWN_ERROR } from "./utils/errors";
+import * as marked from "marked";
+import { lightSpeedManager } from "../../extension";
+import {
+  ExplanationResponseParams,
+  GenerationListEntry,
+} from "../../interfaces/lightspeed";
+import { LightSpeedAPI } from "./api";
+
+import { v4 as uuidv4 } from "uuid";
+import { getOneClickTrialProvider } from "./utils/oneClickTrial";
+import * as fs from "fs/promises";
+import { getRoleNameFromFilePath } from "./utils/getRoleNameFromFilePath";
+import { getRoleNamePathFromFilePath } from "./utils/getRoleNamePathFromFilePath";
+import { getRoleYamlFiles } from "./utils/data";
+
+function directoryContainsSomeRoleDirectories(files: string[]): boolean {
+  const roleDirectories = [
+    "tasks",
+    "handlers",
+    "templates",
+    "files",
+    "vars",
+    "defaults",
+    "meta",
+  ];
+  return files.some((file) => roleDirectories.includes(file));
+}
+
+export async function isDocumentInRole(
+  document: vscode.TextDocument,
+): Promise<boolean> {
+  const fileNameParts = document.fileName.split("/");
+  const rolesIndex = fileNameParts.findIndex((part) => part === "roles");
+  if (rolesIndex >= 0 && rolesIndex + 1 < fileNameParts.length) {
+    const dir = await fs.readdir(
+      fileNameParts.slice(0, rolesIndex + 2).join("/"),
+    );
+
+    const containsRoleDirectories = directoryContainsSomeRoleDirectories(dir);
+    if (containsRoleDirectories) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export const roleExplanation = async (extensionUri: vscode.Uri) => {
+  if (!vscode.window.activeTextEditor) {
+    return;
+  }
+  const document = vscode.window.activeTextEditor.document;
+  const documentInRole = await isDocumentInRole(document);
+
+  if (!documentInRole) {
+    return;
+  }
+
+  const explanationId = uuidv4();
+  const currentPanel = RoleExplanationPanel.createOrShow(
+    extensionUri,
+    explanationId,
+  );
+
+  lightSpeedManager.apiInstance.feedbackRequest(
+    { roleExplanation: { explanationId: explanationId } },
+    false,
+    false,
+  );
+
+  const roleName = getRoleNameFromFilePath(document.fileName);
+  const rolePath = getRoleNamePathFromFilePath(document.fileName);
+
+  const files = await getRoleYamlFiles(rolePath);
+
+  currentPanel.setContent(
+    `<div id="icons">
+        <span class="codicon codicon-loading codicon-modifier-spin"></span>
+        &nbsp;Generating the explanation for role: ${roleName}
+      </div>`,
+  );
+
+  const lightSpeedStatusbarText =
+    await lightSpeedManager.statusBarProvider.getLightSpeedStatusBarText();
+
+  let markdown = "";
+  lightSpeedManager.statusBarProvider.statusBar.text = `$(loading~spin) ${lightSpeedStatusbarText}`;
+  try {
+    await generateRoleExplanation(
+      lightSpeedManager.apiInstance,
+      files,
+      roleName,
+      explanationId,
+    ).then(async (response: ExplanationResponseParams | IError) => {
+      if (isError(response)) {
+        const oneClickTrialProvider = getOneClickTrialProvider();
+        if (!(await oneClickTrialProvider.showPopup(response))) {
+          const errorMessage: string = `${response.message ?? UNKNOWN_ERROR} ${response.detail ?? ""}`;
+          vscode.window.showErrorMessage(errorMessage);
+          currentPanel.setContent(
+            `<p><span class="codicon codicon-error"></span>The operation has failed:<p>${errorMessage}</p></p>`,
+          );
+        }
+      } else {
+        markdown = response.content;
+        if (markdown.length === 0) {
+          markdown = "### No explanation provided.";
+        }
+        const html_snippet = marked.parse(markdown) as string;
+        currentPanel.setContent(html_snippet, true);
+      }
+    });
+  } catch (e) {
+    currentPanel.setContent(
+      `<p><span class="codicon codicon-error"></span>
+      &nbsp;Cannot load the explanation: <code>${e}</code></p>`,
+    );
+    return;
+  } finally {
+    lightSpeedManager.statusBarProvider.statusBar.text =
+      lightSpeedStatusbarText;
+  }
+};
+
+async function generateRoleExplanation(
+  apiInstance: LightSpeedAPI,
+  files: GenerationListEntry[],
+  roleName: string,
+  explanationId: string,
+): Promise<ExplanationResponseParams | IError> {
+  const response: ExplanationResponseParams | IError =
+    await apiInstance.roleExplanationRequest({
+      files: files,
+      roleName: roleName,
+      explanationId: explanationId,
+    });
+
+  return response;
+}
+
+export class RoleExplanationPanel {
+  public static readonly currentPanel: RoleExplanationPanel | undefined;
+
+  public static readonly viewType = "Explanation";
+
+  private readonly _panel: vscode.WebviewPanel;
+  private readonly _extensionUri: vscode.Uri;
+  private readonly _disposables: vscode.Disposable[] = [];
+
+  public static createOrShow(extensionUri: vscode.Uri, explanationId: string) {
+    const panel = vscode.window.createWebviewPanel(
+      RoleExplanationPanel.viewType,
+      "Explanation",
+      vscode.ViewColumn.Beside,
+      {
+        enableScripts: true,
+        localResourceRoots: [
+          vscode.Uri.joinPath(extensionUri, "out"),
+          vscode.Uri.joinPath(extensionUri, "media"),
+        ],
+        enableCommandUris: true,
+        retainContextWhenHidden: true,
+      },
+    );
+
+    panel.webview.onDidReceiveMessage((message) => {
+      const command = message.command;
+      switch (command) {
+        case "thumbsUp":
+        case "thumbsDown":
+          vscode.commands.executeCommand(
+            "ansible.lightspeed.roleThumbsUpDown",
+            {
+              action: message.action,
+              explanationId: explanationId,
+            },
+          );
+          break;
+      }
+    });
+
+    return new RoleExplanationPanel(panel, extensionUri);
+  }
+
+  private constructor(panel: vscode.WebviewPanel, extensionUri: vscode.Uri) {
+    this._panel = panel;
+    this._extensionUri = extensionUri;
+
+    this._panel.webview.onDidReceiveMessage(
+      (message) => {
+        if (message.command === "alert") {
+          vscode.window.showErrorMessage(message.text);
+        }
+      },
+      null,
+      this._disposables,
+    );
+  }
+
+  public setContent(htmlSnippet: string, showFeedbackBox = false) {
+    this._panel.webview.html = this.buildFullHtml(htmlSnippet, showFeedbackBox);
+  }
+
+  private buildFullHtml(htmlSnippet: string, showFeedbackBox = false) {
+    const webview = this._panel.webview;
+    const webviewUri = getUri(webview, this._extensionUri, [
+      "out",
+      "client",
+      "webview",
+      "apps",
+      "lightspeed",
+      "roleExplanation",
+      "main.js",
+    ]);
+    const styleUri = getUri(webview, this._extensionUri, [
+      "media",
+      "roleExplanation",
+      "style.css",
+    ]);
+    const codiconsUri = getUri(webview, this._extensionUri, [
+      "media",
+      "codicons",
+      "codicon.css",
+    ]);
+    const nonce = getNonce();
+
+    const feedbackBoxSnippet = `<div class="stickyFeedbackContainer">
+    <div class="feedbackContainer">
+    <vscode-button class="iconButton" appearance="icon" id="thumbsup-button">
+        <span class="codicon codicon-thumbsup"></span>
+    </vscode-button>
+    <vscode-button class="iconButton" appearance="icon" id="thumbsdown-button">
+        <span class="codicon codicon-thumbsdown"></span>
+    </vscode-button>
+    </div>
+    </div>`;
+
+    return `<!DOCTYPE html>
+			<html lang="en">
+			<head>
+				<meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'nonce-${nonce}'; style-src ${
+          webview.cspSource
+        }; font-src ${webview.cspSource};">
+        <link rel="stylesheet" href="${codiconsUri}">
+        <link rel="stylesheet" href="${styleUri}">
+				<title>Role explanation</title>
+			</head>
+			<body>
+        <div class="roleExplanation">
+          ${htmlSnippet}
+          <div class="roleExplanationSpacer"></div>
+        </div>
+        ${showFeedbackBox ? feedbackBoxSnippet : ""}
+
+        <script type="module" nonce="${nonce}" src="${webviewUri}"></script>
+			</body>
+			</html>`;
+  }
+}

--- a/src/features/lightspeed/utils/explorerView.ts
+++ b/src/features/lightspeed/utils/explorerView.ts
@@ -1,6 +1,7 @@
 import { Disposable, Webview, Uri, commands } from "vscode";
 import { getUri } from "../../utils/getUri";
 import { getNonce } from "../../utils/getNonce";
+import { lightSpeedManager } from "../../../extension";
 
 export function getWebviewContentWithLoginForm(
   webview: Webview,
@@ -54,6 +55,7 @@ export function getWebviewContentWithActiveSession(
   extensionUri: Uri,
   content: string,
   has_playbook_opened: boolean,
+  has_role_opened: boolean,
 ) {
   const webviewUri = getUri(webview, extensionUri, [
     "out",
@@ -86,6 +88,16 @@ export function getWebviewContentWithActiveSession(
   <script type="module" nonce="${nonce}" src="${webviewUri}"></script>
   </form>
   </div>`;
+  const explainRoleForm = `<div class="button-container">
+  <form id="role-explanation-form">
+    <vscode-button id="lightspeed-explorer-role-explanation-submit" class="lightspeedExplorerButton" ${
+      has_role_opened
+        ? ""
+        : "disabled title='The file in the active editor view is not part of an Ansible role' "
+    }>Explain the current role</vscode-button>
+  <script type="module" nonce="${nonce}" src="${webviewUri}"></script>
+  </form>
+  </div>`;
 
   return /*html*/ `
   <!DOCTYPE html>
@@ -105,6 +117,7 @@ export function getWebviewContentWithActiveSession(
       ${content}
       ${generateForm}
       ${explainForm}
+      ${lightSpeedManager.lightspeedExplorerProvider.lightspeedExperimentalEnabled ? explainRoleForm : ""}
     </div>
     </body>
   </html>
@@ -132,6 +145,9 @@ export function setWebviewMessageListener(
           return;
         case "explain":
           commands.executeCommand("ansible.lightspeed.playbookExplanation");
+          return;
+        case "explainRole":
+          commands.executeCommand("ansible.lightspeed.roleExplanation");
           return;
       }
     },

--- a/src/features/lightspeed/utils/getRoleNameFromFilePath.ts
+++ b/src/features/lightspeed/utils/getRoleNameFromFilePath.ts
@@ -1,0 +1,12 @@
+import * as path from "path";
+
+export function getRoleNameFromFilePath(filePath: string): string {
+  const fileNameParts = filePath.split(path.sep);
+  const rolesIndex = fileNameParts.lastIndexOf("roles");
+
+  if (rolesIndex >= 0 && rolesIndex + 1 < fileNameParts.length) {
+    return fileNameParts[rolesIndex + 1];
+  }
+
+  return "";
+}

--- a/src/features/lightspeed/utils/getRoleNamePathFromFilePath.ts
+++ b/src/features/lightspeed/utils/getRoleNamePathFromFilePath.ts
@@ -1,0 +1,14 @@
+import * as path from "path";
+
+export function getRoleNamePathFromFilePath(filePath: string): string {
+  const fileNameParts = filePath.split(path.sep);
+  const rolesIndex = fileNameParts.lastIndexOf("roles");
+  if (rolesIndex >= 0 && rolesIndex + 1 < fileNameParts.length) {
+    return fileNameParts
+      .concat(path.sep)
+      .slice(0, rolesIndex + 2)
+      .join(path.sep);
+  }
+
+  return "";
+}

--- a/src/features/lightspeed/utils/watchers.ts
+++ b/src/features/lightspeed/utils/watchers.ts
@@ -4,7 +4,7 @@ import * as fs from "fs";
 import { globalFileSystemWatcher } from "../../../extension";
 import { LightSpeedManager } from "../base";
 import { IAnsibleType } from "../../../interfaces/watchers";
-import { getRolePathFromPathWithinRole } from "./data";
+import { getRoleNamePathFromFilePath } from "./getRoleNamePathFromFilePath";
 import { readVarFiles } from "./readVarFiles";
 import { updateRoleContext, updateRolesContext } from "./updateRolesContext";
 
@@ -98,7 +98,7 @@ export function watchRolesDirectory(
     const currentWorkspaceRoot = vscode.workspace.workspaceFolders;
     if (currentWorkspaceRoot) {
       const workspaceRoot = currentWorkspaceRoot[0].uri.fsPath;
-      const rolePath = getRolePathFromPathWithinRole(uri.fsPath);
+      const rolePath = getRoleNamePathFromFilePath(uri.fsPath);
       updateRoleContext(
         lightSpeedManager.ansibleRolesCache,
         rolePath,
@@ -132,7 +132,7 @@ export function watchRolesDirectory(
     const currentWorkspaceRoot = vscode.workspace.workspaceFolders;
     if (currentWorkspaceRoot) {
       const workspaceRoot = currentWorkspaceRoot[0].uri.fsPath;
-      const rolePath = getRolePathFromPathWithinRole(uri.fsPath);
+      const rolePath = getRoleNamePathFromFilePath(uri.fsPath);
       updateRoleContext(
         lightSpeedManager.ansibleRolesCache,
         rolePath,

--- a/src/interfaces/lightspeed.ts
+++ b/src/interfaces/lightspeed.ts
@@ -96,6 +96,16 @@ export interface RoleGenerationActionEvent {
   toPage?: number;
 }
 
+export interface RoleExplanationEvent {
+  explanationId?: string;
+}
+
+export interface RoleFeedbackEvent {
+  action: ThumbsUpDownAction;
+  explanationId?: string;
+  generationId?: string;
+}
+
 export interface FeedbackRequestParams {
   inlineSuggestion?: InlineSuggestionEvent;
   sentimentFeedback?: SentimentFeedbackEvent;
@@ -105,6 +115,8 @@ export interface FeedbackRequestParams {
   playbookExplanationFeedback?: PlaybookFeedbackEvent;
   playbookGenerationAction?: PlaybookGenerationActionEvent;
   roleGenerationAction?: RoleGenerationActionEvent;
+  roleExplanation?: RoleExplanationEvent;
+  roleExplanationFeedback?: RoleFeedbackEvent;
   playbookOutlineFeedback?: PlaybookFeedbackEvent;
   model?: string;
 }
@@ -161,7 +173,7 @@ export interface PlaybookGenerationResponseParams {
   generationId: string;
 }
 
-export enum GenerationFileType {
+export enum RoleFileType {
   Default = "default",
   Task = "task",
   Playbook = "playbook",
@@ -169,7 +181,7 @@ export enum GenerationFileType {
 
 export interface GenerationListEntry {
   path: string;
-  file_type: GenerationFileType;
+  file_type: RoleFileType;
   content: string;
 }
 
@@ -178,6 +190,12 @@ export interface RoleGenerationResponseParams {
   outline?: string;
   generationId: string;
   role: string;
+}
+
+export interface RoleExplanationRequestParams {
+  files: GenerationListEntry[];
+  explanationId: string;
+  roleName: string;
 }
 
 export interface ExplanationRequestParams {

--- a/src/webview/apps/lightspeed/explorer/main.ts
+++ b/src/webview/apps/lightspeed/explorer/main.ts
@@ -27,6 +27,10 @@ function main() {
     "lightspeed-explorer-playbook-explanation-submit",
     lightspeedExplorerPlaybookExplanation,
   );
+  setListener(
+    "lightspeed-explorer-role-explanation-submit",
+    lightspeedExplorerRoleExplanation,
+  );
 }
 
 function lightspeedConnect() {
@@ -39,4 +43,8 @@ function lightspeedExplorerPlaybookGeneration() {
 
 function lightspeedExplorerPlaybookExplanation() {
   vscode.postMessage({ command: "explain" });
+}
+
+function lightspeedExplorerRoleExplanation() {
+  vscode.postMessage({ command: "explainRole" });
 }

--- a/src/webview/apps/lightspeed/roleExplanation/main.ts
+++ b/src/webview/apps/lightspeed/roleExplanation/main.ts
@@ -1,0 +1,62 @@
+import {
+  provideVSCodeDesignSystem,
+  Button,
+  vsCodeButton,
+} from "@vscode/webview-ui-toolkit";
+import { ThumbsUpDownAction } from "../../../../definitions/lightspeed";
+
+provideVSCodeDesignSystem().register(vsCodeButton());
+
+const vscode = acquireVsCodeApi();
+
+window.addEventListener("load", main);
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function setListener(id: string, func: any) {
+  const button = document.getElementById(id) as Button;
+  if (button) {
+    button.addEventListener("click", () => func());
+  }
+}
+
+function main() {
+  setListener("thumbsup-button", sendThumbsup);
+  setListener("thumbsdown-button", sendThumbsdown);
+  changeDisplay("feedbackContainer", "flex");
+}
+
+function changeDisplay(className: string, displayState: string) {
+  const elements = document.getElementsByClassName(className);
+  for (const element of elements) {
+    (element as HTMLElement).style.display = displayState;
+  }
+}
+function sendThumbsup() {
+  const thumbsUpButton = document.getElementById("thumbsup-button") as Button;
+  const thumbsDownButton = document.getElementById(
+    "thumbsdown-button",
+  ) as Button;
+  thumbsUpButton.setAttribute("class", "iconButtonSelected");
+  thumbsUpButton.setAttribute("disabled", "true");
+  thumbsDownButton.setAttribute("class", "iconButton");
+  thumbsDownButton.setAttribute("disabled", "true");
+  vscode.postMessage({
+    command: "thumbsUp",
+    action: ThumbsUpDownAction.UP,
+  });
+}
+
+function sendThumbsdown() {
+  const thumbsUpButton = document.getElementById("thumbsup-button") as Button;
+  const thumbsDownButton = document.getElementById(
+    "thumbsdown-button",
+  ) as Button;
+  thumbsUpButton.setAttribute("class", "iconButton");
+  thumbsUpButton.setAttribute("disabled", "true");
+  thumbsDownButton.setAttribute("class", "iconButtonSelected");
+  thumbsDownButton.setAttribute("disabled", "true");
+  vscode.postMessage({
+    command: "thumbsDown",
+    action: ThumbsUpDownAction.DOWN,
+  });
+}

--- a/test/mockLightspeedServer/roleExplanations.ts
+++ b/test/mockLightspeedServer/roleExplanations.ts
@@ -1,0 +1,53 @@
+import { v4 as uuidv4 } from "uuid";
+import { logger, options, permissionDeniedCanApplyForTrial } from "./server";
+
+export function roleExplanations(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  req: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  res: any,
+) {
+  const roleName = req.body.roleName;
+  const explanationId = req.body.explanationId
+    ? req.body.explanationId
+    : uuidv4();
+  const format = "markdown";
+  logger.info(`role: ${roleName}`);
+
+  if (options.oneClick) {
+    return res.status(403).json(permissionDeniedCanApplyForTrial());
+  }
+
+  // Special case to replicate the feature being unavailable
+  if (roleName && roleName === "role_not_available") {
+    logger.info("Returning 404. Feature is not available");
+    return res.status(404).send({
+      code: "feature_not_available",
+      message: "The feature is not available",
+    });
+  }
+
+  // Special case to replicate explanation being unavailable
+  if (roleName !== undefined && roleName === "role_no_explanation") {
+    logger.info("Returning empty content. Explanation is not available");
+    return res.send({
+      content: "",
+      format,
+      explanationId,
+    });
+  }
+
+  // cSpell: disable
+  const content = `
+## Role overview
+
+This is an example role overview.
+`;
+  // cSpell: enable
+
+  return res.send({
+    content,
+    format,
+    explanationId,
+  });
+}

--- a/test/mockLightspeedServer/server.ts
+++ b/test/mockLightspeedServer/server.ts
@@ -6,6 +6,7 @@ import { explanations } from "./explanations";
 import { feedback, getFeedbacks } from "./feedback";
 import { playbookGeneration } from "./playbookGeneration";
 import { roleGeneration } from "./roleGeneration";
+import { roleExplanations } from "./roleExplanations";
 import { me } from "./me";
 import { openUrl } from "./openUrl";
 import * as winston from "winston";
@@ -100,6 +101,11 @@ export default class Server {
     app.post(`${API_ROOT}/ai/explanations`, async (req, res) => {
       await new Promise((r) => setTimeout(r, 500)); // fake 500ms latency
       return explanations(req, res);
+    });
+
+    app.post(`${API_ROOT_V1}/ai/explanations/role`, async (req, res) => {
+      await new Promise((r) => setTimeout(r, 500)); // fake 500ms latency
+      return roleExplanations(req, res);
     });
 
     app.post(`${API_ROOT}/ai/feedback`, (req, res) => {

--- a/test/testFixtures/lightspeed/roles/example_role/tasks/main.yml
+++ b/test/testFixtures/lightspeed/roles/example_role/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- name: Print hello world
+  ansible.builtin.debug:
+    msg: "Hello world"

--- a/test/ui-test/lightspeedUiTestRoleExpTest.ts
+++ b/test/ui-test/lightspeedUiTestRoleExpTest.ts
@@ -1,0 +1,108 @@
+// BEFORE: ansible.lightspeed.suggestions.enabled: true
+
+import { expect, config } from "chai";
+import { By, VSBrowser, EditorView, Workbench } from "vscode-extension-tester";
+import * as path from "path";
+import {
+  getFixturePath,
+  sleep,
+  getWebviewByLocator,
+  workbenchExecuteCommand,
+  dismissNotifications,
+} from "./uiTestHelper";
+
+config.truncateThreshold = 0;
+
+async function testThumbsButtonInteraction(buttonToClick: string) {
+  const folder = path.join("lightspeed", "roles", "example_role", "tasks");
+  const filePath = getFixturePath(folder, "main.yml");
+
+  // Open file in the editor
+  await VSBrowser.instance.openResources(filePath);
+
+  // Open role explanation webview.
+  await workbenchExecuteCommand("Explain the role with Ansible Lightspeed");
+  await sleep(2000);
+
+  await new EditorView().openEditor("Explanation", 1);
+  // Locate the role explanation webview
+  const webView = await getWebviewByLocator(
+    By.xpath("//div[contains(@class, 'roleExplanation') ]"),
+  );
+
+  // Find the main div element of the webview and verify the expected text is found.
+  const mainDiv = await webView.findWebElement(
+    By.xpath("//div[contains(@class, 'roleExplanation') ]"),
+  );
+  expect(mainDiv, "mainDiv should not be undefined").not.to.be.undefined;
+  const text = await mainDiv.getText();
+  expect(text.includes("This is an example role overview.")).to.be.true;
+
+  const thumbsUpButton = await webView.findWebElement(
+    By.xpath("//vscode-button[@id='thumbsup-button']"),
+  );
+  expect(thumbsUpButton, "thumbsUpButton should not be undefined").not.to.be
+    .undefined;
+
+  const thumbsDownButton = await webView.findWebElement(
+    By.xpath("//vscode-button[@id='thumbsdown-button']"),
+  );
+  expect(thumbsDownButton, "thumbsDownButton should not be undefined").not.to.be
+    .undefined;
+
+  expect(
+    await thumbsUpButton.isEnabled(),
+    `Thumbs up button should be enabled now`,
+  ).to.be.true;
+
+  expect(
+    await thumbsDownButton.isEnabled(),
+    `Thumbs down button should be enabled now`,
+  ).to.be.true;
+
+  const button =
+    buttonToClick === "thumbsup" ? thumbsUpButton : thumbsDownButton;
+  await button.click();
+
+  await sleep(2000);
+
+  expect(
+    await thumbsUpButton.getAttribute("disabled"),
+    "Thumbs up button should be disabled now",
+  ).equals("true");
+
+  expect(
+    await thumbsDownButton.getAttribute("disabled"),
+    "Thumbs down button should be disabled now",
+  ).equals("true");
+
+  await webView.switchBack();
+  await workbenchExecuteCommand("View: Close All Editor Groups");
+}
+
+describe("Verify role explanation features work as expected", function () {
+  let workbench: Workbench;
+  beforeEach(function () {
+    if (!process.env.TEST_LIGHTSPEED_URL) {
+      this.skip();
+    }
+  });
+
+  before(async function () {
+    workbench = new Workbench();
+    await workbenchExecuteCommand(
+      "Ansible Lightspeed: Enable experimental features",
+    );
+    await workbenchExecuteCommand("View: Close All Editor Groups");
+
+    await dismissNotifications(workbench);
+  });
+
+  it("Role explanation thumbs up/down button disabled after thumbs up", async function () {
+    await testThumbsButtonInteraction("thumbsup");
+  });
+
+  it("Role explanation thumbs up/down button disabled after thumbs down", async function () {
+    await testThumbsButtonInteraction("thumbsdown");
+  });
+});

--- a/test/units/lightspeed/utils/getRoleNameFromRolePath.test.ts
+++ b/test/units/lightspeed/utils/getRoleNameFromRolePath.test.ts
@@ -1,0 +1,44 @@
+import { expect } from "chai";
+import * as path from "path";
+import { getRoleNameFromFilePath } from "../../../../src/features/lightspeed/utils/getRoleNameFromFilePath";
+
+describe("getRoleNameFromFilePath", () => {
+  it("should return the role name when the path contains 'roles'", () => {
+    const testPath = path.join(
+      "some",
+      "path",
+      "roles",
+      "my_role",
+      "tasks",
+      "main.yml",
+    );
+    const roleName = getRoleNameFromFilePath(testPath);
+    expect(roleName).to.equal("my_role");
+  });
+
+  it("should return an empty string when the path does not contain 'roles'", () => {
+    const testPath = path.join("some", "path", "my_role", "tasks", "main.yml");
+    const roleName = getRoleNameFromFilePath(testPath);
+    expect(roleName).to.equal("");
+  });
+
+  it("should return an empty string when 'roles' is the last part of the path", () => {
+    const testPath = path.join("some", "path", "roles");
+    const roleName = getRoleNameFromFilePath(testPath);
+    expect(roleName).to.equal("");
+  });
+
+  it("should handle paths with multiple 'roles' segments correctly", () => {
+    const testPath = path.join(
+      "some",
+      "roles",
+      "path",
+      "roles",
+      "my_role",
+      "tasks",
+      "main.yml",
+    );
+    const roleName = getRoleNameFromFilePath(testPath);
+    expect(roleName).to.equal("my_role");
+  });
+});

--- a/test/units/lightspeed/utils/getRoleNamePathFromFilePath.test.ts
+++ b/test/units/lightspeed/utils/getRoleNamePathFromFilePath.test.ts
@@ -1,0 +1,51 @@
+import { expect } from "chai";
+import * as path from "path";
+import { getRoleNamePathFromFilePath } from "../../../../src/features/lightspeed/utils/getRoleNamePathFromFilePath";
+
+describe("getRoleNamePathFromFilePath", () => {
+  it("should return the correct role name path when the file path contains 'roles'", () => {
+    const testPath = path.join(
+      "vscode-ansible",
+      "roles",
+      "myRole",
+      "tasks",
+      "main.yml",
+    );
+    const result = getRoleNamePathFromFilePath(testPath);
+    expect(result).to.equal(path.join("vscode-ansible", "roles", "myRole"));
+  });
+
+  it("should return an empty string when the file path does not contain 'roles'", () => {
+    const testPath = path.join("vscode-ansible", "playbooks", "main.yml");
+    const result = getRoleNamePathFromFilePath(testPath);
+    expect(result).to.equal("");
+  });
+
+  it("should return the correct role name path when the file path contains multiple 'roles'", () => {
+    const testPath = path.join(
+      "Users",
+      "ansible",
+      "Desktop",
+      "vscode-ansible",
+      "roles",
+      "role1",
+      "roles",
+      "role2",
+      "tasks",
+      "main.yml",
+    );
+    const result = getRoleNamePathFromFilePath(testPath);
+    expect(result).to.equal(
+      path.join(
+        "Users",
+        "ansible",
+        "Desktop",
+        "vscode-ansible",
+        "roles",
+        "role1",
+        "roles",
+        "role2",
+      ),
+    );
+  });
+});

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -166,6 +166,19 @@ const playbookExplanationWebviewConfig = {
   },
 };
 
+const roleExplanationWebviewConfig = {
+  ...config,
+  target: ["web", "es2020"],
+  entry: "./src/webview/apps/lightspeed/roleExplanation/main.ts",
+  experiments: { outputModule: true },
+  output: {
+    path: path.resolve(__dirname, "out"),
+    filename: "./client/webview/apps/lightspeed/roleExplanation/main.js",
+    libraryTarget: "module",
+    chunkFormat: "module",
+  },
+};
+
 const createAnsibleCollectionWebviewConfig = {
   ...config,
   target: ["web", "es2020"],
@@ -261,6 +274,7 @@ module.exports = (_env: any, argv: { mode: string }) => {
     createAnsibleCollectionWebviewConfig,
     playbookExplorerWebviewConfig,
     playbookExplanationWebviewConfig,
+    roleExplanationWebviewConfig,
     createAnsibleProjectWebviewConfig,
     createDevfileWebviewConfig,
     createDevcontainerWebviewConfig,

--- a/webviews/lightspeed/src/PlaybookGenApp.vue
+++ b/webviews/lightspeed/src/PlaybookGenApp.vue
@@ -4,7 +4,7 @@ import type { Ref } from 'vue'
 import { vscodeApi } from './utils';
 import { allComponents, provideVSCodeDesignSystem } from '@vscode/webview-ui-toolkit';
 
-import { PlaybookGenerationResponseParams, GenerationFileType, FeedbackRequestParams } from "../../../src/interfaces/lightspeed";
+import { PlaybookGenerationResponseParams, RoleFileType, FeedbackRequestParams } from "../../../src/interfaces/lightspeed";
 import { WizardGenerationActionType } from '../../../src/definitions/lightspeed';
 
 import OutlineReview from './components/OutlineReview.vue';
@@ -126,7 +126,7 @@ sendActionEvent(WizardGenerationActionType.OPEN, undefined, 1);
 
   <div v-else-if="page === 3">
     <GeneratedFileEntry
-      :file="{ 'content': response ? response.playbook : '', 'path': 'new_playbook.yaml', 'file_type': GenerationFileType.Playbook }" />
+      :file="{ 'content': response ? response.playbook : '', 'path': 'new_playbook.yaml', 'file_type': RoleFileType.Playbook }" />
     <div>
       <vscode-button @click="openEditor">
         Open editor


### PR DESCRIPTION
Addresses https://issues.redhat.com/browse/AAP-40496

This PR adds UI support for role explanation.  It includes basic logic to detect whether a focused file is part of a "role" by traversing the file directory structure looking for the hallmarks of an Ansible role like a `/roles` directory along with one of the required sub-directories (see https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_reuse_roles.html#role-directory-structure).

Note that the right-click menu item shows up all the time.  I'll be filing a follow-up ticket to address that functionality in a later PR.

Also of note, the corresponding lightspeed API endpoint is currently being built.  Until that's available the request to actually fetch the explanation will fail