### PR TITLE
chore: temporary workaround for /tmp bug with vscode-test

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -184,6 +184,8 @@ tasks:
     env:
       NODE_NO_WARNINGS: "1"
       DONT_PROMPT_WSL_INSTALL: "1"
+      # Possible workaround for: https://github.com/microsoft/vscode-test-cli/issues/555
+      TMP: out/tmp/e2e
     generates:
       - out/junit/e2e/test-results.xml
       - out/coverage/e2e/cobertura-coverage.xml
@@ -196,6 +198,7 @@ tasks:
       - exclude: test/testFixtures/diagnostics/yaml/invalid_yaml.yml
       - exclude: test/unit/lightspeed/utils/samples/collections/ansible_collections/community/broken_MANIFEST/MANIFEST.json
     cmds:
+      - mkdir -p out/tmp/e2e
       # dry run to fail fast if we misconfigure it
       - "{{.XVFB}}vscode-test --dry-run --fail-zero"
       # cannot put coverage option inside .vscode-test.mjs

--- a/test/e2e/diagnostics/ansibleWithoutEE.test.ts
+++ b/test/e2e/diagnostics/ansibleWithoutEE.test.ts
@@ -41,8 +41,8 @@ describe("ansible-diag-no-ee", function () {
     it("should complain about no task names", async function () {
       await activate(docUri1);
       await vscode.commands.executeCommand("workbench.action.files.save");
-      // Use longer timeout and quickCheckTimeout for lint tests since ansible-lint may take time to start
-      await waitForDiagnosisCompletion(150, 5000, 3000); // Wait for the diagnostics to compute on this file
+      // Use longer timeout and quickCheckTimeout for lint tests since ansible-lint may take time to start, especially on WSL
+      await waitForDiagnosisCompletion(150, 7000, 3000); // Wait for the diagnostics to compute on this file
 
       await testDiagnostics(docUri1, [
         {


### PR DESCRIPTION
Related: https://github.com/microsoft/vscode-test-cli/issues/555
