### PR TITLE
Add Slack notifications for CI failures

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -558,3 +558,16 @@ jobs:
       - run: npm publish --access public @ansible-ansible-language-server-*.tgz
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  notify:
+    if: failure() && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/devel/main') # runs only if *any* previous job failed on main branches
+    runs-on: ubuntu-latest
+    needs:
+      - build
+      - check
+    steps:
+      - name: Send Slack notification
+        run: |
+          curl -X POST -H 'Content-type: application/json' \
+          --data '{"text":"❌ CI failed on main branch for '${{ github.repository }}'. Check logs: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"}' \
+          ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -560,7 +560,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   notify:
-    if: failure() && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/devel/main') # runs only if *any* previous job failed on main branches
+    if: failure() && github.ref == 'refs/heads/main' # runs only if *any* previous job failed on main branch
     runs-on: ubuntu-latest
     needs:
       - build


### PR DESCRIPTION
This PR integrates Slack alerts into the GitHub Actions workflow. When a CI job fails on the main branch, a notification is sent to the channel via a secure Slack webhook stored in GitHub Secrets.

<img width="1003" height="121" alt="image" src="https://github.com/user-attachments/assets/a360709d-21a8-4c7d-9343-d4842f507cd0" />
