### PR TITLE
Avoid cleaning cached vscode binaries before ui test

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -161,7 +161,6 @@ tasks:
     cmds:
       - yarn webpack-dev
       - "{{.VIRTUAL_ENV}}/bin/python3 --version"
-      - bash -c 'rm -rf ./out/test-resources ./out/ext'
       - ' {{.XVFB}} bash -c ''. "{{.VIRTUAL_ENV}}/bin/activate" && COVERAGE=1 MOCK_LIGHTSPEED_API=1 ./tools/test-launcher.sh'''
     interactive: true
   test-unit:


### PR DESCRIPTION
This change prevents downloading vscode binaries each time the test
suite is running. This also prevented the caching from working on CI
too, not only on local.
