### PR TITLE
Hide Lightspeed status bar when user is not logged in

### DIFF
--- a/src/features/lightspeed/statusBar.ts
+++ b/src/features/lightspeed/statusBar.ts
@@ -94,7 +94,12 @@ export class LightspeedStatusBar {
   }
 
   public async updateLightSpeedStatusbar(): Promise<void> {
-    if (vscode.window.activeTextEditor?.document.languageId !== "ansible") {
+    const userDetails =
+      await this.lightspeedAuthenticatedUser.getLightspeedUserDetails(false);
+    if (
+      vscode.window.activeTextEditor?.document.languageId !== "ansible" ||
+      !userDetails
+    ) {
       this.statusBar.hide();
       return;
     }


### PR DESCRIPTION
Relates to: https://issues.redhat.com/browse/AAP-42377

The intent here is to hide the Lightspeed status bar when the user is not logged in to Lightspeed.  The impetus for this was the removal of the Lightspeed enabled checkbox which used to control whether or not this item showed up in the status bar.  Now that that checkbox is gone we need different logic to hide it.