### PR TITLE
fix: relative import of codicon.ttf

### DIFF
--- a/test/unit/viteConfig.test.ts
+++ b/test/unit/viteConfig.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import viteConfig from "../../vite.config";
+
+describe("vite.config.ts", () => {
+  describe("experimental.renderBuiltUrl", () => {
+    const renderBuiltUrl = viteConfig.experimental?.renderBuiltUrl;
+
+    it("should have renderBuiltUrl defined", () => {
+      expect(renderBuiltUrl).toBeDefined();
+      expect(typeof renderBuiltUrl).toBe("function");
+    });
+
+    it("should return { relative: true } for assets/codicon.ttf", () => {
+      const result = renderBuiltUrl?.("assets/codicon.ttf", {
+        hostId: "html",
+        hostType: "html",
+        type: "asset",
+        ssr: false,
+      });
+      expect(result).toEqual({ relative: true });
+    });
+
+    it("should return { relative: true } for assets/codicon.ttf with hash suffix", () => {
+      const result = renderBuiltUrl?.("assets/codicon.ttf?hash=abc123", {
+        hostId: "html",
+        hostType: "html",
+        type: "asset",
+        ssr: false,
+      });
+      expect(result).toEqual({ relative: true });
+    });
+
+    it("should return undefined for other asset files", () => {
+      const result = renderBuiltUrl?.("assets/other-font.woff2", {
+        hostId: "html",
+        hostType: "html",
+        type: "asset",
+        ssr: false,
+      });
+      expect(result).toBeUndefined();
+    });
+
+    it("should return undefined for JavaScript files", () => {
+      const result = renderBuiltUrl?.("assets/main.js", {
+        hostId: "html",
+        hostType: "html",
+        type: "asset",
+        ssr: false,
+      });
+      expect(result).toBeUndefined();
+    });
+
+    it("should return undefined for CSS files", () => {
+      const result = renderBuiltUrl?.("assets/style.css", {
+        hostId: "html",
+        hostType: "html",
+        type: "asset",
+        ssr: false,
+      });
+      expect(result).toBeUndefined();
+    });
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,6 +23,13 @@ export default defineConfig({
     }),
   ],
   publicDir: "media",
+  experimental: {
+    renderBuiltUrl(filename) {
+      if (filename.startsWith("assets/codicon.ttf")) {
+        return { relative: true };
+      }
+    },
+  },
   build: {
     minify: false,
     outDir: "out/vitebuild",


### PR DESCRIPTION
Vite rebases the URL import by `url()` to a static format[^1]. By default,
the path is `/assets/{the-resource-name}`.
This doesn't work well with `@tomjs/vite-plugin-vscode` because it
dynamically adjust the base url during the run time. This works well
for JS files, but not for CSS, and VSCode will prevent the direct
access to `/assets` (err 401).
Another option is to use `baseUrl: ''`[^2] to avoid the use of static URL,
but this is also not an option because, depending on if we are in
prod mode (.vsix) or in dev with the live reloading, all the URL
either have to be relative to `./out/vitebuild/extension/extension.js`
(prod), or the associated `.html` page of the view (live reloading).
We could write the `extension.js` directly in the `out/vitebuild/webview/`
directory, but this sounds over-complicated.
Come this solution, where we preserve the dynamic nature of the URL of
single file we care about.

[^1] https://vite.dev/guide/features#import-inlining-and-rebasing
[^2] https://cli.vuejs.org/config/#baseurl
