### PR TITLE
chore: cleanup build scripts

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -1,4 +1,5 @@
 ABRT
+CACHEDIR
 Containerfile
 Customizer
 Devfile
@@ -84,6 +85,7 @@ primevue
 priyamsahoo
 progressspinner
 projectuser
+pyvenv
 relogin
 rhsso
 seealso

--- a/.config/mise.toml
+++ b/.config/mise.toml
@@ -27,6 +27,11 @@ experimental = true
 idiomatic_version_file_enable_tools = ["python"]
 lockfile = true
 
+[plugins]
+# required in order to ensure `mise doctor` returns correct exit code
+# see: https://github.com/jdx/mise/discussions/4432
+mise_version = "2025.6.2"
+
 [tools]
 gh = "latest"
 # do not add tools unsupported on windows such: gh, yarn

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -11,6 +11,10 @@ runs:
     - uses: jdx/mise-action@146a28175021df8ca24f8ee1828cc2a60f980bd5 # v3.5.1
       with:
         experimental: true
+        # without specific version here will not upgrade old existing versions
+        version: 2025.11.11
+        # https://github.com/jdx/mise-action/issues/165
+        dir: ~/.local/bin
         reshim: true
 
     - name: Corepack enable

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -260,29 +260,19 @@ jobs:
       #       ~/.config/containers
       #     key: ${{ runner.os }}-${{ matrix.task-name }}-${{ hashFiles('package.json', 'yarn.lock', '.config/requirements.txt', '**/Taskfile.yml', 'tools/*.*') }}
 
-      - name: Setup python
-        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
-        with:
-          python-version-file: .python-version
-
       - name: Ensure .env file is automatically loaded (mise)
         run: |
-          set -ex
-          mise doctor || true
+          set -exuo pipefail
+          mise reshim
+          mise doctor
           test "${VIRTUAL_ENV:-}" = "${HOME}/.local/share/virtualenvs/vsa" || {
             echo "VIRTUAL_ENV mismatch"
             exit 99
           }
           test "$(mise exec -- which python3)" = "${HOME}/.local/share/virtualenvs/vsa/bin/python3" || {
-            echo "::warning::python3 mismatch"
-            # exit 98
+            echo "::warning::python3 mismatch $(mise exec -- which python3) != ${HOME}/.local/share/virtualenvs/vsa/bin/python3"
+            exit 98
           }
-
-      - name: Install dependencies
-        uses: coactions/actions/yarn-install@b3c1841fd69e1658ac631afafd0fb140a2309024 # fix/install
-        # backstage/actions/yarn-install@b3c1841fd69e1658ac631afafd0fb140a2309024 # v0.6.17
-        with:
-          cache-prefix: ${{ runner.os }}-v${{ matrix.node-version }}
 
       - name: task setup
         # starting podman machine can randomly get stuck on macos
@@ -637,13 +627,8 @@ jobs:
           files: "*.vsix"
 
       - run: |
-          npm exec -- yarn install --immutable
+          yarn install --immutable
           ls -la *.vsix
-
-      - name: Setup python
-        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
-        with:
-          python-version-file: .python-version
 
       - name: Publish extension to marketplaces
         run: |

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -40,9 +40,13 @@ build:
     build:
       html:
         - >
-          UV_PROJECT_ENVIRONMENT=$READTHEDOCS_VIRTUALENV_PATH
-          PATH=~/.local/bin:$PATH
           CI=1
+          FORCE_COLOR=0
+          PATH=~/.local/bin:$PATH
+          SKIP_DOCKER=1
+          SKIP_PODMAN=1
+          UV_CONCURRENT_BUILDS=1
+          UV_PROJECT_ENVIRONMENT=$READTHEDOCS_VIRTUALENV_PATH
           ~/.local/bin/mise exec -- task docs
     create_environment:
       - curl https://mise.run | sh

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -2,6 +2,8 @@ compressionLevel: mixed
 
 enableGlobalCache: true
 
+enableTelemetry: 0
+
 nodeLinker: node-modules
 
 supportedArchitectures:

--- a/Taskfile.base.yml
+++ b/Taskfile.base.yml
@@ -2,31 +2,41 @@
 # see https://taskfile.dev/#/
 version: "3"
 tasks:
-  install:
+  yarn:
     cmds:
-      - uv sync --no-progress -q --active
-      - bash ./tools/install.sh
       - yarn install --immutable --silent
-    deps:
-      - setup
     dir: "{{ .TASKFILE_DIR }}"
     generates:
       - node_modules/.yarn-state.yml
     sources:
       - package.json
       - packages/*/package.json
+      - .yarn.lock
+    run: once
+    interactive: true
+  uv:
+    cmds:
+      - uv sync --no-progress -q --active
+      - bash ./tools/uv.sh
+    generates:
+      - "{{ .VIRTUAL_ENV }}/pyvenv.cfg"
+      - "{{ .VIRTUAL_ENV }}/CACHEDIR.TAG"
+    dir: "{{ .TASKFILE_DIR }}"
+    sources:
       - pyproject.toml
-      - tools/test-setup.sh
       - uv.lock
-      - yarn.lock
+      - tools/uv.sh
     run: once
     interactive: true
   setup:
-    desc: Install dependencies
+    desc: Setup build toolchain and install missing dependencies
     env:
       # used inside test-setup.sh
       OS: "{{OS}}"
       ARCH: "{{ARCH}}"
+    deps:
+      - yarn
+      - uv
     dir: "{{ .TASKFILE_DIR }}"
     cmds:
       - bash ./tools/precheck.sh

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -28,7 +28,7 @@ tasks:
   default:
     desc: Run most commands
     cmds:
-      - task: install
+      - task: setup
       - task: lint
       - task: package
       - task: docs
@@ -48,14 +48,13 @@ tasks:
   build:
     desc: Build the project
     deps:
-      - install
+      - setup
     cmds:
       - task: als:build
       - task: mcp:build
-      - npm exec -- yarn run clean
-      - npm exec -- yarn run als-compile
-      - npm exec -- yarn run compile
-      - npm exec -- tsc -p ./
+      - yarn run clean
+      - yarn run als-compile
+      - yarn run compile
     sources:
       - Taskfile.yml
       - package.json
@@ -82,7 +81,7 @@ tasks:
         sh: node -p "require('./package.json').engines.vscode"
     cmds:
       - task: "deps:python"
-      - task: install
+      - task: setup
       # upgrade yarn itself
       - yarn set version latest
       # bumps some developments dependencies
@@ -115,6 +114,8 @@ tasks:
   docs:
     dir: "{{ .TASKFILE_DIR }}"
     desc: Build the documentation
+    deps:
+      - setup
     sources:
       - docs/**/*
       - media/**/*
@@ -124,7 +125,6 @@ tasks:
     generates:
       - out/html/**/*
     cmds:
-      - task: install # implies setup, needed to install node deps
       # Retrieve possibly missing commits:
       - $(git rev-parse --is-shallow-repository) && git fetch --unshallow > /dev/null || true
       - git fetch --tags --force
@@ -239,6 +239,8 @@ tasks:
     silent: true
   pr:
     desc: Opens a pull request using gh
+    deps:
+      - setup
     cmds:
       - task: lint
       - gh pr create
@@ -246,7 +248,6 @@ tasks:
   release:
     desc: Create a new release (used by CI)
     cmds:
-      - task: install
       - ./tools/release.sh
     interactive: true
   builder:

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -17,6 +17,43 @@ along with their descriptions.
 $ task -l
 ```
 
+The diagram below shows the dependencies between the command task commands.
+
+```mermaid
+flowchart TD
+    build --> setup
+    docs --> setup
+    package --> build
+    test --> build
+    test --> ui
+    test --> e2e
+    test --> mcp
+    test --> unit
+    test --> als
+    default --> lint
+    default --> docs
+    default --> package
+    default --> test
+    lint --> setup
+    clean
+    code --> package
+    deps --> setup
+    ui --> build
+    unit --> build
+    e2e --> build
+    mcp --> build
+    als --> build
+
+    subgraph testing
+      test
+      mcp
+      ui
+      e2e
+      unit
+      als
+    end
+```
+
 ## Release and publication of extension
 
 Github Actions pipeline has two publishing jobs, one for marketplace publishing

--- a/package.json
+++ b/package.json
@@ -1113,7 +1113,7 @@
   "scripts": {
     "als-compile": "yarn workspace @ansible/ansible-language-server compile",
     "clean": "rimraf out/client out/server out/mcp out/tsconfig.tsbuildinfo out/syntaxHighlighter coverage .nyc_output",
-    "compile": "tsc -b && tsc -p ./packages/ansible-language-server/tsconfig.json --outDir ./out/server --sourceMap",
+    "compile": "yarn run clean && tsc -b --sourceMap && tsc -p ./packages/ansible-language-server/tsconfig.json --outDir ./out/server --sourceMap",
     "coverage-all": "MOCK_LIGHTSPEED_API=1 TEST_TYPE=e2e COVERAGE=1 ./tools/test-launcher.sh",
     "coverage-ui-current": "COVERAGE=1 ./tools/test-launcher.sh",
     "coverage-ui-oldest": "COVERAGE=1 CODE_VERSION='min' ./tools/test-launcher.sh",
@@ -1121,8 +1121,7 @@
     "package": "./tools/helper --package",
     "preinstall": "",
     "pretest": "node --max-old-space-size=8192 node_modules/webpack/bin/webpack.js --mode development --config ./webpack.config.ts",
-    "test-compile": "yarn run clean && yarn run compile && tsc -p ./ --sourceMap",
-    "test-e2e": "yarn run test-compile && MOCK_LIGHTSPEED_API=1 TEST_TYPE=e2e ./tools/test-launcher.sh",
+    "test-e2e": "yarn run compile && MOCK_LIGHTSPEED_API=1 TEST_TYPE=e2e ./tools/test-launcher.sh",
     "test-ui": "yarn run test-ui-current && yarn run test-ui-oldest",
     "test-ui-current": "./tools/test-launcher.sh",
     "test-ui-oldest": "CODE_VERSION='min' ./tools/test-launcher.sh",
@@ -1134,7 +1133,7 @@
     "watch": "tsc -b -w",
     "watch-server": "tsc -p ../ansible-language-server --outDir out/server -w",
     "webpack": "yarn run clean && yarn run mcp-compile && webpack --mode production --config ./webpack.config.ts",
-    "webpack-dev": "yarn run clean && yarn test-compile && yarn run mcp-compile && webpack --mode development --config ./webpack.config.ts",
+    "webpack-dev": "yarn compile && yarn run mcp-compile && webpack --mode development --config ./webpack.config.ts",
     "webpack:watch": "webpack --mode development --config ./webpack.config.ts --watch"
   },
   "segmentWriteKey": "zJzQozAVCyM6DTyxk3TjqTX1yd05G4Ow",

--- a/packages/ansible-language-server/Taskfile.yml
+++ b/packages/ansible-language-server/Taskfile.yml
@@ -43,9 +43,9 @@ tasks:
     dir: "{{ .TASKFILE_DIR }}"
     desc: Build the project
     deps:
-      - install
+      - setup
     cmds:
-      - npm exec -- yarn run compile
+      - yarn run compile
     sources:
       - package-lock.json
       - package.json
@@ -108,7 +108,7 @@ tasks:
       - build
     cmds:
       - rm -f {{ .TASKFILE_DIR }}/*.tgz
-      - npm exec -- yarn pack --out '{{ .TASKFILE_DIR }}/%s-%v.tgz'
+      - yarn pack --out '{{ .TASKFILE_DIR }}/%s-%v.tgz'
     silent: false
   release:
     desc: Create a new release (used by CI)

--- a/packages/ansible-language-server/tools/can-release.sh
+++ b/packages/ansible-language-server/tools/can-release.sh
@@ -16,7 +16,7 @@ git checkout HEAD -- package.json
 npm add ../../@ansible-ansible-language-server-*.tgz
 npm install
 git checkout HEAD -- package.json
-npm exec -- ts-node ../../test/validate-ls.ts
+ts-node ../../test/validate-ls.ts
 popd
 
 

--- a/packages/ansible-mcp-server/Taskfile.yml
+++ b/packages/ansible-mcp-server/Taskfile.yml
@@ -29,7 +29,7 @@ tasks:
     dir: "{{ .TASKFILE_DIR }}"
     desc: Build the project
     deps:
-      - install
+      - setup
     cmds:
       - npm run build
     generates:
@@ -83,7 +83,7 @@ tasks:
       - "*.tgz"
     cmds:
       - rm -f {{ .TASKFILE_DIR }}/*.tgz
-      - npm exec -- yarn pack --out '{{ .TASKFILE_DIR }}/%s-%v.tgz'
+      - yarn pack --out '{{ .TASKFILE_DIR }}/%s-%v.tgz'
     silent: false
   clean:
     desc: Clean build artifacts

--- a/tools/helper
+++ b/tools/helper
@@ -131,25 +131,25 @@ def cli() -> None:
             logging.error(msg)
             sys.exit(2)
         run(
-            f"npm exec -- vsce publish {pre_release_arg} --skip-duplicate --packagePath"
+            f"vsce publish {pre_release_arg} --skip-duplicate --packagePath"
             f" {vsix_files[0]} --readme-path docs/README.md"
         )
-        run(f"npm exec -- ovsx publish {pre_release_arg} --skip-duplicate {vsix_files[0]}")
+        run(f"ovsx publish {pre_release_arg} --skip-duplicate {vsix_files[0]}")
         sys.exit()
     if opt.package:
         run("rm -f ./*.vsix")
-        run("npm exec -- yarn run webpack")
+        run("yarn run webpack")
         # --no-dependencies and --no-yarn needed due to https://github.com/microsoft/vscode-vsce/issues/439
-        run("npm exec -- yarn run vite-build")
+        run("yarn run vite-build")
         # Build and stage the MCP server into out/mcp so it is included in the VSIX
-        run("npm exec -- yarn workspace @ansible/ansible-mcp-server build")
+        run("yarn workspace @ansible/ansible-mcp-server build")
         run("mkdir -p out/mcp && cp -r packages/ansible-mcp-server/out/server/src/* out/mcp/")
 
         run(
-            "npm exec -- vsce package --follow-symlinks --no-dependencies --no-git-tag-version"
+            "vsce package --follow-symlinks --no-dependencies --no-git-tag-version"
             f" --no-update-package-json --readme-path docs/README.md {pre_release_arg} {version}"
         )
-        # Using zipinfo instead of `npm exec -- vsce ls` due to https://github.com/microsoft/vscode-vsce/issues/517
+        # Using zipinfo instead of `vsce ls` due to https://github.com/microsoft/vscode-vsce/issues/517
         run("mkdir -p out/log")
         run("zipinfo -1 ./*.vsix > out/log/package.log")
         vsix_file = f"ansible-{version}.vsix"

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-creator_resources_path="$(uv run python -c "from pathlib import Path; import ansible_creator; print(Path(ansible_creator.__file__).parent)")/resources"
-mkdir -p resources/contentCreator/createDevcontainer
-mkdir -p resources/contentCreator/createDevfile
-ln -fs "$creator_resources_path/common/devfile/devfile.yaml.j2" "resources/contentCreator/createDevfile/devfile-template.txt"
-ln -fs "$creator_resources_path/common/devcontainer/.devcontainer" "resources/contentCreator/createDevcontainer/"

--- a/tools/test-launcher.sh
+++ b/tools/test-launcher.sh
@@ -153,10 +153,10 @@ fi
 
 # Start the mock Lightspeed server and run UI tests with the new VS Code
 
-retry_command 3 2 npm exec -- extest get-vscode -c "${CODE_VERSION}" -s out/test-resources
+retry_command 3 2 extest get-vscode -c "${CODE_VERSION}" -s out/test-resources
 
 log notice "Downloading ChromeDriver..."
-retry_command 3 2 npm exec -- extest get-chromedriver -c "${CODE_VERSION}" -s out/test-resources
+retry_command 3 2 extest get-chromedriver -c "${CODE_VERSION}" -s out/test-resources
 
 # Pre-pull ansible-navigator container image for UI tests (non-macOS only)
 if [[ "$OSTYPE" != "darwin"* ]]; then
@@ -189,9 +189,9 @@ if [[ "$COVERAGE" == "" ]]; then
     fi
     yarn compile
 
-    npm exec -- extest install-vsix -f "${vsix}" -e out/ext -s out/test-resources
+    extest install-vsix -f "${vsix}" -e out/ext -s out/test-resources
 fi
-npm exec -- extest install-from-marketplace redhat.vscode-yaml ms-python.python -e out/ext -s out/test-resources
+extest install-from-marketplace redhat.vscode-yaml ms-python.python -e out/ext -s out/test-resources
 
 export COVERAGE
 
@@ -215,7 +215,7 @@ if [[ "${TEST_TYPE}" == "ui" ]]; then
                 start_server
             fi
             refresh_settings "${test_file}" "${TEST_ID}"
-            timeout --kill-after=15 --preserve-status 150s npm exec -- extest run-tests "${COVERAGE_ARG}" \
+            timeout --kill-after=15 --preserve-status 150s extest run-tests "${COVERAGE_ARG}" \
                 --mocha_config test/ui/.mocharc.js \
                 -s out/test-resources \
                 -e out/ext \
@@ -256,7 +256,7 @@ if [[ "${TEST_TYPE}" == "e2e" ]]; then
     rm -f out/junit/e2e/*.*
     cp -f test/testFixtures/settings.json out/userdata/User/settings.json
     # no not try to use junit reporter here as it gives an internal error, but it works well when setup as the sole mocha reporter inside .vscode-test.mjs file
-    npm exec -- vscode-test --install-extensions ansible-*.vsix --coverage --coverage-output ./out/coverage/e2e --coverage-reporter text --coverage-reporter cobertura --coverage-reporter lcov
+    vscode-test --install-extensions ansible-*.vsix --coverage --coverage-output ./out/coverage/e2e --coverage-reporter text --coverage-reporter cobertura --coverage-reporter lcov
     touch out/junit/e2e/.passed
     rm -f test/testFixtures/.vscode/settings.json
 fi

--- a/tools/uv.sh
+++ b/tools/uv.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+DIR="$(dirname "$(realpath "$0")")"
+# shellcheck source=/dev/null
+. "$DIR/_utils.sh"
+
+creator_resources_path="$(uv run python -c "from pathlib import Path; import ansible_creator; print(Path(ansible_creator.__file__).parent)")/resources"
+mkdir -p resources/contentCreator/createDevcontainer
+mkdir -p resources/contentCreator/createDevfile
+ln -fs "$creator_resources_path/common/devfile/devfile.yaml.j2" "resources/contentCreator/createDevfile/devfile-template.txt"
+ln -fs "$creator_resources_path/common/devcontainer/.devcontainer" "resources/contentCreator/createDevcontainer/"
+
+log notice "Using $(python3 --version) from $(uv run which python3)"
+printenv VIRTUAL_ENV
+printenv PATH
+if [[ "$(which python3)" != ${VIRTUAL_ENV}/bin/python3 ]]; then
+    log warning "Virtualenv broken $(which python3) != ${VIRTUAL_ENV}/bin/python3, trying to recreate it ..."
+    uv venv --clear "${VIRTUAL_ENV}"
+    # shellcheck disable=SC1091
+    . "${VIRTUAL_ENV}/bin/activate"
+    if [[ "$(which python3)" != ${VIRTUAL_ENV}/bin/python3 ]]; then
+        log error "Virtualenv still broken."
+        exit 99
+    fi
+fi
+# Fail fast if user has broken dependencies
+uv pip check || {
+        log error "pip check failed with exit code $?"
+        if [[ $MACHTYPE == x86_64* && "${OSTYPE:-}" != darwin* ]] ; then
+            exit 98
+        else
+            log error "Ignored pip check failure on this platform due to https://sourceforge.net/p/ruamel-yaml/tickets/521/"
+        fi
+}
+
+# GHA failsafe only: ensure ansible and ansible-lint cannot be found anywhere
+# other than our own virtualenv. (test isolation)
+if [[ -n "${CI:-}" ]]; then
+    command -v ansible >/dev/null 2>&1 || {
+        log warning "Attempting to remove pre-installed ansible on CI ..."
+        pipx uninstall --verbose ansible || true
+        if [[ "$(which -a ansible | wc -l | tr -d ' ')" != "1" ]]; then
+            log error "Please ensure there is no preinstalled copy of ansible on CI.\n$(which -a ansible)"
+            exit 66
+        fi
+    }
+    command -v ansible-lint >/dev/null 2>&1 || {
+        log warning "Attempting to remove pre-installed ansible-lint on CI ..."
+        pipx uninstall --verbose ansible-lint || true
+        if [[ "$(which -a ansible-lint | wc -l | tr -d ' ')" != "1" ]]; then
+            log error "Please ensure there is no preinstalled copy of ansible-lint on CI.\n$(which -a ansible-lint)"
+            exit 67
+        fi
+    }
+    if [[ -d "${HOME}/.ansible" ]]; then
+        log warning "Removing unexpected ~/.ansible folder found on CI to avoid test contamination."
+        rm -rf "${HOME}/.ansible"
+    fi
+fi
+
+# Fail if detected tool paths are not from inside out out/ folder
+for CMD in ansible ansible-lint ansible-navigator; do
+    CMD=$(command -v $CMD 2>/dev/null)
+    [[ "${CMD}" == "$VIRTUAL_ENV"* ]] || {
+        log error "${CMD} executable is not from our own virtualenv ($VIRTUAL_ENV)"
+        exit 68
+    }
+done
+unset CMD

--- a/vscode-ansible.Containerfile
+++ b/vscode-ansible.Containerfile
@@ -4,6 +4,8 @@ FROM ghcr.io/jdx/mise:latest
 ENV CI=1
 ENV MISE_TRUSTED_CONFIG_PATHS=/
 ENV SKIP_UI=1
+ENV SKIP_DOCKER=1
+ENV SKIP_PODMAN=1
 WORKDIR /usr/src/app
 
 # install ansible-dev-tools specific packages and dependencies while avoiding
@@ -19,5 +21,4 @@ mise exec -- uv sync --no-progress -q --active && \
 mise exec -- python --version && \
 free -h
 RUN mise exec -- task setup
-RUN mise exec -- task install
 RUN mise exec -- task package


### PR DESCRIPTION
- remove use on `npm exec --` as `node_modules/bin` are added by mise to PATH
- required minimal version of mise
- removed multiple unused npm scripts
- split test-setup to separate python/uv logic (ease maintenance)
- simplified brew install
- improved docker detection/setup logic
- disabled yarn telemetry
- documented dependency between most used task commands
- removed unneeded use of setup-python and yarn-install actions as we rely on mise
- added fail-safe test for availability of node tools like: tsc, vsce, ovsx

Related: AAP-58298
