### PR TITLE
chore: allow using extester extension to manually run ui tests

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -54,6 +54,7 @@ docstrings
 equalto
 eslintcache
 extest
+extester
 fqcn
 genai
 haaaad

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,7 +55,7 @@ jobs:
           show-progress: false
 
       - name: task setup
-        timeout-minutes: 1 # expected under 10s for container builds
+        timeout-minutes: 2 # expected under 10s for container builds
         run: |
           set -ex
           pwd
@@ -365,7 +365,7 @@ jobs:
             out/coverage
             out/junit
             out/log
-            out/test-resources/screenshots
+            out/test-resources/screenshots/**/*
           # Not secure to collect due to 'token' being logged by vscode trace logs.
           # out/userdata/logs
           # out/test-resources/settings/logs

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -40,6 +40,7 @@
   "[yaml]": {
     "editor.formatOnSave": false
   },
+  "claudeCode.environmentVariables": [],
   "editor.codeActionsOnSave": {
     "source.fixAll.biome": "explicit",
     "source.fixAll.eslint": "explicit"
@@ -47,6 +48,20 @@
   "editor.formatOnSave": true,
   "eslint.useESLintClass": true,
   "explorer.fileNesting.enabled": true,
+  "extesterRunner.additionalArgs": [
+    "--mocha_config",
+    "test/ui/.mocharc.js",
+    "--code_settings",
+    "out/test-resources/settings/User/settings.json",
+    "-e",
+    "out/ext",
+    "--offline",
+    "--coverage",
+    "--log_level",
+    "Debug"
+  ],
+  "extesterRunner.outputFolder": "out/client",
+  "extesterRunner.rootFolder": "",
   "extesterRunner.tempFolder": "out/test-resources",
   "extesterRunner.testFileGlob": "test/ui/**/*.test.ts",
   "files.exclude": {

--- a/.yarn/plugins/plugin-list.cjs
+++ b/.yarn/plugins/plugin-list.cjs
@@ -1,0 +1,126 @@
+module.exports = {
+  name: "plugin-list",
+  factory: (require) => {
+    const fs = require("fs");
+    const { BaseCommand } = require("@yarnpkg/cli");
+    const { Command, Option } = require("clipanion");
+    const { parseSyml } = require("@yarnpkg/parsers");
+
+    class ListCommand extends BaseCommand {
+      static paths = [["list"]];
+
+      static usage = Command.Usage({
+        description: "Lists installed packages.",
+      });
+
+      prod = Option.Boolean("--prod", false);
+      json = Option.Boolean("--json", false);
+
+      async execute() {
+        if (!this.prod || !this.json) {
+          throw new Error(
+            "This command can only be used with the --prod and --json " +
+              "args to match the behavior required by VSCE. See: " +
+              "https://github.com/microsoft/vscode-vsce/blob/main/src/npm.ts",
+          );
+        }
+
+        const packageJsonContents = fs.readFileSync("package.json", "utf-8");
+        const { dependencies = {}, resolutions = {} } =
+          JSON.parse(packageJsonContents);
+
+        const lockContents = fs.readFileSync("yarn.lock", "utf-8");
+        const resolved = parseSyml(lockContents);
+
+        const trees = [];
+
+        function addDependency(packageName, versionRange) {
+          const packageInfo = lookup(
+            resolved,
+            getLockFileKey(packageName, versionRange, resolutions),
+          );
+          if (!packageInfo) {
+            throw new Error(
+              `Cannot resolve "${packageName}" with version range "${versionRange}"`,
+            );
+          }
+
+          const { version, dependencies } = packageInfo;
+          const name = `${packageName}@${version}`;
+          if (trees.find((tree) => tree.name === name)) {
+            return; // Dependency already added as part of another tree.
+          }
+
+          if (dependencies) {
+            const children = Object.entries(dependencies).map(
+              ([name, range]) => ({ name: `${name}@${range}` }),
+            );
+            trees.push({ name, children });
+
+            addDependencies(dependencies);
+          } else {
+            trees.push({ name, children: [] });
+          }
+        }
+
+        function addDependencies(dependencies) {
+          for (const [packageName, versionRange] of Object.entries(
+            dependencies,
+          )) {
+            addDependency(packageName, versionRange);
+          }
+        }
+
+        addDependencies(dependencies);
+
+        const output = {
+          type: "tree",
+          data: { type: "list", trees },
+        };
+
+        this.context.stdout.write(JSON.stringify(output));
+      }
+    }
+
+    return {
+      commands: [ListCommand],
+    };
+  },
+};
+
+function getLockFileKey(packageName, versionSpecifier, resolutions) {
+  // If the package name is in the resolutions field, use the version from there.
+  const resolvedVersionSpecifier = resolutions[packageName] ?? versionSpecifier;
+
+  // If the version field contains a URL, don't attempt to use the NPM registry
+  return resolvedVersionSpecifier.includes(":")
+    ? `${packageName}@${resolvedVersionSpecifier}`
+    : `${packageName}@npm:${resolvedVersionSpecifier}`;
+}
+
+/**
+ * @param resolved All the resolved dependencies as found in the lock file.
+ * @param dependencyKey Key of the dependency to look up. Can be created using
+ *                      `getLockFileKey()`.
+ */
+function lookup(resolved, dependencyKey) {
+  const packageInfo = resolved[dependencyKey];
+  if (packageInfo) {
+    return packageInfo;
+  }
+
+  // Fall back to slower iteration-based lookup for combined keys.
+  for (const [key, packageInfo] of Object.entries(resolved)) {
+    // Resolving ranges: "@babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.12.13, @babel/runtime@npm:^7.12.5"
+    const versionRanges = key.split(",");
+    if (versionRanges.some((key) => key.trim() === dependencyKey)) {
+      return packageInfo;
+    }
+
+    // Resolving yarn link resolutions: "@kaoto/kaoto-ui@portal:/home/rmartinez/repos/kaoto-ui::locator=vscode-kaoto%40workspace%3A."
+    const yarnLinkResolution = key.split("::")[0];
+    if (yarnLinkResolution === dependencyKey) {
+      return packageInfo;
+    }
+  }
+}

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -6,6 +6,11 @@ enableTelemetry: 0
 
 nodeLinker: node-modules
 
+plugins:
+  - checksum: 113fae572c391623e3032d2be1c3eac64ca8d00cfb7fa62a4dab433b87bb66864a577acad63c0a16895869930a41587f409d9de2de69fd1ad539dee6ea9c6bdf
+    path: .yarn/plugins/plugin-list.cjs
+    spec: "https://github.com/arendjr/yarn-plugin-list/releases/latest/download/yarn-plugin-list.js"
+
 supportedArchitectures:
   cpu:
     - x64

--- a/package.json
+++ b/package.json
@@ -1183,7 +1183,11 @@
   "version": "0.0.0",
   "vsce": {
     "dependencies": false,
-    "yarn": false
+    "followSymlinks": true,
+    "gitTagVersion": false,
+    "readmePath": "docs/README.md",
+    "updatePackageJson": false,
+    "yarn": true
   },
   "workspaces": [
     "packages/*"

--- a/test/e2e/diagnostics/ansibleWithoutEE.test.ts
+++ b/test/e2e/diagnostics/ansibleWithoutEE.test.ts
@@ -8,6 +8,7 @@ import {
   waitForDiagnosisCompletion,
   clearActivationCache,
   run_lightspeed_tests_only,
+  sleep,
 } from "../e2e.utils";
 
 describe("ansible-diag-no-ee", function () {
@@ -25,6 +26,7 @@ describe("ansible-diag-no-ee", function () {
     before(async function () {
       await updateSettings("validation.lint.enabled", true);
       await vscode.commands.executeCommand("workbench.action.closeAllEditors");
+      await sleep(2000);
       // Give language server time to process document close and settings change
       await new Promise((resolve) => setTimeout(resolve, 500));
       clearActivationCache(); // Clear cache after editors closed

--- a/tools/helper
+++ b/tools/helper
@@ -13,6 +13,7 @@ from datetime import datetime
 
 def run(cmd: str) -> subprocess.CompletedProcess[bytes]:
     """Helper to easy calling subprocess."""
+    logging.info("run: %s", cmd)
     return subprocess.run(cmd, shell=True, check=True)
 
 
@@ -147,15 +148,18 @@ def cli() -> None:
         # The bundled code uses __dirname which will be out/mcp/, so resources should be at out/mcp/data/
         run("task build")
         run("mkdir -p out/mcp/data")
-        run("cp -r packages/ansible-mcp-server/src/resources/data/* out/mcp/data/ 2>/dev/null || true")
-
         run(
-            "vsce package --follow-symlinks --no-dependencies --no-git-tag-version"
-            f" --no-update-package-json --readme-path docs/README.md {pre_release_arg} {version}"
+            "cp -r packages/ansible-mcp-server/src/resources/data/* out/mcp/data/ 2>/dev/null || true"
         )
-        # Using zipinfo instead of `vsce ls` due to https://github.com/microsoft/vscode-vsce/issues/517
+
+        # most options are supposed to be loaded from package.json but --no-update-package-json apparently is still needed
+        run(f"vsce package --no-update-package-json {pre_release_arg} {version}")
+
+        # running `vsce ls` is a must as it is also executed by extester so we need
+        # to be sure that the command succeeds.
+        # --yarn needed to avoid a warning message as package.json config does not prevent it
+        run("vsce ls --yarn | sort > out/log/package.log")
         run("mkdir -p out/log")
-        run("zipinfo -1 ./*.vsix > out/log/package.log")
         vsix_file = f"ansible-{version}.vsix"
         size = os.path.getsize(vsix_file) / 1024 / 1024
         vsx_size_limit_mb = 8.0


### PR DESCRIPTION
- Added fake yarn list output to emulate yarn v1 behavior for vsce compatibility
- Configured extester settings in VS Code workspace settings
- Moved vsce command-line arguments to package.json configuration
- Added vsce ls smoke test during packaging to catch regressions early

Related: AAP-62156
