### PR TITLE
README: updated Lightspeed Getting Started link

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -150,7 +150,7 @@ holding `ctrl`/`cmd`.
 
 AI based Ansible code recommendations
 
-- [Getting started](https://access.redhat.com/documentation/en-us/red_hat_ansible_lightspeed_with_ibm_watsonx_code_assistant/2.x_latest/html/red_hat_ansible_lightspeed_with_ibm_watsonx_code_assistant_user_guide/configuring-with-code-assistant_lightspeed-user-guide#doc-wrapper)
+- [Getting started](https://docs.redhat.com/en/documentation/red_hat_ansible_lightspeed_with_ibm_watsonx_code_assistant/2.x_latest/html/red_hat_ansible_lightspeed_with_ibm_watsonx_code_assistant_user_guide/set-up-lightspeed_lightspeed-user-guide#set-up-lightspeed_lightspeed-user-guide)
 
 - [Contact](https://matrix.to/#/%23ansible-lightspeed:ansible.im)
 


### PR DESCRIPTION
The actual Getting Started link actually returns a 404 that prevents users from accessing the documentation making the process of setting up Lightspeed a bit more annoying.
I replaced it with the actual, working link