### PR TITLE
chore(build): clean uv cache and avoid build artifacts

### DIFF
--- a/.env
+++ b/.env
@@ -7,3 +7,9 @@ PATH="${HOME}/.local/share/virtualenvs/vsa/bin:${PATH}"
 
 UV_PROJECT_ENVIRONMENT="${HOME}/.local/share/virtualenvs/vsa"
 # Do not add NODE_OPTIONS here because this is not allowed by GHA.
+
+# Isolated from user level config, disable logging/artifacts
+ANSIBLE_NAVIGATOR_CONFIG=examples/ansible-navigator.yml
+# mcp tests do not use ^ but the benefit from next line
+ANSIBLE_NAVIGATOR_PLAYBOOK_ARTIFACT_ENABLE=false
+ANSIBLE_NAVIGATOR_LOGGING_FILE=/dev/null

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -29,8 +29,9 @@ runs:
       # left out due to having their own caching: yarn, node_modules, mise
       uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
+        # we cache only wheels because http cache cannot be cleaned well
         path: |
-          ~/.cache/pip
+          ~/.cache/pip/wheels
           ~/.cache/uv
         key: py-${{ env.IMAGE_OS_VERSION }}-${{ matrix.id }}-${{ hashFiles('uv.lock', '.python-version') }}
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -130,6 +130,9 @@ jobs:
         run: |
           task package && task package --status
 
+      - name: task finish
+        run: task finish
+
       - name: Upload vsix artifact
         uses: ansible/actions/upload-artifact@main
         with:
@@ -369,6 +372,9 @@ jobs:
           set -e
           task ui ${{ matrix.env.TASKFILE_ARGS }} || { task flush && task ui ${{ matrix.env.TASKFILE_ARGS }}; }
           task ui ${{ matrix.env.TASKFILE_ARGS }} --status
+
+      - name: task finish
+        run: task finish
 
       - name: Remove invalid files
         if: ${{ always() }}

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -43,6 +43,9 @@ tasks:
   finish:
     desc: Commands to run at the end
     cmds:
+      # clean up uv cache, important for CI especially for caching size reduction
+      - uv cache prune --ci
+      - find `python3 -m pip cache dir`/wheels -type f -atime +30 -delete || true
       - tools/dirty.sh
 
   build:

--- a/examples/ansible-navigator.yml
+++ b/examples/ansible-navigator.yml
@@ -1,0 +1,8 @@
+# Used for testing purposes to isolated from user configured one
+# https://github.com/ansible/ansible-navigator/issues/1732
+ansible-navigator:
+  logging:
+    level: debug
+    file: /dev/null
+  playbook-artifact:
+    enable: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,9 @@ ignore-words-list = ["als", "ro", "stdio", "isPlay", "afterAll"]
 ignore-words = ".config/dictionary.txt"
 skip = ".cache,.yarn,out,node_modules,.mypy_cache,.ruff_cache,site,codicon.css,yarn.lock,package-lock.json,.vscode-test,.git,dictionary.txt,settings.md,.eslintcache,.venv,media"
 
+[tool.distutils.egg_info]
+egg_base = "out"
+
 # We have no python tests in this project, but we keep this config to prevent
 # vscode python extension from showing errors while trying to collect tests.
 [tool.pytest.ini_options]


### PR DESCRIPTION
- reduce size of uv cache which slowed down CI (especially wsl)
- disable artifact and log generation in navigator
- isolated navigator from user setu0p
