### PR TITLE
chore: add eslint rule to prevent incorrect use of spawnSync

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -97,6 +97,7 @@ progressspinner
 projectuser
 pydoclint
 pyvenv
+quasis
 relogin
 rhsso
 rimraf

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,6 +11,7 @@ import path from "path";
 import { fileURLToPath } from "url";
 import html from "@html-eslint/eslint-plugin";
 import { defineConfig } from "eslint/config";
+import noUnsafeSpawnRule from "./test/eslint/no-unsafe-spawn.ts";
 
 const __filename = fileURLToPath(import.meta.url); // get the resolved path to the file
 const __dirname = path.dirname(__filename); // get the name of the directory
@@ -33,6 +34,32 @@ export default defineConfig(
       "site/*",
       "webviews/**",
     ],
+  },
+  {
+    // Configuration for ESLint rule files (TypeScript)
+    // Must come before TypeScript configs to override parser
+    files: ["test/eslint/**/*.ts"],
+    languageOptions: {
+      globals: {
+        ...globals.node,
+        ...globals.es2017,
+      },
+      // Use TypeScript parser for rule files, but without project for type checking
+      // since rule files don't need full type checking
+      parser: tsParser,
+      parserOptions: {
+        ecmaVersion: 2022,
+        sourceType: "module",
+      },
+    },
+    rules: {
+      // Allow some TypeScript-specific rules for rule files, but disable strict ones
+      "@typescript-eslint/no-unsafe-member-access": "off",
+      "@typescript-eslint/no-unsafe-assignment": "off",
+      "@typescript-eslint/no-unsafe-call": "off",
+      "@typescript-eslint/no-unsafe-return": "off",
+      "@typescript-eslint/no-unsafe-argument": "off",
+    },
   },
   eslint.configs.recommended,
   prettierRecommendedConfig,
@@ -68,6 +95,7 @@ export default defineConfig(
       // loaded implicitly, will trigger 'Cannot redefine plugin' if enabled:
       // "@typescript-eslint": ts,
       tsdoc: tsdocPlugin,
+      "custom-rules": noUnsafeSpawnRule,
     },
     rules: {
       eqeqeq: ["error", "smart"],
@@ -97,6 +125,7 @@ export default defineConfig(
       "@typescript-eslint/await-thenable": "off",
       "@typescript-eslint/restrict-template-expressions": "off",
       "@typescript-eslint/only-throw-error": "off",
+      "custom-rules/no-unsafe-spawn": "error",
       "no-case-declarations": "error",
       "no-constant-condition": "error",
       "no-control-regex": "error",

--- a/test/e2e/rootMochaHooks.ts
+++ b/test/e2e/rootMochaHooks.ts
@@ -14,13 +14,14 @@ process.env = {
 };
 
 // display ansible-lint version and exit testing if ansible-lint is absent
-const command = "ansible-lint --version --offline";
+const command = "ansible-lint";
+const args = ["--version", "--offline"];
 try {
   // ALWAYS use 'shell: true' when we execute external commands inside the
   // extension because some of the tools may be installed in a way that does
   // not make them available without a shell, common examples tools that may
   // do this are: mise, asdf, pyenv.
-  const result = cp.spawnSync(command, { shell: true });
+  const result = cp.spawnSync(command, args, { shell: true });
   if (result.status === 0) {
     console.info(`Detected: ${result.stdout}`);
   } else {
@@ -33,7 +34,7 @@ try {
     .map(([k, v]) => `${k}=${v}`)
     .join("\n");
   console.error(
-    `error: test requisites not met, '${command}' returned ${err}\n${env}`,
+    `error: test requisites not met, '${command} ${args.join(" ")}' returned ${err}\n${env}`,
   );
   process.exit(PRETEST_ERR_RC);
 }

--- a/test/eslint/no-unsafe-spawn.ts
+++ b/test/eslint/no-unsafe-spawn.ts
@@ -1,0 +1,196 @@
+/**
+ * ESLint rule to detect unsafe child_process spawn/spawnSync calls
+ * that use a single string argument instead of separate command and args array.
+ *
+ * This prevents shell injection vulnerabilities and ensures proper argument handling.
+ */
+
+import type { Rule } from "eslint";
+
+// Extend RuleContext to include report method which exists at runtime
+interface ExtendedRuleContext extends Rule.RuleContext {
+  report(options: { node: Rule.Node; messageId: string }): void;
+}
+
+// Extend RuleModule to require meta (it's optional in the base type)
+interface ExtendedRuleModule extends Rule.RuleModule {
+  meta: {
+    type: "problem";
+    docs: {
+      description: string;
+      category: string;
+      recommended: boolean;
+    };
+    fixable: undefined;
+    schema: [];
+    messages: {
+      unsafeSpawn: string;
+      unsafeSpawnSync: string;
+    };
+  };
+  create(context: ExtendedRuleContext): Rule.RuleListener;
+}
+
+const rule: ExtendedRuleModule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "disallow child_process.spawn/spawnSync with single string argument containing spaces",
+      category: "Security",
+      recommended: true,
+    },
+    fixable: undefined,
+    schema: [],
+    messages: {
+      unsafeSpawn:
+        "Use spawn(command, args[]) instead of spawn(commandString). Split the command string into command and args array to prevent shell injection.",
+      unsafeSpawnSync:
+        "Use spawnSync(command, args[]) instead of spawnSync(commandString). Split the command string into command and args array to prevent shell injection.",
+    },
+  },
+  create(context: ExtendedRuleContext): Rule.RuleListener {
+    /**
+     * Check if a call expression is spawn or spawnSync
+     */
+    function isSpawnCall(
+      node: Rule.Node,
+    ): node is Rule.Node & { type: "CallExpression" } {
+      if (node.type !== "CallExpression" || !("callee" in node)) {
+        return false;
+      }
+
+      const callee = node.callee;
+
+      // Check for: spawnSync(...) or spawn(...) as identifier
+      if (callee.type === "Identifier") {
+        return callee.name === "spawnSync" || callee.name === "spawn";
+      }
+
+      // Check for: child_process.spawnSync(...) or cp.spawnSync(...)
+      if (
+        callee.type === "MemberExpression" &&
+        "property" in callee &&
+        callee.property &&
+        callee.property.type === "Identifier"
+      ) {
+        const methodName = callee.property.name;
+        return methodName === "spawnSync" || methodName === "spawn";
+      }
+
+      return false;
+    }
+
+    /**
+     * Check if the call is unsafe (command string instead of command + args array)
+     */
+    function isUnsafeCall(
+      node: Rule.Node & { type: "CallExpression" },
+    ): boolean {
+      const args = node.arguments;
+      if (!args || args.length === 0) {
+        return false;
+      }
+
+      const firstArg = args[0];
+      if (!firstArg) {
+        return false;
+      }
+
+      // If there's a second argument that's an array, it's safe (proper usage)
+      if (args.length > 1 && args[1].type === "ArrayExpression") {
+        return false;
+      }
+
+      // Check if second argument is an options object with shell: true
+      // This is unsafe because it goes through shell interpretation
+      if (
+        args.length > 1 &&
+        args[1].type === "ObjectExpression" &&
+        "properties" in args[1]
+      ) {
+        const properties = args[1].properties;
+        for (const prop of properties) {
+          if (
+            prop.type === "Property" &&
+            "key" in prop &&
+            prop.key.type === "Identifier" &&
+            prop.key.name === "shell" &&
+            "value" in prop &&
+            prop.value.type === "Literal" &&
+            prop.value.value === true
+          ) {
+            // shell: true is unsafe - flag it
+            return true;
+          }
+        }
+      }
+
+      // Check if first argument is a string literal with spaces
+      if (firstArg.type === "Literal" && typeof firstArg.value === "string") {
+        const value = firstArg.value.trim();
+        // Flag if it contains spaces (command + args) but allow single commands
+        return value.includes(" ") && value.length > 0;
+      }
+
+      // Check if it's a template literal
+      if (firstArg.type === "TemplateLiteral") {
+        const quasis = firstArg.quasis || [];
+        for (const quasi of quasis) {
+          const raw = ("value" in quasi && quasi.value?.raw) || "";
+          // If template literal contains spaces, flag it
+          if (raw.includes(" ")) {
+            return true;
+          }
+        }
+      }
+
+      // Check if first argument is a variable and second is options (not array)
+      // This is potentially unsafe - we can't know the variable's value statically,
+      // but if it's not followed by an array, it's likely a command string
+      if (
+        firstArg.type === "Identifier" &&
+        args.length > 1 &&
+        args[1].type === "ObjectExpression"
+      ) {
+        // Variable with options object (not array) - likely unsafe
+        return true;
+      }
+
+      return false;
+    }
+
+    return {
+      CallExpression(node: Rule.Node) {
+        if (!isSpawnCall(node)) {
+          return;
+        }
+
+        // Check if it's an unsafe call
+        if (isUnsafeCall(node)) {
+          const methodName =
+            node.callee.type === "Identifier"
+              ? node.callee.name
+              : node.callee.type === "MemberExpression" &&
+                  "property" in node.callee &&
+                  node.callee.property &&
+                  node.callee.property.type === "Identifier"
+                ? node.callee.property.name
+                : "spawn";
+
+          context.report({
+            node,
+            messageId:
+              methodName === "spawnSync" ? "unsafeSpawnSync" : "unsafeSpawn",
+          });
+        }
+      },
+    };
+  },
+};
+
+export default {
+  rules: {
+    "no-unsafe-spawn": rule,
+  },
+};

--- a/test/eslint/package.json
+++ b/test/eslint/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}


### PR DESCRIPTION
This also fixes ansible-lint detection in e2e testing.

Related: https://github.com/eslint-community/eslint-plugin-n/issues/493
Related: AAP-58298
