### PR TITLE
chore: Skip coverage thresholds on WSL

### DIFF
--- a/packages/ansible-language-server/vitest.config.ts
+++ b/packages/ansible-language-server/vitest.config.ts
@@ -21,7 +21,11 @@ export default defineConfig({
       reporter: ["cobertura", "json", "lcovonly"],
       reportsDirectory: "./out/coverage/als", // relative to config root entry
       thresholds: {
-        branches: process.platform === "linux" ? 22.78 : 0.0,
+        // Enforce coverage thresholds on pure Linux, skip on WSL
+        branches:
+          process.platform === "linux" && process.env.IS_WSL !== "1"
+            ? 22.78
+            : 0.0,
       },
     },
     include: [`${__dirname}/test/**/*.test.ts`],


### PR DESCRIPTION
**Skip coverage thresholds on WSL, enforce only on pure Linux -**

- Updated coverage threshold to skip on WSL (via IS_WSL env var) and only enforce on pure Linux, preventing false failures due to WSL coverage differences.
- To fix - https://github.com/ansible/vscode-ansible/actions/runs/21426621454/job/61706011912?pr=2455#step:14:519