### PR TITLE
lightspeed: avoid a race condition when enabling lightpseed

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -289,6 +289,9 @@ export async function activate(context: ExtensionContext): Promise<void> {
         if (!editor) {
           await ignorePendingSuggestion();
         }
+        if (!extSettings.settings.lightSpeedService.enabled) {
+          return;
+        }
         lightSpeedManager.lightspeedExplorerProvider.refreshWebView();
       },
     ),
@@ -300,7 +303,9 @@ export async function activate(context: ExtensionContext): Promise<void> {
         lightSpeedManager,
         pythonInterpreterManager,
       );
-      lightSpeedManager.lightspeedExplorerProvider.refreshWebView();
+      if (!extSettings.settings.lightSpeedService.enabled) {
+        return;
+      }
       metaData.sendAnsibleMetadataTelemetry();
     }),
   );
@@ -368,6 +373,9 @@ export async function activate(context: ExtensionContext): Promise<void> {
       await lightSpeedManager.lightspeedAuthenticatedUser.refreshLightspeedUser();
       if (!lightSpeedManager.lightspeedAuthenticatedUser.isAuthenticated()) {
         lightSpeedManager.currentModelValue = undefined;
+      }
+      if (!extSettings.settings.lightSpeedService.enabled) {
+        return;
       }
       if (lightSpeedManager.lightspeedExplorerProvider.webviewView) {
         lightSpeedManager.lightspeedExplorerProvider.refreshWebView();
@@ -672,6 +680,9 @@ export async function activate(context: ExtensionContext): Promise<void> {
         );
         lightSpeedManager.lightspeedExplorerProvider.lightspeedExperimentalEnabled =
           true;
+        if (!extSettings.settings.lightSpeedService.enabled) {
+          return;
+        }
         lightSpeedManager.lightspeedExplorerProvider.refreshWebView();
       },
     ),

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -9,9 +9,8 @@ export async function updateConfigurationChanges(
   extSettings: SettingsManager,
   lightSpeedManager: LightSpeedManager,
 ): Promise<void> {
+  await extSettings.reinitialize();
   await metaData.updateAnsibleInfoInStatusbar();
   await lightSpeedManager.reInitialize();
   await pythonInterpreter.updatePythonInfoInStatusbar();
-
-  await extSettings.reinitialize();
 }


### PR DESCRIPTION
- refresh the settings first before refreshing the webviews.
- also, ensure lightspeed is enabled before firing a view refresh
