### PR TITLE
Fix bug where role explanation always shows up in context menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -817,7 +817,8 @@
         },
         {
           "group": "2_main@1",
-          "command": "ansible.lightspeed.roleExplanation"
+          "command": "ansible.lightspeed.roleExplanation",
+          "when": "redhat.ansible.lightspeedSuggestionsEnabled && ansible.isDocumentInRole"
         },
         {
           "when": "resourceFilename == 'execution-environment.yml' || resourceFilename == 'execution-environment.yaml'",

--- a/package.json
+++ b/package.json
@@ -818,7 +818,7 @@
         {
           "group": "2_main@1",
           "command": "ansible.lightspeed.roleExplanation",
-          "when": "redhat.ansible.lightspeedSuggestionsEnabled && ansible.isDocumentInRole"
+          "when": "redhat.ansible.lightspeedSuggestionsEnabled && redhat.ansible.isDocumentInRole"
         },
         {
           "when": "resourceFilename == 'execution-environment.yml' || resourceFilename == 'execution-environment.yaml'",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -309,6 +309,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
           lightSpeedManager,
           pythonInterpreterManager,
         );
+        await updateDocumentInRoleContext();
         if (!editor) {
           await ignorePendingSuggestion();
         }
@@ -1051,4 +1052,16 @@ async function lightspeedLogin(
       `Welcome back ${authenticatedUser.displayNameWithUserType}`,
     );
   }
+}
+
+async function updateDocumentInRoleContext() {
+  const document = vscode.window.activeTextEditor?.document;
+  const isInRole = document
+    ? await isDocumentInRole(document).catch(() => false)
+    : false;
+  vscode.commands.executeCommand(
+    "setContext",
+    "ansible.isDocumentInRole",
+    isInRole,
+  );
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1061,7 +1061,7 @@ async function updateDocumentInRoleContext() {
     : false;
   vscode.commands.executeCommand(
     "setContext",
-    "ansible.isDocumentInRole",
+    "redhat.ansible.isDocumentInRole",
     isInRole,
   );
 }

--- a/test/ui/lightspeedUiTestPlaybookExpTest.ts
+++ b/test/ui/lightspeedUiTestPlaybookExpTest.ts
@@ -24,6 +24,7 @@ async function testThumbsButtonInteraction(buttonToClick: string) {
   // Open file in the editor
   await VSBrowser.instance.openResources(filePath);
 
+  // This won't work on MacOS, see: https://github.com/redhat-developer/vscode-extension-tester/issues/1875
   if (process.platform !== "darwin") {
     const editorView = new EditorView();
     const editor = await editorView.openEditor("playbook_1.yml");

--- a/test/ui/lightspeedUiTestPlaybookExpTest.ts
+++ b/test/ui/lightspeedUiTestPlaybookExpTest.ts
@@ -24,6 +24,30 @@ async function testThumbsButtonInteraction(buttonToClick: string) {
   // Open file in the editor
   await VSBrowser.instance.openResources(filePath);
 
+  if (process.platform !== "darwin") {
+    const editorView = new EditorView();
+    const editor = await editorView.openEditor("playbook_1.yml");
+    const contextMenu = await editor.openContextMenu();
+
+    const hasExplainRoleMenuItem = await contextMenu.hasItem(
+      "Explain the role with Ansible Lightspeed",
+    );
+    expect(
+      hasExplainRoleMenuItem,
+      '"Explain the role with Ansible Lightspeed" should not be present in the context menu',
+    ).not.to.be.true;
+
+    const hasExplainPlaybookMenuItem = await contextMenu.hasItem(
+      "Explain the playbook with Ansible Lightspeed",
+    );
+    expect(
+      hasExplainPlaybookMenuItem,
+      '"Explain the playbook with Ansible Lightspeed" should be present in the context menu',
+    ).to.be.true;
+
+    await contextMenu.close();
+  }
+
   // Open playbook explanation webview.
   await workbenchExecuteCommand("Explain the playbook with Ansible Lightspeed");
 

--- a/test/ui/lightspeedUiTestRoleExpTest.ts
+++ b/test/ui/lightspeedUiTestRoleExpTest.ts
@@ -20,6 +20,28 @@ async function testThumbsButtonInteraction(buttonToClick: string) {
   // Open file in the editor
   await VSBrowser.instance.openResources(filePath);
 
+  if (process.platform !== "darwin") {
+    const editorView = new EditorView();
+    const editor = await editorView.openEditor("main.yml");
+    const contextMenu = await editor.openContextMenu();
+
+    const hasExplainRoleMenuItem = await contextMenu.hasItem(
+      "Explain the role with Ansible Lightspeed",
+    );
+    expect(
+      hasExplainRoleMenuItem,
+      '"Explain the role with Ansible Lightspeed" should be present in the context menu',
+    ).to.be.true;
+
+    const hasFoobarMenuItem = await contextMenu.hasItem("this is foobar");
+    expect(
+      hasFoobarMenuItem,
+      '"this is foobar" should not be present in the context menu',
+    ).not.to.be.true;
+
+    await contextMenu.close();
+  }
+
   // Open role explanation webview.
   await workbenchExecuteCommand("Explain the role with Ansible Lightspeed");
 

--- a/test/ui/lightspeedUiTestRoleExpTest.ts
+++ b/test/ui/lightspeedUiTestRoleExpTest.ts
@@ -20,6 +20,7 @@ async function testThumbsButtonInteraction(buttonToClick: string) {
   // Open file in the editor
   await VSBrowser.instance.openResources(filePath);
 
+  // This won't work on MacOS, see: https://github.com/redhat-developer/vscode-extension-tester/issues/1875
   if (process.platform !== "darwin") {
     const editorView = new EditorView();
     const editor = await editorView.openEditor("main.yml");


### PR DESCRIPTION
fixes https://issues.redhat.com/browse/AAP-45176

Adds a context for tracking whether or not a file is detected as within a role.  We'll then use that context to show/hide the "Explain this role with Ansible Lightspeed" menu item.

# Before review

- [x] All tests are passing
- [x] Description mentions issue via
      `(fixes|closes|related): #<issue_number|AAP-number>`
- [x] PR is kept as **draft** until all checks above are met

# Review checklist

- [ ] Size of change. If it can be split into smaller PRs, please do so.
- [ ] Docs checks:
  - [ ] heading titles are **short** and render without wrapping in sidebar
  - [ ] code blocks and diagrams render correctly in dark/light mode
  - [ ] images and videos are not blurry, small in size and use appropriate
        format such as `png`, `svg`, `webp`, `mp4` (not `gif`).
  - [ ] Less is more, no boilerplate language. Feel free to use AI to help with
        this and with correct grammar.
