### PR TITLE
fix: use beforeAll instead of beforeEach in e2e hooks

### DIFF
--- a/test/e2e/rootMochaHooks.ts
+++ b/test/e2e/rootMochaHooks.ts
@@ -70,8 +70,8 @@ const overrideConsole = (method: ConsoleMethod) => {
 (["log", "info", "warn", "error"] as ConsoleMethod[]).forEach(overrideConsole);
 
 export const mochaHooks = {
-  beforeEach() {
-    fs.rmSync("out/junit/e2e", { recursive: true });
+  beforeAll() {
+    fs.rmSync("out/junit/e2e", { recursive: true, force: true });
     fs.mkdirSync("out/userdata/User/", { recursive: true });
     fs.mkdirSync("out/junit/e2e", { recursive: true });
     fs.cpSync(
@@ -81,7 +81,7 @@ export const mochaHooks = {
   },
 
   // Delete test fixture settings.json after all tests complete
-  afterEach() {
+  afterAll() {
     const settingsPath = path.join("test/testFixtures/.vscode/settings.json");
     try {
       if (fs.existsSync(settingsPath)) {


### PR DESCRIPTION
Related: AAP-61949

Problem -
The `beforeEach` hook in `test/e2e/rootMochaHooks.ts` was deleting and recreating the `out/junit/e2e` directory before every single test. Since the mocha-junit-reporterwrites to `./out/junit/e2e/test-results.xml`, this caused the reporter to fail when finalizing the XML output.

