### PR TITLE
Remove use of --path argument in ansible-creator commands

### DIFF
--- a/src/features/lightspeed/vue/views/ansibleCreatorUtils.ts
+++ b/src/features/lightspeed/vue/views/ansibleCreatorUtils.ts
@@ -548,9 +548,9 @@ export class AnsibleCreatorOperations {
     const creatorVersion = await getCreatorVersion();
 
     if (semver.gte(creatorVersion, ANSIBLE_CREATOR_VERSION_MIN)) {
-      return `ansible-creator init playbook ${namespace}.${collection} --path ${url} --no-ansi`;
-    } else {
       return `ansible-creator init playbook ${namespace}.${collection} ${url} --no-ansi`;
+    } else {
+      return `ansible-creator init --project=ansible-project --init-path=${url} --scm-org=${namespace} --scm-project=${collection} --no-ansi`;
     }
   }
 }


### PR DESCRIPTION
Removes use of `--path` in the `ansible-creator init playbook` command and replaces it with the older creator arguments.

This was a regression introduced in 25.7.0.