### PR TITLE
AAP-42164: lightspeedl: roleGen: properly pass the role name key

### DIFF
--- a/src/features/lightspeed/api.ts
+++ b/src/features/lightspeed/api.ts
@@ -9,7 +9,8 @@ import {
   ExplanationResponseParams,
   FeedbackRequestParams,
   FeedbackResponseParams,
-  GenerationRequestParams,
+  PlaybookGenerationRequestParams,
+  RoleGenerationRequestParams,
   PlaybookGenerationResponseParams,
   RoleGenerationResponseParams,
   RoleExplanationRequestParams,
@@ -319,7 +320,7 @@ export class LightSpeedAPI {
   }
 
   public async playbookGenerationRequest(
-    inputData: GenerationRequestParams,
+    inputData: PlaybookGenerationRequestParams,
   ): Promise<PlaybookGenerationResponseParams | IError> {
     try {
       const requestData = {
@@ -352,7 +353,7 @@ export class LightSpeedAPI {
   }
 
   public async roleGenerationRequest(
-    inputData: GenerationRequestParams,
+    inputData: RoleGenerationRequestParams,
   ): Promise<RoleGenerationResponseParams | IError> {
     try {
       const requestData = {
@@ -370,6 +371,11 @@ export class LightSpeedAPI {
       );
 
       const data = await response.json();
+
+      // to remove after roleGen GA
+      if (data.role && !data.name) {
+        data.name = data.role;
+      }
 
       if (!response.ok) {
         throw new HTTPError(response, response.status, data);

--- a/src/features/lightspeed/vue/views/helper.ts
+++ b/src/features/lightspeed/vue/views/helper.ts
@@ -10,6 +10,7 @@ import {
   RoleGenerationResponseParams,
   GenerationListEntry,
   FeedbackRequestParams,
+  RoleGenerationRequestParams,
 } from "../../../../interfaces/lightspeed";
 
 import { lightSpeedManager } from "../../../../extension";
@@ -61,19 +62,23 @@ async function getRoleBaseDir(
 
 async function generateRole(
   apiInstance: LightSpeedAPI,
+  name: string | undefined,
   text: string,
   outline: string,
   generationId: string,
 ): Promise<RoleGenerationResponseParams | IError> {
   const createOutline = outline.length === 0;
 
+  const params: RoleGenerationRequestParams = {
+    text,
+    outline: outline.length > 0 ? outline : undefined,
+    createOutline,
+    generationId,
+    name: name,
+  };
+
   const response: RoleGenerationResponseParams | IError =
-    await apiInstance.roleGenerationRequest({
-      text,
-      outline: outline.length > 0 ? outline : undefined,
-      createOutline,
-      generationId,
-    });
+    await apiInstance.roleGenerationRequest(params);
   return response;
 }
 
@@ -142,6 +147,7 @@ export class WebviewHelper {
             const generationId = uuidv4();
             const response = await generateRole(
               lightSpeedManager.apiInstance,
+              data.name,
               data.text,
               data.outline,
               generationId,

--- a/src/interfaces/lightspeed.ts
+++ b/src/interfaces/lightspeed.ts
@@ -159,7 +159,16 @@ export interface ISuggestionDetails {
   isPlaybook: boolean;
 }
 
-export interface GenerationRequestParams {
+export interface PlaybookGenerationRequestParams {
+  text: string;
+  outline?: string;
+  generationId: string;
+  createOutline: boolean;
+  wizardId?: string;
+}
+
+export interface RoleGenerationRequestParams {
+  name?: string;
   text: string;
   outline?: string;
   generationId: string;
@@ -189,7 +198,8 @@ export interface RoleGenerationResponseParams {
   files: GenerationListEntry[];
   outline?: string;
   generationId: string;
-  role: string;
+  name: string;
+  role?: string; // deprecated
 }
 
 export interface RoleExplanationRequestParams {

--- a/test/mockLightspeedServer/roleGeneration.ts
+++ b/test/mockLightspeedServer/roleGeneration.ts
@@ -52,6 +52,7 @@ export function roleGeneration(
   return res.send({
     files,
     outline: createOutline ? outline : "",
+    //name: "install_nginx",
     role: "install_nginx",
     generationId,
   });

--- a/test/ui-test/lightspeedRoleGenTest.ts
+++ b/test/ui-test/lightspeedRoleGenTest.ts
@@ -125,11 +125,6 @@ describe("Verify Role generation feature works as expected", function () {
     await collectionNameTextField.sendKeys("community.dummy");
     await collectionNameTextField.click();
 
-    // const button = await webView.findWebElement(
-    //   By.xpath("//vscode-button[contains(text(), 'Analyze')]"),
-    // );
-    // await button.click();
-
     await (
       await webView.findWebElement(
         By.xpath("//vscode-button[contains(text(), 'Save files')]"),

--- a/webviews/lightspeed/src/RoleGenApp.vue
+++ b/webviews/lightspeed/src/RoleGenApp.vue
@@ -47,18 +47,18 @@ async function nextPage() {
     return;
   }
   loadingNewResponse.value = true;
-  await vscodeApi.post('generateRole', { text: prompt.value, outline: outline.value });
+  await vscodeApi.post('generateRole', { name: roleName.value, text: prompt.value, outline: outline.value });
 
 }
 
 vscodeApi.on('generateRole', (data: any) => {
   response.value = undefined; // To disable the watchers
-  roleName.value = data["role"];
   outline.value = data["outline"] || outline.value;
   if (Array.isArray(data["warnings"])) {
     errorMessages.value.push(...data["warnings"]);
   }
   response.value = data as RoleGenerationResponseParams;
+  roleName.value = data["name"];
   loadingNewResponse.value = false;
   page.value++;
 });
@@ -79,7 +79,7 @@ watch(prompt, (newPrompt) => {
 })
 
 watch(roleName, (newRoleName) => {
-  if (response.value !== undefined && response.value["role"] !== newRoleName) {
+  if (response.value !== undefined && response.value["name"] !== newRoleName) {
     response.value = undefined;
   }
 })


### PR DESCRIPTION
We need the role `name` key to allow the user to overwrite the default name as returned by the LLM.

See: https://github.com/ansible/ansible-ai-connect-service/pull/1569
