### PR TITLE
chore: use node 25 during build and testing

### DIFF
--- a/.config/mise.toml
+++ b/.config/mise.toml
@@ -35,7 +35,7 @@ mise_version = "2025.6.2"
 [tools]
 gh = "latest"
 # do not add tools unsupported on windows such: gh, yarn
-node = "22.20.0"
+node = "25.2.1"
 python = "3.13"
 task = "latest"  # >=3.45 but mise does not support minimal condition
 uv = "latest"

--- a/.env
+++ b/.env
@@ -13,3 +13,6 @@ ANSIBLE_NAVIGATOR_CONFIG=examples/ansible-navigator.yml
 # mcp tests do not use ^ but the benefit from next line
 ANSIBLE_NAVIGATOR_PLAYBOOK_ARTIFACT_ENABLE=false
 ANSIBLE_NAVIGATOR_LOGGING_FILE=/dev/null
+
+
+NODE_OPTIONS=-"-experimental-transform-types"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -324,7 +324,7 @@ jobs:
         run: task als ${{ matrix.env.TASKFILE_ARGS }} && task als ${{ matrix.env.TASKFILE_ARGS }} --status
 
       - name: task mcp
-        if: contains(matrix.name, 'test') && steps.ready_to_test.outputs.ready_to_test == 'true'
+        if: ${{ !cancelled() && contains(matrix.name, 'test') && steps.ready_to_test.outputs.ready_to_test == 'true' }}
         run: task mcp:test ${{ matrix.env.TASKFILE_ARGS }} && task mcp:test ${{ matrix.env.TASKFILE_ARGS }} --status
 
       - name: task e2e

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -47,6 +47,7 @@
   "editor.formatOnSave": true,
   "eslint.useESLintClass": true,
   "explorer.fileNesting.enabled": true,
+  "extesterRunner.testFileGlob": "test/ui/**/*.test.ts",
   "files.exclude": {
     ".task": true,
     ".vscode-test": true,

--- a/packages/ansible-language-server/.c8rc.json
+++ b/packages/ansible-language-server/.c8rc.json
@@ -1,5 +1,5 @@
 {
-  "branches": 81.24,
+  "branches": 80.19,
   "check-coverage": true,
   "extends": "../../.c8rc.json",
   "lines": 0,

--- a/packages/ansible-mcp-server/tsconfig.json
+++ b/packages/ansible-mcp-server/tsconfig.json
@@ -4,7 +4,7 @@
     "moduleResolution": "node",
     "outDir": "./out/server",
     "resolveJsonModule": true,
-    "target": "ES2022"
+    "target": "esnext"
   },
   "exclude": ["node_modules", "out", "coverage"],
   "extends": "../../tsconfig.base.json"

--- a/test/ui/.mocharc.js
+++ b/test/ui/.mocharc.js
@@ -4,6 +4,7 @@
 module.exports = {
   color: true, // needed to keep colors inside vscode terminal
   recursive: true,
+  spec: "test/**/*.ts",
   extension: ["ts"],
   require: ["ts-node/register"],
   package: "../../package.json",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -9,6 +9,6 @@
     "skipLibCheck": true,
     "sourceMap": true,
     "strict": true,
-    "target": "ES2022"
+    "target": "esnext"
   }
 }


### PR DESCRIPTION
Use node 25 as this adds --experimental-transform-types which would
allow us to run tests files without transpile.
