### PR TITLE
lightspeed: use the logger and reduce the severity of msgs

### DIFF
--- a/src/features/lightspeed/api.ts
+++ b/src/features/lightspeed/api.ts
@@ -36,6 +36,7 @@ import {
   OneClickTrialProvider,
 } from "./utils/oneClickTrial";
 import { mapError } from "./handleApiError";
+import { Log } from "../../utils/logger";
 
 const UNKNOWN_ERROR: string = "An unknown error occurred.";
 
@@ -53,17 +54,20 @@ export class LightSpeedAPI {
   private _suggestionFeedbacks: string[];
   private _extensionVersion: string;
   private _oneClickTrialProvider: OneClickTrialProvider;
+  private logger: Log;
 
   constructor(
     settingsManager: SettingsManager,
     lightspeedAuthenticatedUser: LightspeedUser,
     context: vscode.ExtensionContext,
+    logger: Log,
   ) {
     this.settingsManager = settingsManager;
     this.lightspeedAuthenticatedUser = lightspeedAuthenticatedUser;
     this._suggestionFeedbacks = [];
     this._extensionVersion = context.extension.packageJSON.version;
     this._oneClickTrialProvider = getOneClickTrialProvider();
+    this.logger = logger;
   }
 
   private async lightspeedPost(endpoint: string, body: string) {
@@ -99,7 +103,7 @@ export class LightSpeedAPI {
     inputData: CompletionRequestParams,
   ): Promise<CompletionResponseParams> {
     const suggestionId = inputData.suggestionId;
-    console.log(
+    this.logger.info(
       `[ansible-lightspeed] Completion request sent to lightspeed: ${JSON.stringify(
         inputData,
       )}`,
@@ -139,7 +143,7 @@ export class LightSpeedAPI {
         );
         return {} as CompletionResponseParams;
       }
-      console.log(
+      this.logger.debug(
         `[ansible-lightspeed] Completion response: ${JSON.stringify(data)}`,
       );
       return data;
@@ -211,7 +215,7 @@ export class LightSpeedAPI {
       ...inputData,
       metadata: { ansibleExtensionVersion: this._extensionVersion },
     };
-    console.log(
+    this.logger.debug(
       `[ansible-lightspeed] Feedback request sent to lightspeed: ${JSON.stringify(
         requestData,
       )}`,
@@ -262,7 +266,7 @@ export class LightSpeedAPI {
         metadata: { ansibleExtensionVersion: this._extensionVersion },
       };
 
-      console.log(
+      this.logger.debug(
         `[ansible-lightspeed] Content Match request sent to lightspeed: ${JSON.stringify(
           requestData,
         )}`,
@@ -295,8 +299,8 @@ export class LightSpeedAPI {
         metadata: { ansibleExtensionVersion: this._extensionVersion },
       };
 
-      console.log(
-        `[ansible-lightspeed] Explanation request sent to lightspeed: ${JSON.stringify(
+      this.logger.info(
+        `[ansible-lightspeed] Playbook Explanation request sent to lightspeed: ${JSON.stringify(
           requestData,
         )}`,
       );
@@ -328,8 +332,8 @@ export class LightSpeedAPI {
         metadata: { ansibleExtensionVersion: this._extensionVersion },
       };
 
-      console.log(
-        `[ansible-lightspeed] Generation request sent to lightspeed: ${JSON.stringify(
+      this.logger.info(
+        `[ansible-lightspeed] Playbook generation request sent to lightspeed: ${JSON.stringify(
           requestData,
         )}`,
       );
@@ -360,7 +364,7 @@ export class LightSpeedAPI {
         ...inputData,
         metadata: { ansibleExtensionVersion: this._extensionVersion },
       };
-      console.log(
+      this.logger.info(
         `[ansible-lightspeed] Role Generation request sent to lightspeed: ${JSON.stringify(
           requestData,
         )}`,
@@ -397,8 +401,8 @@ export class LightSpeedAPI {
         metadata: { ansibleExtensionVersion: this._extensionVersion },
       };
 
-      console.log(
-        `[ansible-lightspeed] Role explanation request sent to lightspeed: ${JSON.stringify(
+      this.logger.info(
+        `[ansible-lightspeed] Role Explanation request sent to lightspeed: ${JSON.stringify(
           requestData,
         )}`,
       );

--- a/src/features/lightspeed/base.ts
+++ b/src/features/lightspeed/base.ts
@@ -73,6 +73,7 @@ export class LightSpeedManager {
       this.settingsManager,
       this.lightspeedAuthenticatedUser,
       this.context,
+      this.logger,
     );
     this.contentMatchesProvider = new ContentMatchesWebview(
       this.context,

--- a/src/features/lightspeed/lightSpeedOAuthProvider.ts
+++ b/src/features/lightspeed/lightSpeedOAuthProvider.ts
@@ -428,7 +428,7 @@ export class LightSpeedAuthenticationProvider
       "Content-Type": "application/x-www-form-urlencoded",
     };
 
-    this._logger.debug(
+    this._logger.trace(
       "[ansible-lightspeed-oauth] Sending request for a new access token...",
     );
 
@@ -505,7 +505,7 @@ export class LightSpeedAuthenticationProvider
    * it requests for a new token and updates the secret store
    */
   public async refreshAccessToken(session: AuthenticationSession) {
-    this._logger.debug("[ansible-lightspeed-oauth] Getting access token...");
+    this._logger.trace("[ansible-lightspeed-oauth] Refresh access token...");
 
     const sessionId = session.id;
 
@@ -514,7 +514,7 @@ export class LightSpeedAuthenticationProvider
       throw new Error(`Unable to fetch account`);
     }
 
-    this._logger.debug("[ansible-lightspeed-oauth] Account found");
+    this._logger.trace("[ansible-lightspeed-oauth] Account found");
 
     const currentAccount: OAuthAccount = JSON.parse(account);
     let tokenToBeReturned = currentAccount.accessToken;

--- a/src/features/lightspeed/lightspeedUser.ts
+++ b/src/features/lightspeed/lightspeedUser.ts
@@ -502,7 +502,7 @@ export class LightspeedUser {
   }
 
   public async getLightspeedUserAccessToken() {
-    this._logger.info("[ansible-lightspeed-user] Getting access token...");
+    this._logger.trace("[ansible-lightspeed-user] Getting access token...");
 
     if (process.env.TEST_LIGHTSPEED_ACCESS_TOKEN) {
       this._logger.info("[ansible-lightspeed-user] Test access token returned");
@@ -510,7 +510,7 @@ export class LightspeedUser {
     }
 
     if (!this._session) {
-      this._logger.info(
+      this._logger.trace(
         "[ansible-lightspeed-user] Session not found. Returning...",
       );
       const selection = await vscode.window.showWarningMessage(
@@ -531,7 +531,7 @@ export class LightspeedUser {
       }
       return;
     }
-    this._logger.info(
+    this._logger.debug(
       `[ansible-lightspeed-user] Session found for auth provider "${this._userType}" with scopes "${this._session.scopes}"`,
     );
 


### PR DESCRIPTION
- Use the logger instead of `console.log`.
- Reduce the severity of most of the messages.
- Improve/clarify the wording of some of the traces.
