### PR TITLE
chore(build): fixes c8, lcovonly, xauth and mise node path

### DIFF
--- a/.c8rc.json
+++ b/.c8rc.json
@@ -1,6 +1,6 @@
 {
-  "check-coverage": true,
-  "lines": 91.45,
+  "//": "Do not enable 'check-coverage' or text reporters because we loop over the tests from test-launcher.sh.",
+  "check-coverage": false,
   "clean": true,
   "exclude": [
     "**/__tests__/**",
@@ -17,7 +17,7 @@
     "test{,s}/**"
   ],
   "exclude-after-remap": true,
-  "reporter": ["cobertura", "lcov", "text"],
-  "reports-dir": "./out/coverage/unit",
-  "temp-directory": "./out/tmp/.c8-tmp-unit"
+  "reporter": ["cobertura", "lcovonly"],
+  "reports-dir": "./out/coverage/ui",
+  "temp-directory": "./out/tmp/.c8-tmp-ui"
 }

--- a/.config/mise.toml
+++ b/.config/mise.toml
@@ -15,6 +15,7 @@ _.python.venv = { create = true, path = "~/.local/share/virtualenvs/vsa", python
   "--seed",
 ] }  # pass args to uv venv
 _.file = { path = ".env", tools = true }
+_.path = ["./node_modules/.bin"]
 
 # Do not use other hooks than preinstall or postinstall because they will
 # not work without 'mise activate' command, something that we do not use on CI.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -326,31 +326,36 @@ jobs:
           EOT
           podman info
 
+      - name: Save ready_to_test=true
+        id: ready_to_test
+        if: ${{ contains(matrix.name, 'test') && success() }}
+        run: echo "ready_to_test=true" >> "$GITHUB_OUTPUT"
+
       - name: task ${{ matrix.task-name }}
-        if: "${{ !contains(matrix.name, 'test') }}"
+        if: "${{ !contains(matrix.name, 'test') && steps.ready_to_test.outputs.ready_to_test == 'true' }}"
         run: task ${{ matrix.task-name }} ${{ matrix.env.TASKFILE_ARGS }}
 
       - name: task mcp
-        if: contains(matrix.name, 'test')
+        if: contains(matrix.name, 'test') && steps.ready_to_test.outputs.ready_to_test == 'true'
         run: task mcp:test ${{ matrix.env.TASKFILE_ARGS }}
 
       - name: task unit
-        if: contains(matrix.name, 'test')
+        if: contains(matrix.name, 'test') && steps.ready_to_test.outputs.ready_to_test == 'true'
         run: task unit ${{ matrix.env.TASKFILE_ARGS }}
 
       - name: task ui
         # https://github.com/ansible/vscode-ansible/issues/1451
-        if: ${{ !cancelled() && contains(matrix.name, 'test') && !contains(matrix.name, 'wsl') }}
+        if: ${{ !cancelled() && contains(matrix.name, 'test') && !contains(matrix.name, 'wsl') && steps.ready_to_test.outputs.ready_to_test == 'true'}}
         run: task ui ${{ matrix.env.TASKFILE_ARGS }}
 
       - name: task e2e
         # https://github.com/ansible/vscode-ansible/issues/1451
-        if: ${{ !cancelled() && contains(matrix.name, 'test') }}
+        if: ${{ !cancelled() && contains(matrix.name, 'test') && steps.ready_to_test.outputs.ready_to_test == 'true' }}
         run: task e2e ${{ matrix.env.TASKFILE_ARGS }}
 
       - name: task als
         # https://github.com/ansible/vscode-ansible/issues/1451
-        if: ${{ !cancelled() && contains(matrix.name, 'test') }}
+        if: ${{ !cancelled() && contains(matrix.name, 'test') && steps.ready_to_test.outputs.ready_to_test == 'true' }}
         run: task als ${{ matrix.env.TASKFILE_ARGS }}
 
       - name: Upload vsix artifact

--- a/.vscode-test.mjs
+++ b/.vscode-test.mjs
@@ -31,7 +31,7 @@ export default defineConfig({
     timeout: 50_000,
     reporter: "cypress-multi-reporters",
     reporterOptions: {
-      reporterEnabled: "spec, mocha-junit-reporter",
+      reporterEnabled: "spec,mocha-junit-reporter",
       mochaJunitReporterReporterOptions: {
         attachments: true,
         includePending: true,

--- a/Containerfile
+++ b/Containerfile
@@ -55,6 +55,7 @@ libxrandr2 \
 libxshmfence1 \
 lsof \
 sudo \
+xauth \
 xvfb \
 2> /dev/null && \
 mkdir -p /root/.local/bin && \

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -219,8 +219,6 @@ tasks:
       - tools/helper
       - src/**/*
       - test/**/*
-      - packages/*/src/**/*
-      - packages/*/test/**/*
       - media/**/*
     generates:
       - "*.vsix"

--- a/package.json
+++ b/package.json
@@ -1126,7 +1126,7 @@
     "test-ui": "yarn run test-ui-current && yarn run test-ui-oldest",
     "test-ui-current": "./tools/test-launcher.sh",
     "test-ui-oldest": "CODE_VERSION='min' ./tools/test-launcher.sh",
-    "unit-tests": "sh -c \"c8 --config test/unit/.c8rc mocha --recursive test/unit/lightspeed test/unit/mcp ${MOCHA_OPTS:-}\"",
+    "unit-tests": "sh -c \"c8 --config test/unit/.c8rc.json mocha --recursive test/unit/lightspeed test/unit/mcp ${MOCHA_OPTS:-}\"",
     "vite-build": "vue-tsc --noEmit && vite build",
     "vite-dev": "vite build && vue-tsc --noEmit && vite",
     "vite-preview": "vite preview",

--- a/packages/ansible-language-server/.c8rc.json
+++ b/packages/ansible-language-server/.c8rc.json
@@ -1,7 +1,7 @@
 {
-  "check-coverage": true,
-  "extends": "../../.c8rc",
   "branches": 80.31,
+  "check-coverage": true,
+  "extends": "../../.c8rc.json",
   "lines": 0,
   "reporter": ["cobertura", "lcov", "text", "text-summary"],
   "reports-dir": "../../out/coverage/als",

--- a/test/unit/.c8rc.json
+++ b/test/unit/.c8rc.json
@@ -1,6 +1,5 @@
 {
-  "//": "Do not enable 'check-coverage' or text reporters because we loop over the tests from test-launcher.sh.",
-  "check-coverage": false,
+  "check-coverage": true,
   "clean": true,
   "exclude": [
     "**/__tests__/**",
@@ -17,7 +16,8 @@
     "test{,s}/**"
   ],
   "exclude-after-remap": true,
-  "reporter": ["cobertura", "lcov"],
-  "reports-dir": "./out/coverage/ui",
-  "temp-directory": "./out/tmp/.c8-tmp-ui"
+  "lines": 91.45,
+  "reporter": ["cobertura", "lcov", "text"],
+  "reports-dir": "./out/coverage/unit",
+  "temp-directory": "./out/tmp/.c8-tmp-unit"
 }

--- a/tools/test-setup.sh
+++ b/tools/test-setup.sh
@@ -20,9 +20,9 @@ EE_ANSIBLE_VERSION=null
 EE_ANSIBLE_LINT_VERSION=null
 
 if command -v sudo >/dev/null 2>&1; then
-    SUDO=""
-else
     SUDO=sudo
+else
+    SUDO=""
 fi
 
 mkdir -p out/log
@@ -49,28 +49,6 @@ get_version () {
         log error "Got $? while trying to retrieve ${1:-} version"
         return 99
     fi
-}
-
-find_powershell() {
-    # Sometimes these are not in PATH under wsl, so we need to look deeper
-    local candidates=(
-        "pwsh.exe"
-        "powershell.exe"
-        "/mnt/c/Program Files/PowerShell/7/pwsh.exe"
-        "/mnt/c/Program Files (x86)/PowerShell/7/pwsh.exe"
-        "/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe"
-    )
-    for exe in "${candidates[@]}"; do
-        if cmd=$(command -v "$exe" 2>/dev/null); then
-            echo "$cmd"
-            exit 0
-        elif [ -x "$exe" ]; then
-            echo "$exe"
-            exit 0
-        fi
-    done
-    log error "Failed to find powershell executable"
-    exit 2
 }
 
 if [[ -z "${HOSTNAME:-}" ]]; then
@@ -150,11 +128,8 @@ else
         OS_VERSION="$(lsb_release --id --short 2> /dev/null)-$(lsb_release --release --short 2> /dev/null)"
         OS_VERSION="${OS_VERSION,,}"
         if [[ "$WSL" -eq 1 ]]; then
-            OS_VERSION=$($(find_powershell) -Command 'Get-CimInstance -ClassName Win32_OperatingSystem | Select-Object -property Caption, BuildNumber' | grep "Microsoft " | \
-            tr -d '\r' | \
-            sed 's/^Microsoft //I' | \
-            tr '[:upper:]' '[:lower:]' | \
-            sed 's/[ -]\+/-/g')-wsl-$OS_VERSION
+            # is wsl is configured with interop disabled, calling cmd.exe can fail ugly and without output on GHA
+            OS_VERSION=$(cmd.exe /c ver 2>/dev/null | awk '/Version/ {match($0, /\[Version ([0-9.]+)\]/, a); print a[1]}' || echo 'unknown')
         fi
     else # when inside a container this would be needed
         # shellcheck disable=SC1091
@@ -173,7 +148,7 @@ if [[ -f "/usr/bin/apt-get" ]]; then
     # qemu-user-static is required by podman on arm64
     # python3-dev is needed for headers as some packages might need to compile
     # DEBS=(curl file git python3-dev python3-venv python3-pip qemu-user-static xvfb x11-xserver-utils libgbm-dev libssh-dev libonig-dev)
-    DEBS=(curl file git)
+    DEBS=(curl file git gcc libonig-dev)
     # add nodejs to DEBS only if node is not already installed because
     # GHA has newer versions preinstalled and installing the rpm would
     # basically downgrade it
@@ -298,9 +273,13 @@ fi
 VIRTUAL_ENV=${EXPECTED_VENV}
 if [[ -d "${VIRTUAL_ENV}" ]]; then
     log notice "Running uv sync ..."
+    if [[ "$WSL" -eq 1 ]]; then
+        log warning "Setting UV_CONCURRENT_INSTALLS=1 because WSL was detected, see https://github.com/astral-sh/uv/issues/13481#issuecomment-3375527015"
+        export UV_CONCURRENT_INSTALLS=1
+    fi
     timed uv sync --no-progress -q || {
-        log warning "Removing broken venv from ${VIRTUAL_ENV} ..."
-        rm -rf "${VIRTUAL_ENV}"
+    log warning "Removing broken venv from ${VIRTUAL_ENV} ..."
+    rm -rf "${VIRTUAL_ENV}"
     }
 fi
 if [[ ! -d "${VIRTUAL_ENV}" ]]; then


### PR DESCRIPTION
- rename c8rc config to use json extension (better biome support)
- fix WSL version detection to address recent failure (seen on linked PR runs)
- avoid generating lcov HTML reports by using lcovonly reporter (gitleaks would report failure due to some secrets being listed in the reports)
- include xauth in builder image to allow run of ui/e2e tests (seen on linked PR runs)
- configure mise to add node_modules bin to PATH so we can call them without the ugly `node exec --`

Partial: #2318
Related: AAP-58298
