### PR TITLE
chore: use npm project directory instead of __dirname

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -45,9 +45,10 @@ tasks:
     cmds:
       - task: shared:install
     sources:
-      - "**/package.json"
+      - "package.json"
+      - "packages/*/package.json"
       - yarn.lock
-      - node_modules/**/*
+      - node_modules/.yarn-state.yml
     interactive: true
   build:
     desc: Build the project

--- a/test/index.ts
+++ b/test/index.ts
@@ -4,9 +4,11 @@ import { glob } from "glob";
 import { MochaOptions } from "vscode-extension-tester";
 import NYC from "nyc";
 
+const project_dir = process.env.INIT_CWD || process.cwd();
+
 function setupCoverage() {
   const nyc = new NYC({
-    cwd: path.join(__dirname, "..", "..", ".."),
+    cwd: project_dir,
     reporter: ["text", "html", "lcov"],
     all: true,
     silent: false,
@@ -16,7 +18,7 @@ function setupCoverage() {
     hookRunInThisContext: true,
     include: ["out/client/src/**/*.js", "out/server/src/**/*.js"],
     reportDir: "out/coverage/e2e",
-    tempDir: "out/.nyc_output",
+    tempDir: "out/tmp/e2e/.nyc_output",
   });
 
   nyc.reset();
@@ -58,7 +60,7 @@ export async function run(): Promise<void> {
   // Create the mocha test
   const mocha = new Mocha(mochaOptions);
 
-  const testsRoot = path.resolve(__dirname, "..");
+  const testsRoot = path.resolve(project_dir, "out/client");
 
   const files = await glob("**/**.test.js", { cwd: testsRoot });
 

--- a/test/testRunner.ts
+++ b/test/testRunner.ts
@@ -6,8 +6,13 @@ import {
   resolveCliPathFromVSCodeExecutablePath,
 } from "@vscode/test-electron";
 import fs from "fs";
+const project_dir = process.env.INIT_CWD || process.cwd();
 
-export const FIXTURES_BASE_PATH = path.join("test", "testFixtures");
+export const FIXTURES_BASE_PATH = path.join(
+  project_dir,
+  "test",
+  "testFixtures",
+);
 export const ANSIBLE_COLLECTIONS_FIXTURES_BASE_PATH = path.resolve(
   FIXTURES_BASE_PATH,
   "common",
@@ -44,8 +49,8 @@ async function main(): Promise<void> {
       executable,
       downloadPlatform,
     );
-    const userDataPath = path.resolve(__dirname, "../../userdata");
-    const extPath = path.resolve(__dirname, "../../ext");
+    const userDataPath = path.resolve(project_dir, "out/userdata");
+    const extPath = path.resolve(project_dir, "out/ext");
     // We want to avoid using developer data dir as this is likely to break
     // testing and make its outcome very hard to reproduce across machines.
     // https://code.visualstudio.com/docs/getstarted/settings#_settings-file-locations
@@ -62,20 +67,14 @@ async function main(): Promise<void> {
 
     // Copy default user settings.json
     const settings_src = path.join(
-      __dirname,
-      "..",
-      "..",
-      "..",
+      project_dir,
       "test",
       "testFixtures",
       "settings.json",
     );
 
     const settings_dst = path.join(
-      __dirname,
-      "..",
-      "..",
-      "..",
+      project_dir,
       "out",
       "userdata",
       "User",
@@ -103,11 +102,14 @@ async function main(): Promise<void> {
 
     // The folder containing the Extension Manifest package.json
     // Passed to `--extensionDevelopmentPath`
-    const extensionDevelopmentPath = path.resolve(__dirname, "../../../");
+    const extensionDevelopmentPath = path.resolve(project_dir);
 
     // The path to test runner
     // Passed to --extensionTestsPath
-    const extensionTestsPath = path.resolve(__dirname, "./index");
+    const extensionTestsPath = path.resolve(
+      project_dir,
+      "out/client/test/index",
+    );
 
     // Download VS Code, unzip it and run the integration test
     await runTests({


### PR DESCRIPTION
This change should allow us to refactor (move) files around without causing many problems due to broken paths. All relative paths should be relative to project_dir, which is defined by node.

Partial: AAP-45167