### PR TITLE
AAP-44214: new command to communicate with WCA-Core

### DIFF
--- a/package.json
+++ b/package.json
@@ -448,6 +448,14 @@
         "title": "Ansible Lightspeed: Enable experimental features"
       },
       {
+        "command": "ansible.lightspeed.get_token",
+        "title": "Ansible Lightspeed: Get token"
+      },
+      {
+        "command": "ansible.lightspeed.show_token",
+        "title": "Ansible Lightspeed: Show token"
+      },
+      {
         "command": "ansible.walkthrough.gettingStarted.setLanguage",
         "title": "Ansible: Getting started - Set Language"
       },


### PR DESCRIPTION
Expose a new command called `ansible.lightspeed.get_token` to share the
Lightspeed Bearer token with a third party extension.
