### PR TITLE
Update podman devcontainer template to match ansible-creator

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -22,6 +22,7 @@ KUBEDOCK
 Launay
 Maciążek
 Miku
+MKNOD
 Nalawade
 OPTSTRING
 OSTYPE

--- a/resources/contentCreator/createDevcontainer/.devcontainer/podman/devcontainer-template.txt
+++ b/resources/contentCreator/createDevcontainer/.devcontainer/podman/devcontainer-template.txt
@@ -3,6 +3,8 @@
   "image": "{{ dev_container_image }}",
   "containerUser": "root",
   "runArgs": [
+    "--cap-add=CAP_MKNOD",
+    "--cap-add=NET_ADMIN",
     "--cap-add=SYS_ADMIN",
     "--cap-add=SYS_RESOURCE",
     "--device",
@@ -13,10 +15,10 @@
     "label=disable",
     "--security-opt",
     "apparmor=unconfined",
+    "--security-opt",
+    "unmask=/sys/fs/cgroup",
     "--userns=host",
-    "--hostname=ansible-dev-container",
-    "--volume",
-    "ansible-dev-tools-container-storage:/var/lib/containers"
+    "--hostname=ansible-dev-container"
   ],
   "customizations": {
     "vscode": {


### PR DESCRIPTION
Updates the podman devcontainer template to match the [updated ansible-creator template](https://github.com/ansible/ansible-creator/pull/401).

Resolves an OCI error that appears when launching the devcontainer with podman and the Dev Containers extension. 