### PR TITLE
build: enable webpack caching

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -167,6 +167,7 @@ jobs:
           path: |
             .vscode-test
             .yarn/cache
+            node_modules/.cache/webpack
             out/ext
             out/test-resources
             out/test-resources-oldest

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -12,6 +12,12 @@ const entry: EntryType = {
 };
 
 const config = {
+  cache: {
+    type: "filesystem",
+    buildDependencies: {
+      config: [__filename],
+    },
+  },
   devtool: "source-map",
   entry,
   externals: {


### PR DESCRIPTION
This change reduced the time required to perform webpack from ~80s to
~20s. Further changes can be implemented to improve it based on
https://webpack.js.org/guides/build-performance/
