### PR TITLE
chore: enable reruns for selenium test failures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dev = [
   "pip>=22.3.1",
   "pre-commit>=4.0.1",
   "pre-commit-uv>=4.1.4",
+  "pytest-rerunfailures>=16.1",
   "selenium>=4.40.0",
   "typing-inspect>=0.8.0,<0.10.0",
   "uv>=0.4.29",
@@ -87,6 +88,8 @@ norecursedirs = [
 strict_markers = true
 strict_xfail = true
 testpaths = ["test/selenium/ui"]
+reruns = 2  # pytest-rerunfailures
+reruns_delay = 60  # pytest-rerunfailures
 
 [tool.ruff]
 cache-dir = "./.cache/.ruff"

--- a/uv.lock
+++ b/uv.lock
@@ -1632,6 +1632,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-rerunfailures"
+version = "16.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/04/71e9520551fc8fe2cf5c1a1842e4e600265b0815f2016b7c27ec85688682/pytest_rerunfailures-16.1.tar.gz", hash = "sha256:c38b266db8a808953ebd71ac25c381cb1981a78ff9340a14bcb9f1b9bff1899e", size = 30889, upload-time = "2025-10-10T07:06:01.238Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/54/60eabb34445e3db3d3d874dc1dfa72751bfec3265bd611cb13c8b290adea/pytest_rerunfailures-16.1-py3-none-any.whl", hash = "sha256:5d11b12c0ca9a1665b5054052fcc1084f8deadd9328962745ef6b04e26382e86", size = 14093, upload-time = "2025-10-10T07:06:00.019Z" },
+]
+
+[[package]]
 name = "pytest-sugar"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2311,6 +2324,7 @@ dev = [
     { name = "pip" },
     { name = "pre-commit" },
     { name = "pre-commit-uv" },
+    { name = "pytest-rerunfailures" },
     { name = "selenium" },
     { name = "typing-inspect" },
     { name = "uv" },
@@ -2338,6 +2352,7 @@ dev = [
     { name = "pip", specifier = ">=22.3.1" },
     { name = "pre-commit", specifier = ">=4.0.1" },
     { name = "pre-commit-uv", specifier = ">=4.1.4" },
+    { name = "pytest-rerunfailures", specifier = ">=16.1" },
     { name = "selenium", specifier = ">=4.40.0" },
     { name = "typing-inspect", specifier = ">=0.8.0,<0.10.0" },
     { name = "uv", specifier = ">=0.4.29" },


### PR DESCRIPTION
- pytest-rerunfailures is already used by EDO project and seems to
  have reliable testing pipelines for each stable python
- should avoid errors like https://github.com/ansible/vscode-ansible/actions/runs/21356243463/job/61464229285?pr=2492#step:17:242

Related: AAP-64063
Related: ANSTRAT-1445