### PR TITLE
chore(e2e): test vsix file instead of using extension development mode

### DIFF
--- a/.config/mise.toml
+++ b/.config/mise.toml
@@ -34,6 +34,7 @@ mise_version = "2025.6.2"
 
 [tools]
 gh = "latest"
+jq = "latest"
 # do not add tools unsupported on windows such: gh, yarn
 node = "22.20.0"
 python = "3.13"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -190,7 +190,14 @@ tasks:
       - .vscode-test.mjs
     cmds:
       # cannot put coverage option inside .vscode-test.mjs
-      - "{{.XVFB}}vscode-test --install-extensions ansible-*.vsix --coverage --coverage-output ./out/coverage/e2e --coverage-reporter text --coverage-reporter cobertura --coverage-reporter lcovonly"
+      - >
+        {{.XVFB}}vscode-test --install-extensions ansible-*.vsix --coverage
+        --coverage-output=./out/coverage/e2e
+        --coverage-reporter=text
+        --coverage-reporter=cobertura
+        --coverage-reporter=lcovonly
+        --coverage-reporter=text-summary
+        --coverage-exclude=out/
     interactive: true
   ui:
     desc: Run UI tests with extest {{.XVFB}}

--- a/packages/ansible-language-server/tools/can-release.sh
+++ b/packages/ansible-language-server/tools/can-release.sh
@@ -11,10 +11,10 @@ DIR=$( cd -P "$( dirname "$SOURCE" )" > /dev/null 2>&1 && pwd )
 
 # installs the package inside an isolated project and executes its entry point
 # in order to check if we packaged everything needed.
-pushd "${DIR}/../out/test-als"
+pushd "${DIR}/../out/test-als" >/dev/null
 git checkout HEAD -- package.json
-npm add ../../@ansible-ansible-language-server-*.tgz
-npm install
+npm add --silent ../../@ansible-ansible-language-server-*.tgz
+npm install --silent --no-fund
 git checkout HEAD -- package.json
 ts-node ../../test/validate-ls.ts
 popd
@@ -32,7 +32,7 @@ else
     else
         echo "::warning::Version ${VERSION} was not published but is missing from the changelog, so we should not release."
     fi
-    npm publish --dry-run --access public "${DIR}/../"@ansible-ansible-language-server-*.tgz
+    npm publish --silent --dry-run --access public "${DIR}/../"@ansible-ansible-language-server-*.tgz
     echo "Version ${VERSION} can be published."
     if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
         echo "Setting can_release_to_npm=true"


### PR DESCRIPTION
This should catch packaging errors.
Partial: AAP-58298
