### PR TITLE
Add retry for VS Code download in tests

### DIFF
--- a/tools/test-launcher.sh
+++ b/tools/test-launcher.sh
@@ -90,7 +90,7 @@ function retry_command() {
     local attempt=1
     shift 2
     local command=("$@")
-    
+
     while [ $attempt -le "$max_attempts" ]; do
         if "${command[@]}"; then
             return 0


### PR DESCRIPTION
Adds a retry mechanism to improve resilience in tests when downloading VS Code using `extester get-vscode`. 