### PR TITLE
chore: Disable ansible-playbook with arg (terminalUITest)

### DIFF
--- a/test/ui/terminalUiTest.ts
+++ b/test/ui/terminalUiTest.ts
@@ -22,7 +22,7 @@ describe(__filename, function () {
     const file = "playbook.yml";
     const playbookFile = getFixturePath(folder, file);
 
-    it("Execute ansible-playbook command with arg", async function () {
+    it.skip("Execute ansible-playbook command with arg", async function () {
       await VSBrowser.instance.driver.switchTo().defaultContent();
 
       settingsEditor = await openSettings();


### PR DESCRIPTION
Disables the `"Execute ansible-playbook command with arg"` test due to excessive flakiness. We plan to refactor the UI tests soon and also plan to remove settings modifications via UI, so this will be accounted for.