### PR TITLE
fix: use @vscode/codicons and avoid duplication

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -13,9 +13,6 @@
 !images/logo.png
 !jinja-language-configuration.json
 !media/style.css
-!media/codicons/codicon.css
-!media/codicons/codicon.ttf
-!media/codicons/codicon.css
 !media/baseStyles/baseFormStyle.css
 !media/contentCreator/icons/ansible-creator-create.png
 !media/contentCreator/icons/ansible-creator-init.png

--- a/package.json
+++ b/package.json
@@ -1040,6 +1040,7 @@
     "@types/ini": "^4.1.1",
     "@vitejs/plugin-vue": "^5.2.4",
     "@vscode-elements/elements": "^2.0.0",
+    "@vscode/codicons": "^0.0.44",
     "electron": "^40.0.0",
     "highlight.js": "^11.11.1",
     "ini": "^6.0.0",

--- a/webviews/add-plugin.html
+++ b/webviews/add-plugin.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Add Plugin</title>
-    <link rel="stylesheet" type="text/css" href="/codicons/codicon.css" id="vscode-codicon-stylesheet" />
+    <link rel="stylesheet" type="text/css" href="/node_modules/@vscode/codicons/dist/codicon.css" id="vscode-codicon-stylesheet" />
 </head>
 <body>
     <div id="app"></div>

--- a/webviews/create-ansible-collection.html
+++ b/webviews/create-ansible-collection.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Create Ansible collection</title>
-    <link rel="stylesheet" type="text/css" href="/codicons/codicon.css" id="vscode-codicon-stylesheet" />
+    <link rel="stylesheet" type="text/css" href="/node_modules/@vscode/codicons/dist/codicon.css" id="vscode-codicon-stylesheet" />
   </head>
   <body>
     <div id="app"></div>

--- a/webviews/create-ansible-project.html
+++ b/webviews/create-ansible-project.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Create Ansible Collection</title>
-    <link rel="stylesheet" type="text/css" href="/codicons/codicon.css" id="vscode-codicon-stylesheet" />
+    <link rel="stylesheet" type="text/css" href="/node_modules/@vscode/codicons/dist/codicon.css" id="vscode-codicon-stylesheet" />
   </head>
   <body>
     <div id="app"></div>

--- a/webviews/create-devcontainer.html
+++ b/webviews/create-devcontainer.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Create Devcontainer</title>
-    <link rel="stylesheet" type="text/css" href="/codicons/codicon.css" id="vscode-codicon-stylesheet" />
+    <link rel="stylesheet" type="text/css" href="/node_modules/@vscode/codicons/dist/codicon.css" id="vscode-codicon-stylesheet" />
     </head>
     <body>
     <div id="app"></div>

--- a/webviews/create-devfile.html
+++ b/webviews/create-devfile.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Create Devfile</title>
-    <link rel="stylesheet" type="text/css" href="/codicons/codicon.css" id="vscode-codicon-stylesheet" />
+    <link rel="stylesheet" type="text/css" href="/node_modules/@vscode/codicons/dist/codicon.css" id="vscode-codicon-stylesheet" />
     </head>
     <body>
     <div id="app"></div>

--- a/webviews/create-execution-env.html
+++ b/webviews/create-execution-env.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Create Execution Environment</title>
-    <link rel="stylesheet" type="text/css" href="/codicons/codicon.css" id="vscode-codicon-stylesheet" />
+    <link rel="stylesheet" type="text/css" href="/node_modules/@vscode/codicons/dist/codicon.css" id="vscode-codicon-stylesheet" />
   </head>
   <body>
     <div id="app"></div>

--- a/webviews/create-role.html
+++ b/webviews/create-role.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Create Role</title>
-    <link rel="stylesheet" type="text/css" href="/codicons/codicon.css" id="vscode-codicon-stylesheet" />
+    <link rel="stylesheet" type="text/css" href="/node_modules/@vscode/codicons/dist/codicon.css" id="vscode-codicon-stylesheet" />
   </head>
   <body>
     <div id="app"></div>

--- a/webviews/lightspeed/explanation.html
+++ b/webviews/lightspeed/explanation.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Ansible Lightspeed Explanation</title>
-    <link rel="stylesheet" type="text/css" href="/codicons/codicon.css" />
+    <link rel="stylesheet" type="text/css" href="/node_modules/@vscode/codicons/dist/codicon.css" id="vscode-codicon-stylesheet" />
   </head>
   <body>
     <div id="app"></div>

--- a/webviews/lightspeed/explorer.html
+++ b/webviews/lightspeed/explorer.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + Vue + TS</title>
-    <link rel="stylesheet" type="text/css" href="@vscode/codicons/dist/codicon.css" />
+    <link rel="stylesheet" type="text/css" href="/node_modules/@vscode/codicons/dist/codicon.css" id="vscode-codicon-stylesheet" />
 
   </head>
 

--- a/webviews/lightspeed/feedback.html
+++ b/webviews/lightspeed/feedback.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Ansible Lightspeed Feedback</title>
-    <link rel="stylesheet" type="text/css" href="@vscode/codicons/dist/codicon.css" />
+    <link rel="stylesheet" type="text/css" href="/node_modules/@vscode/codicons/dist/codicon.css" id="vscode-codicon-stylesheet" />
   </head>
 
   <body>

--- a/webviews/lightspeed/hello-world.html
+++ b/webviews/lightspeed/hello-world.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + Vue + TS</title>
-    <link rel="stylesheet" type="text/css" href="@vscode/codicons/dist/codicon.css" />
+    <link rel="stylesheet" type="text/css" href="/node_modules/@vscode/codicons/dist/codicon.css" id="vscode-codicon-stylesheet" />
 
   </head>
 

--- a/webviews/lightspeed/playbook-generation.html
+++ b/webviews/lightspeed/playbook-generation.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + Vue + TS</title>
-    <link rel="stylesheet" type="text/css" href="@vscode/codicons/dist/codicon.css" />
+    <link rel="stylesheet" type="text/css" href="/node_modules/@vscode/codicons/dist/codicon.css" id="vscode-codicon-stylesheet" />
 
   </head>
 

--- a/webviews/lightspeed/role-generation.html
+++ b/webviews/lightspeed/role-generation.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + Vue + TS</title>
-    <link rel="stylesheet" type="text/css" href="@vscode/codicons/dist/codicon.css" />
+    <link rel="stylesheet" type="text/css" href="/node_modules/@vscode/codicons/dist/codicon.css" id="vscode-codicon-stylesheet" />
 
   </head>
 

--- a/webviews/lightspeed/src/hello-world.ts
+++ b/webviews/lightspeed/src/hello-world.ts
@@ -4,7 +4,6 @@ import App from "./HelloWorld.vue";
 import hljs from "highlight.js/lib/core";
 import yaml from "highlight.js/lib/languages/yaml";
 import hljsVuePlugin from "@highlightjs/vue-plugin";
-import ProgressSpinner from "primevue/progressspinner";
 import PrimeVue from "primevue/config";
 import { definePreset } from "@primeuix/themes";
 import Nora from "@primeuix/themes/nora";

--- a/webviews/quick-links.html
+++ b/webviews/quick-links.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Ansible Development Tools</title>
-    <link rel="stylesheet" type="text/css" href="/codicons/codicon.css" id="vscode-codicon-stylesheet" />
+    <link rel="stylesheet" type="text/css" href="/node_modules/@vscode/codicons/dist/codicon.css" id="vscode-codicon-stylesheet" />
   </head>
   <body>
     <div id="app"></div>

--- a/webviews/welcome-page.html
+++ b/webviews/welcome-page.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Ansible Development Tools</title>
-    <link rel="stylesheet" type="text/css" href="/codicons/codicon.css" id="vscode-codicon-stylesheet" />
+    <link rel="stylesheet" type="text/css" href="/node_modules/@vscode/codicons/dist/codicon.css" id="vscode-codicon-stylesheet" />
     </head>
     <body>
     <div id="app"></div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2781,6 +2781,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vscode/codicons@npm:^0.0.44":
+  version: 0.0.44
+  resolution: "@vscode/codicons@npm:0.0.44"
+  checksum: 10/1e74e688290ac4e1188c04528878d85c74b38860c03350559ac006bac790e27d95cb8fbb73afe5f24c503135fc5be9d73e6e34ed8286559721ca83243a0a9471
+  languageName: node
+  linkType: hard
+
 "@vscode/test-cli@npm:^0.0.12":
   version: 0.0.12
   resolution: "@vscode/test-cli@npm:0.0.12"
@@ -3501,6 +3508,7 @@ __metadata:
     "@vitest/coverage-v8": "npm:^4.0.17"
     "@vitest/ui": "npm:^4.0.17"
     "@vscode-elements/elements": "npm:^2.0.0"
+    "@vscode/codicons": "npm:^0.0.44"
     "@vscode/test-cli": "npm:^0.0.12"
     "@vscode/test-electron": "npm:^2.5.2"
     "@vscode/vsce": "npm:^3.7.1"


### PR DESCRIPTION
Use the same method to access the `@vscode/codicons` CSS.
