### PR TITLE
chore: check mise, increase scheduled jobs, debug info, biome package.json

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ on:
     types: [synchronize, opened, reopened]
     branches: ["main", "devel/*"]
   schedule:
-    - cron: "0 0,12 * * *"
+    - cron: "0 0,6,12,18 * * *"
   workflow_dispatch:
     inputs:
       publish:
@@ -426,7 +426,9 @@ jobs:
 
       - name: Show git ignored files to debug "task ... --status" failures
         if: ${{ always() && failure() }}
-        run: git status --porcelain --ignored
+        run: |
+          git diff
+          git status --porcelain --ignored
 
       - name: Report unexpected failures
         if: ${{ always() && failure() && github.ref == 'refs/heads/main' }}

--- a/.issuetracker
+++ b/.issuetracker
@@ -1,0 +1,7 @@
+# Integration with Issue Tracker
+#
+# (note that '\' need to be escaped).
+
+[issuetracker "jira"]
+  regex = "(AAP|ANSTRAT)-(\\d+)"
+  url = "https://issues.redhat.com/browse/$1-$2"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,7 @@ ci:
   autoupdate_schedule: monthly
   autofix_commit_msg: "chore: auto fixes from pre-commit.com hooks"
   skip:
+    - biome
     - codecov
     - codespell # missing uv
     - knip
@@ -38,13 +39,6 @@ repos:
       - id: codespell
       - id: yamllint
       - id: md
-  - repo: https://github.com/biomejs/pre-commit
-    rev: "v2.3.10"
-    hooks:
-      - id: biome-check
-        name: biome
-        alias: biome
-        args: [--unsafe]
   - repo: https://github.com/streetsidesoftware/cspell-cli
     rev: v9.4.0
     hooks:
@@ -72,6 +66,13 @@ repos:
           - SC1091
   - repo: local
     hooks:
+      - id: biome
+        name: biome
+        alias: biome
+        language: system
+        pass_filenames: false
+        always_run: true
+        entry: biome check --write --unsafe
       - id: knip
         name: knip (typescript declutter)
         entry: yarn knip --fix

--- a/Taskfile.base.yml
+++ b/Taskfile.base.yml
@@ -35,6 +35,7 @@ tasks:
       OS: "{{OS}}"
       ARCH: "{{ARCH}}"
     deps:
+      - mise
       - yarn
       - uv
     dir: "{{ .TASKFILE_DIR }}"
@@ -49,3 +50,12 @@ tasks:
       - out/log/manifest-*.yml
     run: once
     interactive: true
+  mise:
+    desc: Check if mise is installed and working
+    internal: true
+    silent: true
+    status:
+      - '[ -n "$CI" ]'
+    cmds:
+      - "mise --version >>/dev/null || { echo ''ERROR: mise not found in PATH'' >&2; exit 1; }"
+      - "mise doctor >>/dev/null || { mise doctor || echo 'ERROR: mise doctor failed, resolve reported problems.' >&2 && exit 1; }"

--- a/biome.json
+++ b/biome.json
@@ -38,6 +38,22 @@
       "indentStyle": "space"
     }
   },
+  "overrides": [
+    {
+      "assist": {
+        "actions": {
+          "source": {
+            "useSortedKeys": "off"
+          }
+        },
+        "enabled": true
+      },
+      "includes": ["package.json", "**/package.json"],
+      "json": {
+        "formatter": { "expand": "always" }
+      }
+    }
+  ],
   "vcs": {
     "clientKind": "git",
     "enabled": true,

--- a/knip.ts
+++ b/knip.ts
@@ -13,6 +13,7 @@ const config: KnipConfig = {
   includeEntryExports: true,
   ignoreDependencies: [
     "@ansible/ansible-mcp-server",
+    "@biomejs/biome",
     "@tomjs/vite-plugin-vue",
     "@types/vscode",
     "@types/vscode-webview", // provides acquireVsCodeApi

--- a/package.json
+++ b/package.json
@@ -1059,6 +1059,7 @@
   },
   "description": "Ansible language support",
   "devDependencies": {
+    "@biomejs/biome": "^2.3.13",
     "@eslint/js": "^9.39.2",
     "@html-eslint/eslint-plugin": "^0.54.0",
     "@types/chai": "^5.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -301,6 +301,97 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@biomejs/biome@npm:^2.3.13":
+  version: 2.3.13
+  resolution: "@biomejs/biome@npm:2.3.13"
+  dependencies:
+    "@biomejs/cli-darwin-arm64": "npm:2.3.13"
+    "@biomejs/cli-darwin-x64": "npm:2.3.13"
+    "@biomejs/cli-linux-arm64": "npm:2.3.13"
+    "@biomejs/cli-linux-arm64-musl": "npm:2.3.13"
+    "@biomejs/cli-linux-x64": "npm:2.3.13"
+    "@biomejs/cli-linux-x64-musl": "npm:2.3.13"
+    "@biomejs/cli-win32-arm64": "npm:2.3.13"
+    "@biomejs/cli-win32-x64": "npm:2.3.13"
+  dependenciesMeta:
+    "@biomejs/cli-darwin-arm64":
+      optional: true
+    "@biomejs/cli-darwin-x64":
+      optional: true
+    "@biomejs/cli-linux-arm64":
+      optional: true
+    "@biomejs/cli-linux-arm64-musl":
+      optional: true
+    "@biomejs/cli-linux-x64":
+      optional: true
+    "@biomejs/cli-linux-x64-musl":
+      optional: true
+    "@biomejs/cli-win32-arm64":
+      optional: true
+    "@biomejs/cli-win32-x64":
+      optional: true
+  bin:
+    biome: bin/biome
+  checksum: 10/bd658217572d91c6dfd89b8aa64a6cbbb6e24c25971c376a1f7f34b005862e62c30e4623425414b72f050ce042cd1db68a23dcbedbe7a752e13f227ad2c97372
+  languageName: node
+  linkType: hard
+
+"@biomejs/cli-darwin-arm64@npm:2.3.13":
+  version: 2.3.13
+  resolution: "@biomejs/cli-darwin-arm64@npm:2.3.13"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@biomejs/cli-darwin-x64@npm:2.3.13":
+  version: 2.3.13
+  resolution: "@biomejs/cli-darwin-x64@npm:2.3.13"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@biomejs/cli-linux-arm64-musl@npm:2.3.13":
+  version: 2.3.13
+  resolution: "@biomejs/cli-linux-arm64-musl@npm:2.3.13"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@biomejs/cli-linux-arm64@npm:2.3.13":
+  version: 2.3.13
+  resolution: "@biomejs/cli-linux-arm64@npm:2.3.13"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@biomejs/cli-linux-x64-musl@npm:2.3.13":
+  version: 2.3.13
+  resolution: "@biomejs/cli-linux-x64-musl@npm:2.3.13"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@biomejs/cli-linux-x64@npm:2.3.13":
+  version: 2.3.13
+  resolution: "@biomejs/cli-linux-x64@npm:2.3.13"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@biomejs/cli-win32-arm64@npm:2.3.13":
+  version: 2.3.13
+  resolution: "@biomejs/cli-win32-arm64@npm:2.3.13"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@biomejs/cli-win32-x64@npm:2.3.13":
+  version: 2.3.13
+  resolution: "@biomejs/cli-win32-x64@npm:2.3.13"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@colors/colors@npm:1.6.0, @colors/colors@npm:^1.6.0":
   version: 1.6.0
   resolution: "@colors/colors@npm:1.6.0"
@@ -3479,6 +3570,7 @@ __metadata:
   dependencies:
     "@ansible/ansible-language-server": "workspace:^"
     "@ansible/ansible-mcp-server": "workspace:^"
+    "@biomejs/biome": "npm:^2.3.13"
     "@eslint/js": "npm:^9.39.2"
     "@google/genai": "npm:^1.38.0"
     "@highlightjs/vue-plugin": "npm:2.1.0"


### PR DESCRIPTION
- fail early if mise is missing or misconfigured
- run scheduled jobs 4 times a day
- reconfigure biome to no sort package.json
- display debugging information when CI jobs are failing