### PR TITLE
Avoid potentially unnecessary webpack step inside task-ui

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -159,7 +159,7 @@ tasks:
     desc: Run UI tests {{.XVFB}}
     aliases: [ui]
     cmds:
-      - yarn webpack-dev
+      # - yarn webpack-dev
       - "{{.VIRTUAL_ENV}}/bin/python3 --version"
       - ' {{.XVFB}} bash -c ''. "{{.VIRTUAL_ENV}}/bin/activate" && COVERAGE=1 MOCK_LIGHTSPEED_API=1 ./tools/test-launcher.sh'''
     interactive: true

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -159,6 +159,7 @@ tasks:
     desc: Run UI tests {{.XVFB}}
     aliases: [ui]
     cmds:
+      - task: package
       - "{{.VIRTUAL_ENV}}/bin/python3 --version"
       - ' {{.XVFB}} bash -c ''. "{{.VIRTUAL_ENV}}/bin/activate" && COVERAGE=1 MOCK_LIGHTSPEED_API=1 ./tools/test-launcher.sh'''
     interactive: true

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -159,7 +159,6 @@ tasks:
     desc: Run UI tests {{.XVFB}}
     aliases: [ui]
     cmds:
-      # - yarn webpack-dev
       - "{{.VIRTUAL_ENV}}/bin/python3 --version"
       - ' {{.XVFB}} bash -c ''. "{{.VIRTUAL_ENV}}/bin/activate" && COVERAGE=1 MOCK_LIGHTSPEED_API=1 ./tools/test-launcher.sh'''
     interactive: true


### PR DESCRIPTION
### PR Description

The `yarn webpack-dev` command in the `task-ui` step was redundant, as it was already being executed during the `task package` step. So instead of that `task package` command is being run as the first step in `task-ui`. This update removes the duplication and streamlines the process. Instead 

#### Timings Improvement:
- **test(linux)**: From ~15 min 6 sec to ~13 min 50 sec
- **test(macos)**: From ~18 min 22 sec to ~16 min 17 sec

After this change it is observed that the timings slightly improve across both Linux and macOS environments.
