### PR TITLE
Add ansible prefix in the MCP server command option

### DIFF
--- a/package.json
+++ b/package.json
@@ -204,11 +204,11 @@
       },
       {
         "command": "ansible.mcpServer.enabled",
-        "title": "Enable Ansible Development Tools MCP Server"
+        "title": "Ansible: Enable Ansible Development Tools MCP Server"
       },
       {
         "command": "ansible.mcpServer.disable",
-        "title": "Disable Ansible Development Tools MCP Server"
+        "title": "Ansible: Disable Ansible Development Tools MCP Server"
       },
       {
         "command": "ansible.lightspeed.testProviderConnection",


### PR DESCRIPTION
This PR adds the "Ansible:" prefix to MCP (Model Context Protocol) server command titles to improve consistency and discoverability in the VS Code command palette. The changes align with the existing naming convention used for other Ansible commands in the extension.

- Adds "Ansible:" prefix to MCP server enable command title
- Adds "Ansible:" prefix to MCP server disable command title

JIRA - AAP-60913