### PR TITLE
chore: remove boilerplate from test names

### DIFF
--- a/packages/ansible-language-server/test/providers/completionProvider.test.ts
+++ b/packages/ansible-language-server/test/providers/completionProvider.test.ts
@@ -933,7 +933,7 @@ describe("doCompletion()", function () {
       });
     });
 
-    describe("Check module kind and documentation of completion item", function () {
+    describe("module kind and documentation of completion item", function () {
       describe("@ee", function () {
         before(async function () {
           setFixtureAnsibleCollectionPathEnv(

--- a/packages/ansible-language-server/test/utils/getAnsibleMetaData.test.ts
+++ b/packages/ansible-language-server/test/utils/getAnsibleMetaData.test.ts
@@ -74,7 +74,7 @@ function getExecutionEnvironmentTestInfo() {
 }
 
 function testCommands() {
-  describe("Verify the working of command executions", function () {
+  describe("command executions", function () {
     const tests = [
       {
         args: ["ansible", "--version"],
@@ -283,7 +283,7 @@ describe("getAnsibleMetaData()", function () {
       });
     });
 
-    describe("Verify the absence of execution environment details", function () {
+    describe("absence of execution environment details", function () {
       it("should not contain execution environment details", function () {
         expect(actualAnsibleMetaData["execution environment information"]).to.be
           .undefined;
@@ -308,7 +308,7 @@ describe("getAnsibleMetaData()", function () {
       executionEnvironmentInfoForTest = getExecutionEnvironmentTestInfo();
     });
 
-    describe("Verify the presence of execution environment details", function () {
+    describe("presence of execution environment details", function () {
       it("should have a valid container engine", function () {
         if (actualAnsibleMetaData["execution environment information"]) {
           expect(

--- a/test/e2e/diagnostics/testAnsibleWithoutEE.test.ts
+++ b/test/e2e/diagnostics/testAnsibleWithoutEE.test.ts
@@ -9,7 +9,7 @@ import {
 } from "../../helper";
 
 export function testDiagnosticsAnsibleWithoutEE(): void {
-  describe("TEST FOR ANSIBLE DIAGNOSTICS WITHOUT EE", function () {
+  describe("ansible-diag-no-ee", function () {
     const docUri1 = getDocUri("diagnostics/ansible/without_ee/playbook_1.yml");
     const docUri2 = getDocUri("diagnostics/ansible/without_ee/playbook_2.yml");
 
@@ -96,7 +96,7 @@ export function testDiagnosticsAnsibleWithoutEE(): void {
       });
     });
 
-    describe("Diagnostic test for no diagnostics", function () {
+    describe("no diagnostics", function () {
       before(async function () {
         await updateSettings("validation.enabled", false);
         await vscode.commands.executeCommand(

--- a/test/e2e/diagnostics/testYamlWithoutEE.test.ts
+++ b/test/e2e/diagnostics/testYamlWithoutEE.test.ts
@@ -9,14 +9,14 @@ import {
 } from "../../helper";
 
 export function testDiagnosticsYAMLWithoutEE(): void {
-  describe("TEST FOR YAML DIAGNOSTICS WITHOUT EE", function () {
+  describe("yaml-diag-no-ee", function () {
     const docUri1 = getDocUri("diagnostics/yaml/invalid_yaml.yml");
 
     before(async function () {
       await vscode.commands.executeCommand("workbench.action.closeAllEditors");
     });
 
-    describe("YAML diagnostics in the presence of ansible-lint", function () {
+    describe("yaml-diag-ansible-lint", function () {
       it("should provide diagnostics with YAML validation (with ansible-lint)", async function () {
         await activate(docUri1);
         await waitForDiagnosisCompletion(); // Wait for the diagnostics to compute on this file
@@ -71,7 +71,7 @@ export function testDiagnosticsYAMLWithoutEE(): void {
       });
     });
 
-    describe("YAML diagnostics in the absence of ansible-lint", function () {
+    describe("yaml-diag-no-ansible-lint", function () {
       before(async function () {
         await updateSettings("validation.lint.enabled", false);
         await vscode.commands.executeCommand(
@@ -140,7 +140,7 @@ export function testDiagnosticsYAMLWithoutEE(): void {
       });
     });
 
-    describe("YAML diagnostics when diagnostics is disabled", function () {
+    describe("yaml-diag-disabled", function () {
       before(async function () {
         await updateSettings("validation.enabled", false);
         await vscode.commands.executeCommand(

--- a/test/e2e/hover/testWithEE.test.ts
+++ b/test/e2e/hover/testWithEE.test.ts
@@ -7,7 +7,7 @@ import {
 } from "../../helper";
 
 export function testHoverEE(): void {
-  describe("TEST FOR HOVER (WITH EE)", function () {
+  describe("hover-ee", function () {
     const docUri1 = getDocUri("hover/with_ee/1.yml");
 
     before(async function () {

--- a/test/e2e/hover/testWithoutEE.test.ts
+++ b/test/e2e/hover/testWithoutEE.test.ts
@@ -2,7 +2,7 @@ import * as vscode from "vscode";
 import { getDocUri, activate, testHover } from "../../helper";
 
 export function testHoverWithoutEE(): void {
-  describe("TEST FOR HOVER WITHOUT EE", function () {
+  describe("hover-no-ee", function () {
     const docUri1 = getDocUri("hover/without_ee/1.yml");
 
     before(async function () {

--- a/test/e2e/lightspeed/e2eInlineSuggestion.test.ts
+++ b/test/e2e/lightspeed/e2eInlineSuggestion.test.ts
@@ -79,7 +79,7 @@ export async function testInlineSuggestionByAnotherProvider(): Promise<void> {
       );
       await sleep(LIGHTSPEED_INLINE_SUGGESTION_AFTER_COMMIT_WAIT_TIME);
 
-      // Make sure vscode's commit command was issued as expected
+      // Make sure vscode's commit command was issued
       let foundCommitCommand = false;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       executeCommandSpy.args.forEach((arg: any) => {
@@ -166,7 +166,7 @@ export async function testInlineSuggestionProviderCoExistence(): Promise<void> {
       );
       await sleep(LIGHTSPEED_INLINE_SUGGESTION_AFTER_COMMIT_WAIT_TIME);
 
-      // Make sure vscode's commit command was issued as expected
+      // Make sure vscode's commit command was issued
       let foundCommitCommand = false;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       executeCommandSpy.args.forEach((arg: any) => {

--- a/test/e2e/lightspeed/testLightspeed.test.ts
+++ b/test/e2e/lightspeed/testLightspeed.test.ts
@@ -500,7 +500,7 @@ export function testLightspeed(): void {
         feedbackRequest.returns(Promise.resolve());
       });
 
-      describe("Test suggestion functions.", function () {
+      describe("suggestion-functions", function () {
         it("Test Reject pending suggestion.", async function () {
           inlineSuggestionsEnabled.returns(true);
           isSuggestionFeedbackInProgress.returns(false);

--- a/test/ui/contentCreatorUiTest.ts
+++ b/test/ui/contentCreatorUiTest.ts
@@ -69,7 +69,7 @@ describe("Content Creator UI Tests", function () {
     await sleep(2000);
   });
 
-  describe("Test execution-environment project scaffolding at default path", function () {
+  describe("ee-project-scaffolding-at-default-path", function () {
     it("Check execution-environment webview elements", async function () {
       const eeWebview = await openCreateWebview(
         "Ansible: Create an Execution Environment file",
@@ -121,7 +121,7 @@ describe("Content Creator UI Tests", function () {
     });
   });
 
-  describe("Test Ansible playbook and collection project scaffolding at provided path", function () {
+  describe("Ansible playbook and collection project scaffolding at provided path", function () {
     let editorView: EditorView;
 
     async function testWebViewElements(command: string, editorTitle: string) {
@@ -193,7 +193,7 @@ describe("Content Creator UI Tests", function () {
     });
   });
 
-  describe("Test Ansible playbook and collection project scaffolding at default path", function () {
+  describe("Ansible playbook and collection project scaffolding at default path", function () {
     let createButton: WebElement;
     let editorView: EditorView;
 
@@ -280,7 +280,7 @@ describe("Content Creator UI Tests", function () {
     });
   });
 
-  describe("Test collection plugins scaffolding", function () {
+  describe("collection plugins scaffolding", function () {
     let createButton: WebElement;
     let editorView: EditorView;
 
@@ -522,7 +522,7 @@ describe("Content Creator UI Tests", function () {
     });
   });
 
-  describe("Test role scaffolding in an existing collection", function () {
+  describe("role scaffolding in an existing collection", function () {
     let editorView: EditorView;
 
     async function testWebViewElements(command: string, editorTitle: string) {

--- a/test/ui/contentCreatorUiTestNoCreatorTest.ts
+++ b/test/ui/contentCreatorUiTestNoCreatorTest.ts
@@ -56,7 +56,7 @@ afterEach(async function () {
 });
 
 describe(__filename, function () {
-  describe("Test devfile generation webview (without creator)", function () {
+  describe("devfile generation webview (without creator)", function () {
     it("Check create-devfile webview elements", async function () {
       const devfileWebview = await openCreateWebview(
         "Ansible: Create a Devfile",
@@ -94,7 +94,7 @@ describe(__filename, function () {
     });
   });
 
-  describe("Test devcontainer generation webview (without creator)", function () {
+  describe("devcontainer generation webview (without creator)", function () {
     it("Check create-devcontainer webview elements", async function () {
       const devcontainerWebview = await openCreateWebview(
         "Ansible: Create a Devcontainer",
@@ -140,7 +140,7 @@ describe(__filename, function () {
     });
   });
 
-  describe("Test execution-environment generation webview (without creator)", function () {
+  describe("execution-environment generation webview (without creator)", function () {
     it("Check execution-environment webview elements", async function () {
       const eeWebview = await openCreateWebview(
         "Ansible: Create an Execution Environment file",

--- a/test/ui/extensionUITest.ts
+++ b/test/ui/extensionUITest.ts
@@ -10,7 +10,7 @@ const WAIT_TIME = 10000;
 
 config.truncateThreshold = 0;
 
-describe("Verify base assets are available after installation", function () {
+describe("base assets are available after installation", function () {
   let view: ViewControl;
   let sideBar: SideBarView;
 

--- a/test/ui/lightspeedOneClickTrialUITest.ts
+++ b/test/ui/lightspeedOneClickTrialUITest.ts
@@ -36,7 +36,7 @@ before(function () {
   }
 });
 
-describe("Test One Click Trial feature", function () {
+describe("One Click Trial feature", function () {
   let workbench: Workbench;
   let explorerView: WebviewView;
   let modalDialog: ModalDialog;

--- a/test/ui/lightspeedRoleGenTest.ts
+++ b/test/ui/lightspeedRoleGenTest.ts
@@ -41,7 +41,7 @@ before(function () {
   }
 });
 
-describe("Verify Role generation feature works as expected", function () {
+describe("Role generation feature works", function () {
   let workbench: Workbench;
 
   before(async function () {
@@ -85,7 +85,7 @@ describe("Verify Role generation feature works as expected", function () {
     }
   });
 
-  it("Role generation webview works as expected", async function () {
+  it("Role generation webview works", async function () {
     await workbenchExecuteCommand("Ansible Lightspeed: Role generation");
     let webView = await getWebviewByLocator(
       By.xpath("//*[text()='Create a role with Ansible Lightspeed']"),

--- a/test/ui/lightspeedUiTestActiveBarTest.ts
+++ b/test/ui/lightspeedUiTestActiveBarTest.ts
@@ -15,7 +15,7 @@ import {
 
 config.truncateThreshold = 0;
 
-describe("Verify the presence of lightspeed login button in the activity bar", function () {
+describe("presence of lightspeed login button in the activity bar", function () {
   let view: ViewControl;
   let sideBar: SideBarView;
   let adtView: ViewSection;

--- a/test/ui/lightspeedUiTestExplorerTest.ts
+++ b/test/ui/lightspeedUiTestExplorerTest.ts
@@ -27,7 +27,7 @@ import { WizardGenerationActionType } from "../../src/definitions/lightspeed";
 import { PlaybookGenerationActionEvent } from "../../src/interfaces/lightspeed";
 import { expect } from "chai";
 
-describe("Test Lightspeed Explorer features", function () {
+describe("Lightspeed Explorer features", function () {
   let workbench: Workbench;
   let explorerView: WebviewView;
   let modalDialog: ModalDialog;

--- a/test/ui/lightspeedUiTestPlaybookExpTest.ts
+++ b/test/ui/lightspeedUiTestPlaybookExpTest.ts
@@ -97,7 +97,7 @@ async function testThumbsButtonInteraction(buttonToClick: string) {
 }
 
 describe(__filename, function () {
-  describe("Verify playbook explanation features work as expected", function () {
+  describe("playbook explanation features work", function () {
     beforeEach(function () {
       if (!process.env.TEST_LIGHTSPEED_URL) {
         this.skip();
@@ -166,7 +166,7 @@ describe(__filename, function () {
     });
   });
 
-  describe("Feedback webview provider works as expected", function () {
+  describe("Feedback webview provider works", function () {
     let editorView: EditorView;
 
     before(async function () {

--- a/test/ui/lightspeedUiTestPlaybookExpTestNoExpTest.ts
+++ b/test/ui/lightspeedUiTestPlaybookExpTestNoExpTest.ts
@@ -20,7 +20,7 @@ describe.skip("Verify playbook explanation features when no explanation is retur
     }
   });
 
-  it("Playbook explanation webview works as expected, no explanation", async function () {
+  it("Playbook explanation webview works, no explanation", async function () {
     if (!process.env.TEST_LIGHTSPEED_URL) {
       this.skip();
     }

--- a/test/ui/lightspeedUiTestPlaybookGenNotAvailableTest.ts
+++ b/test/ui/lightspeedUiTestPlaybookGenNotAvailableTest.ts
@@ -6,7 +6,7 @@ import { getFixturePath, sleep, workbenchExecuteCommand } from "./uiTestHelper";
 
 config.truncateThreshold = 0;
 
-describe("Verify playbook generation features work as expected", function () {
+describe("playbook generation features work", function () {
   beforeEach(function () {
     if (!process.env.TEST_LIGHTSPEED_URL) {
       this.skip();
@@ -21,7 +21,7 @@ describe("Verify playbook generation features work as expected", function () {
     });
   });
 
-  it("Playbook explanation webview works as expected (feature unavailable)", async function () {
+  it("Playbook explanation webview works (feature unavailable)", async function () {
     if (!process.env.TEST_LIGHTSPEED_URL) {
       this.skip();
     }

--- a/test/ui/lightspeedUiTestPlaybookGenWebviewPart1Test.ts
+++ b/test/ui/lightspeedUiTestPlaybookGenWebviewPart1Test.ts
@@ -17,7 +17,7 @@ import {
 
 config.truncateThreshold = 0;
 
-describe("Verify playbook generation features work as expected", function () {
+describe("playbook generation features work", function () {
   let explorerView: WebviewView;
   let adtView: ViewSection;
 
@@ -72,7 +72,7 @@ describe("Verify playbook generation features work as expected", function () {
     );
   });
 
-  it("Playbook generation webview works as expected (full path) - part 1", async function () {
+  it("Playbook generation webview works (full path) - part 1", async function () {
     await workbenchExecuteCommand("Ansible Lightspeed: Playbook generation");
 
     // Start operations on Playbook Generation UI

--- a/test/ui/lightspeedUiTestPlaybookGenWebviewPart2Test.ts
+++ b/test/ui/lightspeedUiTestPlaybookGenWebviewPart2Test.ts
@@ -26,7 +26,7 @@ before(function () {
   }
 });
 
-describe("Verify playbook generation features work as expected", function () {
+describe("playbook generation features work", function () {
   beforeEach(function () {
     if (!process.env.TEST_LIGHTSPEED_URL) {
       this.skip();
@@ -39,7 +39,7 @@ describe("Verify playbook generation features work as expected", function () {
     }
   });
 
-  it("Playbook generation webview works as expected (full path) - part 2", async function () {
+  it("Playbook generation webview works (full path) - part 2", async function () {
     // just to cleanup any previous feedbacks that might pollute the test
     await fetch(`${process.env.TEST_LIGHTSPEED_URL}/__debug__/feedbacks`, {
       method: "GET",
@@ -129,7 +129,7 @@ describe("Verify playbook generation features work as expected", function () {
     }
   });
 
-  it("Playbook explanation webview works as expected", async function () {
+  it("Playbook explanation webview works", async function () {
     this.timeout(60000); // Set timeout to 60 seconds for this test
 
     if (!process.env.TEST_LIGHTSPEED_URL) {

--- a/test/ui/lightspeedUiTestRoleExpTest.ts
+++ b/test/ui/lightspeedUiTestRoleExpTest.ts
@@ -99,7 +99,7 @@ async function testThumbsButtonInteraction(buttonToClick: string) {
   await workbenchExecuteCommand("View: Close All Editor Groups");
 }
 
-describe("Verify role explanation features work as expected", function () {
+describe("role explanation features work", function () {
   let workbench: Workbench;
 
   beforeEach(function () {

--- a/test/ui/lightspeedUiTestStatusBarAndExplorerViewNoLSTest.ts
+++ b/test/ui/lightspeedUiTestStatusBarAndExplorerViewNoLSTest.ts
@@ -15,7 +15,7 @@ import { getFixturePath } from "./uiTestHelper";
 
 config.truncateThreshold = 0;
 
-describe("Verify the presence of lightspeed element in the status bar and the explorer view", function () {
+describe("presence of lightspeed element in the status bar and the explorer view", function () {
   let statusBar: StatusBar;
   let editorView: EditorView;
   let viewControl: ViewControl;

--- a/test/ui/lightspeedUiTestStatusBarAndExplorerViewTest.ts
+++ b/test/ui/lightspeedUiTestStatusBarAndExplorerViewTest.ts
@@ -11,7 +11,7 @@ import {
 
 config.truncateThreshold = 0;
 
-describe("Verify the presence of lightspeed element in the status bar and the explorer view", function () {
+describe("presence of lightspeed element in the status bar and the explorer view", function () {
   const folder = "lightspeed";
   const file = "playbook_1.yml";
   const filePath = getFixturePath(folder, file);

--- a/test/ui/terminalUiTest.ts
+++ b/test/ui/terminalUiTest.ts
@@ -15,7 +15,7 @@ import {
 
 config.truncateThreshold = 0;
 describe(__filename, function () {
-  describe("Verify the execution of playbook using ansible-playbook command", function () {
+  describe("execution of playbook using ansible-playbook command", function () {
     let workbench: Workbench;
     let settingsEditor: SettingsEditor;
     const folder = "terminal";
@@ -62,7 +62,7 @@ describe(__filename, function () {
     });
   });
 
-  describe("Verify the execution of playbook using ansible-navigator command", function () {
+  describe("execution of playbook using ansible-navigator command", function () {
     let workbench: Workbench;
     let settingsEditor: SettingsEditor;
     const folder = "terminal";

--- a/test/ui/welcomePageUITest.ts
+++ b/test/ui/welcomePageUITest.ts
@@ -15,7 +15,7 @@ import {
 
 config.truncateThreshold = 0;
 
-describe("Verify welcome page is displayed as expected", function () {
+describe("welcome page is displayed", function () {
   let view: ViewControl;
   let sideBar: SideBarView;
   let webviewView: InstanceType<typeof WebviewView>;

--- a/test/unit/lightspeed/editableList.test.ts
+++ b/test/unit/lightspeed/editableList.test.ts
@@ -3,7 +3,7 @@ import { JSDOM } from "jsdom";
 
 import { EditableList } from "../../../src/webview/apps/common/editableList";
 
-describe("Test EditableList", function () {
+describe("EditableList", function () {
   let dom: JSDOM;
   let domWithEmptyList: JSDOM;
   const SAMPLE_TEXT = `1. Do this

--- a/test/unit/lightspeed/parsePlays.test.ts
+++ b/test/unit/lightspeed/parsePlays.test.ts
@@ -8,7 +8,7 @@ function parseYaml(yamlString: string) {
   });
 }
 
-describe("Test parsePlays", function () {
+describe("parsePlays", function () {
   it("Test a playbook with tasks", function () {
     const PLAYBOOK = `---
 - name: Test 1

--- a/test/unit/lightspeed/utils/handleApiError.test.ts
+++ b/test/unit/lightspeed/utils/handleApiError.test.ts
@@ -32,7 +32,7 @@ function createError(
   return error;
 }
 
-describe("testing the error handling", function () {
+describe("error handling", function () {
   function withDetailTest(statusCode: integer, expectedMessage: string) {
     const error = mapError(
       createError(statusCode, { detail: { item: "details" } }),

--- a/test/unit/lightspeed/utils/multiLinePromptForMultiTasks.test.ts
+++ b/test/unit/lightspeed/utils/multiLinePromptForMultiTasks.test.ts
@@ -5,7 +5,7 @@ import {
 } from "../../../../src/features/lightspeed/utils/multiLinePromptForMultiTasks";
 
 describe(__filename, function () {
-  describe("Test getContentWithMultiLinePromptForMultiTasksSuggestions", function () {
+  describe("getContentWithMultiLinePromptForMultiTasksSuggestions", function () {
     const testsData = [
       {
         name: "should parse and generate new prompt for playbook",
@@ -105,7 +105,7 @@ tasks:
     );
   });
 
-  describe("Test shouldRequestForPromptPosition", function () {
+  describe("shouldRequestForPromptPosition", function () {
     it("should trigger request even when document starts with empty line", function () {
       const promptContent = `
 ---

--- a/test/unit/lightspeed/utils/updateRolesContext.ts
+++ b/test/unit/lightspeed/utils/updateRolesContext.ts
@@ -8,7 +8,7 @@ import fs from "fs";
 
 import { IWorkSpaceRolesContext } from "../../../../src/interfaces/lightspeed";
 
-describe("testing updateRolesContext", function () {
+describe("updateRolesContext", function () {
   const tmpDir = tmp.dirSync();
 
   after(function () {
@@ -156,7 +156,7 @@ describe("testing updateRolesContext", function () {
     );
   });
 
-  it("with a role where 'defaults' is a file, not a directory, but 'vars' is a directory as expected", function () {
+  it("with a role where 'defaults' is a file, not a directory, but 'vars' is a directory", function () {
     const ansibleRolesCache: IWorkSpaceRolesContext = {};
 
     const root_dir = `${tmpDir.name}/role_where_defaults_is_a_file_and_vars_is_a_directory`;


### PR DESCRIPTION
This makes it easier to navigate the test reports by avoiding
repetition of text that does not bring any value. It is obvious that
any test does "test/check/verify" something. The way mocha does
compose the tested tests, makes this issue even more serious and the
resulting test identifiers can become a nightmare to real.

Despite the fact that test name are configured with it() and
describe(), it does NOT mean that they are "descriptions". We can
still use comments to add details, but we should aim to keep the
arguments passed to these as short as possible and unique, with
names that should be easy to copy and search inside the code to
find them.

https://app.codecov.io/gh/ansible/vscode-ansible/tests/main
