### PR TITLE
lightspeed: ensure completion doesn't finish with a \n

### DIFF
--- a/src/features/lightspeed/inlineSuggestions.ts
+++ b/src/features/lightspeed/inlineSuggestions.ts
@@ -389,7 +389,7 @@ const onDoSingleTasksSuggestion: CallbackEntry = async function (
     if (leadingWhitespaceCount > 0) {
       leadingWhitespace = " ".repeat(leadingWhitespaceCount);
     }
-    let insertText = `${leadingWhitespace}${LIGHTSPEED_SUGGESTION_GHOST_TEXT_COMMENT}${prediction}`;
+    let insertText = `${leadingWhitespace}${LIGHTSPEED_SUGGESTION_GHOST_TEXT_COMMENT}${prediction.trimEnd()}`;
     insertText = adjustInlineSuggestionIndent(
       insertText,
       inlinePosition.position,


### PR DESCRIPTION
Not clear yet why, but when the prediction ends with a `\n` and we are
at the top of a short file, the completion is not properly displayed
by VSCode.

This only happens with recent (=~ less than 1 month) release. e.g
1.102.1 in my case.

This is a new behaviour that seems to be connected with some recent
changes within `reshapeMultiLineInsertion()`[0]

[0]: https://github.com/microsoft/vscode/blob/20724f79ba5142f9055a0a38a188fee3f15f79a4/src/vs/editor/contrib/inlineCompletions/browser/model/inlineSuggestionItem.ts#L681
