### PR TITLE
Enabling konflux

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -246,6 +246,7 @@ seccomp
 tamasfe
 taskfile
 tasklist
+tekton
 testenv
 testhost
 testorg

--- a/.tekton/vscode-ansible-pull-request.yaml
+++ b/.tekton/vscode-ansible-pull-request.yaml
@@ -1,0 +1,629 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+    annotations:
+        build.appstudio.openshift.io/repo: https://github.com/ansible/vscode-ansible?rev={{revision}}
+        build.appstudio.redhat.com/commit_sha: "{{revision}}"
+        build.appstudio.redhat.com/pull_request_number: "{{pull_request_number}}"
+        build.appstudio.redhat.com/target_branch: "{{target_branch}}"
+        pipelinesascode.tekton.dev/cancel-in-progress: "true"
+        pipelinesascode.tekton.dev/max-keep-runs: "3"
+        pipelinesascode.tekton.dev/on-cel-expression:
+            event == "pull_request" && target_branch
+            == "main"
+    creationTimestamp: null
+    labels:
+        appstudio.openshift.io/application: vscode-ansible
+        appstudio.openshift.io/component: vscode-ansible
+        pipelines.appstudio.openshift.io/type: build
+    name: vscode-ansible-on-pull-request
+    namespace: ansible-lightspeed-tenant
+spec:
+    params:
+        - name: git-url
+          value: "{{source_url}}"
+        - name: revision
+          value: "{{revision}}"
+        - name: output-image
+          value: quay.io/redhat-user-workloads/ansible-lightspeed-tenant/vscode-ansible:on-pr-{{revision}}
+        - name: image-expires-after
+          value: 5d
+        - name: dockerfile
+          value: ./vscode-ansible.Containerfile
+    pipelineSpec:
+        description: |
+            This pipeline is ideal for building container images from a Containerfile while reducing network traffic.
+
+            _Uses `buildah` to create a container image. It also optionally creates a source image and runs some build-time tests. EC will flag a violation for [`trusted_task.trusted`](https://enterprisecontract.dev/docs/ec-policies/release_policy.html#trusted_task__trusted) if any tasks are added to the pipeline.
+            This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/repository/konflux-ci/tekton-catalog/pipeline-docker-build?tab=tags)_
+        finally:
+            - name: show-sbom
+              params:
+                  - name: IMAGE_URL
+                    value: $(tasks.build-image-index.results.IMAGE_URL)
+              taskRef:
+                  params:
+                      - name: name
+                        value: show-sbom
+                      - name: bundle
+                        value: quay.io/konflux-ci/tekton-catalog/task-show-sbom:0.1@sha256:002f7c8c1d2f9e09904035da414aba1188ae091df0ea9532cd997be05e73d594
+                      - name: kind
+                        value: task
+                  resolver: bundles
+            - name: show-summary
+              params:
+                  - name: pipelinerun-name
+                    value: $(context.pipelineRun.name)
+                  - name: git-url
+                    value: $(tasks.clone-repository.results.url)?rev=$(tasks.clone-repository.results.commit)
+                  - name: image-url
+                    value: $(params.output-image)
+                  - name: build-task-status
+                    value: $(tasks.build-image-index.status)
+              taskRef:
+                  params:
+                      - name: name
+                        value: summary
+                      - name: bundle
+                        value: quay.io/konflux-ci/tekton-catalog/task-summary:0.2@sha256:76075b709fa06ed824cbc84f41448b397b85bfde1cf9809395ba6d286f5b7cbd
+                      - name: kind
+                        value: task
+                  resolver: bundles
+              workspaces:
+                  - name: workspace
+                    workspace: workspace
+        params:
+            - description: Source Repository URL
+              name: git-url
+              type: string
+            - default: ""
+              description: Revision of the Source Repository
+              name: revision
+              type: string
+            - description: Fully Qualified Output Image
+              name: output-image
+              type: string
+            - default: .
+              description:
+                  Path to the source code of an application's component from where
+                  to build image.
+              name: path-context
+              type: string
+            - default: Dockerfile
+              description:
+                  Path to the Dockerfile inside the context specified by parameter
+                  path-context
+              name: dockerfile
+              type: string
+            - default: "false"
+              description: Force rebuild image
+              name: rebuild
+              type: string
+            - default: "false"
+              description: Skip checks against built image
+              name: skip-checks
+              type: string
+            - default: "false"
+              description: Execute the build with network isolation
+              name: hermetic
+              type: string
+            - default: ""
+              description: Build dependencies to be prefetched by Cachi2
+              name: prefetch-input
+              type: string
+            - default: ""
+              description:
+                  Image tag expiration time, time values could be something like
+                  1h, 2d, 3w for hours, days, and weeks, respectively.
+              name: image-expires-after
+            - default: "false"
+              description: Build a source image.
+              name: build-source-image
+              type: string
+            - default: "false"
+              description: Add built image into an OCI image index
+              name: build-image-index
+              type: string
+            - default: []
+              description: Array of --build-arg values ("arg=value" strings) for buildah
+              name: build-args
+              type: array
+            - default: ""
+              description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
+              name: build-args-file
+              type: string
+            - default: "false"
+              description:
+                  Whether to enable privileged mode, should be used only with remote
+                  VMs
+              name: privileged-nested
+              type: string
+        results:
+            - description: ""
+              name: IMAGE_URL
+              value: $(tasks.build-image-index.results.IMAGE_URL)
+            - description: ""
+              name: IMAGE_DIGEST
+              value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+            - description: ""
+              name: CHAINS-GIT_URL
+              value: $(tasks.clone-repository.results.url)
+            - description: ""
+              name: CHAINS-GIT_COMMIT
+              value: $(tasks.clone-repository.results.commit)
+        tasks:
+            - name: init
+              params:
+                  - name: image-url
+                    value: $(params.output-image)
+                  - name: rebuild
+                    value: $(params.rebuild)
+                  - name: skip-checks
+                    value: $(params.skip-checks)
+              taskRef:
+                  params:
+                      - name: name
+                        value: init
+                      - name: bundle
+                        value: quay.io/konflux-ci/tekton-catalog/task-init:0.2@sha256:7a24924417260b7094541caaedd2853dc8da08d4bb0968f710a400d3e8062063
+                      - name: kind
+                        value: task
+                  resolver: bundles
+            - name: clone-repository
+              params:
+                  - name: url
+                    value: $(params.git-url)
+                  - name: revision
+                    value: $(params.revision)
+              runAfter:
+                  - init
+              taskRef:
+                  params:
+                      - name: name
+                        value: git-clone
+                      - name: bundle
+                        value: quay.io/konflux-ci/tekton-catalog/task-git-clone:0.1@sha256:3ced9a6b9d8520773d3ffbf062190515a362ecda11e72f56e38e4dd980294b57
+                      - name: kind
+                        value: task
+                  resolver: bundles
+              when:
+                  - input: $(tasks.init.results.build)
+                    operator: in
+                    values:
+                        - "true"
+              workspaces:
+                  - name: output
+                    workspace: workspace
+                  - name: basic-auth
+                    workspace: git-auth
+            - name: prefetch-dependencies
+              params:
+                  - name: input
+                    value: $(params.prefetch-input)
+              runAfter:
+                  - clone-repository
+              taskRef:
+                  params:
+                      - name: name
+                        value: prefetch-dependencies
+                      - name: bundle
+                        value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies:0.2@sha256:89fb1850fdfa76eb9cc9d38952cb637f3b44108bf9b53cad5ed3716e17c53678
+                      - name: kind
+                        value: task
+                  resolver: bundles
+              workspaces:
+                  - name: source
+                    workspace: workspace
+                  - name: git-basic-auth
+                    workspace: git-auth
+                  - name: netrc
+                    workspace: netrc
+            - name: build-container
+              params:
+                  - name: IMAGE
+                    value: $(params.output-image)
+                  - name: DOCKERFILE
+                    value: $(params.dockerfile)
+                  - name: CONTEXT
+                    value: $(params.path-context)
+                  - name: HERMETIC
+                    value: $(params.hermetic)
+                  - name: PREFETCH_INPUT
+                    value: $(params.prefetch-input)
+                  - name: IMAGE_EXPIRES_AFTER
+                    value: $(params.image-expires-after)
+                  - name: COMMIT_SHA
+                    value: $(tasks.clone-repository.results.commit)
+                  - name: BUILD_ARGS
+                    value:
+                        - $(params.build-args[*])
+                  - name: BUILD_ARGS_FILE
+                    value: $(params.build-args-file)
+                  - name: PRIVILEGED_NESTED
+                    value: $(params.privileged-nested)
+              runAfter:
+                  - prefetch-dependencies
+              taskRef:
+                  params:
+                      - name: name
+                        value: buildah
+                      - name: bundle
+                        value: quay.io/konflux-ci/tekton-catalog/task-buildah:0.4@sha256:c777fdb0947aff3e4ac29a93ed6358c6f7994e6b150154427646788ec773c440
+                      - name: kind
+                        value: task
+                  resolver: bundles
+              when:
+                  - input: $(tasks.init.results.build)
+                    operator: in
+                    values:
+                        - "true"
+              workspaces:
+                  - name: source
+                    workspace: workspace
+            - name: build-image-index
+              params:
+                  - name: IMAGE
+                    value: $(params.output-image)
+                  - name: COMMIT_SHA
+                    value: $(tasks.clone-repository.results.commit)
+                  - name: IMAGE_EXPIRES_AFTER
+                    value: $(params.image-expires-after)
+                  - name: ALWAYS_BUILD_INDEX
+                    value: $(params.build-image-index)
+                  - name: IMAGES
+                    value:
+                        - $(tasks.build-container.results.IMAGE_URL)@$(tasks.build-container.results.IMAGE_DIGEST)
+              runAfter:
+                  - build-container
+              taskRef:
+                  params:
+                      - name: name
+                        value: build-image-index
+                      - name: bundle
+                        value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.1@sha256:462ecbf94ec44a8b770d6ef8838955f91f57ee79795e5c18bdc0fcb0df593742
+                      - name: kind
+                        value: task
+                  resolver: bundles
+              when:
+                  - input: $(tasks.init.results.build)
+                    operator: in
+                    values:
+                        - "true"
+            - name: build-source-image
+              params:
+                  - name: BINARY_IMAGE
+                    value: $(params.output-image)
+              runAfter:
+                  - build-image-index
+              taskRef:
+                  params:
+                      - name: name
+                        value: source-build
+                      - name: bundle
+                        value: quay.io/konflux-ci/tekton-catalog/task-source-build:0.2@sha256:11029fa30652154f772b44132f8a116382c136a6223e8f9576137f99b9901dcb
+                      - name: kind
+                        value: task
+                  resolver: bundles
+              when:
+                  - input: $(tasks.init.results.build)
+                    operator: in
+                    values:
+                        - "true"
+                  - input: $(params.build-source-image)
+                    operator: in
+                    values:
+                        - "true"
+              workspaces:
+                  - name: workspace
+                    workspace: workspace
+            - name: deprecated-base-image-check
+              params:
+                  - name: IMAGE_URL
+                    value: $(tasks.build-image-index.results.IMAGE_URL)
+                  - name: IMAGE_DIGEST
+                    value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+              runAfter:
+                  - build-image-index
+              taskRef:
+                  params:
+                      - name: name
+                        value: deprecated-image-check
+                      - name: bundle
+                        value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:ecd33669676b3a193ff4c2c6223cb912cc1b0cf5cc36e080eaec7718500272cf
+                      - name: kind
+                        value: task
+                  resolver: bundles
+              when:
+                  - input: $(params.skip-checks)
+                    operator: in
+                    values:
+                        - "false"
+            - name: clair-scan
+              params:
+                  - name: image-digest
+                    value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+                  - name: image-url
+                    value: $(tasks.build-image-index.results.IMAGE_URL)
+              runAfter:
+                  - build-image-index
+              taskRef:
+                  params:
+                      - name: name
+                        value: clair-scan
+                      - name: bundle
+                        value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.2@sha256:878ae247ffc58d95a9ac68e4d658ef91ef039363e03e65a386bc0ead02d9d7d8
+                      - name: kind
+                        value: task
+                  resolver: bundles
+              when:
+                  - input: $(params.skip-checks)
+                    operator: in
+                    values:
+                        - "false"
+            - name: ecosystem-cert-preflight-checks
+              params:
+                  - name: image-url
+                    value: $(tasks.build-image-index.results.IMAGE_URL)
+              runAfter:
+                  - build-image-index
+              taskRef:
+                  params:
+                      - name: name
+                        value: ecosystem-cert-preflight-checks
+                      - name: bundle
+                        value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:dea8d9b4bec3e99d612d799798acf132df48276164b5193ea68f9f3c25ae425b
+                      - name: kind
+                        value: task
+                  resolver: bundles
+              when:
+                  - input: $(params.skip-checks)
+                    operator: in
+                    values:
+                        - "false"
+            - name: sast-snyk-check
+              params:
+                  - name: image-digest
+                    value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+                  - name: image-url
+                    value: $(tasks.build-image-index.results.IMAGE_URL)
+              runAfter:
+                  - build-image-index
+              taskRef:
+                  params:
+                      - name: name
+                        value: sast-snyk-check
+                      - name: bundle
+                        value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check:0.4@sha256:0d22dbaa528c8edf59aafab3600a0537b5408b80a4f69dd9cb616620795ecdc8
+                      - name: kind
+                        value: task
+                  resolver: bundles
+              when:
+                  - input: $(params.skip-checks)
+                    operator: in
+                    values:
+                        - "false"
+              workspaces:
+                  - name: workspace
+                    workspace: workspace
+            - name: clamav-scan
+              params:
+                  - name: image-digest
+                    value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+                  - name: image-url
+                    value: $(tasks.build-image-index.results.IMAGE_URL)
+              runAfter:
+                  - build-image-index
+              taskRef:
+                  params:
+                      - name: name
+                        value: clamav-scan
+                      - name: bundle
+                        value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.2@sha256:24182598bf5161c4007988a7236e240f361c77a0a9b6973a6712dbae50d296bc
+                      - name: kind
+                        value: task
+                  resolver: bundles
+              when:
+                  - input: $(params.skip-checks)
+                    operator: in
+                    values:
+                        - "false"
+            - name: sast-coverity-check
+              params:
+                  - name: image-digest
+                    value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+                  - name: image-url
+                    value: $(tasks.build-image-index.results.IMAGE_URL)
+                  - name: IMAGE
+                    value: $(params.output-image)
+                  - name: DOCKERFILE
+                    value: $(params.dockerfile)
+                  - name: CONTEXT
+                    value: $(params.path-context)
+                  - name: HERMETIC
+                    value: $(params.hermetic)
+                  - name: PREFETCH_INPUT
+                    value: $(params.prefetch-input)
+                  - name: IMAGE_EXPIRES_AFTER
+                    value: $(params.image-expires-after)
+                  - name: COMMIT_SHA
+                    value: $(tasks.clone-repository.results.commit)
+                  - name: BUILD_ARGS
+                    value:
+                        - $(params.build-args[*])
+                  - name: BUILD_ARGS_FILE
+                    value: $(params.build-args-file)
+              runAfter:
+                  - coverity-availability-check
+              taskRef:
+                  params:
+                      - name: name
+                        value: sast-coverity-check
+                      - name: bundle
+                        value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check:0.3@sha256:d7d9682b679c98ffe4633dd24b62cafb0799264d459cf2ab9fa1593e1a42bfdf
+                      - name: kind
+                        value: task
+                  resolver: bundles
+              when:
+                  - input: $(params.skip-checks)
+                    operator: in
+                    values:
+                        - "false"
+                  - input: $(tasks.coverity-availability-check.results.STATUS)
+                    operator: in
+                    values:
+                        - success
+              workspaces:
+                  - name: source
+                    workspace: workspace
+            - name: coverity-availability-check
+              runAfter:
+                  - build-image-index
+              taskRef:
+                  params:
+                      - name: name
+                        value: coverity-availability-check
+                      - name: bundle
+                        value: quay.io/konflux-ci/tekton-catalog/task-coverity-availability-check:0.2@sha256:8b58c4fae00c0dfe3937abfb8a9a61aa3c408cca4278b817db53d518428d944e
+                      - name: kind
+                        value: task
+                  resolver: bundles
+              when:
+                  - input: $(params.skip-checks)
+                    operator: in
+                    values:
+                        - "false"
+            - name: sast-shell-check
+              params:
+                  - name: image-digest
+                    value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+                  - name: image-url
+                    value: $(tasks.build-image-index.results.IMAGE_URL)
+              runAfter:
+                  - build-image-index
+              taskRef:
+                  params:
+                      - name: name
+                        value: sast-shell-check
+                      - name: bundle
+                        value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check:0.1@sha256:188a4f6a582ac43d4de46c3998ded3c2a8ee237fb0604d90559a3b6e0aa62b0f
+                      - name: kind
+                        value: task
+                  resolver: bundles
+              when:
+                  - input: $(params.skip-checks)
+                    operator: in
+                    values:
+                        - "false"
+              workspaces:
+                  - name: workspace
+                    workspace: workspace
+            - name: sast-unicode-check
+              params:
+                  - name: image-digest
+                    value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+                  - name: image-url
+                    value: $(tasks.build-image-index.results.IMAGE_URL)
+              runAfter:
+                  - build-image-index
+              taskRef:
+                  params:
+                      - name: name
+                        value: sast-unicode-check
+                      - name: bundle
+                        value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check:0.2@sha256:e4a5215b45b1886a185a9db8ab392f8440c2b0848f76d719885637cf8d2628ed
+                      - name: kind
+                        value: task
+                  resolver: bundles
+              when:
+                  - input: $(params.skip-checks)
+                    operator: in
+                    values:
+                        - "false"
+              workspaces:
+                  - name: workspace
+                    workspace: workspace
+            - name: apply-tags
+              params:
+                  - name: IMAGE
+                    value: $(tasks.build-image-index.results.IMAGE_URL)
+              runAfter:
+                  - build-image-index
+              taskRef:
+                  params:
+                      - name: name
+                        value: apply-tags
+                      - name: bundle
+                        value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.1@sha256:3f89ba89cacf8547261b5ce064acce81bfe470c8ace127794d0e90aebc8c347d
+                      - name: kind
+                        value: task
+                  resolver: bundles
+            - name: push-dockerfile
+              params:
+                  - name: IMAGE
+                    value: $(tasks.build-image-index.results.IMAGE_URL)
+                  - name: IMAGE_DIGEST
+                    value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+                  - name: DOCKERFILE
+                    value: $(params.dockerfile)
+                  - name: CONTEXT
+                    value: $(params.path-context)
+              runAfter:
+                  - build-image-index
+              taskRef:
+                  params:
+                      - name: name
+                        value: push-dockerfile
+                      - name: bundle
+                        value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile:0.1@sha256:c82189e5d331e489cff99f0399f133fd3fad08921bea86747dfa379d1b5c748d
+                      - name: kind
+                        value: task
+                  resolver: bundles
+              workspaces:
+                  - name: workspace
+                    workspace: workspace
+            - name: rpms-signature-scan
+              params:
+                  - name: image-url
+                    value: $(tasks.build-image-index.results.IMAGE_URL)
+                  - name: image-digest
+                    value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+              runAfter:
+                  - build-image-index
+              taskRef:
+                  params:
+                      - name: name
+                        value: rpms-signature-scan
+                      - name: bundle
+                        value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:297c2d8928aa3b114fcb1ba5d9da8b10226b68fed30706e78a6a5089c6cd30e3
+                      - name: kind
+                        value: task
+                  resolver: bundles
+              when:
+                  - input: $(params.skip-checks)
+                    operator: in
+                    values:
+                        - "false"
+        workspaces:
+            - name: workspace
+            - name: git-auth
+              optional: true
+            - name: netrc
+              optional: true
+    taskRunTemplate:
+        serviceAccountName: build-pipeline-vscode-ansible
+    workspaces:
+        - name: workspace
+          volumeClaimTemplate:
+              metadata:
+                  creationTimestamp: null
+              spec:
+                  accessModes:
+                      - ReadWriteOnce
+                  resources:
+                      requests:
+                          storage: 1Gi
+              status: {}
+        - name: git-auth
+          secret:
+              secretName: "{{ git_auth_secret }}"
+status: {}

--- a/.tekton/vscode-ansible-push.yaml
+++ b/.tekton/vscode-ansible-push.yaml
@@ -1,0 +1,626 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+    annotations:
+        build.appstudio.openshift.io/repo: https://github.com/ansible/vscode-ansible?rev={{revision}}
+        build.appstudio.redhat.com/commit_sha: "{{revision}}"
+        build.appstudio.redhat.com/target_branch: "{{target_branch}}"
+        pipelinesascode.tekton.dev/cancel-in-progress: "false"
+        pipelinesascode.tekton.dev/max-keep-runs: "3"
+        pipelinesascode.tekton.dev/on-cel-expression:
+            event == "push" && target_branch
+            == "main"
+    creationTimestamp: null
+    labels:
+        appstudio.openshift.io/application: vscode-ansible
+        appstudio.openshift.io/component: vscode-ansible
+        pipelines.appstudio.openshift.io/type: build
+    name: vscode-ansible-on-push
+    namespace: ansible-lightspeed-tenant
+spec:
+    params:
+        - name: git-url
+          value: "{{source_url}}"
+        - name: revision
+          value: "{{revision}}"
+        - name: output-image
+          value: quay.io/redhat-user-workloads/ansible-lightspeed-tenant/vscode-ansible:{{revision}}
+        - name: dockerfile
+          value: ./vscode-ansible.Containerfile
+    pipelineSpec:
+        description: |
+            This pipeline is ideal for building container images from a Containerfile while reducing network traffic.
+
+            _Uses `buildah` to create a container image. It also optionally creates a source image and runs some build-time tests. EC will flag a violation for [`trusted_task.trusted`](https://enterprisecontract.dev/docs/ec-policies/release_policy.html#trusted_task__trusted) if any tasks are added to the pipeline.
+            This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/repository/konflux-ci/tekton-catalog/pipeline-docker-build?tab=tags)_
+        finally:
+            - name: show-sbom
+              params:
+                  - name: IMAGE_URL
+                    value: $(tasks.build-image-index.results.IMAGE_URL)
+              taskRef:
+                  params:
+                      - name: name
+                        value: show-sbom
+                      - name: bundle
+                        value: quay.io/konflux-ci/tekton-catalog/task-show-sbom:0.1@sha256:002f7c8c1d2f9e09904035da414aba1188ae091df0ea9532cd997be05e73d594
+                      - name: kind
+                        value: task
+                  resolver: bundles
+            - name: show-summary
+              params:
+                  - name: pipelinerun-name
+                    value: $(context.pipelineRun.name)
+                  - name: git-url
+                    value: $(tasks.clone-repository.results.url)?rev=$(tasks.clone-repository.results.commit)
+                  - name: image-url
+                    value: $(params.output-image)
+                  - name: build-task-status
+                    value: $(tasks.build-image-index.status)
+              taskRef:
+                  params:
+                      - name: name
+                        value: summary
+                      - name: bundle
+                        value: quay.io/konflux-ci/tekton-catalog/task-summary:0.2@sha256:76075b709fa06ed824cbc84f41448b397b85bfde1cf9809395ba6d286f5b7cbd
+                      - name: kind
+                        value: task
+                  resolver: bundles
+              workspaces:
+                  - name: workspace
+                    workspace: workspace
+        params:
+            - description: Source Repository URL
+              name: git-url
+              type: string
+            - default: ""
+              description: Revision of the Source Repository
+              name: revision
+              type: string
+            - description: Fully Qualified Output Image
+              name: output-image
+              type: string
+            - default: .
+              description:
+                  Path to the source code of an application's component from where
+                  to build image.
+              name: path-context
+              type: string
+            - default: Dockerfile
+              description:
+                  Path to the Dockerfile inside the context specified by parameter
+                  path-context
+              name: dockerfile
+              type: string
+            - default: "false"
+              description: Force rebuild image
+              name: rebuild
+              type: string
+            - default: "false"
+              description: Skip checks against built image
+              name: skip-checks
+              type: string
+            - default: "false"
+              description: Execute the build with network isolation
+              name: hermetic
+              type: string
+            - default: ""
+              description: Build dependencies to be prefetched by Cachi2
+              name: prefetch-input
+              type: string
+            - default: ""
+              description:
+                  Image tag expiration time, time values could be something like
+                  1h, 2d, 3w for hours, days, and weeks, respectively.
+              name: image-expires-after
+            - default: "false"
+              description: Build a source image.
+              name: build-source-image
+              type: string
+            - default: "false"
+              description: Add built image into an OCI image index
+              name: build-image-index
+              type: string
+            - default: []
+              description: Array of --build-arg values ("arg=value" strings) for buildah
+              name: build-args
+              type: array
+            - default: ""
+              description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
+              name: build-args-file
+              type: string
+            - default: "false"
+              description:
+                  Whether to enable privileged mode, should be used only with remote
+                  VMs
+              name: privileged-nested
+              type: string
+        results:
+            - description: ""
+              name: IMAGE_URL
+              value: $(tasks.build-image-index.results.IMAGE_URL)
+            - description: ""
+              name: IMAGE_DIGEST
+              value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+            - description: ""
+              name: CHAINS-GIT_URL
+              value: $(tasks.clone-repository.results.url)
+            - description: ""
+              name: CHAINS-GIT_COMMIT
+              value: $(tasks.clone-repository.results.commit)
+        tasks:
+            - name: init
+              params:
+                  - name: image-url
+                    value: $(params.output-image)
+                  - name: rebuild
+                    value: $(params.rebuild)
+                  - name: skip-checks
+                    value: $(params.skip-checks)
+              taskRef:
+                  params:
+                      - name: name
+                        value: init
+                      - name: bundle
+                        value: quay.io/konflux-ci/tekton-catalog/task-init:0.2@sha256:7a24924417260b7094541caaedd2853dc8da08d4bb0968f710a400d3e8062063
+                      - name: kind
+                        value: task
+                  resolver: bundles
+            - name: clone-repository
+              params:
+                  - name: url
+                    value: $(params.git-url)
+                  - name: revision
+                    value: $(params.revision)
+              runAfter:
+                  - init
+              taskRef:
+                  params:
+                      - name: name
+                        value: git-clone
+                      - name: bundle
+                        value: quay.io/konflux-ci/tekton-catalog/task-git-clone:0.1@sha256:3ced9a6b9d8520773d3ffbf062190515a362ecda11e72f56e38e4dd980294b57
+                      - name: kind
+                        value: task
+                  resolver: bundles
+              when:
+                  - input: $(tasks.init.results.build)
+                    operator: in
+                    values:
+                        - "true"
+              workspaces:
+                  - name: output
+                    workspace: workspace
+                  - name: basic-auth
+                    workspace: git-auth
+            - name: prefetch-dependencies
+              params:
+                  - name: input
+                    value: $(params.prefetch-input)
+              runAfter:
+                  - clone-repository
+              taskRef:
+                  params:
+                      - name: name
+                        value: prefetch-dependencies
+                      - name: bundle
+                        value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies:0.2@sha256:89fb1850fdfa76eb9cc9d38952cb637f3b44108bf9b53cad5ed3716e17c53678
+                      - name: kind
+                        value: task
+                  resolver: bundles
+              workspaces:
+                  - name: source
+                    workspace: workspace
+                  - name: git-basic-auth
+                    workspace: git-auth
+                  - name: netrc
+                    workspace: netrc
+            - name: build-container
+              params:
+                  - name: IMAGE
+                    value: $(params.output-image)
+                  - name: DOCKERFILE
+                    value: $(params.dockerfile)
+                  - name: CONTEXT
+                    value: $(params.path-context)
+                  - name: HERMETIC
+                    value: $(params.hermetic)
+                  - name: PREFETCH_INPUT
+                    value: $(params.prefetch-input)
+                  - name: IMAGE_EXPIRES_AFTER
+                    value: $(params.image-expires-after)
+                  - name: COMMIT_SHA
+                    value: $(tasks.clone-repository.results.commit)
+                  - name: BUILD_ARGS
+                    value:
+                        - $(params.build-args[*])
+                  - name: BUILD_ARGS_FILE
+                    value: $(params.build-args-file)
+                  - name: PRIVILEGED_NESTED
+                    value: $(params.privileged-nested)
+              runAfter:
+                  - prefetch-dependencies
+              taskRef:
+                  params:
+                      - name: name
+                        value: buildah
+                      - name: bundle
+                        value: quay.io/konflux-ci/tekton-catalog/task-buildah:0.4@sha256:c777fdb0947aff3e4ac29a93ed6358c6f7994e6b150154427646788ec773c440
+                      - name: kind
+                        value: task
+                  resolver: bundles
+              when:
+                  - input: $(tasks.init.results.build)
+                    operator: in
+                    values:
+                        - "true"
+              workspaces:
+                  - name: source
+                    workspace: workspace
+            - name: build-image-index
+              params:
+                  - name: IMAGE
+                    value: $(params.output-image)
+                  - name: COMMIT_SHA
+                    value: $(tasks.clone-repository.results.commit)
+                  - name: IMAGE_EXPIRES_AFTER
+                    value: $(params.image-expires-after)
+                  - name: ALWAYS_BUILD_INDEX
+                    value: $(params.build-image-index)
+                  - name: IMAGES
+                    value:
+                        - $(tasks.build-container.results.IMAGE_URL)@$(tasks.build-container.results.IMAGE_DIGEST)
+              runAfter:
+                  - build-container
+              taskRef:
+                  params:
+                      - name: name
+                        value: build-image-index
+                      - name: bundle
+                        value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.1@sha256:462ecbf94ec44a8b770d6ef8838955f91f57ee79795e5c18bdc0fcb0df593742
+                      - name: kind
+                        value: task
+                  resolver: bundles
+              when:
+                  - input: $(tasks.init.results.build)
+                    operator: in
+                    values:
+                        - "true"
+            - name: build-source-image
+              params:
+                  - name: BINARY_IMAGE
+                    value: $(params.output-image)
+              runAfter:
+                  - build-image-index
+              taskRef:
+                  params:
+                      - name: name
+                        value: source-build
+                      - name: bundle
+                        value: quay.io/konflux-ci/tekton-catalog/task-source-build:0.2@sha256:11029fa30652154f772b44132f8a116382c136a6223e8f9576137f99b9901dcb
+                      - name: kind
+                        value: task
+                  resolver: bundles
+              when:
+                  - input: $(tasks.init.results.build)
+                    operator: in
+                    values:
+                        - "true"
+                  - input: $(params.build-source-image)
+                    operator: in
+                    values:
+                        - "true"
+              workspaces:
+                  - name: workspace
+                    workspace: workspace
+            - name: deprecated-base-image-check
+              params:
+                  - name: IMAGE_URL
+                    value: $(tasks.build-image-index.results.IMAGE_URL)
+                  - name: IMAGE_DIGEST
+                    value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+              runAfter:
+                  - build-image-index
+              taskRef:
+                  params:
+                      - name: name
+                        value: deprecated-image-check
+                      - name: bundle
+                        value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:ecd33669676b3a193ff4c2c6223cb912cc1b0cf5cc36e080eaec7718500272cf
+                      - name: kind
+                        value: task
+                  resolver: bundles
+              when:
+                  - input: $(params.skip-checks)
+                    operator: in
+                    values:
+                        - "false"
+            - name: clair-scan
+              params:
+                  - name: image-digest
+                    value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+                  - name: image-url
+                    value: $(tasks.build-image-index.results.IMAGE_URL)
+              runAfter:
+                  - build-image-index
+              taskRef:
+                  params:
+                      - name: name
+                        value: clair-scan
+                      - name: bundle
+                        value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.2@sha256:878ae247ffc58d95a9ac68e4d658ef91ef039363e03e65a386bc0ead02d9d7d8
+                      - name: kind
+                        value: task
+                  resolver: bundles
+              when:
+                  - input: $(params.skip-checks)
+                    operator: in
+                    values:
+                        - "false"
+            - name: ecosystem-cert-preflight-checks
+              params:
+                  - name: image-url
+                    value: $(tasks.build-image-index.results.IMAGE_URL)
+              runAfter:
+                  - build-image-index
+              taskRef:
+                  params:
+                      - name: name
+                        value: ecosystem-cert-preflight-checks
+                      - name: bundle
+                        value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:dea8d9b4bec3e99d612d799798acf132df48276164b5193ea68f9f3c25ae425b
+                      - name: kind
+                        value: task
+                  resolver: bundles
+              when:
+                  - input: $(params.skip-checks)
+                    operator: in
+                    values:
+                        - "false"
+            - name: sast-snyk-check
+              params:
+                  - name: image-digest
+                    value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+                  - name: image-url
+                    value: $(tasks.build-image-index.results.IMAGE_URL)
+              runAfter:
+                  - build-image-index
+              taskRef:
+                  params:
+                      - name: name
+                        value: sast-snyk-check
+                      - name: bundle
+                        value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check:0.4@sha256:0d22dbaa528c8edf59aafab3600a0537b5408b80a4f69dd9cb616620795ecdc8
+                      - name: kind
+                        value: task
+                  resolver: bundles
+              when:
+                  - input: $(params.skip-checks)
+                    operator: in
+                    values:
+                        - "false"
+              workspaces:
+                  - name: workspace
+                    workspace: workspace
+            - name: clamav-scan
+              params:
+                  - name: image-digest
+                    value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+                  - name: image-url
+                    value: $(tasks.build-image-index.results.IMAGE_URL)
+              runAfter:
+                  - build-image-index
+              taskRef:
+                  params:
+                      - name: name
+                        value: clamav-scan
+                      - name: bundle
+                        value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.2@sha256:24182598bf5161c4007988a7236e240f361c77a0a9b6973a6712dbae50d296bc
+                      - name: kind
+                        value: task
+                  resolver: bundles
+              when:
+                  - input: $(params.skip-checks)
+                    operator: in
+                    values:
+                        - "false"
+            - name: sast-coverity-check
+              params:
+                  - name: image-digest
+                    value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+                  - name: image-url
+                    value: $(tasks.build-image-index.results.IMAGE_URL)
+                  - name: IMAGE
+                    value: $(params.output-image)
+                  - name: DOCKERFILE
+                    value: $(params.dockerfile)
+                  - name: CONTEXT
+                    value: $(params.path-context)
+                  - name: HERMETIC
+                    value: $(params.hermetic)
+                  - name: PREFETCH_INPUT
+                    value: $(params.prefetch-input)
+                  - name: IMAGE_EXPIRES_AFTER
+                    value: $(params.image-expires-after)
+                  - name: COMMIT_SHA
+                    value: $(tasks.clone-repository.results.commit)
+                  - name: BUILD_ARGS
+                    value:
+                        - $(params.build-args[*])
+                  - name: BUILD_ARGS_FILE
+                    value: $(params.build-args-file)
+              runAfter:
+                  - coverity-availability-check
+              taskRef:
+                  params:
+                      - name: name
+                        value: sast-coverity-check
+                      - name: bundle
+                        value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check:0.3@sha256:d7d9682b679c98ffe4633dd24b62cafb0799264d459cf2ab9fa1593e1a42bfdf
+                      - name: kind
+                        value: task
+                  resolver: bundles
+              when:
+                  - input: $(params.skip-checks)
+                    operator: in
+                    values:
+                        - "false"
+                  - input: $(tasks.coverity-availability-check.results.STATUS)
+                    operator: in
+                    values:
+                        - success
+              workspaces:
+                  - name: source
+                    workspace: workspace
+            - name: coverity-availability-check
+              runAfter:
+                  - build-image-index
+              taskRef:
+                  params:
+                      - name: name
+                        value: coverity-availability-check
+                      - name: bundle
+                        value: quay.io/konflux-ci/tekton-catalog/task-coverity-availability-check:0.2@sha256:8b58c4fae00c0dfe3937abfb8a9a61aa3c408cca4278b817db53d518428d944e
+                      - name: kind
+                        value: task
+                  resolver: bundles
+              when:
+                  - input: $(params.skip-checks)
+                    operator: in
+                    values:
+                        - "false"
+            - name: sast-shell-check
+              params:
+                  - name: image-digest
+                    value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+                  - name: image-url
+                    value: $(tasks.build-image-index.results.IMAGE_URL)
+              runAfter:
+                  - build-image-index
+              taskRef:
+                  params:
+                      - name: name
+                        value: sast-shell-check
+                      - name: bundle
+                        value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check:0.1@sha256:188a4f6a582ac43d4de46c3998ded3c2a8ee237fb0604d90559a3b6e0aa62b0f
+                      - name: kind
+                        value: task
+                  resolver: bundles
+              when:
+                  - input: $(params.skip-checks)
+                    operator: in
+                    values:
+                        - "false"
+              workspaces:
+                  - name: workspace
+                    workspace: workspace
+            - name: sast-unicode-check
+              params:
+                  - name: image-digest
+                    value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+                  - name: image-url
+                    value: $(tasks.build-image-index.results.IMAGE_URL)
+              runAfter:
+                  - build-image-index
+              taskRef:
+                  params:
+                      - name: name
+                        value: sast-unicode-check
+                      - name: bundle
+                        value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check:0.2@sha256:e4a5215b45b1886a185a9db8ab392f8440c2b0848f76d719885637cf8d2628ed
+                      - name: kind
+                        value: task
+                  resolver: bundles
+              when:
+                  - input: $(params.skip-checks)
+                    operator: in
+                    values:
+                        - "false"
+              workspaces:
+                  - name: workspace
+                    workspace: workspace
+            - name: apply-tags
+              params:
+                  - name: IMAGE
+                    value: $(tasks.build-image-index.results.IMAGE_URL)
+              runAfter:
+                  - build-image-index
+              taskRef:
+                  params:
+                      - name: name
+                        value: apply-tags
+                      - name: bundle
+                        value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.1@sha256:3f89ba89cacf8547261b5ce064acce81bfe470c8ace127794d0e90aebc8c347d
+                      - name: kind
+                        value: task
+                  resolver: bundles
+            - name: push-dockerfile
+              params:
+                  - name: IMAGE
+                    value: $(tasks.build-image-index.results.IMAGE_URL)
+                  - name: IMAGE_DIGEST
+                    value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+                  - name: DOCKERFILE
+                    value: $(params.dockerfile)
+                  - name: CONTEXT
+                    value: $(params.path-context)
+              runAfter:
+                  - build-image-index
+              taskRef:
+                  params:
+                      - name: name
+                        value: push-dockerfile
+                      - name: bundle
+                        value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile:0.1@sha256:c82189e5d331e489cff99f0399f133fd3fad08921bea86747dfa379d1b5c748d
+                      - name: kind
+                        value: task
+                  resolver: bundles
+              workspaces:
+                  - name: workspace
+                    workspace: workspace
+            - name: rpms-signature-scan
+              params:
+                  - name: image-url
+                    value: $(tasks.build-image-index.results.IMAGE_URL)
+                  - name: image-digest
+                    value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+              runAfter:
+                  - build-image-index
+              taskRef:
+                  params:
+                      - name: name
+                        value: rpms-signature-scan
+                      - name: bundle
+                        value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:297c2d8928aa3b114fcb1ba5d9da8b10226b68fed30706e78a6a5089c6cd30e3
+                      - name: kind
+                        value: task
+                  resolver: bundles
+              when:
+                  - input: $(params.skip-checks)
+                    operator: in
+                    values:
+                        - "false"
+        workspaces:
+            - name: workspace
+            - name: git-auth
+              optional: true
+            - name: netrc
+              optional: true
+    taskRunTemplate:
+        serviceAccountName: build-pipeline-vscode-ansible
+    workspaces:
+        - name: workspace
+          volumeClaimTemplate:
+              metadata:
+                  creationTimestamp: null
+              spec:
+                  accessModes:
+                      - ReadWriteOnce
+                  resources:
+                      requests:
+                          storage: 1Gi
+              status: {}
+        - name: git-auth
+          secret:
+              secretName: "{{ git_auth_secret }}"
+status: {}

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -21,6 +21,8 @@ ignorePaths:
   - syntaxes
   - syntaxes/external/*.*
   - test/testFixtures/lightspeed/*.yml
+  - .tekton/
+  - ./vscode-ansible.Containerfile
 ignoreRegExpList:
   # ignore github usernames like @foo
   - "@[\\w]+"

--- a/vscode-ansible.Containerfile
+++ b/vscode-ansible.Containerfile
@@ -1,0 +1,15 @@
+FROM node:lts-slim
+
+WORKDIR /usr/src/app
+
+RUN corepack enable
+
+RUN apt-get update && \
+    apt-get install -y python3 python3-pip unzip git git-lfs && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY . .
+
+RUN yarn install --immutable
+
+RUN npm run package


### PR DESCRIPTION
related https://issues.redhat.com/browse/AAP-45944

This PR enables us to leverage Tekton and Konflux to run security scans and other relate tasks in two scenarios:

1. On each PR
2. On each merge

The approach is pretty simple, I've added a container definition which does the following:

1. Uses the lts-slim version of the official node image from Docker Hub
2. Defines a working directory
3. Enables Corepack, allowing the use of the Yarn version specified in package.json
4. Installs core dependencies like python and git using apt-get
5. Copies all the files into the working directory
6. Installs the project's dependencies using Yarn
7. Compiles/packages the project resulting in a .vsix file

The Tekton pipelines utilize this container definition within the workflow.  The rest of the pipeline is pretty much boilerplate from Red Hat's Konflux onboarding docs.

# Before review

- [x] All tests are passing
- [x] Description mentions issue via
      `(fixes|closes|related): #<issue_number|AAP-number>`
- [x] PR is kept as **draft** until all checks above are met

# Review checklist

- [ ] Size of change. If it can be split into smaller PRs, please do so.
- [ ] Docs checks:
  - [ ] heading titles are **short** and render without wrapping in sidebar
  - [ ] code blocks and diagrams render correctly in dark/light mode
  - [ ] images and videos are not blurry, small in size and use appropriate
        format such as `png`, `svg`, `webp`, `mp4` (not `gif`).
  - [ ] Less is more, no boilerplate language. Feel free to use AI to help with
        this and with correct grammar.
