### PR TITLE
gha: do not run ack as part of ci workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -365,11 +365,6 @@ jobs:
       #   if: ${{ always() }}
       #   uses: mxschmitt/action-tmate@v3
 
-  ack:
-    if: github.event_name == 'pull_request'
-    uses: ansible/team-devtools/.github/workflows/ack.yml@main
-    secrets: inherit
-
   check: # This job does nothing and is only used for the branch protection
     if: always()
 


### PR DESCRIPTION
A simple mislabeling would break the entire CI workflow and fixing it would not retrigger the same workflow. Better to use the separated ack workflow.