### PR TITLE
Fix Resource Loading and Packaging for MCP Server

### DIFF
--- a/package.json
+++ b/package.json
@@ -1083,6 +1083,7 @@
     "@vscode/test-electron": "^2.5.2",
     "@vscode/vsce": "^3.7.1",
     "chai": "^6.2.2",
+    "copy-webpack-plugin": "^13.0.1",
     "cypress-multi-reporters": "^2.0.5",
     "eslint": "^9.39.2",
     "eslint-config-prettier": "^10.1.8",

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -1,4 +1,5 @@
 import WarningsToErrorsPlugin from "warnings-to-errors-webpack-plugin";
+import CopyPlugin from "copy-webpack-plugin";
 
 import path from "path";
 const webpack = require("webpack");
@@ -105,6 +106,14 @@ const config = {
     new WarningsToErrorsPlugin(),
     new webpack.IgnorePlugin({
       resourceRegExp: /^electron$/,
+    }),
+    new CopyPlugin({
+      patterns: [
+        {
+          from: "packages/ansible-mcp-server/src/resources/data/*.{md,json,yml}",
+          to: "mcp/data/[name][ext]",
+        },
+      ],
     }),
   ],
   ignoreWarnings: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -3451,6 +3451,7 @@ __metadata:
     "@vscode/vsce": "npm:^3.7.1"
     "@vscode/webview-ui-toolkit": "npm:^1.4.0"
     chai: "npm:^6.2.2"
+    copy-webpack-plugin: "npm:^13.0.1"
     cypress-multi-reporters: "npm:^2.0.5"
     electron: "npm:^39.2.6"
     eslint: "npm:^9.39.2"
@@ -4404,6 +4405,21 @@ __metadata:
   version: 0.7.2
   resolution: "cookie@npm:0.7.2"
   checksum: 10/24b286c556420d4ba4e9bc09120c9d3db7d28ace2bd0f8ccee82422ce42322f73c8312441271e5eefafbead725980e5996cc02766dbb89a90ac7f5636ede608f
+  languageName: node
+  linkType: hard
+
+"copy-webpack-plugin@npm:^13.0.1":
+  version: 13.0.1
+  resolution: "copy-webpack-plugin@npm:13.0.1"
+  dependencies:
+    glob-parent: "npm:^6.0.1"
+    normalize-path: "npm:^3.0.0"
+    schema-utils: "npm:^4.2.0"
+    serialize-javascript: "npm:^6.0.2"
+    tinyglobby: "npm:^0.2.12"
+  peerDependencies:
+    webpack: ^5.1.0
+  checksum: 10/2abf3b85c32556b1cb9ef47f2198f6497ef414505cf42d249e3b7e65185db738756bec85333b4a32865d1c6b09343ea63eb9e8d154c133ddcebb4c7f066be5af
   languageName: node
   linkType: hard
 
@@ -6076,7 +6092,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob-parent@npm:^6.0.2":
+"glob-parent@npm:^6.0.1, glob-parent@npm:^6.0.2":
   version: 6.0.2
   resolution: "glob-parent@npm:6.0.2"
   dependencies:
@@ -9474,7 +9490,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"schema-utils@npm:^4.3.0, schema-utils@npm:^4.3.3":
+"schema-utils@npm:^4.2.0, schema-utils@npm:^4.3.0, schema-utils@npm:^4.3.3":
   version: 4.3.3
   resolution: "schema-utils@npm:4.3.3"
   dependencies:


### PR DESCRIPTION
Related- AAP-60810

**Core Problem -** 

The MCP server was failing to locate essential resource files (like agents.md and ee-rules.md) at runtime. This resulted in ENOENT errors that incorrectly displayed build-time GitHub Action paths (/__w/vscode-ansible/...) due to source map fallbacks when the physical files were missing from the production bundle.

**Approach & Changes -**

- Updated `webpack.config.ts` to explicitly copy static Markdown, JSON, and YAML assets from the packages/ansible-mcp-server/src/resources/data/ directory into the bundled output folder (out/mcp/data/)
- Ensured the resolveResourcePath utility correctly targets the sibling `data/` folder relative to the compiled cli.js at runtime. This allows the same code to work in both development and production environments.
- Confirmed that the existing `.vscodeignore` rule (!out/mcp/**/*) successfully includes the newly generated data directory in the final .vsix package

**Verification Results -**

- Verified that `out/mcp/data/` is populated after running the webpack build.
- Package Inspection: Inspected the generated .vsix (as a ZIP) to confirm `extension/out/mcp/data/` contains all required files.

<img width="681" height="682" alt="Screenshot 2026-01-19 at 3 53 19 PM" src="https://github.com/user-attachments/assets/04241d16-f12e-408e-9553-f97f69861dc0" />
