### PR TITLE
Add support to scaffold generic module plugins in the plugin webview

### DIFF
--- a/src/features/contentCreator/addPluginPage.ts
+++ b/src/features/contentCreator/addPluginPage.ts
@@ -141,6 +141,7 @@ export class AddPlugin {
                       <vscode-option>Action</vscode-option>
                       <vscode-option>Filter</vscode-option>
                       <vscode-option>Lookup</vscode-option>
+                      <vscode-option>Module</vscode-option>
                     </vscode-single-select>
                   </div>
                 </div>
@@ -357,6 +358,7 @@ export class AddPlugin {
       lookup: "24.12.1",
       filter: "24.12.1",
       action: "25.0.0",
+      module: "25.3.0",
     };
     const requiredCreatorVersion =
       minRequiredCreatorVersion[pluginType.toLowerCase()];

--- a/src/features/contentCreator/addPluginPage.ts
+++ b/src/features/contentCreator/addPluginPage.ts
@@ -9,6 +9,7 @@ import { PluginFormInterface, PostMessageEvent } from "./types";
 import { withInterpreter } from "../utils/commandRunner";
 import { SettingsManager } from "../../settings";
 import { expandPath, runCommand, getCreatorVersion } from "./utils";
+import plugin from "@highlightjs/vue-plugin";
 
 export class AddPlugin {
   public static currentPanel: AddPlugin | undefined;
@@ -385,16 +386,6 @@ export class AddPlugin {
         status: commandResult,
       },
     } as PostMessageEvent);
-
-    if (commandResult === "passed") {
-      const selection = await vscode.window.showInformationMessage(
-        `${pluginType} plugin '${pluginName}' added at: ${destinationPathUrl}/plugins`,
-        `Open plugin file ↗`,
-      );
-      if (selection === "Open plugin file ↗") {
-        this.openFolderInWorkspace(destinationPathUrl, pluginName, pluginType);
-      }
-    }
   }
 
   public async openFolderInWorkspace(
@@ -413,7 +404,11 @@ export class AddPlugin {
     }
 
     // open the plugin file in the editor
-    const pluginFileUrl = `${folderUrl}/plugins/${pluginType.toLowerCase() !== "module" ? pluginType.toLowerCase() : "sample_module"}/${pluginName}.py`;
+    const pluginTypeDir =
+      pluginType.toLowerCase() === "module"
+        ? "sample_module"
+        : pluginType.toLowerCase();
+    const pluginFileUrl = `${folderUrl}/plugins/${pluginTypeDir}/${pluginName}.py`;
     console.log(`[ansible-creator] Plugin file url: ${pluginFileUrl}`);
     const parsedUrl = vscode.Uri.parse(`vscode://file${pluginFileUrl}`);
     console.log(`[ansible-creator] Parsed galaxy file url: ${parsedUrl}`);

--- a/src/features/contentCreator/addPluginPage.ts
+++ b/src/features/contentCreator/addPluginPage.ts
@@ -9,7 +9,6 @@ import { PluginFormInterface, PostMessageEvent } from "./types";
 import { withInterpreter } from "../utils/commandRunner";
 import { SettingsManager } from "../../settings";
 import { expandPath, runCommand, getCreatorVersion } from "./utils";
-import plugin from "@highlightjs/vue-plugin";
 
 export class AddPlugin {
   public static currentPanel: AddPlugin | undefined;

--- a/src/features/contentCreator/addPluginPage.ts
+++ b/src/features/contentCreator/addPluginPage.ts
@@ -413,7 +413,7 @@ export class AddPlugin {
     }
 
     // open the plugin file in the editor
-    const pluginFileUrl = `${folderUrl}/plugins/${pluginType.toLowerCase()}/${pluginName}.py`;
+    const pluginFileUrl = `${folderUrl}/plugins/${pluginType.toLowerCase() !== "module" ? pluginType.toLowerCase() : "sample_module"}/${pluginName}.py`;
     console.log(`[ansible-creator] Plugin file url: ${pluginFileUrl}`);
     const parsedUrl = vscode.Uri.parse(`vscode://file${pluginFileUrl}`);
     console.log(`[ansible-creator] Parsed galaxy file url: ${parsedUrl}`);

--- a/src/webview/apps/contentCreator/addPluginPageApp.ts
+++ b/src/webview/apps/contentCreator/addPluginPageApp.ts
@@ -151,7 +151,7 @@ function toggleCreateButton() {
   if (!collectionPathUrlTextField.value.trim()) {
     initCollectionPathElement.innerHTML = `${
       collectionPathUrlTextField.placeholder
-    }/plugins/${pluginTypeDropdown.value.trim()}/${pluginNameTextField.value.trim()}`;
+    }/plugins/${pluginTypeDropdown.value.trim() !== "module" ? pluginTypeDropdown.value.trim() : "sample_module"}/${pluginNameTextField.value.trim()}`;
 
     if (!pluginNameTextField.value.trim()) {
       initCollectionPathElement.innerHTML =
@@ -222,7 +222,10 @@ function handleInitOpenScaffoldedFolderClick() {
     payload: {
       projectUrl: projectUrl,
       pluginName: pluginNameTextField.value.trim(),
-      pluginType: pluginTypeDropdown.value.trim(),
+      pluginType:
+        pluginTypeDropdown.value.trim() !== "module"
+          ? pluginTypeDropdown.value.trim()
+          : "sample_module",
     },
   });
 }

--- a/src/webview/apps/contentCreator/addPluginPageApp.ts
+++ b/src/webview/apps/contentCreator/addPluginPageApp.ts
@@ -151,7 +151,7 @@ function toggleCreateButton() {
   if (!collectionPathUrlTextField.value.trim()) {
     initCollectionPathElement.innerHTML = `${
       collectionPathUrlTextField.placeholder
-    }/plugins/${pluginTypeDropdown.value.trim() !== "module" ? pluginTypeDropdown.value.trim() : "sample_module"}/${pluginNameTextField.value.trim()}`;
+    }/plugins/${pluginTypeDropdown.value.trim()}/${pluginNameTextField.value.trim()}`;
 
     if (!pluginNameTextField.value.trim()) {
       initCollectionPathElement.innerHTML =
@@ -222,10 +222,7 @@ function handleInitOpenScaffoldedFolderClick() {
     payload: {
       projectUrl: projectUrl,
       pluginName: pluginNameTextField.value.trim(),
-      pluginType:
-        pluginTypeDropdown.value.trim() !== "module"
-          ? pluginTypeDropdown.value.trim()
-          : "sample_module",
+      pluginType: pluginTypeDropdown.value.trim(),
     },
   });
 }

--- a/test/ui-test/contentCreatorUiTest.ts
+++ b/test/ui-test/contentCreatorUiTest.ts
@@ -369,6 +369,15 @@ describe("Test collection plugins scaffolding", () => {
       "Action",
     );
   });
+  it("Check add-plugin webview elements for generic module plugin", async () => {
+    await testWebViewElements(
+      "Ansible: Add a Plugin",
+      "~",
+      "Add Plugin",
+      "test_plugin_name",
+      "Module",
+    );
+  });
   it("Verify Open Plugin button is enabled and plugin file exists", async () => {
     await testWebViewElements(
       "Ansible: Add a Plugin",


### PR DESCRIPTION
**SUMMARY**

This PR updates the existing plugin webview to add support for generic module plugin scaffolding by simply adding "Module" in the existing plugin-type dropdown.
Related JIRA: https://issues.redhat.com/browse/AAP-36651

![image](https://github.com/user-attachments/assets/940ab479-c4f1-4dd1-8338-49974be860f0)
