### PR TITLE
fix: updated broken ruleset_schema URL (fixes #2154)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1011,7 +1011,7 @@
           "rulebooks/*.yaml",
           "rulebooks/*.yml"
         ],
-        "url": "https://raw.githubusercontent.com/ansible/ansible-rulebook/main/schema/ruleset_schema.json"
+        "url": "https://raw.githubusercontent.com/ansible/ansible-rulebook/main/ansible_rulebook/schema/ruleset_schema.json"
       }
     ]
   },


### PR DESCRIPTION
Summary
Updated the ruleset_schema.json URL to the correct path in the ansible-rulebook repository to restore YAML validation.

Fixes #2154