### PR TITLE
Temporarily cap ansible-core at 2.18.x for ansible-lint limitations

### DIFF
--- a/.config/requirements.in
+++ b/.config/requirements.in
@@ -1,5 +1,5 @@
 cython>=3.0.5; python_version >= "3.12"
-ansible-core>=2.13.0
+ansible-core>=2.13.0,<2.19
 ansible-lint>=6.8.7
 ansible-navigator
 mypy # used by vscode


### PR DESCRIPTION
Due to https://github.com/ansible/ansible-lint/issues/4611, we have to cap the version of ansible-core used in tests to 2.18.x. 
We will remove this once ansible-lint is compatible with ansible-core 2.19.x.