### PR TITLE
lightpseed gen: no not "No results found" message

### DIFF
--- a/webviews/lightspeed/src/components/PromptField.vue
+++ b/webviews/lightspeed/src/components/PromptField.vue
@@ -37,7 +37,7 @@ vscodeApi.post('getRecentPrompts', {});
         <label><strong>Describe what you want to achieve in natural language</strong></label>
         <div class="fieldBox">
             <AutoComplete id="PromptTextField" fluid v-model="prompt" size="small" :suggestions="recentPromptsFiltered"
-                :placeholder @complete="search" />
+                :placeholder @complete="search" :showEmptyMessage="false" />
         </div>
     </div>
 </template>


### PR DESCRIPTION
Don't display anymore the `No results found` message when the prompt
history is empty.
