### PR TITLE
chore: tell renovate to not update zod

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -64,7 +64,7 @@
     },
     {
       "branchTopic": "npm",
-      "ignoreDeps": ["@tomjs/vite-plugin-vscode", "@vitejs/plugin-vue"],
+      "ignoreDeps": ["@tomjs/vite-plugin-vscode", "@vitejs/plugin-vue", "zod"],
       "matchDepTypes": ["dependencies"],
       "matchManagers": ["npm"]
     },


### PR DESCRIPTION
As updating zod breaks some of our tests and we don't want the
aggressive renovate noise we disable update of this dependency.
