### PR TITLE
webpack: ensure server.js is properly bundled

### DIFF
--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -80,11 +80,11 @@ const config = {
   ],
   output: {
     filename: (pathData: { chunk: { name: string } }) => {
-        console.log(pathData);
-        console.log(pathData.chunk.name);
-        return pathData.chunk.name === "client"
-            ? "[name]/src/extension.js"
-            : "[name]/src/[name].js";
+      console.log(pathData);
+      console.log(pathData.chunk.name);
+      return pathData.chunk.name === "client"
+        ? "[name]/src/extension.js"
+        : "[name]/src/[name].js";
     },
     path: path.resolve(__dirname, "out"),
     libraryTarget: "commonjs2",

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -18,7 +18,6 @@ const config = {
     vscode: "commonjs vscode", // the vscode-module is created on-the-fly and must be excluded. Add other modules that cannot be webpack'ed
     shiki: "shiki",
   },
-  mode: "none",
   module: {
     rules: [
       {
@@ -80,7 +79,13 @@ const config = {
     },
   ],
   output: {
-    //filename: (pathData: { chunk: { name: string } }) => "[name]/src/[name].js",
+    filename: (pathData: { chunk: { name: string } }) => {
+        console.log(pathData);
+        console.log(pathData.chunk.name);
+        return pathData.chunk.name === "client"
+            ? "[name]/src/extension.js"
+            : "[name]/src/[name].js";
+    },
     path: path.resolve(__dirname, "out"),
     libraryTarget: "commonjs2",
     devtoolModuleFilenameTemplate: (info: { id: string }) => {


### PR DESCRIPTION
- Restore the way `filename` was generated from f15881a419cd855636440442f1e20e00363793f2.
- Ensure the optimizations are enabled for a production build

See: https://webpack.js.org/configuration/mode/#mode-none
