### PR TITLE
chore: ensure that we do not have duplicate executables during testings

### DIFF
--- a/Taskfile.base.yml
+++ b/Taskfile.base.yml
@@ -40,6 +40,7 @@ tasks:
     dir: "{{ .TASKFILE_DIR }}"
     cmds:
       - bash ./tools/test-setup.sh
+      - ./tools/precheck.sh
     sources:
       - ./tools/precheck.sh
       - pyproject.toml

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -47,6 +47,8 @@ tasks:
       # clean up uv cache, important for CI especially for caching size reduction
       - uv cache prune --ci
       - find `python3 -m pip cache dir`/wheels -type f -atime +30 -delete || true
+      # we also need to be sure that at the end of build and test we do not produce undesired side effects
+      - ./tools/precheck.sh
       - tools/dirty.sh
 
   build:

--- a/test/e2e/diagnostics/ansibleWithoutEE.test.ts
+++ b/test/e2e/diagnostics/ansibleWithoutEE.test.ts
@@ -80,7 +80,7 @@ describe("ansible-diag-no-ee", function () {
       await updateSettings("validation.lint.enabled", false);
       await vscode.commands.executeCommand("workbench.action.closeAllEditors");
       // Give language server time to process document close and settings change
-      await new Promise((resolve) => setTimeout(resolve, 500));
+      await new Promise((resolve) => setTimeout(resolve, 2500));
       clearActivationCache(); // Clear cache after editors closed
     });
 

--- a/tools/precheck.sh
+++ b/tools/precheck.sh
@@ -1,1 +1,60 @@
 #!/usr/bin/env bash
+# cSpell:ignore precheck
+set -euo pipefail
+
+
+function check_for_duplicate_executables() {
+    local EXECUTABLES=(
+        "ade"
+        "adt"
+        "ansible"
+        "ansible-creator"
+        "ansible-lint"
+        "ansible-navigator"
+        "molecule"
+    )
+    ERR=0
+    for cmd in "${EXECUTABLES[@]}"; do
+        local found_files=()
+        if ! command -v "$cmd" >/dev/null 2>&1; then
+            echo "ERROR: $cmd not found in PATH" >&2
+            ERR=1
+        else
+            path_remaining="$PATH"
+            while [ -n "$path_remaining" ]; do
+                if [[ "$path_remaining" == *:* ]]; then
+                    dir="${path_remaining%%:*}"
+                    path_remaining="${path_remaining#*:}"
+                else
+                    dir="$path_remaining"
+                    path_remaining=""
+                fi
+                [ -d "$dir" ] || continue
+                file="$dir/$cmd"
+                if [ -f "$file" ] && [ -x "$file" ]; then
+                    # Check if file is already in found_files to avoid duplicates
+                    is_duplicate=0
+                    if [ ${#found_files[@]} -gt 0 ]; then
+                        for existing_file in "${found_files[@]}"; do
+                            if [ "$existing_file" = "$file" ]; then
+                                is_duplicate=1
+                                break
+                            fi
+                        done
+                    fi
+                    if [ $is_duplicate -eq 0 ]; then
+                        found_files+=("$file")
+                    fi
+                fi
+            done
+            count=${#found_files[@]}
+            if [[ $count -ne 1 ]]; then
+                echo "ERROR: Multiple instances of '$cmd' found in PATH, we cannot proceed as it might produce unexpected outcomes: ${found_files[*]}" >&2
+                ERR=1
+            fi
+        fi
+    done
+    return $ERR
+}
+
+check_for_duplicate_executables

--- a/tools/test-setup.sh
+++ b/tools/test-setup.sh
@@ -160,6 +160,16 @@ if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
     echo "OS_VERSION=$OS_VERSION" >> "$GITHUB_OUTPUT"
 fi
 
+if command -v pipx >/dev/null 2>&1; then
+    pipx list 2> /dev/null
+    for pkg in ansible-core ansible-creator ansible-dev-tools ansible-lint ansible-navigator molecule; do
+        if pipx list 2> /dev/null | grep -q "$pkg"; then
+            pipx uninstall -q "$pkg"
+        fi
+    done
+    pipx list 2> /dev/null
+fi
+
 if [[ -f "/usr/bin/apt-get" ]]; then
     INSTALL=0
     DEBS=(curl file git gcc libonig-dev)


### PR DESCRIPTION
We should avoid running if we detect multiple copies of used tools in PATH to avoid unexpected behaviors.
