### PR TITLE
fix: remove unused function and interface exports

### DIFF
--- a/knip.ts
+++ b/knip.ts
@@ -28,16 +28,8 @@ const config: KnipConfig = {
     "mocha-multi-reporters",
     "ovsx",
   ],
-  ignoreExportsUsedInFile: {
-    function: true,
-    interface: true,
-    type: false,
-  },
   mocha: {
-    entry: [
-      // "test/e2e/.mocharc.js",
-      "test/e2e/rootMochaHooks.ts",
-    ],
+    entry: ["test/e2e/rootMochaHooks.ts"],
   },
   typescript: {
     config: ["**/tsconfig*.json"],

--- a/packages/ansible-language-server/src/interfaces/extensionSettings.ts
+++ b/packages/ansible-language-server/src/interfaces/extensionSettings.ts
@@ -22,7 +22,7 @@ export interface ExtensionSettingsWithDescription extends ExtensionSettingsWithD
   python: PythonSettingsWithDescription;
 }
 
-export interface ExtensionSettingsType {
+interface ExtensionSettingsType {
   [name: string]:
     | ExtensionSettingsType
     | string

--- a/packages/ansible-language-server/src/utils/docsFormatter.ts
+++ b/packages/ansible-language-server/src/utils/docsFormatter.ts
@@ -102,7 +102,7 @@ export function formatOption(
   };
 }
 
-export function formatDescription(doc?: IDescription, asList = true): string {
+function formatDescription(doc?: IDescription, asList = true): string {
   let result = "";
   if (doc instanceof Array) {
     const lines: string[] = [];

--- a/packages/ansible-language-server/src/utils/docsParser.ts
+++ b/packages/ansible-language-server/src/utils/docsParser.ts
@@ -106,7 +106,7 @@ export function processRawDocumentation(
   }
 }
 
-export function processRawOptions(rawOptions: unknown): Map<string, IOption> {
+function processRawOptions(rawOptions: unknown): Map<string, IOption> {
   const options = new Map<string, IOption>();
   if (isObject(rawOptions)) {
     for (const [optionName, rawOption] of Object.entries(rawOptions)) {

--- a/packages/ansible-language-server/src/utils/yaml.ts
+++ b/packages/ansible-language-server/src/utils/yaml.ts
@@ -161,7 +161,7 @@ export function getPathAt(
   return null;
 }
 
-export function contains(
+function contains(
   node: Node | null,
   offset: number,
   inclusive: boolean,
@@ -174,7 +174,7 @@ export function contains(
   );
 }
 
-export function getPathAtOffset(
+function getPathAtOffset(
   path: Node[],
   offset: number,
   inclusive: boolean,
@@ -438,7 +438,7 @@ export async function getPossibleOptionsForPath(
  * the values hold a 'list' or a 'dict' is preserved along the way and returned
  * alongside.
  */
-export function getTaskParamPathWithTrace(
+function getTaskParamPathWithTrace(
   path: Node[],
 ): [Node[], [string, "list" | "dict"][]] {
   const trace: [string, "list" | "dict"][] = [];

--- a/packages/ansible-mcp-server/src/resources/agents.ts
+++ b/packages/ansible-mcp-server/src/resources/agents.ts
@@ -18,7 +18,7 @@ const AGENTS_FILE = path.join(__dirname, "data/agents.md");
 /**
  * Represents a section from the agents.md file
  */
-export interface GuidelineSection {
+interface GuidelineSection {
   title: string;
   level: number;
   content: string;

--- a/packages/ansible-mcp-server/src/tools/creator.ts
+++ b/packages/ansible-mcp-server/src/tools/creator.ts
@@ -10,7 +10,7 @@ import { join } from "node:path";
  * @returns A promise that resolves with the output from ansible-creator.
  * @throws An error if the process fails or returns an error.
  */
-export async function runCreator(
+async function runCreator(
   args: string[] = [],
 ): Promise<{ stdout: string; stderr: string }> {
   return new Promise((resolve, reject) => {
@@ -48,7 +48,7 @@ export async function runCreator(
 /**
  * Formats the ansible-creator result into a user-friendly message
  */
-export function formatCreatorResult(
+function formatCreatorResult(
   command: string,
   result: { stdout: string; stderr: string },
 ): string {

--- a/src/features/contentCreator/vue/views/helper.ts
+++ b/src/features/contentCreator/vue/views/helper.ts
@@ -1,11 +1,7 @@
 import type { Disposable, ExtensionContext, Webview } from "vscode";
 import { WebviewMessageHandlers } from "../../../lightspeed/vue/views/webviewMessageHandlers";
 
-export function setupHtml(
-  webview: Webview,
-  context: ExtensionContext,
-  name: string,
-) {
+function setupHtml(webview: Webview, context: ExtensionContext, name: string) {
   return __getWebviewHtml__({
     // vite dev mode
     serverUrl: `${process.env.VITE_DEV_SERVER_URL}webviews/${name}.html`,
@@ -16,7 +12,7 @@ export function setupHtml(
   });
 }
 
-export async function setupWebviewHooks(
+async function setupWebviewHooks(
   webview: Webview,
   disposables: Disposable[],
   context: ExtensionContext,

--- a/src/features/lightspeed/inlineSuggestions.ts
+++ b/src/features/lightspeed/inlineSuggestions.ts
@@ -65,7 +65,7 @@ interface InlinePosition {
   context: vscode.InlineCompletionContext;
 }
 
-export interface CallbackEntry {
+interface CallbackEntry {
   (
     suggestionDisplayed: SuggestionDisplayed,
     inlinePosition: InlinePosition,
@@ -852,7 +852,7 @@ export async function inlineSuggestionHideHandler(
   await inlineSuggestionUserActionHandler(suggestionId, action);
 }
 
-export async function inlineSuggestionUserActionHandler(
+async function inlineSuggestionUserActionHandler(
   suggestionId: string,
   isSuggestionAccepted: UserAction = UserAction.REJECTED,
 ) {

--- a/src/features/lightspeed/vue/views/helper.ts
+++ b/src/features/lightspeed/vue/views/helper.ts
@@ -1,12 +1,7 @@
 import type { Disposable, ExtensionContext, Webview } from "vscode";
 import { WebviewMessageHandlers } from "./webviewMessageHandlers";
 
-// Re-export commonly used functions for backward compatibility
-export function setupHtml(
-  webview: Webview,
-  context: ExtensionContext,
-  name: string,
-) {
+function setupHtml(webview: Webview, context: ExtensionContext, name: string) {
   return __getWebviewHtml__({
     // vite dev mode
     serverUrl: `${process.env.VITE_DEV_SERVER_URL}webviews/lightspeed/${name}.html`,
@@ -17,7 +12,7 @@ export function setupHtml(
   });
 }
 
-export async function setupWebviewHooks(
+async function setupWebviewHooks(
   webview: Webview,
   disposables: Disposable[],
   context: ExtensionContext,

--- a/src/features/utils/ansibleCfg.ts
+++ b/src/features/utils/ansibleCfg.ts
@@ -11,7 +11,7 @@ import * as ini from "ini";
 
 const homeDirectory = os.homedir();
 
-export default function untildify(pathWithTilde: string) {
+function untildify(pathWithTilde: string) {
   if (typeof pathWithTilde !== "string") {
     throw new TypeError(`Expected a string, got ${typeof pathWithTilde}`);
   }
@@ -58,7 +58,7 @@ export type AnsibleVaultConfig = {
   };
 };
 
-export async function scanAnsibleCfg(
+async function scanAnsibleCfg(
   rootPath?: string,
 ): Promise<AnsibleVaultConfig | undefined> {
   /*
@@ -96,7 +96,7 @@ export async function scanAnsibleCfg(
   return cfg;
 }
 
-export async function getValueByCfg(
+async function getValueByCfg(
   path: string,
 ): Promise<AnsibleVaultConfig | undefined> {
   console.log(`Reading '${path}'...`);

--- a/src/features/utils/applyModelines.ts
+++ b/src/features/utils/applyModelines.ts
@@ -56,7 +56,7 @@ export async function configureModelines(
  *
  * @param editor - textEditor
  */
-export async function applyModeLines(
+async function applyModeLines(
   editor: vscode.TextEditor | undefined,
 ): Promise<void> {
   if (!editor || !editor.document || editor.document.isUntitled) {

--- a/src/features/utils/formatAnsibleMetaData.ts
+++ b/src/features/utils/formatAnsibleMetaData.ts
@@ -134,7 +134,7 @@ export function formatAnsibleMetaData(ansibleMetaData: any) {
   };
 }
 
-export function getTildePath(absolutePath: string) {
+function getTildePath(absolutePath: string) {
   if (process.platform === "win32") {
     return path.win32.resolve(absolutePath);
   }

--- a/src/features/utils/python.ts
+++ b/src/features/utils/python.ts
@@ -9,7 +9,7 @@ export interface IInterpreterDetails {
 }
 
 /** Activate python extension */
-export async function activatePythonExtension() {
+async function activatePythonExtension() {
   const extension = extensions.getExtension("ms-python.python");
   if (extension) {
     if (!extension.isActive) {

--- a/src/interfaces/extensionSettings.d.ts
+++ b/src/interfaces/extensionSettings.d.ts
@@ -12,7 +12,7 @@ export interface ExtensionSettings {
   mcpServer: McpServerSettings;
 }
 
-export interface IVolumeMounts {
+interface IVolumeMounts {
   src: string;
   dest: string;
   options: string | undefined;

--- a/src/interfaces/lightspeed.ts
+++ b/src/interfaces/lightspeed.ts
@@ -240,12 +240,12 @@ export interface IVarsFileContext {
   [key: string]: string;
 }
 
-export interface IRoleVarsContext {
+interface IRoleVarsContext {
   defaults: IVarsFileContext;
   vars: IVarsFileContext;
 }
 
-export interface IRoleContext {
+interface IRoleContext {
   name?: string;
   tasks?: string[];
   roleVars?: IRoleVarsContext;
@@ -256,7 +256,7 @@ export interface IRolesContext {
   [rolePath: string]: IRoleContext;
 }
 
-export interface IStandaloneTaskContext {
+interface IStandaloneTaskContext {
   includeVars?: IIncludeVarsContext;
 }
 
@@ -264,14 +264,14 @@ export interface IWorkSpaceRolesContext {
   [workSpaceRoot: string]: IRolesContext;
 }
 
-export interface IPlaybookContext {
+interface IPlaybookContext {
   varInfiles?: IVarsFileContext;
   roles?: IRolesContext;
   taskFileNames?: string[];
   includeVars?: IIncludeVarsContext;
 }
 
-export interface IAdditionalContext {
+interface IAdditionalContext {
   playbookContext?: IPlaybookContext;
   roleContext?: IRoleContext;
   standaloneTaskContext?: IStandaloneTaskContext;

--- a/test/e2e/e2e.utils.ts
+++ b/test/e2e/e2e.utils.ts
@@ -219,9 +219,7 @@ export async function disableLightspeedSettings(): Promise<void> {
   await updateSettings("lightspeed.provider", "wca");
 }
 
-export async function _setInlineSuggestionsWaitWindow(
-  t: number,
-): Promise<void> {
+async function _setInlineSuggestionsWaitWindow(t: number): Promise<void> {
   await updateSettings("lightspeed.suggestions.waitWindow", t);
 }
 


### PR DESCRIPTION
From now on, anything exported must be imported from somewhere, tests at least.
