### PR TITLE
chore(build): rework caching and fail if macos job fails

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,8 +56,6 @@ jobs:
         shell: ${{ matrix.shell || 'bash'}}
     # The type of runner that the job will run on
     runs-on: ${{ matrix.os || 'ubuntu-24.04' }}
-    # see https://github.com/containers/podman/issues/13609
-    continue-on-error: ${{ contains(matrix.name, 'macos') && true || false }}
     outputs:
       can_release_to_npm: ${{ steps.package.outputs.can_release_to_npm }}
     permissions:
@@ -162,22 +160,31 @@ jobs:
       - name: Corepack enable
         run: corepack enable
 
-      - name: Enable caching
+      - name: Runner image version
+        run: echo "IMAGE_OS_VERSION=${ImageOS}-${ImageVersion}" >> "$GITHUB_ENV"
+
+      - name: Enable caching for python
+        # left out due to having their own caching: yarn, node_modules, mise
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: |
+            ~/.cache/pip
+            ~/.cache/uv
+          key: py-${{ env.IMAGE_OS_VERSION }}-${{ matrix.task-name }}-${{ hashFiles('uv.lock', '.python_version') }}
+
+      - name: Enable caching for vscode resources
+        if: "${{ contains(matrix.name, 'test') }}"
+        # left out due to having their own caching: yarn, node_modules, mise
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: |
             .vscode-test
-            .yarn/cache
-            node_modules/.cache/webpack
             out/ext
-            out/test-resources*/Visual Studio Code.app
             out/test-resources*/chromedriver*
             out/test-resources*/driverVersion
             out/test-resources*/stable.zip
-            ~/.cache/pip
-            ~/.cache/yarn
-          key: ${{ runner.os }}-${{ matrix.task-name }}-${{ hashFiles('package.json', 'yarn.lock', '.config/requirements.txt', 'tools/*.*') }}
-
+            out/test-resources*/manifest.json
+          key: ${{ env.IMAGE_OS_VERSION }}-${{ matrix.task-name }}-${{ hashFiles('package.json', 'yarn.lock') }}
       # - name: Enable caching for podman-machine
       #   if: "contains(matrix.os, 'macos')"
       #   uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.0.0


### PR DESCRIPTION
Apparently our caches are too large and this change should speed up the builds by ensuring we cache only what is needed.
