### PR TITLE
Lightspeed/roleGen: miscellaneous minor changes

### DIFF
--- a/src/features/lightspeed/vue/views/helper.ts
+++ b/src/features/lightspeed/vue/views/helper.ts
@@ -273,7 +273,7 @@ export class WebviewHelper {
               };
 
               savedFilesEntries.push({
-                longPath: `collections/${collectionName.replace(".", "/")}/roles/${roleName}/${f.file_type}s/main.yml`,
+                longPath: `${collectionName.replace(".", "/")}/roles/${roleName}/${f.file_type}s/main.yml`,
                 command: `command:vscode.open?${encodeURIComponent(JSON.stringify(linkUri))}`,
               });
             }

--- a/test/ui-test/lightspeedRoleGenTest.ts
+++ b/test/ui-test/lightspeedRoleGenTest.ts
@@ -139,7 +139,7 @@ describe("Verify Role generation feature works as expected", function () {
     await sleep(1000);
     const link = await webView.findWebElement(
       By.xpath(
-        "//a[contains(text(), 'collections/community/dummy/roles/install_nginx/tasks/main.yml')]",
+        "//a[contains(text(), 'community/dummy/roles/install_nginx/tasks/main.yml')]",
       ),
     );
     await link.click();

--- a/webviews/lightspeed/src/components/CollectionSelector.vue
+++ b/webviews/lightspeed/src/components/CollectionSelector.vue
@@ -2,7 +2,8 @@
 import AutoComplete from 'primevue/autocomplete';
 
 import { ref, Ref } from 'vue';
-import { AnsibleCollection } from "../../../../../src/features/lightspeed/utils/scanner";
+import { AnsibleCollection } from "../../../../src/features/lightspeed/utils/scanner";
+
 import { vscodeApi } from '../utils';
 
 const collectionName = defineModel<string>("collectionName", { type: String });

--- a/webviews/lightspeed/src/components/PromptField.vue
+++ b/webviews/lightspeed/src/components/PromptField.vue
@@ -37,7 +37,7 @@ vscodeApi.post('getRecentPrompts', {});
         <label><strong>Describe what you want to achieve in natural language</strong></label>
         <div class="fieldBox">
             <AutoComplete id="PromptTextField" fluid v-model="prompt" size="small" :suggestions="recentPromptsFiltered"
-                :placeholder @complete="search" />
+                :placeholder @complete="search" :showEmptyMessage="false" />
         </div>
     </div>
 </template>


### PR DESCRIPTION
- The file paths were incorrectly built with the `collections/` prefix.
- Also adjust the location of the `AnsibleCollection` class.
- Don't display anymore the `No results found` message when the prompt history is empty.
