### PR TITLE
chore: skip Lightspeed tests on local runs if credentials are not available

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ junit_logging = "all"
 log_cli = true
 log_cli_level = "INFO"
 markers = [
+  "lightspeed: mark tests related to lightspeed that require backend credentials",
   "modify_settings: modify vscode settings.json before/after test",
   "vscode: mark tests for vscode extension",
   "vscode_trial: mark tests related to lightspeed trial",

--- a/test/selenium/ui/test_lightspeed.py
+++ b/test/selenium/ui/test_lightspeed.py
@@ -1,7 +1,6 @@
 """Tests for VSCode extension functionality."""
 
 # pylint: disable=E0401, W0613, R0801, W0603
-import os
 from typing import Any
 
 import pytest
@@ -17,10 +16,7 @@ from test.selenium.utils.ui_utils import (
     wait_displayed,
 )
 
-pytestmark = pytest.mark.skipif(
-    not os.environ.get("LIGHTSPEED_PASSWORD"),
-    reason="LIGHTSPEED_PASSWORD environment variable is not defined",
-)
+pytestmark = pytest.mark.lightspeed
 
 
 GENERATE_TASK = """update all RHEL machines"""

--- a/test/selenium/ui/test_lightspeed_trial.py
+++ b/test/selenium/ui/test_lightspeed_trial.py
@@ -1,17 +1,13 @@
 """This module is for testing the Ansible Lightspeed Trial functionality."""
 
 # pylint: disable=E0401, W0613, R0801, W0603
-import os
 from typing import Any
 
 import pytest
 
 from test.selenium.utils.ui_utils import vscode_login, vscode_trial_button
 
-pytestmark = pytest.mark.skipif(
-    not os.environ.get("LIGHTSPEED_PASSWORD"),
-    reason="LIGHTSPEED_PASSWORD environment variable is not defined",
-)
+pytestmark = pytest.mark.lightspeed
 
 
 PLAYBOOK_CONTENT = """

--- a/test/selenium/ui/test_login.py
+++ b/test/selenium/ui/test_login.py
@@ -1,7 +1,6 @@
 """This module is for testing the login process."""
 
 # pylint: disable=E0401, W0613
-import os
 import time
 from typing import Any
 
@@ -19,10 +18,7 @@ from test.selenium.utils.ui_utils import (
     wait_displayed,
 )
 
-pytestmark = pytest.mark.skipif(
-    not os.environ.get("LIGHTSPEED_PASSWORD"),
-    reason="LIGHTSPEED_PASSWORD environment variable is not defined",
-)
+pytestmark = pytest.mark.lightspeed
 
 
 PLAYBOOK_CONTENT = """


### PR DESCRIPTION
- skip running lightspeed tests on non CI runs if credentials are missing
- inform user about the skipped reason