### PR TITLE
fix: Dynamically find untitled documents in walkthrough UI tests

### DIFF
--- a/test/ui/walkthroughUiTest.ts
+++ b/test/ui/walkthroughUiTest.ts
@@ -16,9 +16,23 @@ let editorView: EditorView;
 const openUntitledFile = async () => {
   return await waitForCondition({
     condition: async () => {
-      return await new EditorView().openEditor("Untitled-1");
+      try {
+        const editorView = new EditorView();
+        const titles = await editorView.getOpenEditorTitles();
+
+        // Find any untitled document
+        const untitledTitle = titles.find((title) =>
+          title.startsWith("Untitled"),
+        );
+        if (untitledTitle) {
+          return await editorView.openEditor(untitledTitle);
+        }
+        return false;
+      } catch {
+        return false;
+      }
     },
-    message: "Timed out waiting for Untitled-1 file to open",
+    message: "Timed out waiting for untitled file to open",
   });
 };
 


### PR DESCRIPTION
### SUMMARY

Tries to fix CI failures in `walkthroughUiTest.ts` for the "Check empty playbook command option" and "Check unauthenticated playbook command option" tests. Failure can be seen [here](https://github.com/ansible/vscode-ansible/actions/runs/18403684053/job/52438655829?pr=2202#step:18:255).

- Dynamic discovery - Instead of assuming "Untitled-1", it gets all open editor titles and finds any that start with "Untitled"
- Error handling - Wraps the logic in try-catch to handle any API errors gracefully
- Backward compatible - Will work regardless of VS Code's untitled document naming behaviour
