### PR TITLE
Avoid registering property already used by redhat.vscode-commons

### DIFF
--- a/package.json
+++ b/package.json
@@ -651,22 +651,6 @@
         }
       },
       {
-        "title": "Telemetry",
-        "properties": {
-          "redhat.telemetry.enabled": {
-            "type": "boolean",
-            "default": null,
-            "markdownDescription": "Enable usage data and errors to be sent to Red Hat servers. Read our [privacy statement](https://developers.redhat.com/article/tool-data-collection).",
-            "order": 0,
-            "tags": [
-              "telemetry",
-              "usesOnlineServices"
-            ],
-            "scope": "window"
-          }
-        }
-      },
-      {
         "title": "Ansible Lightspeed",
         "properties": {
           "ansible.lightspeed.enabled": {


### PR DESCRIPTION
As redhat.vscode-commons extension already registers `redhat.telemetry.enabled` property, we are not allowed to do the same, as this triggers a warning popup at runtime.