### PR TITLE
lightspeed: remove seat management

### DIFF
--- a/src/features/lightspeed/api.ts
+++ b/src/features/lightspeed/api.ts
@@ -190,15 +190,13 @@ export class LightSpeedAPI {
       return {} as FeedbackResponseParams;
     }
 
-    const rhUserHasSeat =
-      await this.lightspeedAuthenticatedUser.rhUserHasSeat();
     const orgOptOutTelemetry =
       await this.lightspeedAuthenticatedUser.orgOptOutTelemetry();
 
     inputData.model =
       lightSpeedManager.settingsManager.settings.lightSpeedService.model;
 
-    if (rhUserHasSeat && orgOptOutTelemetry) {
+    if (orgOptOutTelemetry) {
       if (inputData.inlineSuggestion) {
         delete inputData.inlineSuggestion;
       }

--- a/src/features/lightspeed/contentMatchesWebview.ts
+++ b/src/features/lightspeed/contentMatchesWebview.ts
@@ -222,8 +222,6 @@ export class ContentMatchesWebview implements vscode.WebviewViewProvider {
       return noContentMatchesFoundHtml;
     }
 
-    const rhUserHasSeat =
-      await this.lightspeedAuthenticatedUser.rhUserHasSeat();
     for (let taskIndex = 0; taskIndex < suggestedTasks.length; taskIndex++) {
       let taskNameDescription = suggestedTasks[taskIndex].name;
       if (!taskNameDescription) {
@@ -234,7 +232,6 @@ export class ContentMatchesWebview implements vscode.WebviewViewProvider {
       contentMatchesHtml += this.renderContentMatchWithTasKDescription(
         contentMatchValue.contentmatch,
         taskNameDescription || "",
-        rhUserHasSeat === true,
       );
     }
     const html = `
@@ -249,11 +246,8 @@ export class ContentMatchesWebview implements vscode.WebviewViewProvider {
 
   private renderContentMatches(
     contentMatchResponse: IContentMatchParams,
-    rhUserHasSeat: boolean,
   ): string {
-    const licenseLine = rhUserHasSeat
-      ? `<li>License: ${contentMatchResponse.license}</li>`
-      : "";
+    const licenseLine = `<li>License: ${contentMatchResponse.license}</li>`;
     return `
       <details>
         <summary>${contentMatchResponse.repo_name}</summary>
@@ -271,13 +265,11 @@ export class ContentMatchesWebview implements vscode.WebviewViewProvider {
   private renderContentMatchWithTasKDescription(
     contentMatchesResponse: IContentMatchParams[],
     taskDescription: string,
-    rhUserHasSeat: boolean,
   ): string {
     let taskContentMatch = "";
     for (let index = 0; index < contentMatchesResponse.length; index++) {
       taskContentMatch += this.renderContentMatches(
         contentMatchesResponse[index],
-        rhUserHasSeat,
       );
     }
 

--- a/src/features/lightspeed/inlineSuggestions.ts
+++ b/src/features/lightspeed/inlineSuggestions.ts
@@ -235,41 +235,7 @@ export class LightSpeedInlineSuggestionProvider
   }
 }
 
-const onUnexpectedPromptWithNoSeat: CallbackEntry = async function (
-  suggestionDisplayed: SuggestionDisplayed,
-  inlinePosition: InlinePosition,
-) {
-  suggestionDisplayed.reset();
-  // If the user has triggered the inline suggestion by pressing the configured keys,
-  // we will show an information message to the user to help them understand the
-  // correct cursor position to trigger the inline suggestion.
-  if (
-    inlinePosition.context.triggerKind ===
-    vscode.InlineCompletionTriggerKind.Invoke
-  ) {
-    const suggestionMatchInfo = getSuggestionMatchType(inlinePosition);
-    if (
-      !suggestionMatchInfo.taskMatchedPattern ||
-      !suggestionMatchInfo.currentLineText.isEmptyOrWhitespace
-    ) {
-      vscode.window.showInformationMessage(
-        "Cursor should be positioned on the line after the task name with the same indent as that of the task name line to trigger an inline suggestion.",
-      );
-    } else if (
-      suggestionMatchInfo.taskMatchedPattern &&
-      suggestionMatchInfo.currentLineText.isEmptyOrWhitespace &&
-      suggestionMatchInfo.spacesBeforePromptStart !==
-        suggestionMatchInfo.spacesBeforeCursor
-    ) {
-      vscode.window.showInformationMessage(
-        `Cursor must be in column ${suggestionMatchInfo.spacesBeforePromptStart} to trigger an inline suggestion.`,
-      );
-    }
-  }
-  return [];
-};
-
-const onUnexpectedPromptWithSeat: CallbackEntry = async function (
+const onUnexpectedPrompt: CallbackEntry = async function (
   suggestionDisplayed: SuggestionDisplayed,
   inlinePosition: InlinePosition,
 ) {
@@ -305,13 +271,6 @@ const onUnexpectedPromptWithSeat: CallbackEntry = async function (
   return [];
 };
 
-const onMultiTaskWithNoSeat: CallbackEntry = async function () {
-  console.debug(
-    "[inline-suggestions] Multitask suggestions not supported for a non seat user.",
-  );
-  return [];
-};
-
 const onShouldNotTriggerSuggestion: CallbackEntry = async function () {
   return [];
 };
@@ -336,8 +295,6 @@ async function requestSuggestion(
   documentInfo: DocumentInfo,
   inlinePosition: InlinePosition,
 ): Promise<CompletionResponseParams> {
-  const rhUserHasSeat =
-    await lightSpeedManager.lightspeedAuthenticatedUser.rhUserHasSeat();
   const lightSpeedStatusbarText =
     await lightSpeedManager.statusBarProvider.getLightSpeedStatusBarText();
   const suggestionId = uuidv4();
@@ -364,7 +321,6 @@ async function requestSuggestion(
       documentInfo.parsedAnsibleDocument,
       documentInfo.documentUri,
       activityId,
-      rhUserHasSeat,
       documentInfo.documentDirPath,
       documentInfo.documentFilePath,
       documentInfo.ansibleFileType,
@@ -633,10 +589,8 @@ function loadFile(inlinePosition: InlinePosition): DocumentInfo {
 }
 
 const InlineSuggestionState = {
-  UnexpectedPromptWithNoSeat: onUnexpectedPromptWithNoSeat,
-  UnexpectedPromptWithSeat: onUnexpectedPromptWithSeat,
+  UnexpectedPrompt: onUnexpectedPrompt,
   CancellationRequested: onCancellationRequested,
-  MultiTaskWithNoSeat: onMultiTaskWithNoSeat,
   ShouldNotTriggerSuggestion: onShouldNotTriggerSuggestion,
   DoMultiTasksSuggestion: onDoMultiTasksSuggestion,
   DoSingleTaskSuggestion: onDoSingleTasksSuggestion,
@@ -648,8 +602,6 @@ async function getInlineSuggestionState(
   inlinePosition: InlinePosition,
 ): Promise<CallbackEntry> {
   const suggestionMatchInfo = getSuggestionMatchType(inlinePosition);
-  const rhUserHasSeat =
-    await lightSpeedManager.lightspeedAuthenticatedUser.rhUserHasSeat();
 
   if (
     !suggestionMatchInfo.suggestionMatchType ||
@@ -664,9 +616,7 @@ async function getInlineSuggestionState(
       inlinePosition.context.triggerKind ===
       vscode.InlineCompletionTriggerKind.Invoke
     ) {
-      return rhUserHasSeat
-        ? InlineSuggestionState.UnexpectedPromptWithSeat
-        : InlineSuggestionState.UnexpectedPromptWithNoSeat;
+      return InlineSuggestionState.UnexpectedPrompt;
     }
     return InlineSuggestionState.CancellationRequested;
   }
@@ -692,21 +642,11 @@ async function getInlineSuggestionState(
     return InlineSuggestionState.ShouldNotTriggerSuggestion;
   }
 
-  switch (
-    `${suggestionMatchInfo.suggestionMatchType}-${
-      rhUserHasSeat ? "has-seat" : "no-seat"
-    }`
-  ) {
-    case "MULTI-TASK-no-seat": {
-      return InlineSuggestionState.MultiTaskWithNoSeat;
-    }
-    case "MULTI-TASK-has-seat": {
+  switch (suggestionMatchInfo.suggestionMatchType) {
+    case "MULTI-TASK": {
       return InlineSuggestionState.DoMultiTasksSuggestion;
     }
-    case "SINGLE-TASK-no-seat": {
-      return InlineSuggestionState.DoSingleTaskSuggestion;
-    }
-    case "SINGLE-TASK-has-seat": {
+    case "SINGLE-TASK": {
       return InlineSuggestionState.DoSingleTaskSuggestion;
     }
   }
@@ -728,7 +668,6 @@ async function requestInlineSuggest(
   parsedAnsibleDocument: any,
   documentUri: string,
   activityId: string,
-  rhUserHasSeat: boolean | undefined,
   documentDirPath: string,
   documentFilePath: string,
   ansibleFileType: IAnsibleFileType,

--- a/src/features/lightspeed/lightSpeedOAuthProvider.ts
+++ b/src/features/lightspeed/lightSpeedOAuthProvider.ts
@@ -172,14 +172,9 @@ export class LightSpeedAuthenticationProvider
       const rhOrgHasSubscription = userinfo.rh_org_has_subscription
         ? userinfo.rh_org_has_subscription
         : false;
-      const rhUserHasSeat = userinfo.rh_user_has_seat
-        ? userinfo.rh_user_has_seat
-        : false;
 
-      const userTypeLabel = getUserTypeLabel(
-        rhOrgHasSubscription,
-        rhUserHasSeat,
-      ).toLowerCase();
+      const userTypeLabel =
+        getUserTypeLabel(rhOrgHasSubscription).toLowerCase();
       const label = `${userName} (${userTypeLabel})`;
       const session: LightspeedAuthSession = {
         id: identifier,
@@ -190,7 +185,6 @@ export class LightSpeedAuthenticationProvider
         },
         // scopes: account.scope,
         scopes: [],
-        rhUserHasSeat: rhUserHasSeat,
         rhOrgHasSubscription: userinfo.rh_org_has_subscription
           ? userinfo.rh_org_has_subscription
           : false,

--- a/src/features/lightspeed/lightspeedUser.ts
+++ b/src/features/lightspeed/lightspeedUser.ts
@@ -369,11 +369,9 @@ export class LightspeedUser {
       const displayName = userinfo.external_username || userinfo.username || "";
       const userTypeLabel = getUserTypeLabel(
         userinfo.rh_org_has_subscription,
-        userinfo.rh_user_has_seat,
       ).toLowerCase();
 
       this._userDetails = {
-        rhUserHasSeat: userinfo.rh_user_has_seat,
         rhOrgHasSubscription: userinfo.rh_org_has_subscription,
         rhUserIsOrgAdmin: userinfo.rh_user_is_org_admin,
         displayName,
@@ -453,27 +451,6 @@ export class LightspeedUser {
       await this.getMarkdownLightspeedUserDetails(false);
 
     return markdownUserDetails || "";
-  }
-
-  public async rhUserHasSeat(): Promise<boolean | undefined> {
-    const userDetails = await this.getLightspeedUserDetails(false);
-
-    if (userDetails === undefined) {
-      this._logger.info(
-        "[ansible-lightspeed-user] User authentication session not found for seat check.",
-      );
-      return undefined;
-    } else if (userDetails.rhUserHasSeat) {
-      this._logger.info(
-        `[ansible-lightspeed-user] User "${userDetails.displayNameWithUserType}" has a seat.`,
-      );
-      return true;
-    } else {
-      this._logger.info(
-        `[ansible-lightspeed-user] User "${userDetails.displayNameWithUserType}" does not have a seat.`,
-      );
-      return false;
-    }
   }
 
   public async rhOrgHasSubscription(): Promise<boolean | undefined> {

--- a/src/features/lightspeed/statusBar.ts
+++ b/src/features/lightspeed/statusBar.ts
@@ -53,18 +53,13 @@ export class LightspeedStatusBar {
     }
     return this.getLightSpeedStatusBarTextSync(
       userDetails.rhOrgHasSubscription,
-      userDetails.rhUserHasSeat,
     );
   }
 
   private getLightSpeedStatusBarTextSync(
-    rhUserHasSeat?: boolean,
     rhOrgHasSubscription?: boolean,
   ): string {
-    const userTypeLabel = getUserTypeLabel(
-      rhOrgHasSubscription,
-      rhUserHasSeat,
-    ).toLowerCase();
+    const userTypeLabel = getUserTypeLabel(rhOrgHasSubscription).toLowerCase();
     return `Lightspeed (${userTypeLabel})`;
   }
 

--- a/src/features/lightspeed/utils/webUtils.ts
+++ b/src/features/lightspeed/utils/webUtils.ts
@@ -74,12 +74,11 @@ export function getBaseUri(settingsManager: SettingsManager): string {
 
 export function getUserTypeLabel(
   rhOrgHasSubscription?: boolean,
-  rhUserHasSeat?: boolean,
 ): LIGHTSPEED_USER_TYPE {
   if (rhOrgHasSubscription === undefined) {
     return "Not logged in";
   }
-  return rhOrgHasSubscription && rhUserHasSeat ? "Licensed" : "Unlicensed";
+  return rhOrgHasSubscription ? "Licensed" : "Unlicensed";
 }
 
 export function getLoggedInUserDetails(
@@ -87,10 +86,7 @@ export function getLoggedInUserDetails(
 ): LightspeedSessionInfo {
   const userInfo: LightspeedSessionUserInfo = {};
   const modelInfo: LightspeedSessionModelInfo = {};
-  userInfo.userType = getUserTypeLabel(
-    sessionData?.rhOrgHasSubscription,
-    sessionData?.rhUserHasSeat,
-  );
+  userInfo.userType = getUserTypeLabel(sessionData?.rhOrgHasSubscription);
   if (sessionData?.rhUserIsOrgAdmin) {
     userInfo.role = "Administrator";
   }

--- a/src/interfaces/lightspeed.ts
+++ b/src/interfaces/lightspeed.ts
@@ -7,12 +7,10 @@ import {
 } from "../definitions/lightspeed";
 
 export interface LightspeedAuthSession extends AuthenticationSession {
-  rhUserHasSeat: boolean;
   rhOrgHasSubscription: boolean;
   rhUserIsOrgAdmin: boolean;
 }
 export interface LightspeedUserDetails {
-  rhUserHasSeat: boolean;
   rhOrgHasSubscription: boolean;
   rhUserIsOrgAdmin: boolean;
   displayName: string;

--- a/test/testScripts/lightspeed/testLightSpeedFunctions.test.ts
+++ b/test/testScripts/lightspeed/testLightSpeedFunctions.test.ts
@@ -12,12 +12,10 @@ import {
 import * as inlineSuggestions from "../../../src/features/lightspeed/inlineSuggestions";
 
 function getLightSpeedUserDetails(
-  rhUserHasSeat: boolean,
   rhOrgHasSubscription: boolean,
   rhUserIsOrgAdmin: boolean = false,
 ): LightspeedUserDetails {
   return {
-    rhUserHasSeat: rhUserHasSeat,
     rhOrgHasSubscription: rhOrgHasSubscription,
     rhUserIsOrgAdmin: rhUserIsOrgAdmin,
     displayName: "jane_doe",
@@ -29,31 +27,15 @@ function getLightSpeedUserDetails(
 function testGetLoggedInUserDetails(): void {
   describe("Test getLoggedInUserDetails", function () {
     it(`Verify a seated user`, function () {
-      const session = getLightSpeedUserDetails(true, true, false);
+      const session = getLightSpeedUserDetails(true, true);
       const { userInfo } = getLoggedInUserDetails(session);
       assert.equal(userInfo?.userType, "Licensed");
       assert.isTrue(userInfo?.subscribed);
       assert.isUndefined(userInfo.role);
     });
 
-    it(`Verify an unseated user`, function () {
-      const session = getLightSpeedUserDetails(false, true, false);
-      const { userInfo } = getLoggedInUserDetails(session);
-      assert.equal(userInfo?.userType, "Unlicensed");
-      assert.isTrue(userInfo?.subscribed);
-      assert.isUndefined(userInfo.role);
-    });
-
-    it(`Verify an unseated user of an unsubscribed org`, function () {
-      const session = getLightSpeedUserDetails(false, false, false);
-      const { userInfo } = getLoggedInUserDetails(session);
-      assert.equal(userInfo?.userType, "Unlicensed");
-      assert.isNotTrue(userInfo?.subscribed);
-      assert.isUndefined(userInfo?.role);
-    });
-
     it(`Verify a seated administrator`, function () {
-      const session = getLightSpeedUserDetails(true, true, true);
+      const session = getLightSpeedUserDetails(true, true);
       const { userInfo } = getLoggedInUserDetails(session);
       assert.equal(userInfo?.userType, "Licensed");
       assert.isTrue(userInfo?.subscribed);

--- a/test/testScripts/lightspeed/testLightspeed.test.ts
+++ b/test/testScripts/lightspeed/testLightspeed.test.ts
@@ -201,36 +201,24 @@ export function testLightspeed(): void {
 
     describe("Test Ansible Lightspeed multitask inline completion suggestions", function () {
       const docUri1 = getDocUri("lightspeed/playbook_1.yml");
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      let rhUserHasSeatStub: any;
 
       before(async function () {
         await vscode.commands.executeCommand(
           "workbench.action.closeAllEditors",
         );
         await activate(docUri1);
-        rhUserHasSeatStub = sinon.stub(
-          lightSpeedManager.lightspeedAuthenticatedUser,
-          "rhUserHasSeat",
-        );
       });
 
       const tests = testMultiTaskSuggestionPrompts();
 
       tests.forEach(({ taskName, expectedModule }) => {
         it(`Should give multitask inline suggestion for task prompt '${taskName}'`, async function () {
-          rhUserHasSeatStub.returns(Promise.resolve(true));
           await testInlineSuggestion(taskName, expectedModule, true);
         });
 
         it(`Should not give multitask inline suggestion for task prompt '${taskName}' if the user is unseated`, async function () {
-          rhUserHasSeatStub.returns(Promise.resolve(false));
           await testInlineSuggestionNotTriggered(taskName, true);
         });
-      });
-
-      after(async function () {
-        rhUserHasSeatStub.restore();
       });
     });
 
@@ -241,8 +229,7 @@ export function testLightspeed(): void {
       let completionRequestSpy: any;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       let isAuthenticatedStub: any;
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      let rhUserHasSeatStub: any;
+
       const docUri1 = getDocUri("lightspeed/playbook_1.yml");
 
       before(async function () {
@@ -261,10 +248,6 @@ export function testLightspeed(): void {
         isAuthenticatedStub = sinon.stub(
           lightSpeedManager.lightspeedAuthenticatedUser,
           "isAuthenticated",
-        );
-        rhUserHasSeatStub = sinon.stub(
-          lightSpeedManager.lightspeedAuthenticatedUser,
-          "rhUserHasSeat",
         );
         isAuthenticatedStub.returns(Promise.resolve(true));
       });
@@ -319,7 +302,6 @@ export function testLightspeed(): void {
 
       it(`Should not call completion API with a keystroke before Wait Window (multi task) '${taskName}'`, async function () {
         try {
-          rhUserHasSeatStub.returns(Promise.resolve(true));
           await setInlineSuggestionsWaitWindow();
           await testInlineSuggestion(
             taskName,
@@ -367,7 +349,6 @@ export function testLightspeed(): void {
         feedbackRequestSpy.restore();
         completionRequestSpy.restore();
         isAuthenticatedStub.restore();
-        rhUserHasSeatStub.restore();
         sinon.restore();
       });
     });

--- a/test/testScripts/lightspeed/testLightspeedUser.test.ts
+++ b/test/testScripts/lightspeed/testLightspeedUser.test.ts
@@ -197,7 +197,6 @@ function testRedHatSignInCommand() {
       );
       getLightspeedUserDetailsStub.returns(
         Promise.resolve({
-          rhUserHasSeat: true,
           rhOrgHasSubscription: true,
           rhUserIsOrgAdmin: true,
           displayName: "Joe Lightspeed",

--- a/test/units/lightspeed/contentmatches.test.ts
+++ b/test/units/lightspeed/contentmatches.test.ts
@@ -204,21 +204,7 @@ describe("GetWebviewContent", () => {
       return createMatchResponse();
     };
 
-    function setRhUserHasSeat(has_seat: boolean) {
-      cmw["lightspeedAuthenticatedUser"].rhUserHasSeat = async (): Promise<
-        boolean | undefined
-      > => {
-        return has_seat;
-      };
-    }
-
-    setRhUserHasSeat(false);
-    let res = await cmw["getWebviewContent"]();
-    assert.match(res, new RegExp("<summary>ansible.ansible</summary>"));
-    assert.doesNotMatch(res, new RegExp("<li>License:.*</li>"));
-
-    setRhUserHasSeat(true);
-    res = await cmw["getWebviewContent"]();
+    const res = await cmw["getWebviewContent"]();
     assert.match(res, new RegExp("<summary>ansible.ansible</summary>"));
     assert.match(res, new RegExp("<li>License:.*</li>"));
   });


### PR DESCRIPTION
Seat management was removed by a commit from 2024-02-14.

See: https://github.com/ansible/ansible-ai-connect-service/commit/6cc86fe71d4866dba94a26b04c1f8c5dfef92653
