### PR TITLE
Remove duplicated section in README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -32,8 +32,7 @@ Before you begin, make sure your system has:
 It is recommended to open a folder containing Ansible files with a VS Code
 workspace.
 
-![Linter support](https://raw.githubusercontent.com/wiki/ansible/vscode-ansible/images/activate-extension.gif){
-width=750 height=750 }
+![Linter support](https://raw.githubusercontent.com/wiki/ansible/vscode-ansible/images/activate-extension.gif)
 
 Note:
 
@@ -256,21 +255,6 @@ or
 Rest all the .yml, or .yaml files will remain yaml by default unless the user
 explicitly changes the language to ansible for which the process is mentioned
 below.
-
-## Manual extension activation
-
-It is recommended to open a folder containing Ansible files with a VS Code
-workspace.
-
-![Linter support](https://raw.githubusercontent.com/wiki/ansible/vscode-ansible/images/activate-extension.gif)
-
-Note:
-
-- For Ansible files open in an editor window ensure the language mode is set to
-  `Ansible` (bottom right of VS Code window).
-- The runtime status of extension should be in activate state. It can be
-  verified in the `Extension` window `Runtime Status` tab for `Ansible`
-  extension.
 
 ## Features
 


### PR DESCRIPTION

---
name: Modification in user docs
about: Removed the duplication section of Manual extension activation and height and width of image which was showing up
---

<!--- Provide a general summary of your changes. Feel free to remove checklist
elements that do *not* apply for your PR. -->

# Before review

- [x] All tests are passing
- [x] Description mentions issue via
      `(fixes|closes|related): #<issue_number|AAP-number>`
- [x] PR is kept as **draft** until all checks above are met

# Review checklist

- [x] Size of change. If it can be split into smaller PRs, please do so.
- [ ] Docs checks:
  - [ ] heading titles are **short** and render without wrapping in sidebar
  - [ ] code blocks and diagrams render correctly in dark/light mode
  - [ ] images and videos are not blurry, small in size and use appropriate
        format such as `png`, `svg`, `webp`, `mp4` (not `gif`).
  - [ ] Less is more, no boilerplate language. Feel free to use AI to help with
        this and with correct grammar.
