### PR TITLE
Add support to scaffold Test plugin in Collection plugin webview

### DIFF
--- a/src/features/contentCreator/addPluginPage.ts
+++ b/src/features/contentCreator/addPluginPage.ts
@@ -142,6 +142,7 @@ export class AddPlugin {
                       <vscode-option>Filter</vscode-option>
                       <vscode-option>Lookup</vscode-option>
                       <vscode-option>Module</vscode-option>
+                      <vscode-option>Test</vscode-option>
                     </vscode-single-select>
                   </div>
                 </div>
@@ -359,6 +360,7 @@ export class AddPlugin {
       filter: "24.12.1",
       action: "25.0.0",
       module: "25.3.0",
+      test: "25.3.1",
     };
     const requiredCreatorVersion =
       minRequiredCreatorVersion[pluginType.toLowerCase()];

--- a/test/ui-test/contentCreatorUiTest.ts
+++ b/test/ui-test/contentCreatorUiTest.ts
@@ -458,6 +458,15 @@ describe("Test collection plugins scaffolding", () => {
       "Module",
     );
   });
+  it("Check add-plugin webview elements for test plugin", async () => {
+    await testWebViewElements(
+      "Ansible: Add a Plugin",
+      "~",
+      "Add Plugin",
+      "test_plugin_name",
+      "Test",
+    );
+  });
   it("Verify Open Plugin button is enabled and plugin file exists", async () => {
     await testWebViewElements(
       "Ansible: Add a Plugin",


### PR DESCRIPTION
Related Jira issue : https://issues.redhat.com/browse/AAP-41976 

## Description
Add Support for Test Plugin Scaffolding in Collection Plugin Webview

## Summary
This Pull Request enhances the existing Collection Plugin webview by adding support for Test Plugin scaffolding. Users can now select `Test` as a plugin type from the existing plugin-type dropdown to scaffold a test plugin.

## Changes
- Updated the plugin-type dropdown to include the "Test" option.

## Testing
- Verified that the "Test" option is available in the plugin-type dropdown.
- Confirmed that selecting "Test" triggers the correct scaffold generation.

<img width="992" alt="Screenshot 2025-03-25 at 9 39 57 PM" src="https://github.com/user-attachments/assets/12379d50-ce7a-4507-acf8-ccb82b8ab583" />
