### PR TITLE
GHA: ignore error during upload-artifactcall with WSL

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -338,6 +338,8 @@ jobs:
           # out/test-resources/settings/logs
           if-no-files-found: ignore
           retention-days: 90
+        # until the WSL/gitleaks failure is resolved
+        continue-on-error: true
 
       - name: Upload test results to Codecov (als)
         if: ${{ !cancelled() && hashFiles('out/junit/als/*.xml') != '' }}


### PR DESCRIPTION
The step is known for being currently broken.
