### PR TITLE
chore: refactor coverage uploading

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -378,7 +378,7 @@ jobs:
         if: ${{ !cancelled() }}
         uses: ansible/actions/upload-artifact@main
         with:
-          name: logs-${{ steps.setup.outputs.OS_VERSION }}-${{ matrix.id }}.zip
+          name: logs-${{ steps.setup.outputs.OS_VERSION }}-${{ matrix.id }}-${{ github.run_attempt }}.zip
           path: |
             out/coverage
             out/junit
@@ -390,7 +390,16 @@ jobs:
           if-no-files-found: ignore
           retention-days: 90
 
-      - name: Upload test results to Codecov
+      - name: Upload test coverage data to codecov.io
+        if: ${{ always() }}
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
+        with:
+          files: ./out/coverage/**/*coverage.xml
+          disable_search: true
+          fail_ci_if_error: true
+          use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
+
+      - name: Upload junit test results to codecov.io
         if: ${{ !cancelled() && hashFiles('out/junit/**/*.xml') != '' }}
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
@@ -442,15 +451,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Merge logs into a single archive
-        if: ${{ !failure() }}
-        uses: actions/upload-artifact/merge@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
-        with:
-          name: logs.zip
-          pattern: logs-*.zip
-          separate-directories: true
-          delete-merged: true
-
       - name: Download artifacts
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
@@ -462,61 +462,6 @@ jobs:
           find . -name '*\?*' -exec rm -r {} \; || true
           find . -name '*"*' -exec rm -r {} \; || true
           find . -name '*:*' -exec rm -r {} \; || true
-
-      - name: Upload als test coverage data [1/5]
-        if: ${{ always() }}
-        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
-        with:
-          name: als
-          files: ./**/coverage/als/cobertura-coverage.xml
-          flags: als
-          disable_search: true
-          fail_ci_if_error: true
-          use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
-
-      - name: Upload unit test coverage data [2/5]
-        if: ${{ always() }}
-        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
-        with:
-          name: unit
-          files: ./**/coverage/unit/*cobertura-coverage.xml
-          flags: unit
-          disable_search: true
-          fail_ci_if_error: true
-          use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
-
-      - name: Upload ui test coverage data [3/5]
-        if: ${{ always() }}
-        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
-        with:
-          name: ui
-          files: ./**/coverage/ui/*cobertura-coverage.xml
-          flags: ui
-          disable_search: true
-          fail_ci_if_error: true
-          use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
-
-      - name: Upload e2e test coverage data [4/5]
-        if: ${{ always() }}
-        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
-        with:
-          name: e2e
-          files: ./**/coverage/e2e/*cobertura-coverage.xml
-          flags: e2e
-          disable_search: true
-          fail_ci_if_error: true
-          use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
-
-      - name: Upload mcp test coverage data [5/5]
-        if: ${{ always() }}
-        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
-        with:
-          name: mcp
-          files: ./**/coverage/mcp/*cobertura-coverage.xml
-          flags: mcp
-          disable_search: true
-          fail_ci_if_error: true
-          use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
 
       - name: SonarCloud scan
         # Run only for pull requests or push to main


### PR DESCRIPTION
- stops merging the build logs (lost data)
- keep build logs on retried jobs
- upload coverage data to codecovi.io from each build phase (faster)
- we no longer flag different coverage files to reduce complexity
  of the upload (test suites names can be used to identify the source)

This should make it easier to debug builds and likely will allow
codecov to report status much faster.
