### PR TITLE
fix: import codicon.css from TypeScript

### DIFF
--- a/webviews/AddPluginPageApp.vue
+++ b/webviews/AddPluginPageApp.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import '@vscode/codicons/dist/codicon.css';
 import { onMounted, ref, computed } from 'vue';
 import { vscodeApi } from './lightspeed/src/utils';
 import {

--- a/webviews/CreateAnsibleCollectionApp.vue
+++ b/webviews/CreateAnsibleCollectionApp.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import '@vscode/codicons/dist/codicon.css';
 import { onMounted, ref, computed, nextTick } from 'vue';
 import { vscodeApi } from './lightspeed/src/utils';
 import {

--- a/webviews/CreateAnsibleProjectApp.vue
+++ b/webviews/CreateAnsibleProjectApp.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import '@vscode/codicons/dist/codicon.css';
 import { onMounted, ref, computed } from 'vue';
 import { vscodeApi } from './lightspeed/src/utils';
 import {

--- a/webviews/CreateDevcontainerApp.vue
+++ b/webviews/CreateDevcontainerApp.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import '@vscode/codicons/dist/codicon.css';
 import { onMounted, ref, computed, watch } from 'vue';
 import { vscodeApi } from './lightspeed/src/utils';
 import {

--- a/webviews/CreateDevfileApp.vue
+++ b/webviews/CreateDevfileApp.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import '@vscode/codicons/dist/codicon.css';
 import { onMounted, ref, computed, watch } from 'vue';
 import { vscodeApi } from './lightspeed/src/utils';
 import {

--- a/webviews/CreateExecutionEnvApp.vue
+++ b/webviews/CreateExecutionEnvApp.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import '@vscode/codicons/dist/codicon.css';
 import { onMounted, ref, computed, watch } from 'vue';
 import { vscodeApi } from './lightspeed/src/utils';
 import {

--- a/webviews/CreateRoleApp.vue
+++ b/webviews/CreateRoleApp.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import '@vscode/codicons/dist/codicon.css';
 import { onMounted, ref, computed, watch } from 'vue';
 import { vscodeApi } from './lightspeed/src/utils';
 import {

--- a/webviews/QuickLinksApp.vue
+++ b/webviews/QuickLinksApp.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import '@vscode/codicons/dist/codicon.css';
 import { onMounted, ref } from 'vue';
 import { vscodeApi } from './lightspeed/src/utils';
 

--- a/webviews/WelcomePageApp.vue
+++ b/webviews/WelcomePageApp.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import '@vscode/codicons/dist/codicon.css';
 import { onMounted, ref, computed } from 'vue';
 import { vscodeApi } from './lightspeed/src/utils';
 

--- a/webviews/add-plugin.html
+++ b/webviews/add-plugin.html
@@ -5,7 +5,6 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Add Plugin</title>
-    <link rel="stylesheet" type="text/css" href="/node_modules/@vscode/codicons/dist/codicon.css" id="vscode-codicon-stylesheet" />
 </head>
 <body>
     <div id="app"></div>

--- a/webviews/create-ansible-collection.html
+++ b/webviews/create-ansible-collection.html
@@ -4,7 +4,6 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Create Ansible collection</title>
-    <link rel="stylesheet" type="text/css" href="/node_modules/@vscode/codicons/dist/codicon.css" id="vscode-codicon-stylesheet" />
   </head>
   <body>
     <div id="app"></div>

--- a/webviews/create-ansible-project.html
+++ b/webviews/create-ansible-project.html
@@ -5,7 +5,6 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Create Ansible Collection</title>
-    <link rel="stylesheet" type="text/css" href="/node_modules/@vscode/codicons/dist/codicon.css" id="vscode-codicon-stylesheet" />
   </head>
   <body>
     <div id="app"></div>

--- a/webviews/create-devcontainer.html
+++ b/webviews/create-devcontainer.html
@@ -4,7 +4,6 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Create Devcontainer</title>
-    <link rel="stylesheet" type="text/css" href="/node_modules/@vscode/codicons/dist/codicon.css" id="vscode-codicon-stylesheet" />
     </head>
     <body>
     <div id="app"></div>

--- a/webviews/create-devfile.html
+++ b/webviews/create-devfile.html
@@ -4,7 +4,6 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Create Devfile</title>
-    <link rel="stylesheet" type="text/css" href="/node_modules/@vscode/codicons/dist/codicon.css" id="vscode-codicon-stylesheet" />
     </head>
     <body>
     <div id="app"></div>

--- a/webviews/create-execution-env.html
+++ b/webviews/create-execution-env.html
@@ -4,7 +4,6 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Create Execution Environment</title>
-    <link rel="stylesheet" type="text/css" href="/node_modules/@vscode/codicons/dist/codicon.css" id="vscode-codicon-stylesheet" />
   </head>
   <body>
     <div id="app"></div>

--- a/webviews/create-role.html
+++ b/webviews/create-role.html
@@ -4,7 +4,6 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Create Role</title>
-    <link rel="stylesheet" type="text/css" href="/node_modules/@vscode/codicons/dist/codicon.css" id="vscode-codicon-stylesheet" />
   </head>
   <body>
     <div id="app"></div>

--- a/webviews/lightspeed/explanation.html
+++ b/webviews/lightspeed/explanation.html
@@ -4,7 +4,6 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Ansible Lightspeed Explanation</title>
-    <link rel="stylesheet" type="text/css" href="/node_modules/@vscode/codicons/dist/codicon.css" id="vscode-codicon-stylesheet" />
   </head>
   <body>
     <div id="app"></div>

--- a/webviews/lightspeed/explorer.html
+++ b/webviews/lightspeed/explorer.html
@@ -4,8 +4,6 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + Vue + TS</title>
-    <link rel="stylesheet" type="text/css" href="/node_modules/@vscode/codicons/dist/codicon.css" id="vscode-codicon-stylesheet" />
-
   </head>
 
   <body>

--- a/webviews/lightspeed/feedback.html
+++ b/webviews/lightspeed/feedback.html
@@ -4,7 +4,6 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Ansible Lightspeed Feedback</title>
-    <link rel="stylesheet" type="text/css" href="/node_modules/@vscode/codicons/dist/codicon.css" id="vscode-codicon-stylesheet" />
   </head>
 
   <body>

--- a/webviews/lightspeed/hello-world.html
+++ b/webviews/lightspeed/hello-world.html
@@ -4,8 +4,6 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + Vue + TS</title>
-    <link rel="stylesheet" type="text/css" href="/node_modules/@vscode/codicons/dist/codicon.css" id="vscode-codicon-stylesheet" />
-
   </head>
 
   <body>

--- a/webviews/lightspeed/playbook-generation.html
+++ b/webviews/lightspeed/playbook-generation.html
@@ -4,8 +4,6 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + Vue + TS</title>
-    <link rel="stylesheet" type="text/css" href="/node_modules/@vscode/codicons/dist/codicon.css" id="vscode-codicon-stylesheet" />
-
   </head>
 
   <body>

--- a/webviews/lightspeed/role-generation.html
+++ b/webviews/lightspeed/role-generation.html
@@ -4,8 +4,6 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + Vue + TS</title>
-    <link rel="stylesheet" type="text/css" href="/node_modules/@vscode/codicons/dist/codicon.css" id="vscode-codicon-stylesheet" />
-
   </head>
 
   <body>

--- a/webviews/lightspeed/src/ExplanationApp.vue
+++ b/webviews/lightspeed/src/ExplanationApp.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import '@vscode/codicons/dist/codicon.css';
+
 import { ref, toRaw, watch } from "vue";
 import * as marked from "marked";
 import { v4 as uuidv4 } from "uuid";

--- a/webviews/lightspeed/src/ExplorerApp.vue
+++ b/webviews/lightspeed/src/ExplorerApp.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import '@vscode/codicons/dist/codicon.css';
 import { ref, onMounted } from 'vue';
 import type { Ref } from 'vue'
 import { vscodeApi } from './utils';

--- a/webviews/lightspeed/src/FeedbackApp.vue
+++ b/webviews/lightspeed/src/FeedbackApp.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 import { ref, computed } from "vue";
 import { vscodeApi } from "./utils";
+import '@vscode/codicons/dist/codicon.css';
+
 
 // Sentiment feedback state
 const selectedSentiment = ref<number | null>(null);

--- a/webviews/lightspeed/src/HelloWorld.vue
+++ b/webviews/lightspeed/src/HelloWorld.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import '@vscode/codicons/dist/codicon.css';
 import { ref, watch } from 'vue';
 import type { Ref } from 'vue'
 

--- a/webviews/lightspeed/src/PlaybookGenApp.vue
+++ b/webviews/lightspeed/src/PlaybookGenApp.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import '@vscode/codicons/dist/codicon.css';
 import { ref, watch } from 'vue';
 import type { Ref } from 'vue'
 import { vscodeApi } from './utils';

--- a/webviews/lightspeed/src/RoleGenApp.vue
+++ b/webviews/lightspeed/src/RoleGenApp.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import '@vscode/codicons/dist/codicon.css';
 import { ref, watch } from 'vue';
 import type { Ref } from 'vue'
 import { vscodeApi } from './utils';

--- a/webviews/quick-links.html
+++ b/webviews/quick-links.html
@@ -4,7 +4,6 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Ansible Development Tools</title>
-    <link rel="stylesheet" type="text/css" href="/node_modules/@vscode/codicons/dist/codicon.css" id="vscode-codicon-stylesheet" />
   </head>
   <body>
     <div id="app"></div>

--- a/webviews/welcome-page.html
+++ b/webviews/welcome-page.html
@@ -4,7 +4,6 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Ansible Development Tools</title>
-    <link rel="stylesheet" type="text/css" href="/node_modules/@vscode/codicons/dist/codicon.css" id="vscode-codicon-stylesheet" />
     </head>
     <body>
     <div id="app"></div>


### PR DESCRIPTION
Rely on the Vite bundler to import codicon.

<img width="445" height="300" alt="image" src="https://github.com/user-attachments/assets/159a8b5b-2212-4821-8bea-6945d283a934" />
