### PR TITLE
Fix: Pin Zod version to match MCP SDK dependency

### DIFF
--- a/packages/ansible-mcp-server/package.json
+++ b/packages/ansible-mcp-server/package.json
@@ -5,7 +5,7 @@
     "ajv": "^8.17.1",
     "ajv-formats": "^3.0.1",
     "yaml": "^2.8.1",
-    "zod": "^4.1.13"
+    "zod": "^3.23.8"
   },
   "description": "Ansible Development Tools MCP server with linting, workspace access, and expert prompts",
   "devDependencies": {
@@ -39,7 +39,7 @@
   "main": "./out/server/src/server.js",
   "name": "@ansible/ansible-mcp-server",
   "overrides": {
-    "zod": "^4.1.13"
+    "zod": "^3.23.8"
   },
   "publishConfig": {
     "access": "public"

--- a/yarn.lock
+++ b/yarn.lock
@@ -62,7 +62,7 @@ __metadata:
     typescript: "npm:^5.9.3"
     vitest: "npm:^4.0.14"
     yaml: "npm:^2.8.1"
-    zod: "npm:^4.1.13"
+    zod: "npm:^3.23.8"
   bin:
     ansible-mcp-server: out/server/src/cli.js
   languageName: unknown
@@ -11789,12 +11789,5 @@ __metadata:
   version: 3.25.76
   resolution: "zod@npm:3.25.76"
   checksum: 10/f0c963ec40cd96858451d1690404d603d36507c1fc9682f2dae59ab38b578687d542708a7fdbf645f77926f78c9ed558f57c3d3aa226c285f798df0c4da16995
-  languageName: node
-  linkType: hard
-
-"zod@npm:^4.1.13":
-  version: 4.1.13
-  resolution: "zod@npm:4.1.13"
-  checksum: 10/0679190318928f69fcb07751063719de232c663b13955fcdb55db59839569d39f3f29b955cb0cba7af0b724233f88c06b3e84c550397ad4e68f8088fa6799d88
   languageName: node
   linkType: hard


### PR DESCRIPTION
### Problem
After renovatebot upgraded Zod to version 4.x in [PR](https://github.com/ansible/vscode-ansible/pull/2294), MCP server tools stopped working correctly. The tools were failing to receive and parse input arguments properly.

### Root Cause Analysis
The issue stems from a **version incompatibility** between Zod and the MCP SDK:

1. **Renovatebot upgraded Zod** to version 4.x (which introduced breaking API changes)
2. **MCP SDK dependency**: The `@modelcontextprotocol/sdk@^1.17.3` package uses Zod `3.23.8` as a peer dependency

### Solution
Pin Zod to version `3.23.8` to match the MCP SDK's dependency version using npm `overrides`. This ensures:

- Compatibility with the MCP SDK's internal Zod usage
- Consistent Zod version across the entire dependency tree

### Future Considerations (IMP)
We should align our Zod version with the MCP SDK's dependency. When the MCP SDK upgrades its Zod dependency, we can then upgrade ours accordingly. Consider adding a renovatebot rule to prevent automatic major version upgrades for Zod until the MCP SDK supports it.