### PR TITLE
fix: add LS auth in contributes.authentication

### DIFF
--- a/package.json
+++ b/package.json
@@ -1011,6 +1011,12 @@
         ],
         "url": "https://raw.githubusercontent.com/ansible/ansible-rulebook/main/ansible_rulebook/schema/ruleset_schema.json"
       }
+    ],
+    "authentication": [
+      {
+        "id": "auth-lightspeed",
+        "label": "Ansible Lightspeed"
+      }
     ]
   },
   "contributors": [

--- a/src/features/lightspeed/utils/webUtils.ts
+++ b/src/features/lightspeed/utils/webUtils.ts
@@ -10,8 +10,10 @@ import {
 import { LIGHTSPEED_USER_TYPE } from "../../../definitions/lightspeed";
 import { lightSpeedManager } from "../../../extension";
 
-export const ANSIBLE_LIGHTSPEED_AUTH_ID = `auth-lightspeed`;
-export const ANSIBLE_LIGHTSPEED_AUTH_NAME = `Ansible Lightspeed`;
+// Also defined in package.json in "".contributes.authentication"
+export const ANSIBLE_LIGHTSPEED_AUTH_ID = "auth-lightspeed";
+export const ANSIBLE_LIGHTSPEED_AUTH_NAME = "Ansible Lightspeed";
+
 export const RHSSO_AUTH_ID = "redhat-account-auth";
 export const SESSIONS_SECRET_KEY = `${ANSIBLE_LIGHTSPEED_AUTH_ID}.sessions`;
 export const ACCOUNT_SECRET_KEY = `${ANSIBLE_LIGHTSPEED_AUTH_NAME}.account`;


### PR DESCRIPTION
Add the Lightspeed authentication provider in the `contributes` / `authentication`
section of the `package.json`. This to address the following error:

`Authentication provider auth-lightspeed was not declared in the Extension Manifest.`

See:
- https://code.visualstudio.com/api/references/contribution-points#contributes.authentication
- https://github.com/microsoft/vscode/blob/711cf8b1cabd6b4839ccad5e7088046b5a3660d9/src/vs/workbench/api/browser/mainThreadAuthentication.ts#L186
