### PR TITLE
chore: disable sonar coverage checks

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,4 +1,6 @@
 # cspell: ignore multicriteria
+# we rely on codecov.io to ensure that code coverage does not go down
+sonar.coverage.exclusions=**/*
 sonar.cpd.exclusions=\
     packages/ansible-mcp-server/test/integration.ts, \
     packages/ansible-mcp-server/test/server.ts, \


### PR DESCRIPTION
Because we already use codecov.io to check coverage and we seen some
false positive coverage reports from sonar, we disable coverage checks
for it.
