### PR TITLE
Various UX improvements to playbook and role gen views

### DIFF
--- a/test/units/lightspeed/utils/outlineLineNumbers.test.ts
+++ b/test/units/lightspeed/utils/outlineLineNumbers.test.ts
@@ -1,0 +1,90 @@
+import assert from "assert";
+import {
+  textIsOnlyLineNumber,
+  digitsInNumber,
+  countNewlinesBeforePosition,
+  getStringBetweenNewlines,
+  shouldRemoveLine,
+  calculateNewCursorPosition,
+} from "../../../../webviews/lightspeed/src/utils/outlineLineNumbers";
+
+describe("outlineLineNumbers.ts", () => {
+  describe("textIsOnlyLineNumber", () => {
+    it("should return true for valid line numbers or partial line numbers", () => {
+      assert.strictEqual(textIsOnlyLineNumber("1. "), true);
+      assert.strictEqual(textIsOnlyLineNumber("123. "), true);
+      assert.strictEqual(textIsOnlyLineNumber("1"), true);
+      assert.strictEqual(textIsOnlyLineNumber("1."), true);
+    });
+
+    it("should return false for strings that aren't exclusively line numbers", () => {
+      assert.strictEqual(textIsOnlyLineNumber("abc"), false);
+      assert.strictEqual(textIsOnlyLineNumber("1a. "), false);
+      assert.strictEqual(textIsOnlyLineNumber("1.abc"), false);
+      assert.strictEqual(textIsOnlyLineNumber("1. 2"), false);
+      assert.strictEqual(textIsOnlyLineNumber("1.2"), false);
+      assert.strictEqual(textIsOnlyLineNumber("1. 2. "), false);
+    });
+  });
+
+  describe("digitsInNumber", () => {
+    it("should return the correct number of digits", () => {
+      assert.strictEqual(digitsInNumber(1), 1);
+      assert.strictEqual(digitsInNumber(12), 2);
+      assert.strictEqual(digitsInNumber(123), 3);
+      assert.strictEqual(digitsInNumber(1234), 4);
+    });
+  });
+
+  describe("countNewlinesBeforePosition", () => {
+    it("should count newlines correctly", () => {
+      const text = "line1\nline2\nline3\n\n\n\nline8\nline9";
+      assert.strictEqual(countNewlinesBeforePosition(text, 6), 1);
+      assert.strictEqual(countNewlinesBeforePosition(text, 12), 2);
+      assert.strictEqual(countNewlinesBeforePosition(text, 20), 5);
+      assert.strictEqual(countNewlinesBeforePosition(text, 25), 6);
+    });
+
+    it("should handle consecutive newlines correctly", () => {
+      const text = "line1\n\n\nline4\nline5";
+      assert.strictEqual(countNewlinesBeforePosition(text, 6), 1);
+      assert.strictEqual(countNewlinesBeforePosition(text, 7), 2);
+      assert.strictEqual(countNewlinesBeforePosition(text, 8), 3);
+      assert.strictEqual(countNewlinesBeforePosition(text, 14), 4);
+    });
+  });
+
+  describe("getStringBetweenNewlines", () => {
+    it("should return the correct substring", () => {
+      const text = "line1\nline2\nline3\n\n\n\n\nline8\nline9";
+      assert.strictEqual(getStringBetweenNewlines(text, 7), "line2");
+      assert.strictEqual(getStringBetweenNewlines(text, 18), "");
+      assert.strictEqual(getStringBetweenNewlines(text, 30), "line9");
+    });
+  });
+
+  describe("shouldRemoveLine", () => {
+    it("should return true for removable line numbers", () => {
+      assert.strictEqual(shouldRemoveLine("1.", 1), true);
+      assert.strictEqual(shouldRemoveLine("12.", 2), true);
+      assert.strictEqual(shouldRemoveLine("123.", 3), true);
+      assert.strictEqual(shouldRemoveLine("1234.", 4), true);
+    });
+
+    it("should return false for non-removable line numbers", () => {
+      assert.strictEqual(shouldRemoveLine("12.", 1), false);
+      assert.strictEqual(shouldRemoveLine("123.", 2), false);
+      assert.strictEqual(shouldRemoveLine("1. ", 1), false);
+      assert.strictEqual(shouldRemoveLine("1. Install node", 1), false);
+    });
+  });
+
+  describe("calculateNewCursorPosition", () => {
+    it("should calculate the correct new cursor position", () => {
+      const text = "1. line1\n2. line2\n3. line3\n\n\n\nline8\nline9";
+      assert.strictEqual(calculateNewCursorPosition(text, 8, 0, 1), 8);
+      assert.strictEqual(calculateNewCursorPosition(text, 9, 0, 1), 12);
+      assert.strictEqual(calculateNewCursorPosition(text, 28, 0, 1), 31);
+    });
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,12 +4,18 @@
     "lib": ["ES2022", "DOM"],
     "outDir": "out/client"
   },
-  "include": ["vite.config.ts", "src/**/*.ts", "test", "*.js", "*.ts"],
+  "include": [
+    "vite.config.ts",
+    "src/**/*.ts",
+    "webviews/lightspeed/src/utils/*.ts",
+    "test",
+    "*.js",
+    "*.ts"
+  ],
   "exclude": [
     "node_modules",
     "test-resources",
-    "src/features/lightspeed/vue/src",
-    "webviews/**"
+    "src/features/lightspeed/vue/src"
   ],
   "ts-node": {
     "files": true

--- a/webviews/lightspeed/src/PlaybookGenApp.vue
+++ b/webviews/lightspeed/src/PlaybookGenApp.vue
@@ -111,7 +111,9 @@ sendActionEvent(WizardGenerationActionType.OPEN, undefined, 1);
   <div v-else-if="page === 2">
     <StatusBoxPrompt :prompt="prompt" @restart-wizard="page = 1" />
 
-    <OutlineReview :outline
+    <OutlineReview 
+      :outline 
+      type="playbook"
       @outline-update="(newOutline: string) => { console.log(`new outline: ${newOutline}`); outline = newOutline; }" />
 
     <div>

--- a/webviews/lightspeed/src/PlaybookGenApp.vue
+++ b/webviews/lightspeed/src/PlaybookGenApp.vue
@@ -111,8 +111,8 @@ sendActionEvent(WizardGenerationActionType.OPEN, undefined, 1);
   <div v-else-if="page === 2">
     <StatusBoxPrompt :prompt="prompt" @restart-wizard="page = 1" />
 
-    <OutlineReview 
-      :outline 
+    <OutlineReview
+      :outline
       type="playbook"
       @outline-update="(newOutline: string) => { console.log(`new outline: ${newOutline}`); outline = newOutline; }" />
 

--- a/webviews/lightspeed/src/RoleGenApp.vue
+++ b/webviews/lightspeed/src/RoleGenApp.vue
@@ -128,7 +128,9 @@ sendActionEvent(WizardGenerationActionType.OPEN, undefined, 1);
       Role name: <vscode-textfield v-model="roleName" />
     </div>
 
-    <OutlineReview :outline
+    <OutlineReview
+      :outline
+      type="role"
       @outline-update="(newOutline: string) => { console.log(`new outline: ${newOutline}`); outline = newOutline; }" />
 
     <div>

--- a/webviews/lightspeed/src/components/OutlineReview.vue
+++ b/webviews/lightspeed/src/components/OutlineReview.vue
@@ -1,5 +1,8 @@
 <script setup lang="ts">
-defineProps<{ outline: string }>();
+defineProps<{ 
+  outline: string; 
+  type: "playbook" | "role"; 
+}>();
 
 const emit = defineEmits<{ outlineUpdate: [outline: string] }>();
 
@@ -18,7 +21,7 @@ function outlineWithLineNumber() {
 
 <template>
   <div>
-    <h4>Review the suggested steps for your role and modify as needed.</h4>
+    <h4>Review the suggested steps for your {{type}} and modify as needed.</h4>
     <textarea id="outline-field" :rows="outline.split('\n').length + 2" :cols="70" :value="outline.toString()"
       @input="outlineWithLineNumber" />
   </div>

--- a/webviews/lightspeed/src/components/OutlineReview.vue
+++ b/webviews/lightspeed/src/components/OutlineReview.vue
@@ -1,17 +1,17 @@
 <script setup lang="ts">
 import {
-  calculateNewCursorPosition, 
-  digitsInNumber, 
-  countNewlinesBeforePosition, 
-  getStringBetweenNewlines, 
-  reapplyLineNumbers, 
-  removeLine, 
-  shouldRemoveLine 
+  calculateNewCursorPosition,
+  digitsInNumber,
+  countNewlinesBeforePosition,
+  getStringBetweenNewlines,
+  reapplyLineNumbers,
+  removeLine,
+  shouldRemoveLine
 } from '../utils/outlineLineNumbers';
 
-defineProps<{ 
-  outline: string; 
-  type: "playbook" | "role"; 
+defineProps<{
+  outline: string;
+  type: "playbook" | "role";
 }>();
 
 const emit = defineEmits<{ outlineUpdate: [outline: string] }>();

--- a/webviews/lightspeed/src/utils/index.ts
+++ b/webviews/lightspeed/src/utils/index.ts
@@ -1,1 +1,2 @@
 export * from "./vscode";
+export * from "./outlineLineNumbers";

--- a/webviews/lightspeed/src/utils/outlineLineNumbers.ts
+++ b/webviews/lightspeed/src/utils/outlineLineNumbers.ts
@@ -1,0 +1,65 @@
+export function textIsOnlyLineNumber(input: string): boolean {
+  return /^\d*[.]?[ ]?$/.test(input);
+}
+
+export function digitsInNumber(number: number): number {
+  return Math.abs(number).toString().length;
+}
+
+export function countNewlinesBeforePosition(
+  text: string,
+  position: number,
+): number {
+  return (text.slice(0, position).match(/\n/g) || []).length;
+}
+
+export function getStringBetweenNewlines(
+  text: string,
+  position: number,
+): string {
+  const start = text.lastIndexOf("\n", position - 1) + 1;
+  const end = text.indexOf("\n", position);
+  return text.slice(start, end === -1 ? text.length : end);
+}
+
+export function shouldRemoveLine(lineText: string, numDigits: number): boolean {
+  return (
+    textIsOnlyLineNumber(lineText) &&
+    lineText.length > 0 &&
+    lineText.length < numDigits + 2
+  );
+}
+
+export function removeLine(
+  textField: HTMLTextAreaElement,
+  originalPosition: number,
+  previousNewLineIndex: number,
+): void {
+  const nextNewLineIndex = textField.value.indexOf("\n", originalPosition);
+  const beforeLine = textField.value.substring(0, previousNewLineIndex);
+  const afterLine =
+    nextNewLineIndex > 0 ? textField.value.substring(nextNewLineIndex) : "";
+
+  textField.value = beforeLine + afterLine;
+}
+
+export function reapplyLineNumbers(textField: HTMLTextAreaElement): void {
+  textField.value = textField.value
+    .split("\n")
+    .map((line, idx) => `${idx + 1}. ${line.replace(/^\d+[.]?[\s]?/, "")}`)
+    .join("\n");
+}
+
+export function calculateNewCursorPosition(
+  text: string,
+  originalPosition: number,
+  previousNewLineIndex: number,
+  numDigits: number,
+): number {
+  if (text[originalPosition - 1] === "\n") {
+    return originalPosition + numDigits + 2;
+  } else if (originalPosition - previousNewLineIndex < numDigits + 3) {
+    return previousNewLineIndex + numDigits + 3;
+  }
+  return originalPosition;
+}


### PR DESCRIPTION
Resolves https://issues.redhat.com/browse/AAP-42454

1. The first change here is to update some of the text on the playbook gen outline review page.  We were referencing "role" when we should be referencing "playbook".

Old:
<img width="671" alt="Screenshot 2025-04-08 at 12 12 27 PM" src="https://github.com/user-attachments/assets/31180f60-e8ef-4b57-ba8b-e3cf9168810a" />

New:
<img width="644" alt="Screenshot 2025-04-08 at 12 12 10 PM" src="https://github.com/user-attachments/assets/a970f945-8f99-41fe-8673-ae0391d42a43" />

2. The second change handles backspace/removing characters from a line.  When the user starts removing the line number, we jump them to the previous line.

Old:
![outline_remove_line_old](https://github.com/user-attachments/assets/8f15da82-ccc0-4191-96ee-a3e948524eb4)

New:
![outline_remove_line_new](https://github.com/user-attachments/assets/59141a80-86d6-4d8c-a98d-1c146abcdb5b)

3. The third change has to do with the cursor position once you progress past 10 steps.  The cursor position isn't quite right and it results in multiple line numbers being rendered on the same line.

Old:
![line_numbers_old](https://github.com/user-attachments/assets/c6327c38-c6ef-487c-862c-d3e13925df9c)

New:
![line_numbers_new](https://github.com/user-attachments/assets/f718c5b6-5484-45a6-8a61-5a26ae56e720)
