### PR TITLE
chore: refactor ui test temp directories

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -62,14 +62,9 @@ runs:
       uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
       with:
         path: |
-          .vscode-test
+          .vscode-test/extensions
+          .vscode-test/vscode-*
           out/ext
-          out/test-resources*/chromedriver*
-          out/test-resources*/VSCode-*
-          out/test-resources*/Visual*
-          out/test-resources*/driverVersion
-          out/test-resources*/stable.zip
-          out/test-resources*/manifest.json
         key: ${{ env.IMAGE_OS_VERSION }}-${{ matrix.task-name }}-${{ hashFiles('package.json', 'yarn.lock') }}
     # - name: Enable caching for podman-machine
     #   if: "contains(matrix.os, 'macos')"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -392,9 +392,7 @@ jobs:
             out/server
             out/client
             out/vitebuild
-          # Not secure to collect due to 'token' being logged by vscode trace logs.
-          # out/userdata/logs
-          # out/test-resources/settings/logs
+          # we collect transpiled js files as sonar needs them to compute code coverage
           if-no-files-found: ignore
           retention-days: 90
 

--- a/.vscode-test.mjs
+++ b/.vscode-test.mjs
@@ -3,7 +3,7 @@
 import { defineConfig } from "@vscode/test-cli";
 
 export default defineConfig({
-  files: "out/client/test/e2e/**/*.test.js",
+  files: "test/e2e/**/*.test.ts",
   extensionDevelopmentPath: ".", // package.json location
   workspaceFolder: "test/testFixtures",
   launchArgs: [
@@ -11,7 +11,7 @@ export default defineConfig({
     // implicitly use --force and the server can respond with 503 errors.
     // "--install-extensions=ms-python.python,redhat.vscode-yaml",
     "--disable-gpu", // avoids misleading console messages during local or CI/CD test like VK_ERROR_INCOMPATIBLE_DRIVER
-    "--user-data-dir=.vscode-test/user-data",
+    "--user-data-dir=.vscode-test/user-data", // do not try other location because it will split lots in two as some happen before this is effective
     "--extensions-dir=.vscode-test/extensions",
     "--disable-extension=alefragnani.project-manager",
     "--disable-extension=eamodio.gitlens",
@@ -29,6 +29,7 @@ export default defineConfig({
     slow: 25_000,
     timeout: 50_000,
     reporter: "cypress-multi-reporters",
+    preload: "tsx/cjs",
     reporterOptions: {
       reporterEnabled: "spec,mocha-junit-reporter",
       mochaJunitReporterReporterOptions: {
@@ -41,10 +42,12 @@ export default defineConfig({
         suiteTitleSeparatedBy: "::",
       },
     },
-    preload: "ts-node/register",
     require: [
-      "ts-node/register",
       "./test/e2e/rootMochaHooks.ts", // this file must be loaded last
     ],
+  },
+  coverage: {
+    includeAll: true,
+    exclude: ["**/node_modules", "out/server/external", "out/server/webpack/"],
   },
 });

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -61,5 +61,6 @@
   "redhat.telemetry.enabled": false,
   "search.exclude": {
     ".vscode-test": true
-  }
+  },
+  "vitest.maximumConfigs": 10
 }

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,6 +1,6 @@
 ---
 # see https://taskfile.dev/#/
-# cspell: ignore unshallow
+# cspell: ignore unshallow rimraf
 version: "3"
 includes:
   base:
@@ -197,7 +197,7 @@ tasks:
       NODE_NO_WARNINGS: "1"
       DONT_PROMPT_WSL_INSTALL: "1"
       # Possible workaround for: https://github.com/microsoft/vscode-test-cli/issues/555
-      TMP: "{{ .TASKFILE_DIR }}/out/tmp/e2e"
+      TMP: "{{ .TASKFILE_DIR }}/out/e2e/tmp"
     generates:
       - out/junit/e2e-test-results.xml
       - out/coverage/e2e/cobertura-coverage.xml
@@ -211,9 +211,8 @@ tasks:
       - exclude: test/testFixtures/diagnostics/yaml/invalid_yaml.yml
       - exclude: test/unit/lightspeed/utils/samples/collections/ansible_collections/community/broken_MANIFEST/MANIFEST.json
     cmds:
-      - mkdir -p out/tmp/e2e
-      # dry run to fail fast if we misconfigure it
-      - "{{.XVFB}}vscode-test --dry-run --fail-zero"
+      - rimraf .vscode-test/user-data/logs/*
+      - mkdir -p out/e2e/tmp
       # cannot put coverage option inside .vscode-test.mjs
       - "{{.XVFB}}vscode-test --install-extensions out/ansible-*.vsix --coverage --coverage-output ./out/coverage/e2e --coverage-reporter text --coverage-reporter cobertura --coverage-reporter lcovonly"
       - defer: { task: collect-logs, vars: { TEST_PREFIX: "{{.TEST_PREFIX}}" } }
@@ -232,8 +231,9 @@ tasks:
     cmds:
       # settings.json gets changed during tests so we do copy it
       # we use same location for altered settings.json for all test suites
-      - mkdir -p out/test-resources/settings/User/ out/ui-selenium/logs out/ui-selenium/coder-logs
-      - cp -f test/testFixtures/settings.json out/test-resources/settings/User/settings.json
+      - rimraf out/ui-selenium/logs out/ui-selenium/coder-logs
+      - mkdir -p .vscode-test/user-data/User/ out/ui-selenium/logs out/ui-selenium/coder-logs
+      - cp -f test/testFixtures/settings.json .vscode-test/user-data/User/settings.json
       - >
         VSX_FILE=${PWD}/$(ls -1 out/ansible-*.vsix) &&
         podman run
@@ -246,7 +246,7 @@ tasks:
         -p 4444:4444
         -p 5999:5999
         --volume $VSX_FILE:/ansible-latest.vsix:ro,Z
-        --volume ./out/test-resources/settings/User/settings.json:/home/selenium/.local/share/code-server/User/settings.json:rw,Z
+        --volume ./.vscode-test/user-data/User/settings.json:/home/selenium/.local/share/code-server/User/settings.json:rw,Z
         --volume ${PWD}/out/ui-selenium/logs:/home/selenium/.local/share/code-server/logs:rw,Z
         quay.io/tshinhar/selenium-vscode-multi:latest
       - curl -sS --retry 10 --retry-all-errors http://localhost:4444
@@ -325,22 +325,17 @@ tasks:
   flush:
     desc: Cleans cached files that sometimes can affect the build negatively, not a full clean
     cmds:
-      - rm -rf out/test-resources/screenshots/* out/test-resources/settings/logs/* || true
-      - rm -rf .vscode-test/ out/test-resources/VSCode-* out/test-resources/"Visual Studio Code.app" || true
-      - rm -f out/test-resources/*stable.zip out/test-resources/*.tar.gz || true
+      - rm -rf .vscode-test/ || true
   dry:
     desc: Pretend it does run tests, used to validate configuration of the test frameworks
     deps:
       - package
     cmds:
       - vitest list
+      - "{{.XVFB}}vscode-test --dry-run --fail-zero || echo 'Ignored failure to run vscode-test as e2e tests do not yet run inside a containers.'"
   collect-logs:
     requires:
       vars: [TEST_PREFIX]
     cmds:
-      - mkdir -p out/{{.TEST_PREFIX}}/screenshots
-      - |
-        find out/test-resources/logs -name "*.log" -type f -exec cp -v {} out/{{.TEST_PREFIX}}/ \; 2>/dev/null || true
-        find out/test-resources/settings/logs -type f -exec cp -v {} out/{{.TEST_PREFIX}}/ \; 2>/dev/null || true
-        find out/test-resources/screenshots -type f -exec cp -v {} out/{{.TEST_PREFIX}}/screenshots \; 2>/dev/null || true
+      - find .vscode-test/user-data/logs -name "*.log" -type f -exec cp -v {} out/{{.TEST_PREFIX}}/ \; 2>/dev/null || true
       - defer: tools/sanitize-logs.py out/{{.TEST_PREFIX}}/*.log

--- a/test/selenium/utils/settings_utils.py
+++ b/test/selenium/utils/settings_utils.py
@@ -11,7 +11,7 @@ from typing import Any
 log = logging.getLogger(__name__)
 
 PROJECT_ROOT = Path(__file__).parent.parent.parent.parent
-USER_SETTINGS_PATH = PROJECT_ROOT / "out/test-resources/settings/User/settings.json"
+USER_SETTINGS_PATH = PROJECT_ROOT / ".vscode-test/user-data/User/settings.json"
 ORIGINAL_SETTINGS_PATH = PROJECT_ROOT / "test/testFixtures/settings.json"
 
 

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -4,7 +4,7 @@ import { PROJECT_ROOT } from "./setup";
 
 const userSettingsPath = path.join(
   PROJECT_ROOT,
-  "out/test-resources/settings/User/settings.json",
+  ".vscode-test/user-data/User/settings.json",
 );
 const originalSettingsPath = path.join(
   PROJECT_ROOT,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,6 @@
   },
   "exclude": [
     "node_modules",
-    "test-resources",
     "src/features/lightspeed/vue/src",
     "packages/ansible-mcp-server/test",
     "test/unit/webviews"
@@ -15,7 +14,6 @@
     "src/**/*.ts",
     "test/**/*.ts",
     "webviews/lightspeed/src/utils/*.ts",
-    "test",
     "*.js",
     "*.ts"
   ],


### PR DESCRIPTION
- make vscode-test load ts files directly
- remove use of test-resources folder which was specific to extest
- use default temp file location used by vscode-test