### PR TITLE
feat: refactor LLM explorer side panel

### DIFF
--- a/package.json
+++ b/package.json
@@ -216,6 +216,10 @@
       {
         "command": "ansible.lightspeed.switchProvider",
         "title": "Ansible Lightspeed: Switch Provider"
+      },
+      {
+        "command": "ansible.lightspeed.openLlmProviderSettings",
+        "title": "Ansible Lightspeed: Open LLM Provider Settings"
       }
     ],
     "configuration": [
@@ -429,19 +433,6 @@
       },
       {
         "properties": {
-          "ansible.lightspeed.apiEndpoint": {
-            "default": "",
-            "markdownDescription": "API endpoint URL. **Only configurable for WCA provider.** For Google, the endpoint is automatically set and cannot be changed. Default for WCA: https://c.ai.ansible.redhat.com",
-            "order": 4,
-            "scope": "resource",
-            "type": "string"
-          },
-          "ansible.lightspeed.apiKey": {
-            "markdownDescription": "API key for Google provider. Not used for WCA (uses OAuth2 authentication). **Important**: This will be stored in VS Code settings.",
-            "order": 3,
-            "scope": "resource",
-            "type": "string"
-          },
           "ansible.lightspeed.enabled": {
             "default": true,
             "markdownDescription": "Enable Ansible Lightspeed.",
@@ -449,47 +440,66 @@
             "scope": "resource",
             "type": "boolean"
           },
-          "ansible.lightspeed.modelName": {
-            "markdownDescription": "Model name/ID to use. **Optional for Google** (uses smart defaults).",
-            "order": 2,
-            "scope": "resource",
-            "type": "string"
-          },
-          "ansible.lightspeed.provider": {
-            "default": "wca",
-            "enum": [
-              "wca",
-              "google"
-            ],
-            "enumDescriptions": [
-              "Red Hat Ansible Lightspeed with IBM watsonx Code Assistant",
-              "Google Gemini - Direct access to Google Gemini models (use your Google API key)"
-            ],
-            "markdownDescription": "Select the AI provider for Ansible Lightspeed suggestions and generation.",
-            "order": 1,
-            "scope": "resource",
-            "type": "string"
-          },
           "ansible.lightspeed.suggestions.enabled": {
             "default": true,
             "markdownDescription": "Enable inline suggestions. Note: Currently only supported with WCA provider.",
-            "order": 7,
+            "order": 1,
             "scope": "resource",
             "type": "boolean"
           },
           "ansible.lightspeed.suggestions.waitWindow": {
             "default": 0,
             "markdownDescription": "Delay (in msecs) prior to sending an inline suggestion request.",
-            "order": 8,
+            "order": 2,
             "scope": "resource",
             "type": "number"
           },
           "ansible.lightspeed.timeout": {
-            "default": 3000,
+            "default": 30000,
             "markdownDescription": "Request timeout in milliseconds for API calls.",
-            "order": 5,
+            "order": 3,
             "scope": "resource",
             "type": "number"
+          },
+          "ansible.lightspeed.provider": {
+            "type": "string",
+            "enum": [
+              "wca",
+              "google"
+            ],
+            "default": "wca",
+            "markdownDescription": "LLM provider to use.",
+            "deprecated": true,
+            "deprecationMessage": "This setting is deprecated and will be removed in a future release. Use the LLM Provider Settings panel instead (Ansible Lightspeed: Open LLM Provider Settings).",
+            "order": 4,
+            "scope": "resource"
+          },
+          "ansible.lightspeed.apiEndpoint": {
+            "type": "string",
+            "default": "",
+            "markdownDescription": "API endpoint URL for the selected provider.",
+            "deprecated": true,
+            "deprecationMessage": "This setting is deprecated and will be removed in a future release. Use the LLM Provider Settings panel instead.",
+            "order": 5,
+            "scope": "resource"
+          },
+          "ansible.lightspeed.modelName": {
+            "type": "string",
+            "default": "",
+            "markdownDescription": "Model name/ID to use.",
+            "deprecated": true,
+            "deprecationMessage": "This setting is deprecated and will be removed in a future release. Use the LLM Provider Settings panel instead.",
+            "order": 6,
+            "scope": "resource"
+          },
+          "ansible.lightspeed.apiKey": {
+            "type": "string",
+            "default": "",
+            "markdownDescription": "API key for authentication.",
+            "deprecated": true,
+            "deprecationMessage": "This setting is deprecated and will be removed in a future release. Use the LLM Provider Settings panel instead for secure API key storage.",
+            "order": 7,
+            "scope": "resource"
           }
         },
         "title": "Ansible Lightspeed"
@@ -741,13 +751,7 @@
           "when": "resourceFilename == 'execution-environment.yml' || resourceFilename == 'execution-environment.yaml'"
         }
       ],
-      "view/title": [
-        {
-          "command": "ansible.lightspeed.explorer.refresh",
-          "group": "navigation",
-          "when": "view == lightspeed-explorer-webview"
-        }
-      ]
+      "view/title": []
     },
     "submenus": [
       {
@@ -773,13 +777,6 @@
           "id": "ansible-home",
           "name": "Ansible Development Tools",
           "type": "webview"
-        },
-        {
-          "icon": "images/ansible.svg",
-          "id": "lightspeed-explorer-webview",
-          "name": "Ansible Lightspeed",
-          "type": "webview",
-          "when": "config.ansible.lightspeed.enabled"
         },
         {
           "icon": "$(comment-discussion)",

--- a/src/definitions/lightspeed.ts
+++ b/src/definitions/lightspeed.ts
@@ -48,6 +48,8 @@ export namespace LightSpeedCommands {
   export const LIGHTSPEED_OPEN_TRIAL_PAGE = "ansible.lightspeed.openTrialPage";
   export const LIGHTSPEED_REFRESH_EXPLORER_VIEW =
     "ansible.lightspeed.explorer.refresh";
+  export const LIGHTSPEED_OPEN_LLM_PROVIDER_SETTINGS =
+    "ansible.lightspeed.openLlmProviderSettings";
 }
 
 const LIGHTSPEED_API_VERSION = "v0";

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,12 +4,7 @@ import * as path from "node:path";
 import { ExtensionContext, extensions, window, workspace } from "vscode";
 import { Vault } from "./features/vault";
 import { AnsibleCommands } from "./definitions/constants";
-import {
-  LightSpeedCommands,
-  UserAction,
-  GOOGLE_API_ENDPOINT,
-  WCA_API_ENDPOINT_DEFAULT,
-} from "./definitions/lightspeed";
+import { LightSpeedCommands, UserAction } from "./definitions/lightspeed";
 import {
   TelemetryErrorHandler,
   TelemetryOutputChannel,
@@ -63,6 +58,7 @@ import { AnsibleToxController } from "./features/ansibleTox/controller";
 import { AnsibleToxProvider } from "./features/ansibleTox/provider";
 import { findProjectDir } from "./features/ansibleTox/utils";
 import { QuickLinksWebviewViewProvider } from "./features/quickLinks/utils/quickLinksViewProvider";
+import { LlmProviderPanel } from "./features/lightspeed/vue/views/llmProviderPanel";
 import { LightspeedFeedbackWebviewViewProvider } from "./features/lightspeed/feedbackWebviewViewProvider";
 import { LightspeedFeedbackWebviewProvider } from "./features/lightspeed/feedbackWebviewProvider";
 import { WelcomePagePanel } from "./features/welcomePage/welcomePagePanel";
@@ -85,6 +81,7 @@ import { MainPanel as PlaybookGenerationPanel } from "./features/lightspeed/vue/
 import { MainPanel as ExplanationPanel } from "./features/lightspeed/vue/views/explanationPanel";
 import { MainPanel as HelloWorldPanel } from "./features/lightspeed/vue/views/helloWorld";
 import { ProviderCommands } from "./features/lightspeed/commands/providerCommands";
+import { LlmProviderSettings } from "./features/lightspeed/llmProviderSettings";
 import { MainPanel as createAnsibleCollectionPanel } from "./features/contentCreator/vue/views/createAnsibleCollectionPanel";
 import { MainPanel as createAnsibleProjectPanel } from "./features/contentCreator/vue/views/createAnsibleProjectPanel";
 import { MainPanel as addPluginPanel } from "./features/contentCreator/vue/views/addPluginPagePanel";
@@ -118,8 +115,13 @@ export async function activate(context: ExtensionContext): Promise<void> {
   const telemetry = new TelemetryManager(context);
   await telemetry.initTelemetryService();
 
+  // Initialize LLM provider settings (uses globalState and secrets)
+  const llmProviderSettings = new LlmProviderSettings(context);
+  await llmProviderSettings.migrateFromSettingsJson();
+
   // Initialize settings
   const extSettings = new SettingsManager();
+  extSettings.setLlmProviderSettings(llmProviderSettings);
   await extSettings.initialize();
 
   // Vault encrypt/decrypt handler
@@ -200,10 +202,19 @@ export async function activate(context: ExtensionContext): Promise<void> {
   /**
    * Handle "Ansible Lightspeed" in the extension
    */
-  lightSpeedManager = new LightSpeedManager(context, extSettings, telemetry);
+  lightSpeedManager = new LightSpeedManager(
+    context,
+    extSettings,
+    telemetry,
+    llmProviderSettings,
+  );
 
   // Register provider management commands
-  const providerCommands = new ProviderCommands(context, lightSpeedManager);
+  const providerCommands = new ProviderCommands(
+    context,
+    lightSpeedManager,
+    llmProviderSettings,
+  );
   providerCommands.registerCommands();
 
   vscode.commands.executeCommand("setContext", "lightspeedConnectReady", true);
@@ -350,8 +361,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
         if (!extSettings.settings.lightSpeedService.enabled) {
           return;
         }
-        // Send explorer state update when editor changes
-        await updateExplorerState(lightSpeedManager);
+        lightSpeedManager.lightspeedExplorerProvider?.refreshWebView();
       },
     ),
   );
@@ -406,41 +416,6 @@ export async function activate(context: ExtensionContext): Promise<void> {
         );
       }
 
-      // Check if Lightspeed provider changed - refresh explorer panel and set apiEndpoint
-      if (event.affectsConfiguration("ansible.lightspeed.provider")) {
-        const config = workspace.getConfiguration("ansible.lightspeed");
-        const provider = config.get<string>("provider");
-
-        // Determine the configuration target (folder takes precedence over workspace, which takes precedence over global)
-        const providerInspect = config.inspect<string>("provider");
-        let configTarget: vscode.ConfigurationTarget | undefined;
-
-        if (providerInspect?.workspaceFolderValue !== undefined) {
-          configTarget = vscode.ConfigurationTarget.WorkspaceFolder;
-        } else if (providerInspect?.workspaceValue !== undefined) {
-          configTarget = vscode.ConfigurationTarget.Workspace;
-        } else {
-          configTarget = vscode.ConfigurationTarget.Global;
-        }
-
-        // Auto-set apiEndpoint based on provider type
-        if (provider === "google") {
-          await config.update("apiEndpoint", GOOGLE_API_ENDPOINT, configTarget);
-        } else if (provider === "wca") {
-          // For WCA, use default if not set; otherwise keep user's value (for on-prem)
-          const currentEndpoint = config.get<string>("apiEndpoint");
-          if (!currentEndpoint || currentEndpoint.trim() === "") {
-            await config.update(
-              "apiEndpoint",
-              WCA_API_ENDPOINT_DEFAULT,
-              configTarget,
-            );
-          }
-          // If endpoint is already set, keep it (user's custom on-prem WCA deployment)
-        }
-        await updateExplorerState(lightSpeedManager);
-      }
-
       await updateConfigurationChanges(
         metaData,
         pythonInterpreterManager,
@@ -468,26 +443,43 @@ export async function activate(context: ExtensionContext): Promise<void> {
     }),
   );
 
+  // Initialize QuickLinks provider early so it's available in auth callback
+  const quickLinksHome = new QuickLinksWebviewViewProvider(
+    context.extensionUri,
+    context,
+    llmProviderSettings,
+  );
+
   context.subscriptions.push(
     vscode.authentication.onDidChangeSessions(async (e) => {
       if (!LightspeedUser.isLightspeedUserAuthProviderType(e.provider.id)) {
         return;
       }
       await lightSpeedManager.lightspeedAuthenticatedUser.refreshLightspeedUser();
-      if (!lightSpeedManager.lightspeedAuthenticatedUser.isAuthenticated()) {
+      const isAuthenticated =
+        await lightSpeedManager.lightspeedAuthenticatedUser.isAuthenticated();
+
+      if (!isAuthenticated) {
         lightSpeedManager.currentModelValue = undefined;
       }
+
+      // Update WCA connection status based on auth state
+      await llmProviderSettings.setConnectionStatus(isAuthenticated, "wca");
+
+      // Refresh LLM Provider Panel if it's open
+      if (LlmProviderPanel.currentPanel) {
+        await LlmProviderPanel.currentPanel.refreshWebView();
+      }
+
+      // Refresh QuickLinks sidebar to update provider status
+      quickLinksHome.refreshProviderInfo();
+
       if (!extSettings.settings.lightSpeedService.enabled) {
         return;
       }
-      await updateExplorerState(lightSpeedManager);
+      lightSpeedManager.lightspeedExplorerProvider?.refreshWebView();
       lightSpeedManager.statusBarProvider.updateLightSpeedStatusbar();
     }),
-  );
-
-  const quickLinksHome = new QuickLinksWebviewViewProvider(
-    context.extensionUri,
-    context,
   );
 
   const quickLinksDisposable = window.registerWebviewViewProvider(
@@ -496,6 +488,22 @@ export async function activate(context: ExtensionContext): Promise<void> {
   );
 
   context.subscriptions.push(quickLinksDisposable);
+
+  // Register LLM Provider Settings panel command
+  const openLlmProviderSettingsCommand = vscode.commands.registerCommand(
+    LightSpeedCommands.LIGHTSPEED_OPEN_LLM_PROVIDER_SETTINGS,
+    () => {
+      LlmProviderPanel.render(context, {
+        settingsManager: extSettings,
+        providerManager: lightSpeedManager.providerManager,
+        llmProviderSettings: llmProviderSettings,
+        lightspeedUser: lightSpeedManager.lightspeedAuthenticatedUser,
+        quickLinksProvider: quickLinksHome,
+      });
+    },
+  );
+
+  context.subscriptions.push(openLlmProviderSettingsCommand);
 
   // handle lightSpeed feedback
   const lightspeedFeedbackProvider = new LightspeedFeedbackWebviewViewProvider(
@@ -984,7 +992,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
       async () => {
         console.log("Refreshing Lightspeed Explorer View");
         await lightSpeedManager.lightspeedAuthenticatedUser.updateUserInformation();
-        await updateExplorerState(lightSpeedManager);
+        lightSpeedManager.lightspeedExplorerProvider?.refreshWebView();
       },
     ),
   );
@@ -1223,15 +1231,6 @@ export function deactivate(): Thenable<void> | undefined {
     return undefined;
   }
   return client.stop();
-}
-
-/**
- * Updates the explorer state and sends it to the explorer webview if it's open
- */
-async function updateExplorerState(
-  lightSpeedManager: LightSpeedManager,
-): Promise<void> {
-  lightSpeedManager.lightspeedExplorerProvider.refreshWebView();
 }
 
 const handleMcpServerConfigurationChange = async (

--- a/src/features/lightspeed/base.ts
+++ b/src/features/lightspeed/base.ts
@@ -22,11 +22,13 @@ import { LightspeedUser } from "./lightspeedUser";
 import { Log } from "../../utils/logger";
 import { LightspeedExplorerWebviewViewProvider } from "./explorerWebviewViewProvider";
 import { ProviderManager } from "./providerManager";
+import { LlmProviderSettings } from "./llmProviderSettings";
 
 export class LightSpeedManager {
   private context;
   public settingsManager: SettingsManager;
   public telemetry: TelemetryManager;
+  public llmProviderSettings: LlmProviderSettings;
   public apiInstance: LightSpeedAPI;
   public lightSpeedAuthenticationProvider: LightSpeedAuthenticationProvider;
   public lightspeedAuthenticatedUser: LightspeedUser;
@@ -37,7 +39,9 @@ export class LightSpeedManager {
   public ansibleRolesCache: IWorkSpaceRolesContext = {};
   public ansibleIncludeVarsCache: IIncludeVarsContext = {};
   public currentModelValue: string | undefined = undefined;
-  public lightspeedExplorerProvider: LightspeedExplorerWebviewViewProvider;
+  public lightspeedExplorerProvider:
+    | LightspeedExplorerWebviewViewProvider
+    | undefined;
   public providerManager: ProviderManager;
   private logger: Log;
 
@@ -45,10 +49,12 @@ export class LightSpeedManager {
     context: vscode.ExtensionContext,
     settingsManager: SettingsManager,
     telemetry: TelemetryManager,
+    llmProviderSettings: LlmProviderSettings,
   ) {
     this.context = context;
     this.settingsManager = settingsManager;
     this.telemetry = telemetry;
+    this.llmProviderSettings = llmProviderSettings;
     this.lightSpeedActivityTracker = {};
     this.currentModelValue = undefined;
     this.logger = new Log();
@@ -99,15 +105,9 @@ export class LightSpeedManager {
       settingsManager,
     );
 
-    // Register the Explorer webview view provider for the sidebar
-    this.lightspeedExplorerProvider = new LightspeedExplorerWebviewViewProvider(
-      this.context,
-    );
-    const explorerDisposable = vscode.window.registerWebviewViewProvider(
-      LightspeedExplorerWebviewViewProvider.viewType,
-      this.lightspeedExplorerProvider,
-    );
-    context.subscriptions.push(explorerDisposable);
+    // Explorer webview has been replaced by LLM Provider panel
+    // Generative AI features are now in the LLM Provider Settings panel
+    this.lightspeedExplorerProvider = undefined;
 
     // create workspace context for ansible roles
     this.setContext();

--- a/src/features/lightspeed/lightspeedUser.ts
+++ b/src/features/lightspeed/lightspeedUser.ts
@@ -412,8 +412,9 @@ export class LightspeedUser {
     }
 
     // Skip user details check for LLM providers (only needed for WCA)
+    // But allow if explicitly requesting auth (createIfNone = true)
     const provider = this._settingsManager.settings.lightSpeedService.provider;
-    if (provider && provider !== "wca") {
+    if (!createIfNone && provider && provider !== "wca") {
       return undefined;
     }
     if (

--- a/src/features/lightspeed/llmProviderSettings.ts
+++ b/src/features/lightspeed/llmProviderSettings.ts
@@ -1,0 +1,220 @@
+import * as vscode from "vscode";
+import { ExtensionContext } from "vscode";
+import { providerFactory } from "./providers/factory";
+
+/**
+ * Service for managing LLM provider settings.
+ * Uses VS Code's globalState for regular settings and secrets for sensitive data.
+ */
+export class LlmProviderSettings {
+  private static readonly PROVIDER_KEY = "lightspeed.provider";
+  private static readonly SETTING_PREFIX = "lightspeed.setting.";
+  private static readonly SECRET_PREFIX = "lightspeed.secret.";
+  private static readonly CONNECTION_STATUS_PREFIX =
+    "lightspeed.connectionStatus.";
+  private static readonly MIGRATION_KEY = "lightspeed.migratedFromSettings";
+  private static readonly DEFAULT_PROVIDER = "wca";
+
+  constructor(private readonly context: ExtensionContext) {}
+
+  /**
+   * One time import of deprecated settings.json values into Panel storage.
+   * Must be called once during extension activation.
+   */
+  async migrateFromSettingsJson(): Promise<void> {
+    if (
+      this.context.globalState.get<boolean>(LlmProviderSettings.MIGRATION_KEY)
+    ) {
+      return;
+    }
+
+    const cfg = vscode.workspace.getConfiguration("ansible.lightspeed");
+    const inspect = (key: string) => {
+      const i = cfg.inspect<string>(key);
+      return i?.workspaceValue ?? i?.globalValue;
+    };
+
+    // Import provider first — it determines where other fields are stored
+    const legacyProvider = inspect("provider");
+    if (
+      legacyProvider &&
+      this.context.globalState.get(LlmProviderSettings.PROVIDER_KEY) ===
+        undefined
+    ) {
+      await this.setProvider(legacyProvider);
+    }
+
+    // Import remaining fields scoped to the resolved provider
+    const targetProvider = this.getProvider();
+    const providerInfo = this.getProviderInfo(targetProvider);
+
+    for (const key of ["apiEndpoint", "modelName", "apiKey"]) {
+      const legacy = inspect(key);
+      if (!legacy) continue;
+
+      const field = providerInfo?.configSchema.find((f) => f.key === key);
+      if (!field) continue;
+
+      if (field.type === "password") {
+        const secretKey = `${LlmProviderSettings.SECRET_PREFIX}${targetProvider}.${key}`;
+        if ((await this.context.secrets.get(secretKey)) === undefined) {
+          await this.context.secrets.store(secretKey, legacy);
+        }
+      } else {
+        const stateKey = `${LlmProviderSettings.SETTING_PREFIX}${targetProvider}.${key}`;
+        if (this.context.globalState.get<string>(stateKey) === undefined) {
+          await this.context.globalState.update(stateKey, legacy.trim());
+        }
+      }
+    }
+
+    await this.context.globalState.update(
+      LlmProviderSettings.MIGRATION_KEY,
+      true,
+    );
+  }
+
+  /**
+   * Get a setting value for a provider.
+   */
+  async get(provider: string, key: string): Promise<string> {
+    const providerInfo = this.getProviderInfo(provider);
+    const field = providerInfo?.configSchema.find((f) => f.key === key);
+
+    if (field?.type === "password") {
+      const secretKey = `${LlmProviderSettings.SECRET_PREFIX}${provider}.${key}`;
+      return (await this.context.secrets.get(secretKey)) ?? "";
+    }
+
+    const stateKey = `${LlmProviderSettings.SETTING_PREFIX}${provider}.${key}`;
+    const value = this.context.globalState.get<string>(stateKey);
+    if (value !== undefined) {
+      return value.trim();
+    }
+
+    if (key === "apiEndpoint") {
+      return providerInfo?.defaultEndpoint ?? "";
+    }
+    if (key === "modelName") {
+      return providerInfo?.defaultModel ?? "";
+    }
+    return "";
+  }
+
+  /**
+   * Set a setting value for a provider.
+   */
+  async set(
+    provider: string,
+    key: string,
+    value: string | undefined,
+  ): Promise<void> {
+    const providerInfo = this.getProviderInfo(provider);
+    const field = providerInfo?.configSchema.find((f) => f.key === key);
+
+    if (field?.type === "password") {
+      const secretKey = `${LlmProviderSettings.SECRET_PREFIX}${provider}.${key}`;
+      if (value) {
+        await this.context.secrets.store(secretKey, value);
+      } else {
+        await this.context.secrets.delete(secretKey);
+      }
+      return;
+    }
+
+    const stateKey = `${LlmProviderSettings.SETTING_PREFIX}${provider}.${key}`;
+    await this.context.globalState.update(stateKey, value?.trim() ?? "");
+  }
+
+  private getProviderInfo(providerType: string) {
+    return providerFactory
+      .getSupportedProviders()
+      .find((p) => p.type === providerType);
+  }
+
+  getProvider(): string {
+    return (
+      this.context.globalState.get<string>(LlmProviderSettings.PROVIDER_KEY) ??
+      LlmProviderSettings.DEFAULT_PROVIDER
+    );
+  }
+
+  async setProvider(value: string): Promise<void> {
+    await this.context.globalState.update(
+      LlmProviderSettings.PROVIDER_KEY,
+      value,
+    );
+  }
+
+  getConnectionStatus(provider?: string): boolean {
+    const targetProvider = provider ?? this.getProvider();
+    const key = `${LlmProviderSettings.CONNECTION_STATUS_PREFIX}${targetProvider}`;
+    return this.context.globalState.get<boolean>(key) ?? false;
+  }
+
+  async setConnectionStatus(
+    connected: boolean,
+    provider?: string,
+  ): Promise<void> {
+    const targetProvider = provider ?? this.getProvider();
+    const key = `${LlmProviderSettings.CONNECTION_STATUS_PREFIX}${targetProvider}`;
+    await this.context.globalState.update(key, connected);
+  }
+
+  getAllConnectionStatuses(): Record<string, boolean> {
+    const providers = providerFactory.getSupportedProviders();
+    const statuses: Record<string, boolean> = {};
+    for (const provider of providers) {
+      statuses[provider.type] = this.getConnectionStatus(provider.type);
+    }
+    return statuses;
+  }
+
+  async getAllSettings(): Promise<{
+    provider: string;
+    apiEndpoint: string;
+    modelName: string | undefined;
+    apiKey: string;
+    connectionStatuses: Record<string, boolean>;
+  }> {
+    const currentProvider = this.getProvider();
+    const apiEndpoint = await this.get(currentProvider, "apiEndpoint");
+    const modelName = await this.get(currentProvider, "modelName");
+    const apiKey = await this.get(currentProvider, "apiKey");
+
+    return {
+      provider: currentProvider,
+      apiEndpoint,
+      modelName: modelName || undefined,
+      apiKey,
+      connectionStatuses: this.getAllConnectionStatuses(),
+    };
+  }
+
+  async clearAllSettings(): Promise<void> {
+    await this.context.globalState.update(
+      LlmProviderSettings.PROVIDER_KEY,
+      undefined,
+    );
+
+    const providers = providerFactory.getSupportedProviders();
+    for (const provider of providers) {
+      for (const field of provider.configSchema) {
+        if (field.type === "password") {
+          await this.context.secrets.delete(
+            `${LlmProviderSettings.SECRET_PREFIX}${provider.type}.${field.key}`,
+          );
+        } else {
+          await this.context.globalState.update(
+            `${LlmProviderSettings.SETTING_PREFIX}${provider.type}.${field.key}`,
+            undefined,
+          );
+        }
+      }
+      await this.context.globalState.update(
+        `${LlmProviderSettings.CONNECTION_STATUS_PREFIX}${provider.type}`,
+        undefined,
+      );
+    }
+  }
+}

--- a/src/features/lightspeed/providers/factory.ts
+++ b/src/features/lightspeed/providers/factory.ts
@@ -48,6 +48,7 @@ export class LLMProviderFactory implements ProviderFactory {
             `Custom API endpoints are not supported for Google Gemini provider. The endpoint is automatically configured. Please remove 'ansible.lightspeed.apiEndpoint' from your settings.`,
           );
         }
+
         return new GoogleProvider({
           apiKey: config.apiKey,
           modelName: config.modelName || GOOGLE_DEFAULT_MODEL,
@@ -66,11 +67,13 @@ export class LLMProviderFactory implements ProviderFactory {
       {
         type: "wca",
         name: "wca",
-        displayName:
-          "Red Hat Ansible Lightspeed with IBM watsonx Code Assistant",
+        displayName: "IBM watsonx",
         description:
           "Official Red Hat Ansible Lightspeed service with IBM watsonx Code Assistant",
         defaultEndpoint: WCA_API_ENDPOINT_DEFAULT,
+        defaultModel: undefined, // WCA uses organization default
+        usesOAuth: true,
+        requiresApiKey: false,
         configSchema: [
           {
             key: "apiEndpoint",
@@ -88,13 +91,25 @@ export class LLMProviderFactory implements ProviderFactory {
         displayName: "Google Gemini",
         description: "Direct access to Google Gemini models",
         defaultEndpoint: GOOGLE_API_ENDPOINT,
+        defaultModel: GOOGLE_DEFAULT_MODEL,
+        usesOAuth: false,
+        requiresApiKey: true,
         configSchema: [
+          {
+            key: "apiEndpoint",
+            label: "API Endpoint",
+            type: "string",
+            required: false,
+            placeholder: GOOGLE_API_ENDPOINT,
+            description:
+              "API endpoint URL (leave empty for default, only localhost URLs supported for testing)",
+          },
           {
             key: "apiKey",
             label: "API Key",
             type: "password",
             required: true,
-            placeholder: "AIza...",
+            placeholder: "",
             description: "Your Google AI API key",
           },
           {

--- a/src/features/lightspeed/utils/webUtils.ts
+++ b/src/features/lightspeed/utils/webUtils.ts
@@ -7,7 +7,10 @@ import {
   LightspeedUserDetails,
   LightspeedSessionInfo,
 } from "../../../interfaces/lightspeed";
-import { LIGHTSPEED_USER_TYPE } from "../../../definitions/lightspeed";
+import {
+  LIGHTSPEED_USER_TYPE,
+  WCA_API_ENDPOINT_DEFAULT,
+} from "../../../definitions/lightspeed";
 import { lightSpeedManager } from "../../../extension";
 
 // Also defined in package.json in "".contributes.authentication"
@@ -47,7 +50,21 @@ export function calculateTokenExpiryTime(expiresIn: number) {
 }
 
 /* Get base uri in a correct formatted way */
-export function getBaseUri(settingsManager: SettingsManager): string {
+export function getBaseUri(
+  settingsManager: SettingsManager,
+  providerOverride?: string,
+): string {
+  // Check the provider from globalState via lightSpeedManager if available
+  const provider =
+    providerOverride ||
+    lightSpeedManager?.llmProviderSettings?.getProvider() ||
+    settingsManager.settings.lightSpeedService.provider;
+
+  // For WCA, always use the default WCA endpoint
+  if (provider === "wca") {
+    return WCA_API_ENDPOINT_DEFAULT;
+  }
+
   const baseUri = settingsManager.settings.lightSpeedService.apiEndpoint.trim();
   return baseUri.endsWith("/") ? baseUri.slice(0, -1) : baseUri;
 }

--- a/src/features/lightspeed/vue/views/llmProviderMessageHandlers.ts
+++ b/src/features/lightspeed/vue/views/llmProviderMessageHandlers.ts
@@ -1,0 +1,365 @@
+import type { Webview } from "vscode";
+import { window, commands } from "vscode";
+import { SettingsManager } from "../../../../settings";
+import { providerFactory } from "../../providers/factory";
+import { ProviderManager } from "../../providerManager";
+import { LlmProviderSettings } from "../../llmProviderSettings";
+import { LightSpeedCommands } from "../../../../definitions/lightspeed";
+import { LightspeedUser } from "../../lightspeedUser";
+import { QuickLinksWebviewViewProvider } from "../../../quickLinks/utils/quickLinksViewProvider";
+import { ProviderInfo } from "../../../../interfaces/lightspeed";
+
+interface LlmProviderMessage {
+  command: string;
+  provider?: string;
+  config?: Record<string, string>;
+}
+
+/**
+ * Dependencies required by LlmProviderMessageHandlers.
+ */
+export interface LlmProviderDependencies {
+  settingsManager: SettingsManager;
+  providerManager: ProviderManager;
+  llmProviderSettings: LlmProviderSettings;
+  lightspeedUser: LightspeedUser;
+  quickLinksProvider?: QuickLinksWebviewViewProvider;
+}
+
+/**
+ * Handles all message processing for the LLM Provider webview.
+ * Separates business logic from panel lifecycle management.
+ */
+export class LlmProviderMessageHandlers {
+  private readonly settingsManager: SettingsManager;
+  private readonly providerManager: ProviderManager;
+  private readonly llmProviderSettings: LlmProviderSettings;
+  private readonly lightspeedUser: LightspeedUser;
+  private readonly quickLinksProvider?: QuickLinksWebviewViewProvider;
+  private webview?: Webview;
+
+  constructor(deps: LlmProviderDependencies) {
+    this.settingsManager = deps.settingsManager;
+    this.providerManager = deps.providerManager;
+    this.llmProviderSettings = deps.llmProviderSettings;
+    this.lightspeedUser = deps.lightspeedUser;
+    this.quickLinksProvider = deps.quickLinksProvider;
+  }
+
+  /**
+   * Set the webview reference for message handlers.
+   */
+  public setWebview(webview: Webview): void {
+    this.webview = webview;
+  }
+
+  /**
+   * Handle incoming messages from the webview.
+   */
+  public async handleMessage(message: LlmProviderMessage): Promise<void> {
+    if (!this.webview) {
+      console.error("[LlmProviderMessageHandlers] Webview not set");
+      return;
+    }
+
+    switch (message.command) {
+      case "getProviderSettings":
+        await this.sendProviderSettings();
+        break;
+
+      case "saveProviderSettings":
+        await this.handleSaveSettings(message);
+        break;
+
+      case "activateProvider":
+        if (message.provider) {
+          await this.handleActivateProvider(message.provider);
+        }
+        break;
+
+      case "connectProvider":
+        if (message.provider) {
+          await this.handleConnectProvider(message.provider);
+        }
+        break;
+    }
+  }
+
+  /**
+   * Send current provider settings to the webview.
+   */
+  public async sendProviderSettings(): Promise<void> {
+    if (!this.webview) return;
+
+    const providers = providerFactory.getSupportedProviders();
+    const settings = await this.llmProviderSettings.getAllSettings();
+    const connectionStatuses = { ...settings.connectionStatuses };
+
+    // Build configs dynamically based on each provider's configSchema
+    const providerConfigs: Record<string, Record<string, string>> = {};
+    for (const provider of providers) {
+      const config: Record<string, string> = {};
+      for (const field of provider.configSchema) {
+        config[field.key] = await this.llmProviderSettings.get(
+          provider.type,
+          field.key,
+        );
+      }
+      providerConfigs[provider.type] = config;
+    }
+
+    this.webview.postMessage({
+      command: "providerSettings",
+      providers: providers,
+      currentProvider: settings.provider,
+      providerConfigs: providerConfigs,
+      connectionStatuses: connectionStatuses,
+    });
+  }
+
+  /**
+   * Get provider info by type from factory.
+   */
+  private getProviderInfo(providerType: string): ProviderInfo | undefined {
+    return providerFactory
+      .getSupportedProviders()
+      .find((p) => p.type === providerType);
+  }
+
+  /**
+   * Common pattern for updating UI and refreshing providers after changes.
+   */
+  private async updateAndNotify(): Promise<void> {
+    await this.sendProviderSettings();
+    this.quickLinksProvider?.refreshProviderInfo();
+
+    // Run heavy operations in background (don't block UI)
+    this.settingsManager.reinitialize().then(() => {
+      this.providerManager.refreshProviders().catch((error) => {
+        console.error("Failed to refresh providers:", error);
+      });
+    });
+  }
+
+  /**
+   * Handle saving provider settings.
+   */
+  private async handleSaveSettings(message: {
+    provider?: string;
+    config?: Record<string, string>;
+  }): Promise<void> {
+    if (!message.provider || !message.config) return;
+
+    try {
+      const providerInfo = this.getProviderInfo(message.provider);
+
+      // Update active provider
+      await this.llmProviderSettings.setProvider(message.provider);
+
+      // Save each field from the dynamic config based on configSchema
+      if (providerInfo) {
+        for (const field of providerInfo.configSchema) {
+          const value = message.config[field.key];
+          // Skip apiKey only if provider doesn't require it
+          // (but still save empty value to clear existing key)
+          if (field.key === "apiKey" && !providerInfo.requiresApiKey) {
+            continue;
+          }
+          await this.llmProviderSettings.set(
+            message.provider,
+            field.key,
+            value,
+          );
+        }
+      }
+
+      // Reset connection status when settings are changed (require re-connect)
+      await this.llmProviderSettings.setConnectionStatus(
+        false,
+        message.provider,
+      );
+
+      await this.updateAndNotify();
+    } catch (error) {
+      console.error("Failed to save provider settings:", error);
+    }
+  }
+
+  /**
+   * Handle activating a provider without resetting connection status.
+   */
+  private async handleActivateProvider(providerType: string): Promise<void> {
+    try {
+      await this.llmProviderSettings.setProvider(providerType);
+      await this.updateAndNotify();
+    } catch (error) {
+      console.error("Failed to activate provider:", error);
+    }
+  }
+
+  /**
+   * Handle connecting to a provider.
+   */
+  private async handleConnectProvider(providerType: string): Promise<void> {
+    if (!this.webview) return;
+
+    console.log(
+      `[LlmProviderMessageHandlers] handleConnectProvider called for: ${providerType}`,
+    );
+
+    try {
+      await this.llmProviderSettings.setProvider(providerType);
+      const providerInfo = this.getProviderInfo(providerType);
+
+      if (providerInfo?.usesOAuth) {
+        await this.connectWithOAuth(providerType, providerInfo);
+      } else {
+        await this.connectWithApiKey(providerType, providerInfo);
+      }
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : "Connection failed";
+      console.error(`Failed to connect provider ${providerType}:`, error);
+
+      window.showErrorMessage(
+        `Failed to connect to ${providerType.toUpperCase()}: ${errorMessage}`,
+      );
+
+      this.webview.postMessage({
+        command: "connectionResult",
+        provider: providerType,
+        connected: false,
+        error: errorMessage,
+      });
+    }
+  }
+
+  /**
+   * Handle connection result - show notification, update status, notify webview.
+   */
+  private async handleConnectionResult(
+    providerType: string,
+    displayName: string,
+    connected: boolean,
+    error: string | undefined,
+  ): Promise<void> {
+    if (!this.webview) return;
+
+    await this.llmProviderSettings.setConnectionStatus(connected, providerType);
+
+    if (connected) {
+      window.showInformationMessage(
+        `Successfully connected to ${displayName}.`,
+      );
+    } else {
+      window.showErrorMessage(`Failed to connect to ${displayName}: ${error}`);
+    }
+
+    this.webview.postMessage({
+      command: "connectionResult",
+      provider: providerType,
+      connected,
+      error,
+    });
+
+    await this.sendProviderSettings();
+    this.quickLinksProvider?.refreshProviderInfo();
+  }
+
+  /**
+   * Connect to an OAuth-based provider (e.g., WCA).
+   */
+  private async connectWithOAuth(
+    providerType: string,
+    providerInfo: ProviderInfo | undefined,
+  ): Promise<void> {
+    await commands.executeCommand(LightSpeedCommands.LIGHTSPEED_AUTH_REQUEST);
+
+    const isAuth = await this.lightspeedUser.isAuthenticated();
+    const displayName = providerInfo?.displayName || providerType.toUpperCase();
+
+    await this.handleConnectionResult(
+      providerType,
+      displayName,
+      isAuth,
+      isAuth ? undefined : "Authentication failed or was cancelled.",
+    );
+  }
+
+  /**
+   * Connect to an API key-based provider (e.g., Google).
+   */
+  private async connectWithApiKey(
+    providerType: string,
+    providerInfo: ProviderInfo | undefined,
+  ): Promise<void> {
+    const result = await this.validateProviderConnection(providerType);
+    const displayName = providerInfo?.displayName || providerType.toUpperCase();
+
+    await this.handleConnectionResult(
+      providerType,
+      displayName,
+      result.connected,
+      result.error,
+    );
+  }
+
+  /**
+   * Validate connection to a provider.
+   */
+  private async validateProviderConnection(
+    providerType: string,
+  ): Promise<{ connected: boolean; error?: string }> {
+    try {
+      const providerInfo = this.getProviderInfo(providerType);
+
+      const apiKey = await this.llmProviderSettings.get(providerType, "apiKey");
+      const modelName = await this.llmProviderSettings.get(
+        providerType,
+        "modelName",
+      );
+      const storedEndpoint = await this.llmProviderSettings.get(
+        providerType,
+        "apiEndpoint",
+      );
+
+      if (providerInfo?.requiresApiKey && !apiKey) {
+        return {
+          connected: false,
+          error:
+            "API key is required. Please enter your API key in the settings.",
+        };
+      }
+
+      // Use stored endpoint as-is (allows custom endpoints, v2, proxies, etc.)
+      const apiEndpoint = storedEndpoint || "";
+
+      const provider = providerFactory.createProvider(
+        providerType as "google",
+        {
+          apiKey,
+          modelName,
+          apiEndpoint,
+          enabled: true,
+          provider: providerType,
+          timeout: 30000,
+          suggestions: { enabled: true, waitWindow: 0 },
+        },
+      );
+
+      const status = await provider.getStatus();
+      if (!status.connected) {
+        return {
+          connected: false,
+          error: status.error || "Failed to connect to the provider.",
+        };
+      }
+      return { connected: true };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : "Unknown error occurred";
+      console.error(`Provider validation failed for ${providerType}:`, error);
+      return { connected: false, error: errorMessage };
+    }
+  }
+}

--- a/src/features/lightspeed/vue/views/llmProviderPanel.ts
+++ b/src/features/lightspeed/vue/views/llmProviderPanel.ts
@@ -1,0 +1,123 @@
+import type { Disposable, ExtensionContext, WebviewPanel } from "vscode";
+import { ViewColumn, Uri, window } from "vscode";
+import { disposePanelResources } from "./panelUtils";
+import {
+  LlmProviderMessageHandlers,
+  LlmProviderDependencies,
+} from "./llmProviderMessageHandlers";
+import { providerFactory } from "../../providers/factory";
+
+/**
+ * Main panel for LLM Provider settings.
+ * Opens as a full webview panel in the editor area.
+ */
+export class LlmProviderPanel {
+  public static currentPanel: LlmProviderPanel | undefined;
+  private readonly _panel: WebviewPanel;
+  private _disposables: Disposable[] = [];
+  private readonly messageHandlers: LlmProviderMessageHandlers;
+
+  // Get panel title based on active provider.
+  private static getPanelTitle(deps: LlmProviderDependencies): string {
+    const activeProviderType =
+      deps.settingsManager.settings.lightSpeedService.provider;
+
+    if (!activeProviderType) {
+      return "Configure LLM Provider";
+    }
+
+    const providerInfo = providerFactory
+      .getSupportedProviders()
+      .find((p) => p.type === activeProviderType);
+
+    if (providerInfo) {
+      return `LLM Provider: ${providerInfo.displayName}`;
+    }
+
+    return "Configure LLM Provider";
+  }
+
+  private constructor(
+    panel: WebviewPanel,
+    context: ExtensionContext,
+    deps: LlmProviderDependencies,
+  ) {
+    this._panel = panel;
+    this.messageHandlers = new LlmProviderMessageHandlers(deps);
+
+    // Set up panel lifecycle
+    this._panel.onDidDispose(() => this.dispose(), null, this._disposables);
+
+    // Set the HTML content
+    this._panel.webview.html = this._getWebviewContent(context);
+
+    // Set up message handler
+    this.messageHandlers.setWebview(this._panel.webview);
+    this._panel.webview.onDidReceiveMessage(
+      async (message) => {
+        await this.messageHandlers.handleMessage(message);
+      },
+      undefined,
+      this._disposables,
+    );
+
+    // Send initial settings
+    this.messageHandlers.sendProviderSettings();
+  }
+
+  // Renders the LLM Provider panel or reveals it if already open.
+  public static render(
+    context: ExtensionContext,
+    deps: LlmProviderDependencies,
+  ) {
+    if (LlmProviderPanel.currentPanel) {
+      LlmProviderPanel.currentPanel._panel.reveal(ViewColumn.One);
+    } else {
+      const panelTitle = LlmProviderPanel.getPanelTitle(deps);
+      const panel = window.createWebviewPanel(
+        "llm-provider-settings",
+        panelTitle,
+        ViewColumn.One,
+        {
+          enableScripts: true,
+          enableCommandUris: true,
+          retainContextWhenHidden: true,
+          localResourceRoots: [
+            Uri.joinPath(context.extensionUri, "out"),
+            Uri.joinPath(context.extensionUri, "media"),
+          ],
+        },
+      );
+
+      LlmProviderPanel.currentPanel = new LlmProviderPanel(
+        panel,
+        context,
+        deps,
+      );
+    }
+  }
+
+  /**
+   * Refreshes the webview with updated settings.
+   */
+  public async refreshWebView() {
+    await this.messageHandlers.sendProviderSettings();
+  }
+
+  private _getWebviewContent(context: ExtensionContext): string {
+    return __getWebviewHtml__({
+      serverUrl: `${process.env.VITE_DEV_SERVER_URL}webviews/llm-provider.html`,
+      webview: this._panel.webview,
+      context,
+      inputName: "llm-provider",
+    });
+  }
+
+  /**
+   * Cleans up and disposes of webview resources when the webview panel is closed.
+   */
+  public dispose() {
+    LlmProviderPanel.currentPanel = undefined;
+    disposePanelResources(this._panel, this._disposables);
+  }
+}

--- a/src/interfaces/lightspeed.ts
+++ b/src/interfaces/lightspeed.ts
@@ -310,6 +310,11 @@ export interface ProviderInfo {
   description: string;
   configSchema: ConfigField[];
   defaultEndpoint?: string;
+  defaultModel?: string;
+  /** Whether this provider uses OAuth for authentication (e.g., WCA) */
+  usesOAuth?: boolean;
+  /** Whether this provider requires an API key (e.g., Google). False for OAuth providers. */
+  requiresApiKey?: boolean;
 }
 
 export interface ProviderFactory {

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -15,5 +15,5 @@ export async function updateConfigurationChanges(
   await pythonInterpreter.updatePythonInfoInStatusbar();
   // Refresh LLM provider when settings change (API key, model, etc.)
   await lightSpeedManager.providerManager.refreshProviders();
-  lightSpeedManager.lightspeedExplorerProvider.refreshWebView();
+  lightSpeedManager.lightspeedExplorerProvider?.refreshWebView();
 }

--- a/test/ui/test_03_llm_provider_webview.py
+++ b/test/ui/test_03_llm_provider_webview.py
@@ -1,0 +1,94 @@
+"""Smoke tests for the LLM Provider Settings webview."""
+
+# pylint: disable=E0401, W0613, R0801
+from typing import Any
+
+from test.ui.utils.ui_utils import (
+    ensure_vscode_ready,
+    find_element_across_iframes,
+    vscode_run_command,
+)
+
+
+def test_llm_provider_webview_opens(
+    browser_setup: Any,
+    screenshot_on_fail: Any,
+    close_editors: Any,
+) -> None:
+    """Test that the LLM Provider Settings webview opens and renders."""
+    driver, _ = browser_setup
+
+    ensure_vscode_ready(driver)
+
+    vscode_run_command(driver, ">Ansible Lightspeed: Open LLM Provider Settings")
+
+    find_element_across_iframes(
+        driver,
+        "//h1[text()='LLM Provider Settings']",
+        retries=15,
+    )
+
+
+def test_llm_provider_webview_lists_providers(
+    browser_setup: Any,
+    screenshot_on_fail: Any,
+    close_editors: Any,
+) -> None:
+    """Test that all supported providers are listed in the webview."""
+    driver, _ = browser_setup
+
+    ensure_vscode_ready(driver)
+
+    vscode_run_command(driver, ">Ansible Lightspeed: Open LLM Provider Settings")
+
+    find_element_across_iframes(
+        driver,
+        "//h1[text()='LLM Provider Settings']",
+        retries=15,
+    )
+
+    wca_provider = find_element_across_iframes(
+        driver,
+        "//*[contains(@class, 'provider-name') and contains(., 'IBM watsonx')]",
+        retries=10,
+    )
+    assert wca_provider is not None, "IBM watsonx provider should be listed"
+
+    google_provider = find_element_across_iframes(
+        driver,
+        "//*[contains(@class, 'provider-name') and contains(., 'Google Gemini')]",
+        retries=10,
+    )
+    assert google_provider is not None, "Google Gemini provider should be listed"
+
+
+def test_llm_provider_webview_edit_button(
+    browser_setup: Any,
+    screenshot_on_fail: Any,
+    close_editors: Any,
+) -> None:
+    """Test that clicking Edit on a provider reveals the config form."""
+    driver, _ = browser_setup
+
+    ensure_vscode_ready(driver)
+
+    vscode_run_command(driver, ">Ansible Lightspeed: Open LLM Provider Settings")
+
+    find_element_across_iframes(
+        driver,
+        "//h1[text()='LLM Provider Settings']",
+        retries=15,
+    )
+
+    edit_button = find_element_across_iframes(
+        driver,
+        "//button[contains(@class, 'edit-btn')]",
+        retries=10,
+    )
+    edit_button.click()
+
+    find_element_across_iframes(
+        driver,
+        "//button[contains(., 'Save')]",
+        retries=10,
+    )

--- a/test/unit/lightspeed/llmProviderSettings.test.ts
+++ b/test/unit/lightspeed/llmProviderSettings.test.ts
@@ -1,0 +1,579 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import * as vscode from "vscode";
+import { LlmProviderSettings } from "@src/features/lightspeed/llmProviderSettings";
+import type { ExtensionContext, SecretStorage, Memento } from "vscode";
+import { PROVIDER_TYPES, TEST_API_KEYS } from "./testConstants";
+
+vi.mock("@src/features/lightspeed/providers/factory", () => {
+  const mockWcaProvider = {
+    type: "wca",
+    name: "wca",
+    displayName: "IBM watsonx",
+    defaultEndpoint: "https://c.ai.ansible.redhat.com",
+    defaultModel: undefined,
+    configSchema: [
+      {
+        key: "apiEndpoint",
+        label: "Lightspeed URL",
+        type: "string",
+        required: true,
+        placeholder: "https://c.ai.ansible.redhat.com",
+      },
+    ],
+  };
+
+  const mockGoogleProvider = {
+    type: "google",
+    name: "google",
+    displayName: "Google Gemini",
+    defaultEndpoint: "https://generativelanguage.googleapis.com/v1beta",
+    defaultModel: "gemini-2.5-flash",
+    configSchema: [
+      {
+        key: "apiEndpoint",
+        label: "API Endpoint",
+        type: "string",
+        required: false,
+        placeholder: "https://generativelanguage.googleapis.com/v1beta",
+      },
+      {
+        key: "apiKey",
+        label: "API Key",
+        type: "password",
+        required: true,
+        placeholder: "AIza...",
+      },
+      {
+        key: "modelName",
+        label: "Model Name",
+        type: "string",
+        required: false,
+        placeholder: "gemini-2.5-flash",
+      },
+    ],
+  };
+
+  return {
+    providerFactory: {
+      getSupportedProviders: vi.fn(() => [mockWcaProvider, mockGoogleProvider]),
+    },
+  };
+});
+
+describe("LlmProviderSettings", () => {
+  let llmProviderSettings: LlmProviderSettings;
+  let mockContext: ExtensionContext;
+  let mockGlobalState: Memento;
+  let mockSecrets: SecretStorage;
+  let globalStateStore: Map<string, unknown>;
+  let secretsStore: Map<string, string>;
+  let mockGlobalStateGet: ReturnType<typeof vi.fn>;
+  let mockGlobalStateUpdate: ReturnType<typeof vi.fn>;
+  let mockGlobalStateKeys: ReturnType<typeof vi.fn>;
+  let mockSecretsGet: ReturnType<typeof vi.fn>;
+  let mockSecretsStore: ReturnType<typeof vi.fn>;
+  let mockSecretsDelete: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    globalStateStore = new Map();
+    secretsStore = new Map();
+
+    mockGlobalStateGet = vi.fn((key: string) => globalStateStore.get(key));
+    mockGlobalStateUpdate = vi.fn((key: string, value: unknown) => {
+      if (value === undefined) {
+        globalStateStore.delete(key);
+      } else {
+        globalStateStore.set(key, value);
+      }
+      return Promise.resolve();
+    });
+    mockGlobalStateKeys = vi.fn(() => Array.from(globalStateStore.keys()));
+
+    mockSecretsGet = vi.fn((key: string) =>
+      Promise.resolve(secretsStore.get(key)),
+    );
+    mockSecretsStore = vi.fn((key: string, value: string) => {
+      secretsStore.set(key, value);
+      return Promise.resolve();
+    });
+    mockSecretsDelete = vi.fn((key: string) => {
+      secretsStore.delete(key);
+      return Promise.resolve();
+    });
+
+    mockGlobalState = {
+      get: mockGlobalStateGet,
+      update: mockGlobalStateUpdate,
+      keys: mockGlobalStateKeys,
+      setKeysForSync: vi.fn(),
+    } as unknown as Memento;
+
+    mockSecrets = {
+      get: mockSecretsGet,
+      store: mockSecretsStore,
+      delete: mockSecretsDelete,
+      onDidChange: vi.fn(),
+    } as unknown as SecretStorage;
+
+    mockContext = {
+      globalState: mockGlobalState,
+      secrets: mockSecrets,
+    } as unknown as ExtensionContext;
+
+    // Default: no legacy settings in settings.json
+    const defaultConfig = {
+      inspect: vi.fn(() => undefined),
+    };
+    vi.mocked(vscode.workspace.getConfiguration).mockReturnValue(
+      defaultConfig as unknown as vscode.WorkspaceConfiguration,
+    );
+
+    llmProviderSettings = new LlmProviderSettings(mockContext);
+  });
+
+  describe("getProvider / setProvider", () => {
+    it("should return default provider (wca) when no provider is set", () => {
+      const provider = llmProviderSettings.getProvider();
+      expect(provider).toBe("wca");
+    });
+
+    it("should return the set provider", async () => {
+      await llmProviderSettings.setProvider(PROVIDER_TYPES.GOOGLE);
+      const provider = llmProviderSettings.getProvider();
+      expect(provider).toBe(PROVIDER_TYPES.GOOGLE);
+    });
+
+    it("should persist provider to globalState", async () => {
+      await llmProviderSettings.setProvider(PROVIDER_TYPES.GOOGLE);
+      expect(mockGlobalStateUpdate).toHaveBeenCalledWith(
+        "lightspeed.provider",
+        PROVIDER_TYPES.GOOGLE,
+      );
+    });
+  });
+
+  describe("get / set for regular fields", () => {
+    it("should return default endpoint for apiEndpoint field", async () => {
+      const endpoint = await llmProviderSettings.get("google", "apiEndpoint");
+      expect(endpoint).toBe("https://generativelanguage.googleapis.com/v1beta");
+    });
+
+    it("should return default model for modelName field", async () => {
+      const model = await llmProviderSettings.get("google", "modelName");
+      expect(model).toBe("gemini-2.5-flash");
+    });
+
+    it("should return stored value when set", async () => {
+      await llmProviderSettings.set("google", "modelName", "gemini-pro");
+      const model = await llmProviderSettings.get("google", "modelName");
+      expect(model).toBe("gemini-pro");
+    });
+
+    it("should store regular fields in globalState", async () => {
+      await llmProviderSettings.set("google", "modelName", "gemini-pro");
+      expect(mockGlobalStateUpdate).toHaveBeenCalledWith(
+        "lightspeed.setting.google.modelName",
+        "gemini-pro",
+      );
+    });
+
+    it("should return empty string for unknown fields", async () => {
+      const value = await llmProviderSettings.get("google", "unknownField");
+      expect(value).toBe("");
+    });
+  });
+
+  describe("get / set for password fields (secrets)", () => {
+    it("should store API key in secrets storage", async () => {
+      await llmProviderSettings.set("google", "apiKey", TEST_API_KEYS.GOOGLE);
+      expect(mockSecretsStore).toHaveBeenCalledWith(
+        "lightspeed.secret.google.apiKey",
+        TEST_API_KEYS.GOOGLE,
+      );
+    });
+
+    it("should retrieve API key from secrets storage", async () => {
+      secretsStore.set("lightspeed.secret.google.apiKey", TEST_API_KEYS.GOOGLE);
+      const apiKey = await llmProviderSettings.get("google", "apiKey");
+      expect(apiKey).toBe(TEST_API_KEYS.GOOGLE);
+    });
+
+    it("should return empty string when API key not set", async () => {
+      const apiKey = await llmProviderSettings.get("google", "apiKey");
+      expect(apiKey).toBe("");
+    });
+
+    it("should delete API key from secrets when set to empty", async () => {
+      await llmProviderSettings.set("google", "apiKey", "");
+      expect(mockSecretsDelete).toHaveBeenCalledWith(
+        "lightspeed.secret.google.apiKey",
+      );
+    });
+  });
+
+  describe("connection status", () => {
+    it("should return false when no connection status is set", () => {
+      const status = llmProviderSettings.getConnectionStatus("google");
+      expect(status).toBe(false);
+    });
+
+    it("should return true after setting connection status to true", async () => {
+      await llmProviderSettings.setConnectionStatus(true, "google");
+      const status = llmProviderSettings.getConnectionStatus("google");
+      expect(status).toBe(true);
+    });
+
+    it("should use current provider when provider not specified", async () => {
+      await llmProviderSettings.setProvider("google");
+      await llmProviderSettings.setConnectionStatus(true);
+      const status = llmProviderSettings.getConnectionStatus();
+      expect(status).toBe(true);
+    });
+
+    it("should get all connection statuses", async () => {
+      await llmProviderSettings.setConnectionStatus(true, "google");
+      await llmProviderSettings.setConnectionStatus(false, "wca");
+
+      const statuses = llmProviderSettings.getAllConnectionStatuses();
+      expect(statuses).toEqual({
+        wca: false,
+        google: true,
+      });
+    });
+  });
+
+  describe("getAllSettings", () => {
+    it("should return all settings for current provider", async () => {
+      await llmProviderSettings.setProvider("google");
+      secretsStore.set("lightspeed.secret.google.apiKey", TEST_API_KEYS.GOOGLE);
+      await llmProviderSettings.setConnectionStatus(true, "google");
+
+      const settings = await llmProviderSettings.getAllSettings();
+
+      expect(settings.provider).toBe("google");
+      expect(settings.apiKey).toBe(TEST_API_KEYS.GOOGLE);
+      expect(settings.apiEndpoint).toBe(
+        "https://generativelanguage.googleapis.com/v1beta",
+      );
+      expect(settings.modelName).toBe("gemini-2.5-flash");
+      expect(settings.connectionStatuses.google).toBe(true);
+    });
+  });
+
+  describe("clearAllSettings", () => {
+    it("should clear provider setting", async () => {
+      await llmProviderSettings.setProvider("google");
+      await llmProviderSettings.clearAllSettings();
+
+      expect(mockGlobalStateUpdate).toHaveBeenCalledWith(
+        "lightspeed.provider",
+        undefined,
+      );
+    });
+
+    it("should clear secrets for password fields", async () => {
+      await llmProviderSettings.set("google", "apiKey", TEST_API_KEYS.GOOGLE);
+      await llmProviderSettings.clearAllSettings();
+
+      expect(mockSecretsDelete).toHaveBeenCalledWith(
+        "lightspeed.secret.google.apiKey",
+      );
+    });
+
+    it("should clear connection statuses", async () => {
+      await llmProviderSettings.setConnectionStatus(true, "google");
+      await llmProviderSettings.clearAllSettings();
+
+      expect(mockGlobalStateUpdate).toHaveBeenCalledWith(
+        "lightspeed.connectionStatus.google",
+        undefined,
+      );
+    });
+  });
+
+  describe("whitespace handling", () => {
+    it("should trim whitespace from stored values on get", async () => {
+      globalStateStore.set(
+        "lightspeed.setting.google.modelName",
+        "  gemini-pro  ",
+      );
+      const model = await llmProviderSettings.get("google", "modelName");
+      expect(model).toBe("gemini-pro");
+    });
+
+    it("should trim whitespace when setting values", async () => {
+      await llmProviderSettings.set("google", "modelName", "  gemini-pro  ");
+      expect(mockGlobalStateUpdate).toHaveBeenCalledWith(
+        "lightspeed.setting.google.modelName",
+        "gemini-pro",
+      );
+    });
+
+    it("should handle undefined value by storing empty string", async () => {
+      await llmProviderSettings.set("google", "modelName", undefined);
+      expect(mockGlobalStateUpdate).toHaveBeenCalledWith(
+        "lightspeed.setting.google.modelName",
+        "",
+      );
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should return empty string for unknown provider apiEndpoint", async () => {
+      const endpoint = await llmProviderSettings.get(
+        "unknown-provider",
+        "apiEndpoint",
+      );
+      expect(endpoint).toBe("");
+    });
+
+    it("should return empty string for unknown provider modelName", async () => {
+      const model = await llmProviderSettings.get(
+        "unknown-provider",
+        "modelName",
+      );
+      expect(model).toBe("");
+    });
+
+    it("should return stored empty string instead of default", async () => {
+      await llmProviderSettings.set("google", "apiEndpoint", "");
+      const endpoint = await llmProviderSettings.get("google", "apiEndpoint");
+      expect(endpoint).toBe("");
+    });
+  });
+
+  describe("getAllSettings edge cases", () => {
+    it("should return undefined modelName when empty string", async () => {
+      await llmProviderSettings.setProvider("wca");
+      const settings = await llmProviderSettings.getAllSettings();
+      expect(settings.modelName).toBeUndefined();
+    });
+  });
+
+  describe("clearAllSettings comprehensive", () => {
+    it("should clear all regular fields for all providers", async () => {
+      await llmProviderSettings.set(
+        "google",
+        "apiEndpoint",
+        "https://test.com",
+      );
+      await llmProviderSettings.set("google", "modelName", "gemini-pro");
+      await llmProviderSettings.set("wca", "apiEndpoint", "https://wca.com");
+
+      await llmProviderSettings.clearAllSettings();
+
+      expect(mockGlobalStateUpdate).toHaveBeenCalledWith(
+        "lightspeed.setting.google.apiEndpoint",
+        undefined,
+      );
+      expect(mockGlobalStateUpdate).toHaveBeenCalledWith(
+        "lightspeed.setting.google.modelName",
+        undefined,
+      );
+      expect(mockGlobalStateUpdate).toHaveBeenCalledWith(
+        "lightspeed.setting.wca.apiEndpoint",
+        undefined,
+      );
+    });
+
+    it("should clear connection status for all providers", async () => {
+      await llmProviderSettings.setConnectionStatus(true, "google");
+      await llmProviderSettings.setConnectionStatus(true, "wca");
+
+      await llmProviderSettings.clearAllSettings();
+
+      expect(mockGlobalStateUpdate).toHaveBeenCalledWith(
+        "lightspeed.connectionStatus.google",
+        undefined,
+      );
+      expect(mockGlobalStateUpdate).toHaveBeenCalledWith(
+        "lightspeed.connectionStatus.wca",
+        undefined,
+      );
+    });
+  });
+
+  describe("provider info edge cases", () => {
+    it("should handle get for unknown provider without crashing", async () => {
+      const value = await llmProviderSettings.get("nonexistent", "someField");
+      expect(value).toBe("");
+    });
+
+    it("should handle set for unknown provider without crashing", async () => {
+      await llmProviderSettings.set("nonexistent", "someField", "value");
+      expect(mockGlobalStateUpdate).toHaveBeenCalledWith(
+        "lightspeed.setting.nonexistent.someField",
+        "value",
+      );
+    });
+  });
+
+  describe("migrateFromSettingsJson", () => {
+    let mockInspectValues: Record<
+      string,
+      { globalValue?: string; workspaceValue?: string } | undefined
+    >;
+
+    beforeEach(() => {
+      mockInspectValues = {};
+      const mockConfig = {
+        inspect: vi.fn((key: string) => mockInspectValues[key]),
+      };
+      vi.mocked(vscode.workspace.getConfiguration).mockReturnValue(
+        mockConfig as unknown as vscode.WorkspaceConfiguration,
+      );
+    });
+
+    it("should import provider from settings.json", async () => {
+      mockInspectValues["provider"] = {
+        globalValue: PROVIDER_TYPES.GOOGLE,
+      };
+
+      await llmProviderSettings.migrateFromSettingsJson();
+
+      expect(llmProviderSettings.getProvider()).toBe(PROVIDER_TYPES.GOOGLE);
+    });
+
+    it("should import apiEndpoint from settings.json", async () => {
+      mockInspectValues["provider"] = {
+        globalValue: PROVIDER_TYPES.GOOGLE,
+      };
+      mockInspectValues["apiEndpoint"] = {
+        globalValue: "https://custom.example.com",
+      };
+
+      await llmProviderSettings.migrateFromSettingsJson();
+
+      const endpoint = await llmProviderSettings.get("google", "apiEndpoint");
+      expect(endpoint).toBe("https://custom.example.com");
+    });
+
+    it("should import apiKey into secrets", async () => {
+      mockInspectValues["provider"] = {
+        globalValue: PROVIDER_TYPES.GOOGLE,
+      };
+      mockInspectValues["apiKey"] = {
+        globalValue: TEST_API_KEYS.GOOGLE,
+      };
+
+      await llmProviderSettings.migrateFromSettingsJson();
+
+      expect(mockSecretsStore).toHaveBeenCalledWith(
+        "lightspeed.secret.google.apiKey",
+        TEST_API_KEYS.GOOGLE,
+      );
+    });
+
+    it("should import modelName from settings.json", async () => {
+      mockInspectValues["provider"] = {
+        globalValue: PROVIDER_TYPES.GOOGLE,
+      };
+      mockInspectValues["modelName"] = {
+        globalValue: "gemini-pro",
+      };
+
+      await llmProviderSettings.migrateFromSettingsJson();
+
+      const model = await llmProviderSettings.get("google", "modelName");
+      expect(model).toBe("gemini-pro");
+    });
+
+    it("should prefer workspace value over global value", async () => {
+      mockInspectValues["provider"] = {
+        globalValue: PROVIDER_TYPES.WCA,
+        workspaceValue: PROVIDER_TYPES.GOOGLE,
+      };
+
+      await llmProviderSettings.migrateFromSettingsJson();
+
+      expect(llmProviderSettings.getProvider()).toBe(PROVIDER_TYPES.GOOGLE);
+    });
+
+    it("should not overwrite existing Panel values", async () => {
+      await llmProviderSettings.set("google", "modelName", "my-model");
+      await llmProviderSettings.setProvider(PROVIDER_TYPES.GOOGLE);
+      mockGlobalStateUpdate.mockClear();
+
+      mockInspectValues["provider"] = {
+        globalValue: PROVIDER_TYPES.WCA,
+      };
+      mockInspectValues["modelName"] = {
+        globalValue: "deprecated-model",
+      };
+
+      await llmProviderSettings.migrateFromSettingsJson();
+
+      expect(llmProviderSettings.getProvider()).toBe(PROVIDER_TYPES.GOOGLE);
+      const model = await llmProviderSettings.get("google", "modelName");
+      expect(model).toBe("my-model");
+    });
+
+    it("should skip keys not in the provider's configSchema", async () => {
+      mockInspectValues["provider"] = {
+        globalValue: PROVIDER_TYPES.WCA,
+      };
+      mockInspectValues["apiKey"] = {
+        globalValue: "some-key",
+      };
+
+      await llmProviderSettings.migrateFromSettingsJson();
+
+      // WCA has no apiKey in configSchema — should not be imported
+      expect(mockSecretsStore).not.toHaveBeenCalled();
+    });
+
+    it("should skip undefined legacy keys", async () => {
+      await llmProviderSettings.migrateFromSettingsJson();
+
+      expect(llmProviderSettings.getProvider()).toBe("wca");
+      const endpoint = await llmProviderSettings.get("google", "apiEndpoint");
+      expect(endpoint).toBe("https://generativelanguage.googleapis.com/v1beta");
+    });
+
+    it("should run only once", async () => {
+      mockInspectValues["provider"] = {
+        globalValue: PROVIDER_TYPES.GOOGLE,
+      };
+
+      await llmProviderSettings.migrateFromSettingsJson();
+      expect(llmProviderSettings.getProvider()).toBe(PROVIDER_TYPES.GOOGLE);
+
+      // Change legacy value and run again — should be ignored
+      mockInspectValues["provider"] = {
+        globalValue: PROVIDER_TYPES.WCA,
+      };
+      await llmProviderSettings.migrateFromSettingsJson();
+
+      expect(llmProviderSettings.getProvider()).toBe(PROVIDER_TYPES.GOOGLE);
+    });
+
+    it("should not consult settings.json after migration", async () => {
+      mockInspectValues["provider"] = {
+        globalValue: PROVIDER_TYPES.GOOGLE,
+      };
+      mockInspectValues["modelName"] = {
+        globalValue: "gemini-pro",
+      };
+
+      await llmProviderSettings.migrateFromSettingsJson();
+
+      // Change settings.json — get() should NOT reflect it
+      mockInspectValues["modelName"] = {
+        globalValue: "gemini-2.0-flash",
+      };
+      const model = await llmProviderSettings.get("google", "modelName");
+      expect(model).toBe("gemini-pro");
+    });
+
+    it("should set migration flag", async () => {
+      await llmProviderSettings.migrateFromSettingsJson();
+
+      expect(mockGlobalStateUpdate).toHaveBeenCalledWith(
+        "lightspeed.migratedFromSettings",
+        true,
+      );
+    });
+  });
+});

--- a/test/unit/lightspeed/providers/factory.test.ts
+++ b/test/unit/lightspeed/providers/factory.test.ts
@@ -131,7 +131,7 @@ describe("LLMProviderFactory", () => {
       expect(wcaProvider).toBeDefined();
       expect(wcaProvider?.type).toBe(PROVIDER_TYPES.WCA);
       expect(wcaProvider?.name).toBe("wca");
-      expect(wcaProvider?.displayName).toContain("Red Hat Ansible Lightspeed");
+      expect(wcaProvider?.displayName).toContain("IBM watsonx");
     });
 
     it("should include Google provider", () => {

--- a/test/unit/lightspeed/views/llmProviderMessageHandlers.test.ts
+++ b/test/unit/lightspeed/views/llmProviderMessageHandlers.test.ts
@@ -1,0 +1,790 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Webview } from "vscode";
+import { window, commands } from "vscode";
+import {
+  LlmProviderMessageHandlers,
+  LlmProviderDependencies,
+} from "@src/features/lightspeed/vue/views/llmProviderMessageHandlers";
+import type { SettingsManager } from "@src/settings";
+import type { ProviderManager } from "@src/features/lightspeed/providerManager";
+import type { LlmProviderSettings } from "@src/features/lightspeed/llmProviderSettings";
+import type { LightspeedUser } from "@src/features/lightspeed/lightspeedUser";
+import type { QuickLinksWebviewViewProvider } from "@src/features/quickLinks/utils/quickLinksViewProvider";
+import { PROVIDER_TYPES, TEST_API_KEYS, API_ENDPOINTS } from "../testConstants";
+
+const mockWcaProvider = {
+  type: "wca" as const,
+  name: "wca",
+  displayName: "IBM watsonx",
+  description: "Red Hat Ansible Lightspeed with IBM watsonx Code Assistant",
+  defaultEndpoint: "https://c.ai.ansible.redhat.com",
+  defaultModel: undefined,
+  usesOAuth: true,
+  requiresApiKey: false,
+  configSchema: [
+    {
+      key: "apiEndpoint",
+      label: "Lightspeed URL",
+      type: "string" as const,
+      required: true,
+      placeholder: "https://c.ai.ansible.redhat.com",
+    },
+  ],
+};
+
+const mockGoogleProvider = {
+  type: "google" as const,
+  name: "google",
+  displayName: "Google Gemini",
+  description: "Direct access to Google Gemini models",
+  defaultEndpoint: "https://generativelanguage.googleapis.com/v1beta",
+  defaultModel: "gemini-2.5-flash",
+  usesOAuth: false,
+  requiresApiKey: true,
+  configSchema: [
+    {
+      key: "apiEndpoint",
+      label: "API Endpoint",
+      type: "string" as const,
+      required: false,
+      placeholder: "https://generativelanguage.googleapis.com/v1beta",
+    },
+    {
+      key: "apiKey",
+      label: "API Key",
+      type: "password" as const,
+      required: true,
+      placeholder: "AIza...",
+    },
+    {
+      key: "modelName",
+      label: "Model Name",
+      type: "string" as const,
+      required: false,
+      placeholder: "gemini-2.5-flash",
+    },
+  ],
+};
+
+vi.mock("@src/features/lightspeed/providers/factory", () => ({
+  providerFactory: {
+    getSupportedProviders: vi.fn(() => [mockWcaProvider, mockGoogleProvider]),
+    createProvider: vi.fn(() => ({
+      getStatus: vi.fn().mockResolvedValue({ connected: true }),
+    })),
+  },
+}));
+
+import { providerFactory } from "@src/features/lightspeed/providers/factory";
+
+describe("LlmProviderMessageHandlers", () => {
+  let messageHandlers: LlmProviderMessageHandlers;
+  let mockWebview: Webview;
+  let mockDeps: LlmProviderDependencies;
+  let mockSettingsManager: SettingsManager;
+  let mockProviderManager: ProviderManager;
+  let mockLlmProviderSettings: LlmProviderSettings;
+  let mockLightspeedUser: LightspeedUser;
+  let mockQuickLinksProvider: QuickLinksWebviewViewProvider;
+
+  let mockPostMessage: ReturnType<typeof vi.fn>;
+  let mockSetProvider: ReturnType<typeof vi.fn>;
+  let mockSet: ReturnType<typeof vi.fn>;
+  let mockGet: ReturnType<typeof vi.fn>;
+  let mockSetConnectionStatus: ReturnType<typeof vi.fn>;
+  let mockIsAuthenticated: ReturnType<typeof vi.fn>;
+  let mockReinitialize: ReturnType<typeof vi.fn>;
+  let mockRefreshProviderInfo: ReturnType<typeof vi.fn>;
+
+  const mockedCommands = vi.mocked(commands);
+  const mockedWindow = vi.mocked(window);
+
+  const mockedGetSupportedProviders = vi.mocked(
+    providerFactory.getSupportedProviders,
+  );
+  const mockedCreateProvider = vi.mocked(providerFactory.createProvider);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockedGetSupportedProviders.mockReturnValue([
+      mockWcaProvider,
+      mockGoogleProvider,
+    ]);
+    mockedCreateProvider.mockReturnValue({
+      getStatus: vi.fn().mockResolvedValue({ connected: true }),
+    } as unknown as ReturnType<typeof providerFactory.createProvider>);
+
+    mockPostMessage = vi.fn().mockResolvedValue(true);
+    mockSetProvider = vi.fn().mockResolvedValue(undefined);
+    mockSet = vi.fn().mockResolvedValue(undefined);
+    mockGet = vi.fn().mockImplementation((provider: string, key: string) => {
+      if (key === "apiEndpoint")
+        return Promise.resolve(API_ENDPOINTS.WCA_DEFAULT);
+      if (key === "modelName") return Promise.resolve("");
+      if (key === "apiKey") return Promise.resolve(TEST_API_KEYS.GOOGLE);
+      return Promise.resolve("");
+    });
+    mockSetConnectionStatus = vi.fn().mockResolvedValue(undefined);
+    mockIsAuthenticated = vi.fn().mockResolvedValue(true);
+    mockReinitialize = vi.fn().mockResolvedValue(undefined);
+    mockRefreshProviderInfo = vi.fn();
+
+    mockWebview = {
+      postMessage: mockPostMessage,
+    } as unknown as Webview;
+
+    mockSettingsManager = {
+      settings: {
+        lightSpeedService: {
+          provider: "wca",
+        },
+      },
+      reinitialize: mockReinitialize,
+    } as unknown as SettingsManager;
+
+    mockProviderManager = {
+      refreshProviders: vi.fn().mockResolvedValue(undefined),
+    } as unknown as ProviderManager;
+
+    mockLlmProviderSettings = {
+      getProvider: vi.fn().mockReturnValue("wca"),
+      setProvider: mockSetProvider,
+      get: mockGet,
+      set: mockSet,
+      setConnectionStatus: mockSetConnectionStatus,
+      getConnectionStatus: vi.fn().mockReturnValue(false),
+      getAllConnectionStatuses: vi.fn().mockReturnValue({
+        wca: false,
+        google: false,
+      }),
+      getAllSettings: vi.fn().mockResolvedValue({
+        provider: "wca",
+        apiEndpoint: API_ENDPOINTS.WCA_DEFAULT,
+        modelName: undefined,
+        apiKey: "",
+        connectionStatuses: { wca: false, google: false },
+      }),
+    } as unknown as LlmProviderSettings;
+
+    mockLightspeedUser = {
+      isAuthenticated: mockIsAuthenticated,
+    } as unknown as LightspeedUser;
+
+    mockQuickLinksProvider = {
+      refreshProviderInfo: mockRefreshProviderInfo,
+    } as unknown as QuickLinksWebviewViewProvider;
+
+    mockDeps = {
+      settingsManager: mockSettingsManager,
+      providerManager: mockProviderManager,
+      llmProviderSettings: mockLlmProviderSettings,
+      lightspeedUser: mockLightspeedUser,
+      quickLinksProvider: mockQuickLinksProvider,
+    };
+
+    messageHandlers = new LlmProviderMessageHandlers(mockDeps);
+    messageHandlers.setWebview(mockWebview);
+  });
+
+  describe("setWebview", () => {
+    it("should set the webview reference", () => {
+      const handler = new LlmProviderMessageHandlers(mockDeps);
+      handler.setWebview(mockWebview);
+      expect(true).toBe(true);
+    });
+  });
+
+  describe("handleMessage", () => {
+    it("should handle getProviderSettings message", async () => {
+      await messageHandlers.handleMessage({ command: "getProviderSettings" });
+
+      expect(mockPostMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          command: "providerSettings",
+          providers: expect.any(Array),
+          currentProvider: "wca",
+        }),
+      );
+    });
+
+    it("should handle saveProviderSettings message", async () => {
+      const message = {
+        command: "saveProviderSettings",
+        provider: PROVIDER_TYPES.GOOGLE,
+        config: {
+          apiKey: TEST_API_KEYS.GOOGLE,
+          modelName: "gemini-pro",
+          apiEndpoint: "https://custom.endpoint.com",
+        },
+      };
+
+      await messageHandlers.handleMessage(message);
+
+      expect(mockSetProvider).toHaveBeenCalledWith(PROVIDER_TYPES.GOOGLE);
+      expect(mockSet).toHaveBeenCalledWith(
+        PROVIDER_TYPES.GOOGLE,
+        "apiKey",
+        TEST_API_KEYS.GOOGLE,
+      );
+      expect(mockSet).toHaveBeenCalledWith(
+        PROVIDER_TYPES.GOOGLE,
+        "modelName",
+        "gemini-pro",
+      );
+      expect(mockSetConnectionStatus).toHaveBeenCalledWith(
+        false,
+        PROVIDER_TYPES.GOOGLE,
+      );
+    });
+
+    it("should handle activateProvider message", async () => {
+      const message = {
+        command: "activateProvider",
+        provider: PROVIDER_TYPES.GOOGLE,
+      };
+
+      await messageHandlers.handleMessage(message);
+
+      expect(mockSetProvider).toHaveBeenCalledWith(PROVIDER_TYPES.GOOGLE);
+    });
+
+    it("should handle connectProvider message for API key provider", async () => {
+      const message = {
+        command: "connectProvider",
+        provider: PROVIDER_TYPES.GOOGLE,
+      };
+
+      await messageHandlers.handleMessage(message);
+
+      expect(mockSetProvider).toHaveBeenCalledWith(PROVIDER_TYPES.GOOGLE);
+    });
+
+    it("should handle connectProvider message for OAuth provider", async () => {
+      const message = {
+        command: "connectProvider",
+        provider: PROVIDER_TYPES.WCA,
+      };
+
+      await messageHandlers.handleMessage(message);
+
+      expect(mockSetProvider).toHaveBeenCalledWith(PROVIDER_TYPES.WCA);
+      expect(mockedCommands.executeCommand).toHaveBeenCalledWith(
+        "ansible.lightspeed.oauth",
+      );
+      expect(mockIsAuthenticated).toHaveBeenCalled();
+    });
+
+    it("should not process messages when webview is not set", async () => {
+      const handler = new LlmProviderMessageHandlers(mockDeps);
+
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(vi.fn());
+
+      await handler.handleMessage({ command: "getProviderSettings" });
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        "[LlmProviderMessageHandlers] Webview not set",
+      );
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe("sendProviderSettings", () => {
+    it("should send provider settings to webview", async () => {
+      await messageHandlers.sendProviderSettings();
+
+      expect(mockPostMessage).toHaveBeenCalledWith({
+        command: "providerSettings",
+        providers: expect.any(Array),
+        currentProvider: "wca",
+        providerConfigs: expect.any(Object),
+        connectionStatuses: expect.any(Object),
+      });
+    });
+
+    it("should not send when webview is not set", async () => {
+      const handler = new LlmProviderMessageHandlers(mockDeps);
+
+      await handler.sendProviderSettings();
+
+      expect(true).toBe(true);
+    });
+  });
+
+  describe("saveProviderSettings", () => {
+    it("should skip saving when provider or config is missing", async () => {
+      await messageHandlers.handleMessage({
+        command: "saveProviderSettings",
+      });
+
+      expect(mockSetProvider).not.toHaveBeenCalled();
+    });
+
+    it("should handle save errors gracefully", async () => {
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(vi.fn());
+      mockSetProvider.mockRejectedValueOnce(new Error("Save failed"));
+
+      const message = {
+        command: "saveProviderSettings",
+        provider: PROVIDER_TYPES.GOOGLE,
+        config: { apiKey: "test" },
+      };
+
+      await messageHandlers.handleMessage(message);
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        "Failed to save provider settings:",
+        expect.any(Error),
+      );
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe("activateProvider", () => {
+    it("should skip activation when provider is missing", async () => {
+      await messageHandlers.handleMessage({
+        command: "activateProvider",
+      });
+
+      expect(mockSetProvider).not.toHaveBeenCalled();
+    });
+
+    it("should handle activation errors gracefully", async () => {
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(vi.fn());
+      mockSetProvider.mockRejectedValueOnce(new Error("Activation failed"));
+
+      await messageHandlers.handleMessage({
+        command: "activateProvider",
+        provider: PROVIDER_TYPES.GOOGLE,
+      });
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        "Failed to activate provider:",
+        expect.any(Error),
+      );
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe("connectProvider", () => {
+    it("should skip connection when provider is missing", async () => {
+      await messageHandlers.handleMessage({
+        command: "connectProvider",
+      });
+
+      expect(mockSetProvider).not.toHaveBeenCalled();
+    });
+
+    it("should handle connection errors gracefully", async () => {
+      mockSetProvider.mockRejectedValueOnce(new Error("Connection failed"));
+
+      const message = {
+        command: "connectProvider",
+        provider: PROVIDER_TYPES.GOOGLE,
+      };
+
+      await messageHandlers.handleMessage(message);
+
+      expect(mockedWindow.showErrorMessage).toHaveBeenCalledWith(
+        expect.stringContaining("Failed to connect to GOOGLE"),
+      );
+
+      expect(mockPostMessage).toHaveBeenCalledWith({
+        command: "connectionResult",
+        provider: PROVIDER_TYPES.GOOGLE,
+        connected: false,
+        error: "Connection failed",
+      });
+    });
+
+    it("should show error when API key is missing for required provider", async () => {
+      mockGet.mockImplementation((provider: string, key: string) => {
+        if (key === "apiKey") return Promise.resolve("");
+        return Promise.resolve("");
+      });
+
+      await messageHandlers.handleMessage({
+        command: "connectProvider",
+        provider: PROVIDER_TYPES.GOOGLE,
+      });
+
+      expect(mockSetConnectionStatus).toHaveBeenCalledWith(
+        false,
+        PROVIDER_TYPES.GOOGLE,
+      );
+    });
+
+    it("should handle successful OAuth connection", async () => {
+      mockIsAuthenticated.mockResolvedValue(true);
+
+      await messageHandlers.handleMessage({
+        command: "connectProvider",
+        provider: PROVIDER_TYPES.WCA,
+      });
+
+      expect(mockSetConnectionStatus).toHaveBeenCalledWith(
+        true,
+        PROVIDER_TYPES.WCA,
+      );
+    });
+
+    it("should handle failed OAuth connection", async () => {
+      mockIsAuthenticated.mockResolvedValue(false);
+
+      await messageHandlers.handleMessage({
+        command: "connectProvider",
+        provider: PROVIDER_TYPES.WCA,
+      });
+
+      expect(mockSetConnectionStatus).toHaveBeenCalledWith(
+        false,
+        PROVIDER_TYPES.WCA,
+      );
+      expect(mockedWindow.showErrorMessage).toHaveBeenCalled();
+    });
+  });
+
+  describe("unknown commands", () => {
+    it("should ignore unknown commands", async () => {
+      await messageHandlers.handleMessage({
+        command: "unknownCommand",
+      });
+
+      expect(mockSetProvider).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("validateProviderConnection", () => {
+    it("should return connected true when provider validates successfully", async () => {
+      const message = {
+        command: "connectProvider",
+        provider: PROVIDER_TYPES.GOOGLE,
+      };
+
+      await messageHandlers.handleMessage(message);
+
+      expect(mockSetConnectionStatus).toHaveBeenCalledWith(
+        true,
+        PROVIDER_TYPES.GOOGLE,
+      );
+    });
+
+    it("should return connected false when provider.getStatus returns not connected", async () => {
+      mockedCreateProvider.mockReturnValueOnce({
+        getStatus: vi
+          .fn()
+          .mockResolvedValue({ connected: false, error: "Invalid API key" }),
+      } as unknown as ReturnType<typeof providerFactory.createProvider>);
+
+      await messageHandlers.handleMessage({
+        command: "connectProvider",
+        provider: PROVIDER_TYPES.GOOGLE,
+      });
+
+      expect(mockSetConnectionStatus).toHaveBeenCalledWith(
+        false,
+        PROVIDER_TYPES.GOOGLE,
+      );
+    });
+
+    it("should handle status with no error message", async () => {
+      mockedCreateProvider.mockReturnValueOnce({
+        getStatus: vi.fn().mockResolvedValue({ connected: false }),
+      } as unknown as ReturnType<typeof providerFactory.createProvider>);
+
+      await messageHandlers.handleMessage({
+        command: "connectProvider",
+        provider: PROVIDER_TYPES.GOOGLE,
+      });
+
+      expect(mockedWindow.showErrorMessage).toHaveBeenCalledWith(
+        expect.stringContaining("Failed to connect"),
+      );
+    });
+
+    it("should handle exception during validation", async () => {
+      mockedCreateProvider.mockImplementationOnce(() => {
+        throw new Error("Network error");
+      });
+
+      await messageHandlers.handleMessage({
+        command: "connectProvider",
+        provider: PROVIDER_TYPES.GOOGLE,
+      });
+
+      expect(mockSetConnectionStatus).toHaveBeenCalledWith(
+        false,
+        PROVIDER_TYPES.GOOGLE,
+      );
+    });
+
+    it("should handle non-Error exception during validation", async () => {
+      mockedCreateProvider.mockImplementationOnce(() => {
+        throw "String error";
+      });
+
+      await messageHandlers.handleMessage({
+        command: "connectProvider",
+        provider: PROVIDER_TYPES.GOOGLE,
+      });
+
+      expect(mockSetConnectionStatus).toHaveBeenCalledWith(
+        false,
+        PROVIDER_TYPES.GOOGLE,
+      );
+    });
+  });
+
+  describe("handleConnectionResult", () => {
+    it("should show information message on successful connection", async () => {
+      await messageHandlers.handleMessage({
+        command: "connectProvider",
+        provider: PROVIDER_TYPES.GOOGLE,
+      });
+
+      expect(mockedWindow.showInformationMessage).toHaveBeenCalledWith(
+        expect.stringContaining("Successfully connected"),
+      );
+    });
+
+    it("should post connection result to webview on success", async () => {
+      await messageHandlers.handleMessage({
+        command: "connectProvider",
+        provider: PROVIDER_TYPES.GOOGLE,
+      });
+
+      expect(mockPostMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          command: "connectionResult",
+          provider: PROVIDER_TYPES.GOOGLE,
+          connected: true,
+        }),
+      );
+    });
+  });
+
+  describe("saveProviderSettings with configSchema", () => {
+    it("should skip apiKey field when provider does not require it", async () => {
+      const message = {
+        command: "saveProviderSettings",
+        provider: PROVIDER_TYPES.WCA,
+        config: {
+          apiEndpoint: "https://custom.endpoint.com",
+          apiKey: "should-be-skipped",
+        },
+      };
+
+      await messageHandlers.handleMessage(message);
+
+      expect(mockSet).not.toHaveBeenCalledWith(
+        PROVIDER_TYPES.WCA,
+        "apiKey",
+        expect.anything(),
+      );
+    });
+
+    it("should save all fields from configSchema for provider that requires API key", async () => {
+      const message = {
+        command: "saveProviderSettings",
+        provider: PROVIDER_TYPES.GOOGLE,
+        config: {
+          apiEndpoint: "https://custom.endpoint.com",
+          apiKey: TEST_API_KEYS.GOOGLE,
+          modelName: "gemini-pro",
+        },
+      };
+
+      await messageHandlers.handleMessage(message);
+
+      expect(mockSet).toHaveBeenCalledWith(
+        PROVIDER_TYPES.GOOGLE,
+        "apiEndpoint",
+        "https://custom.endpoint.com",
+      );
+      expect(mockSet).toHaveBeenCalledWith(
+        PROVIDER_TYPES.GOOGLE,
+        "apiKey",
+        TEST_API_KEYS.GOOGLE,
+      );
+      expect(mockSet).toHaveBeenCalledWith(
+        PROVIDER_TYPES.GOOGLE,
+        "modelName",
+        "gemini-pro",
+      );
+    });
+  });
+
+  describe("updateAndNotify", () => {
+    it("should refresh quickLinksProvider when available", async () => {
+      await messageHandlers.handleMessage({
+        command: "activateProvider",
+        provider: PROVIDER_TYPES.GOOGLE,
+      });
+
+      expect(mockRefreshProviderInfo).toHaveBeenCalled();
+    });
+
+    it("should call settingsManager.reinitialize", async () => {
+      await messageHandlers.handleMessage({
+        command: "activateProvider",
+        provider: PROVIDER_TYPES.GOOGLE,
+      });
+
+      expect(mockReinitialize).toHaveBeenCalled();
+    });
+  });
+
+  describe("provider display name fallback", () => {
+    it("should use uppercase provider type when displayName is not available", async () => {
+      mockedGetSupportedProviders.mockReturnValueOnce([
+        {
+          type: "google" as const,
+          name: "google",
+          displayName: "",
+          description: "",
+          defaultEndpoint: "",
+          configSchema: [],
+          requiresApiKey: true,
+        },
+      ]);
+
+      mockGet.mockImplementation(() => Promise.resolve("test-key"));
+
+      await messageHandlers.handleMessage({
+        command: "connectProvider",
+        provider: "google",
+      });
+
+      expect(mockedWindow.showInformationMessage).toHaveBeenCalledWith(
+        expect.stringContaining("GOOGLE"),
+      );
+    });
+  });
+
+  describe("handleConnectProvider edge cases", () => {
+    it("should not process when webview is not set", async () => {
+      const handler = new LlmProviderMessageHandlers(mockDeps);
+
+      await handler.handleMessage({
+        command: "connectProvider",
+        provider: PROVIDER_TYPES.GOOGLE,
+      });
+
+      expect(mockSetProvider).not.toHaveBeenCalled();
+    });
+
+    it("should handle OAuth connection when providerInfo is undefined", async () => {
+      vi.useFakeTimers();
+
+      mockedGetSupportedProviders.mockReturnValue([]);
+
+      const handlerWithNoProviders = new LlmProviderMessageHandlers(mockDeps);
+      handlerWithNoProviders.setWebview(mockWebview);
+
+      await handlerWithNoProviders.handleMessage({
+        command: "connectProvider",
+        provider: "unknown",
+      });
+
+      expect(mockSetProvider).toHaveBeenCalledWith("unknown");
+
+      vi.useRealTimers();
+    });
+  });
+
+  describe("updateAndNotify error handling", () => {
+    it("should handle refreshProviders error gracefully", async () => {
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(vi.fn());
+
+      const mockProviderManagerWithError = {
+        refreshProviders: vi
+          .fn()
+          .mockRejectedValue(new Error("Refresh failed")),
+      } as unknown as ProviderManager;
+
+      const depsWithError: LlmProviderDependencies = {
+        ...mockDeps,
+        providerManager: mockProviderManagerWithError,
+      };
+
+      const handlerWithError = new LlmProviderMessageHandlers(depsWithError);
+      handlerWithError.setWebview(mockWebview);
+
+      await handlerWithError.handleMessage({
+        command: "activateProvider",
+        provider: PROVIDER_TYPES.GOOGLE,
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(mockReinitialize).toHaveBeenCalled();
+
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe("saveProviderSettings with unknown provider", () => {
+    it("should handle unknown provider type gracefully", async () => {
+      mockedGetSupportedProviders.mockReturnValue([
+        mockWcaProvider,
+        mockGoogleProvider,
+      ]);
+
+      await messageHandlers.handleMessage({
+        command: "saveProviderSettings",
+        provider: "unknown-provider",
+        config: {
+          apiKey: "test-key",
+        },
+      });
+
+      expect(mockSetProvider).toHaveBeenCalledWith("unknown-provider");
+      expect(mockSetConnectionStatus).toHaveBeenCalledWith(
+        false,
+        "unknown-provider",
+      );
+    });
+  });
+
+  describe("handleConnectionResult without webview", () => {
+    it("should not crash when handleConnectionResult is called indirectly without webview", async () => {
+      const handler = new LlmProviderMessageHandlers(mockDeps);
+
+      await handler.handleMessage({
+        command: "connectProvider",
+        provider: PROVIDER_TYPES.GOOGLE,
+      });
+
+      expect(mockSetConnectionStatus).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("sendProviderSettings builds correct config", () => {
+    it("should build provider configs dynamically from configSchema", async () => {
+      await messageHandlers.sendProviderSettings();
+
+      expect(mockGet).toHaveBeenCalledWith("wca", "apiEndpoint");
+      expect(mockGet).toHaveBeenCalledWith("google", "apiEndpoint");
+      expect(mockGet).toHaveBeenCalledWith("google", "apiKey");
+      expect(mockGet).toHaveBeenCalledWith("google", "modelName");
+    });
+  });
+
+  describe("connectWithApiKey with undefined providerInfo", () => {
+    it("should use uppercase fallback for displayName when providerInfo is undefined", async () => {
+      mockedGetSupportedProviders.mockReturnValue([]);
+
+      const handlerNoProviders = new LlmProviderMessageHandlers(mockDeps);
+      handlerNoProviders.setWebview(mockWebview);
+
+      await handlerNoProviders.handleMessage({
+        command: "connectProvider",
+        provider: "custom",
+      });
+
+      expect(mockedWindow.showInformationMessage).toHaveBeenCalledWith(
+        expect.stringContaining("CUSTOM"),
+      );
+    });
+  });
+});

--- a/test/unit/lightspeed/views/llmProviderPanel.test.ts
+++ b/test/unit/lightspeed/views/llmProviderPanel.test.ts
@@ -1,0 +1,331 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { ExtensionContext, WebviewPanel, Webview } from "vscode";
+import { ViewColumn, window, Uri } from "vscode";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).__getWebviewHtml__ = vi
+  .fn()
+  .mockReturnValue("<html></html>");
+import type { LlmProviderDependencies } from "@src/features/lightspeed/vue/views/llmProviderMessageHandlers";
+import type { SettingsManager } from "@src/settings";
+import type { ProviderManager } from "@src/features/lightspeed/providerManager";
+import type { LlmProviderSettings } from "@src/features/lightspeed/llmProviderSettings";
+import type { LightspeedUser } from "@src/features/lightspeed/lightspeedUser";
+
+vi.mock("@src/features/lightspeed/providers/factory", () => {
+  const mockGoogleProvider = {
+    type: "google",
+    name: "google",
+    displayName: "Google Gemini",
+    defaultEndpoint: "https://generativelanguage.googleapis.com/v1beta",
+    defaultModel: "gemini-2.5-flash",
+    configSchema: [],
+  };
+
+  return {
+    providerFactory: {
+      getSupportedProviders: vi.fn(() => [mockGoogleProvider]),
+    },
+  };
+});
+
+vi.mock("@src/features/lightspeed/vue/views/panelUtils", () => ({
+  disposePanelResources: vi.fn(),
+}));
+
+vi.mock("@src/features/lightspeed/vue/views/llmProviderMessageHandlers", () => {
+  return {
+    LlmProviderMessageHandlers: class MockMessageHandlers {
+      setWebview = vi.fn();
+      handleMessage = vi.fn();
+      sendProviderSettings = vi.fn();
+    },
+  };
+});
+
+import { LlmProviderPanel } from "@src/features/lightspeed/vue/views/llmProviderPanel";
+import { disposePanelResources } from "@src/features/lightspeed/vue/views/panelUtils";
+
+describe("LlmProviderPanel", () => {
+  let mockContext: ExtensionContext;
+  let mockDeps: LlmProviderDependencies;
+  let mockWebviewPanel: WebviewPanel;
+  let mockWebview: Webview;
+  let onDidDisposeCallback: () => void = vi.fn();
+  let onDidReceiveMessageCallback: (message: unknown) => Promise<void> =
+    vi.fn();
+
+  let mockPostMessage: ReturnType<typeof vi.fn>;
+  let mockOnDidReceiveMessage: ReturnType<typeof vi.fn>;
+  let mockReveal: ReturnType<typeof vi.fn>;
+  let mockOnDidDispose: ReturnType<typeof vi.fn>;
+  let mockCreateWebviewPanel: ReturnType<typeof vi.fn>;
+
+  const mockedDisposePanelResources = vi.mocked(disposePanelResources);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    LlmProviderPanel.currentPanel = undefined;
+
+    onDidDisposeCallback = vi.fn();
+    onDidReceiveMessageCallback = vi.fn();
+
+    mockPostMessage = vi.fn().mockResolvedValue(true);
+    mockOnDidReceiveMessage = vi.fn().mockImplementation((callback, _, arr) => {
+      onDidReceiveMessageCallback = callback;
+      arr?.push({ dispose: vi.fn() });
+      return { dispose: vi.fn() };
+    });
+    mockReveal = vi.fn();
+    mockOnDidDispose = vi.fn().mockImplementation((callback, _, arr) => {
+      onDidDisposeCallback = callback;
+      arr?.push({ dispose: vi.fn() });
+      return { dispose: vi.fn() };
+    });
+
+    mockWebview = {
+      html: "",
+      postMessage: mockPostMessage,
+      onDidReceiveMessage: mockOnDidReceiveMessage,
+    } as unknown as Webview;
+
+    mockWebviewPanel = {
+      webview: mockWebview,
+      reveal: mockReveal,
+      dispose: vi.fn(),
+      onDidDispose: mockOnDidDispose,
+    } as unknown as WebviewPanel;
+
+    (Uri as { joinPath?: unknown }).joinPath = vi.fn().mockReturnValue({
+      fsPath: "/test/path",
+    });
+
+    mockCreateWebviewPanel = vi.fn().mockReturnValue(mockWebviewPanel);
+    (window as { createWebviewPanel?: unknown }).createWebviewPanel =
+      mockCreateWebviewPanel;
+
+    mockContext = {
+      extensionUri: { fsPath: "/test/extension" },
+      subscriptions: [],
+    } as unknown as ExtensionContext;
+
+    mockDeps = {
+      settingsManager: {
+        settings: {
+          lightSpeedService: {
+            provider: "google",
+          },
+        },
+        reinitialize: vi.fn(),
+      } as unknown as SettingsManager,
+      providerManager: {
+        refreshProviders: vi.fn(),
+      } as unknown as ProviderManager,
+      llmProviderSettings: {
+        getAllSettings: vi.fn().mockResolvedValue({
+          provider: "google",
+          connectionStatuses: {},
+        }),
+        get: vi.fn().mockResolvedValue(""),
+      } as unknown as LlmProviderSettings,
+      lightspeedUser: {
+        isAuthenticated: vi.fn().mockResolvedValue(true),
+      } as unknown as LightspeedUser,
+    };
+  });
+
+  afterEach(() => {
+    LlmProviderPanel.currentPanel = undefined;
+  });
+
+  describe("render", () => {
+    it("should create a new webview panel when none exists", () => {
+      LlmProviderPanel.render(mockContext, mockDeps);
+
+      expect(mockCreateWebviewPanel).toHaveBeenCalledWith(
+        "llm-provider-settings",
+        expect.stringContaining("LLM Provider"),
+        ViewColumn.One,
+        expect.objectContaining({
+          enableScripts: true,
+          enableCommandUris: true,
+          retainContextWhenHidden: true,
+        }),
+      );
+
+      expect(LlmProviderPanel.currentPanel).toBeDefined();
+    });
+
+    it("should reveal existing panel instead of creating new one", () => {
+      LlmProviderPanel.render(mockContext, mockDeps);
+      mockCreateWebviewPanel.mockClear();
+
+      LlmProviderPanel.render(mockContext, mockDeps);
+
+      expect(mockCreateWebviewPanel).not.toHaveBeenCalled();
+      expect(mockReveal).toHaveBeenCalledWith(ViewColumn.One);
+    });
+
+    it("should use provider display name in title when available", () => {
+      LlmProviderPanel.render(mockContext, mockDeps);
+
+      expect(mockCreateWebviewPanel).toHaveBeenCalledWith(
+        "llm-provider-settings",
+        "LLM Provider: Google Gemini",
+        expect.anything(),
+        expect.anything(),
+      );
+    });
+
+    it("should use default title when no provider is set", () => {
+      mockDeps.settingsManager = {
+        settings: {
+          lightSpeedService: {
+            provider: "",
+          },
+        },
+      } as unknown as SettingsManager;
+
+      LlmProviderPanel.render(mockContext, mockDeps);
+
+      expect(mockCreateWebviewPanel).toHaveBeenCalledWith(
+        "llm-provider-settings",
+        "Configure LLM Provider",
+        expect.anything(),
+        expect.anything(),
+      );
+    });
+
+    it("should use default title when provider is not found", () => {
+      mockDeps.settingsManager = {
+        settings: {
+          lightSpeedService: {
+            provider: "unknown-provider",
+          },
+        },
+      } as unknown as SettingsManager;
+
+      LlmProviderPanel.render(mockContext, mockDeps);
+
+      expect(mockCreateWebviewPanel).toHaveBeenCalledWith(
+        "llm-provider-settings",
+        "Configure LLM Provider",
+        expect.anything(),
+        expect.anything(),
+      );
+    });
+  });
+
+  describe("dispose", () => {
+    it("should clear currentPanel on dispose", () => {
+      LlmProviderPanel.render(mockContext, mockDeps);
+      expect(LlmProviderPanel.currentPanel).toBeDefined();
+
+      onDidDisposeCallback();
+
+      expect(LlmProviderPanel.currentPanel).toBeUndefined();
+    });
+
+    it("should call disposePanelResources on dispose", () => {
+      LlmProviderPanel.render(mockContext, mockDeps);
+
+      onDidDisposeCallback();
+
+      expect(mockedDisposePanelResources).toHaveBeenCalled();
+    });
+  });
+
+  describe("refreshWebView", () => {
+    it("should call sendProviderSettings on message handler", async () => {
+      LlmProviderPanel.render(mockContext, mockDeps);
+
+      await LlmProviderPanel.currentPanel?.refreshWebView();
+
+      expect(true).toBe(true);
+    });
+  });
+
+  describe("message handling", () => {
+    it("should set up message handler on creation", () => {
+      LlmProviderPanel.render(mockContext, mockDeps);
+
+      expect(mockOnDidReceiveMessage).toHaveBeenCalled();
+    });
+
+    it("should forward messages to message handler", async () => {
+      LlmProviderPanel.render(mockContext, mockDeps);
+
+      await onDidReceiveMessageCallback({ command: "getProviderSettings" });
+
+      expect(true).toBe(true);
+    });
+
+    it("should handle different message types", async () => {
+      LlmProviderPanel.render(mockContext, mockDeps);
+
+      await onDidReceiveMessageCallback({ command: "saveProviderSettings" });
+      await onDidReceiveMessageCallback({ command: "activateProvider" });
+      await onDidReceiveMessageCallback({ command: "connectProvider" });
+
+      expect(true).toBe(true);
+    });
+  });
+
+  describe("panel configuration", () => {
+    it("should set enableScripts to true for webview", () => {
+      LlmProviderPanel.render(mockContext, mockDeps);
+
+      expect(mockCreateWebviewPanel).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({
+          enableScripts: true,
+        }),
+      );
+    });
+
+    it("should set retainContextWhenHidden to true", () => {
+      LlmProviderPanel.render(mockContext, mockDeps);
+
+      expect(mockCreateWebviewPanel).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({
+          retainContextWhenHidden: true,
+        }),
+      );
+    });
+
+    it("should set localResourceRoots correctly", () => {
+      LlmProviderPanel.render(mockContext, mockDeps);
+
+      expect(mockCreateWebviewPanel).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({
+          localResourceRoots: expect.any(Array),
+        }),
+      );
+    });
+  });
+
+  describe("webview content", () => {
+    it("should set webview HTML content on creation", () => {
+      LlmProviderPanel.render(mockContext, mockDeps);
+
+      expect(mockWebview.html).toBe("<html></html>");
+    });
+  });
+
+  describe("dispose callback", () => {
+    it("should register dispose callback on panel creation", () => {
+      LlmProviderPanel.render(mockContext, mockDeps);
+
+      expect(mockOnDidDispose).toHaveBeenCalled();
+    });
+  });
+});

--- a/test/unit/settings.test.ts
+++ b/test/unit/settings.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import * as vscode from "vscode";
+import { SettingsManager } from "@src/settings";
+import type { LlmProviderSettings } from "@src/features/lightspeed/llmProviderSettings";
+
+describe("SettingsManager", () => {
+  let settingsManager: SettingsManager;
+
+  beforeEach(() => {
+    settingsManager = new SettingsManager();
+
+    const mockConfig = {
+      get: vi.fn((key: string, defaultValue?: unknown) => defaultValue),
+    };
+    vi.mocked(vscode.workspace.getConfiguration).mockReturnValue(
+      mockConfig as unknown as vscode.WorkspaceConfiguration,
+    );
+  });
+
+  describe("setLlmProviderSettings", () => {
+    it("should store the LlmProviderSettings instance", async () => {
+      const mockGetAllSettings = vi.fn().mockResolvedValue({
+        provider: "google",
+        apiEndpoint: "https://api.google.com",
+        modelName: "gemini-pro",
+        apiKey: "test-key",
+      });
+
+      const mockLlmProviderSettings = {
+        getAllSettings: mockGetAllSettings,
+      } as unknown as LlmProviderSettings;
+
+      settingsManager.setLlmProviderSettings(mockLlmProviderSettings);
+
+      await settingsManager.initialize();
+
+      expect(mockGetAllSettings).toHaveBeenCalled();
+
+      expect(settingsManager.settings.lightSpeedService.provider).toBe(
+        "google",
+      );
+      expect(settingsManager.settings.lightSpeedService.apiEndpoint).toBe(
+        "https://api.google.com",
+      );
+      expect(settingsManager.settings.lightSpeedService.modelName).toBe(
+        "gemini-pro",
+      );
+    });
+
+    it("should use default settings when llmProviderSettings is not set", async () => {
+      await settingsManager.initialize();
+
+      expect(settingsManager.settings.lightSpeedService.provider).toBe("wca");
+      expect(settingsManager.settings.lightSpeedService.apiEndpoint).toBe(
+        "https://c.ai.ansible.redhat.com",
+      );
+      expect(settingsManager.settings.lightSpeedService.apiKey).toBe("");
+    });
+  });
+
+  describe("reinitialize", () => {
+    it("should re-read settings by calling initialize", async () => {
+      const consoleSpy = vi
+        .spyOn(console, "log")
+        // eslint-disable-next-line no-empty-function
+        .mockImplementation(() => {});
+
+      await settingsManager.reinitialize();
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        "Reinitialized extension settings",
+      );
+      expect(settingsManager.settings.lightSpeedService.provider).toBe("wca");
+      consoleSpy.mockRestore();
+    });
+  });
+});

--- a/test/unit/webviews/lightspeed/LlmProviderApp.test.ts
+++ b/test/unit/webviews/lightspeed/LlmProviderApp.test.ts
@@ -1,0 +1,452 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+
+const { mockPostMessage } = vi.hoisted(() => ({
+  mockPostMessage: vi.fn(),
+}));
+
+vi.mock("../../../../webviews/lightspeed/src/utils", () => ({
+  vscodeApi: {
+    postMessage: mockPostMessage,
+  },
+}));
+
+import LlmProviderApp from "../../../../webviews/LlmProviderApp.vue";
+
+describe("LlmProviderApp", () => {
+  let messageHandler: ((event: MessageEvent) => void) | null = null;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    messageHandler = null;
+
+    vi.spyOn(window, "addEventListener").mockImplementation(
+      (event, handler) => {
+        if (event === "message") {
+          messageHandler = handler as (event: MessageEvent) => void;
+        }
+      },
+    );
+  });
+
+  const simulateMessage = (data: unknown) => {
+    if (messageHandler) {
+      messageHandler({ data } as MessageEvent);
+    }
+  };
+
+  describe("initialization", () => {
+    it("renders the main container", () => {
+      const wrapper = mount(LlmProviderApp);
+      expect(wrapper.find("#llmProviderView").exists()).toBe(true);
+    });
+
+    it("shows loading state initially", () => {
+      const wrapper = mount(LlmProviderApp);
+      expect(wrapper.text()).toContain("Loading provider settings");
+    });
+
+    it("requests provider settings on mount", async () => {
+      mount(LlmProviderApp);
+      await flushPromises();
+
+      expect(mockPostMessage).toHaveBeenCalledWith({
+        command: "getProviderSettings",
+      });
+    });
+
+    it("registers message listener on mount", () => {
+      mount(LlmProviderApp);
+
+      expect(window.addEventListener).toHaveBeenCalledWith(
+        "message",
+        expect.any(Function),
+      );
+    });
+  });
+
+  describe("provider settings handling", () => {
+    const mockProviders = [
+      {
+        type: "wca",
+        name: "wca",
+        displayName: "IBM watsonx",
+        description:
+          "Red Hat Ansible Lightspeed with IBM watsonx Code Assistant",
+        defaultEndpoint: "https://c.ai.ansible.redhat.com",
+        configSchema: [
+          {
+            key: "apiEndpoint",
+            label: "Lightspeed URL",
+            type: "string",
+            required: true,
+            placeholder: "https://c.ai.ansible.redhat.com",
+            description: "URL for the Lightspeed service",
+          },
+        ],
+        usesOAuth: true,
+        requiresApiKey: false,
+      },
+      {
+        type: "google",
+        name: "google",
+        displayName: "Google Gemini",
+        description: "Direct access to Google Gemini models",
+        defaultEndpoint: "https://generativelanguage.googleapis.com/v1beta",
+        configSchema: [
+          {
+            key: "apiKey",
+            label: "API Key",
+            type: "password",
+            required: true,
+            placeholder: "AIza...",
+            description: "Your Google AI API key",
+          },
+          {
+            key: "modelName",
+            label: "Model Name",
+            type: "string",
+            required: false,
+            placeholder: "gemini-2.5-flash",
+            description: "The Gemini model to use",
+          },
+        ],
+        usesOAuth: false,
+        requiresApiKey: true,
+      },
+    ];
+
+    it("hides loading state after receiving settings", async () => {
+      const wrapper = mount(LlmProviderApp);
+      await flushPromises();
+
+      simulateMessage({
+        command: "providerSettings",
+        providers: mockProviders,
+        currentProvider: "wca",
+        providerConfigs: {
+          wca: { apiEndpoint: "https://c.ai.ansible.redhat.com" },
+          google: { apiKey: "", modelName: "" },
+        },
+        connectionStatuses: { wca: false, google: false },
+      });
+      await flushPromises();
+
+      expect(wrapper.text()).not.toContain("Loading provider settings");
+    });
+
+    it("renders provider list after receiving settings", async () => {
+      const wrapper = mount(LlmProviderApp);
+      await flushPromises();
+
+      simulateMessage({
+        command: "providerSettings",
+        providers: mockProviders,
+        currentProvider: "wca",
+        providerConfigs: {
+          wca: { apiEndpoint: "https://c.ai.ansible.redhat.com" },
+          google: { apiKey: "", modelName: "" },
+        },
+        connectionStatuses: { wca: false, google: false },
+      });
+      await flushPromises();
+
+      expect(wrapper.text()).toContain("IBM watsonx");
+      expect(wrapper.text()).toContain("Google Gemini");
+    });
+
+    it("shows configured badge for connected providers", async () => {
+      const wrapper = mount(LlmProviderApp);
+      await flushPromises();
+
+      simulateMessage({
+        command: "providerSettings",
+        providers: mockProviders,
+        currentProvider: "google",
+        providerConfigs: {
+          wca: { apiEndpoint: "https://c.ai.ansible.redhat.com" },
+          google: { apiKey: "test-key", modelName: "gemini-pro" },
+        },
+        connectionStatuses: { wca: false, google: true },
+      });
+      await flushPromises();
+
+      expect(wrapper.text()).toContain("Configured");
+    });
+
+    it("shows active badge for active provider", async () => {
+      const wrapper = mount(LlmProviderApp);
+      await flushPromises();
+
+      simulateMessage({
+        command: "providerSettings",
+        providers: mockProviders,
+        currentProvider: "google",
+        providerConfigs: {
+          wca: {},
+          google: {},
+        },
+        connectionStatuses: { wca: false, google: true },
+      });
+      await flushPromises();
+
+      expect(wrapper.text()).toContain("Active");
+    });
+  });
+
+  describe("provider actions", () => {
+    const mockProviders = [
+      {
+        type: "google",
+        name: "google",
+        displayName: "Google Gemini",
+        description: "Test provider",
+        defaultEndpoint: "https://test.com",
+        configSchema: [
+          {
+            key: "apiKey",
+            label: "API Key",
+            type: "password",
+            required: true,
+            placeholder: "test",
+            description: "Test key",
+          },
+        ],
+        usesOAuth: false,
+        requiresApiKey: true,
+      },
+    ];
+
+    it("toggles edit mode when edit button is clicked", async () => {
+      const wrapper = mount(LlmProviderApp);
+      await flushPromises();
+
+      simulateMessage({
+        command: "providerSettings",
+        providers: mockProviders,
+        currentProvider: "google",
+        providerConfigs: { google: { apiKey: "" } },
+        connectionStatuses: { google: false },
+      });
+      await flushPromises();
+
+      const editButton = wrapper.find(".edit-btn");
+      await editButton.trigger("click");
+      await flushPromises();
+
+      expect(wrapper.find(".provider-config").exists()).toBe(true);
+    });
+
+    it("sends connect message when connect button is clicked", async () => {
+      const wrapper = mount(LlmProviderApp);
+      await flushPromises();
+
+      simulateMessage({
+        command: "providerSettings",
+        providers: mockProviders,
+        currentProvider: "google",
+        providerConfigs: { google: { apiKey: "" } },
+        connectionStatuses: { google: false },
+      });
+      await flushPromises();
+      mockPostMessage.mockClear();
+
+      const connectButton = wrapper.find(".connect-btn");
+      await connectButton.trigger("click");
+
+      expect(mockPostMessage).toHaveBeenCalledWith({
+        command: "connectProvider",
+        provider: "google",
+      });
+    });
+
+    it("sends activate message when switch button is clicked", async () => {
+      const wrapper = mount(LlmProviderApp);
+      await flushPromises();
+
+      const twoProviders = [
+        ...mockProviders,
+        {
+          type: "wca",
+          name: "wca",
+          displayName: "IBM watsonx",
+          description: "Test",
+          defaultEndpoint: "https://test.com",
+          configSchema: [],
+          usesOAuth: true,
+          requiresApiKey: false,
+        },
+      ];
+
+      simulateMessage({
+        command: "providerSettings",
+        providers: twoProviders,
+        currentProvider: "wca",
+        providerConfigs: { google: {}, wca: {} },
+        connectionStatuses: { google: true, wca: true },
+      });
+      await flushPromises();
+      mockPostMessage.mockClear();
+
+      const switchButton = wrapper.find(".switch-btn");
+      if (switchButton.exists()) {
+        await switchButton.trigger("click");
+
+        expect(mockPostMessage).toHaveBeenCalledWith({
+          command: "activateProvider",
+          provider: "google",
+        });
+      }
+    });
+
+    it("sends save message when save button is clicked", async () => {
+      const wrapper = mount(LlmProviderApp);
+      await flushPromises();
+
+      simulateMessage({
+        command: "providerSettings",
+        providers: mockProviders,
+        currentProvider: "google",
+        providerConfigs: { google: { apiKey: "" } },
+        connectionStatuses: { google: false },
+      });
+      await flushPromises();
+
+      const editButton = wrapper.find(".edit-btn");
+      await editButton.trigger("click");
+      await flushPromises();
+
+      mockPostMessage.mockClear();
+
+      const saveButton = wrapper.find(".save-btn");
+      await saveButton.trigger("click");
+
+      expect(mockPostMessage).toHaveBeenCalledWith({
+        command: "saveProviderSettings",
+        provider: "google",
+        config: expect.any(Object),
+      });
+    });
+  });
+
+  describe("connection result handling", () => {
+    it("updates connection status on successful connection", async () => {
+      const wrapper = mount(LlmProviderApp);
+      await flushPromises();
+
+      const mockProviders = [
+        {
+          type: "google",
+          name: "google",
+          displayName: "Google Gemini",
+          description: "Test",
+          defaultEndpoint: "https://test.com",
+          configSchema: [],
+        },
+      ];
+
+      simulateMessage({
+        command: "providerSettings",
+        providers: mockProviders,
+        currentProvider: "google",
+        providerConfigs: { google: {} },
+        connectionStatuses: { google: false },
+      });
+      await flushPromises();
+
+      simulateMessage({
+        command: "connectionResult",
+        provider: "google",
+        connected: true,
+      });
+      await flushPromises();
+
+      expect(wrapper.text()).toContain("Configured");
+    });
+
+    it("logs error on failed connection", async () => {
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(vi.fn());
+      mount(LlmProviderApp);
+      await flushPromises();
+
+      const mockProviders = [
+        {
+          type: "google",
+          name: "google",
+          displayName: "Google Gemini",
+          description: "Test",
+          defaultEndpoint: "https://test.com",
+          configSchema: [],
+        },
+      ];
+
+      simulateMessage({
+        command: "providerSettings",
+        providers: mockProviders,
+        currentProvider: "google",
+        providerConfigs: { google: {} },
+        connectionStatuses: { google: false },
+      });
+      await flushPromises();
+
+      simulateMessage({
+        command: "connectionResult",
+        provider: "google",
+        connected: false,
+        error: "Invalid API key",
+      });
+      await flushPromises();
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Connection failed for google"),
+      );
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe("unsaved changes detection", () => {
+    it("detects unsaved changes when config is modified", async () => {
+      const wrapper = mount(LlmProviderApp);
+      await flushPromises();
+
+      const mockProviders = [
+        {
+          type: "google",
+          name: "google",
+          displayName: "Google Gemini",
+          description: "Test",
+          defaultEndpoint: "https://test.com",
+          configSchema: [
+            {
+              key: "apiKey",
+              label: "API Key",
+              type: "password",
+              required: true,
+              placeholder: "test",
+              description: "Test",
+            },
+          ],
+        },
+      ];
+
+      simulateMessage({
+        command: "providerSettings",
+        providers: mockProviders,
+        currentProvider: "google",
+        providerConfigs: { google: { apiKey: "" } },
+        connectionStatuses: { google: false },
+      });
+      await flushPromises();
+
+      const editButton = wrapper.find(".edit-btn");
+      await editButton.trigger("click");
+      await flushPromises();
+
+      const input = wrapper.find('input[type="password"]');
+      await input.setValue("new-api-key");
+      await flushPromises();
+
+      expect(wrapper.text()).toContain("Unsaved changes");
+    });
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -79,6 +79,7 @@ export default defineConfig({
           "webviews/create-execution-env.html",
         ),
         "quick-links": path.resolve(__dirname, "webviews/quick-links.html"),
+        "llm-provider": path.resolve(__dirname, "webviews/llm-provider.html"),
       },
     },
   },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -95,7 +95,7 @@ export default defineConfig({
       clean: true,
       enabled: true,
       exclude: [],
-      include: ["src/**/**.{js,jsx,ts,tsx}"], // Include source files for coverage
+      include: ["src/**/**.{js,jsx,ts,tsx}", "webviews/**/*.{ts,vue}"], // Include source files and webviews for coverage
       provider: "v8",
       reportOnFailure: false,
       reportsDirectory: "./out/coverage/unit",

--- a/webviews/LlmProviderApp.vue
+++ b/webviews/LlmProviderApp.vue
@@ -1,0 +1,287 @@
+<script setup lang="ts">
+import '@vscode/codicons/dist/codicon.css';
+import { useProviderSettings } from './lightspeed/src/components/llmProviderState';
+import ProviderConfigForm from './lightspeed/src/components/ProviderConfigForm.vue';
+import SpinnerLoading from './lightspeed/src/components/SpinnerLoading.vue';
+import ToastNotification from './lightspeed/src/components/ToastNotification.vue';
+
+const {
+  providers,
+  activeProvider,
+  editingProvider,
+  isLoading,
+  saveIndicatorVisible,
+  isConnected,
+  isConnecting,
+  hasUnsavedChanges,
+  getConfigValue,
+  setConfigValue,
+  setActiveProvider,
+  toggleEdit,
+  saveProviderConfig,
+  connectProvider,
+} = useProviderSettings();
+</script>
+
+<template>
+  <div id="llmProviderView">
+    <div class="settings-wrapper">
+      <header class="settings-header">
+        <h1>LLM Provider Settings</h1>
+        <p>Configure which AI provider powers Ansible Lightspeed features like code completion and playbook generation.</p>
+      </header>
+
+      <SpinnerLoading v-if="isLoading" message="Loading provider settings..." />
+
+      <div v-else class="provider-list">
+        <!-- Provider Rows -->
+        <div
+          v-for="provider in providers"
+          :key="provider.type"
+          class="provider-row"
+          :class="{ 'is-editing': editingProvider === provider.type }"
+        >
+          <!-- Provider Header Row -->
+          <div class="provider-header">
+            <div class="provider-info">
+              <div class="provider-name">
+                {{ provider.displayName }}
+                <!-- Configured badge: shown when connected -->
+                <span v-if="isConnected(provider.type)" class="configured-badge">
+                  <span class="codicon codicon-check"></span>
+                  Configured
+                </span>
+              </div>
+              <div class="provider-description">{{ provider.description }}</div>
+            </div>
+
+            <div class="provider-actions">
+              <button
+                class="action-btn edit-btn"
+                :class="{ 'active': editingProvider === provider.type }"
+                @click="toggleEdit(provider.type)"
+                title="Edit configuration"
+              >
+                <span class="codicon codicon-edit"></span>
+                Edit
+              </button>
+
+              <!-- Connect button: shown when not connected -->
+              <button
+                v-if="!isConnected(provider.type)"
+                class="action-btn connect-btn"
+                :disabled="isConnecting(provider.type)"
+                @click="connectProvider(provider.type)"
+                title="Connect to provider"
+              >
+                <span class="codicon codicon-plug"></span>
+                {{ isConnecting(provider.type) ? 'Connecting...' : 'Connect' }}
+              </button>
+
+              <!-- Switch button: shown when connected but not active -->
+              <button
+                v-else-if="activeProvider !== provider.type"
+                class="action-btn switch-btn"
+                @click="setActiveProvider(provider.type)"
+                title="Switch to this provider"
+              >
+                Switch to this Provider
+              </button>
+
+              <!-- Active badge: shown when provider is active -->
+              <span v-else class="active-badge">
+                <span class="codicon codicon-check"></span>
+                Active
+              </span>
+            </div>
+          </div>
+
+          <!-- Provider Config Panel (shown when editing) -->
+          <ProviderConfigForm
+            v-if="editingProvider === provider.type"
+            :provider="provider"
+            :get-config-value="getConfigValue"
+            :has-changes="hasUnsavedChanges(provider.type)"
+            @update:field="(fieldKey: string, value: string) => setConfigValue(provider.type, fieldKey, value)"
+            @save="saveProviderConfig(provider.type)"
+            @cancel="toggleEdit(provider.type)"
+          />
+        </div>
+      </div>
+
+      <!-- Save indicator -->
+      <ToastNotification :visible="saveIndicatorVisible" message="Settings saved" />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+/* LLM Provider Settings */
+
+/* Base container */
+#llmProviderView {
+  display: flex;
+  justify-content: center;
+  padding: 32px 24px;
+  font-family: var(--vscode-font-family);
+  font-size: var(--vscode-font-size);
+  color: var(--vscode-foreground);
+  min-height: 100vh;
+}
+
+.settings-wrapper {
+  width: 100%;
+  max-width: 700px;
+}
+
+/* Header */
+.settings-header {
+  margin-bottom: 32px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid var(--vscode-widget-border);
+}
+
+.settings-header h1 {
+  font-size: 24px;
+  font-weight: 400;
+  margin-bottom: 8px;
+}
+
+.settings-header p {
+  font-size: 13px;
+  color: var(--vscode-descriptionForeground);
+  margin: 0;
+  line-height: 1.5;
+}
+
+/* Provider list & rows */
+.provider-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.provider-row {
+  background-color: var(--vscode-editor-background);
+  border: 1px solid var(--vscode-widget-border);
+  border-radius: 6px;
+  overflow: hidden;
+  transition: border-color 0.2s ease;
+}
+
+.provider-row:hover,
+.provider-row.is-editing {
+  border-color: var(--vscode-focusBorder);
+}
+
+/* Provider header */
+.provider-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 16px;
+  gap: 16px;
+}
+
+.provider-info {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.provider-name {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+
+.provider-description {
+  font-size: 12px;
+  color: var(--vscode-descriptionForeground);
+  line-height: 1.4;
+}
+
+/* Provider actions */
+.provider-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+/* Base button styles */
+.action-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  font-size: 12px;
+  font-weight: 500;
+  border-radius: 4px;
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+  background-color: var(--vscode-button-secondaryBackground);
+  color: var(--vscode-button-secondaryForeground);
+}
+
+.action-btn:hover {
+  background-color: var(--vscode-button-secondaryHoverBackground);
+}
+
+.action-btn .codicon {
+  font-size: 14px;
+}
+
+/* Primary button variants */
+.edit-btn.active,
+.connect-btn,
+.switch-btn {
+  background-color: var(--vscode-button-background);
+  color: var(--vscode-button-foreground);
+}
+
+.connect-btn:hover:not(:disabled),
+.switch-btn:hover {
+  background-color: var(--vscode-button-hoverBackground);
+}
+
+.connect-btn:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+
+/* Badges - shared base */
+.configured-badge,
+.active-badge {
+  display: inline-flex;
+  align-items: center;
+  font-weight: 500;
+  border-radius: 12px;
+}
+
+.configured-badge {
+  gap: 4px;
+  margin-left: 10px;
+  padding: 2px 8px;
+  font-size: 11px;
+  border: 1px solid var(--vscode-charts-green);
+  color: var(--vscode-charts-green);
+}
+
+.active-badge {
+  gap: 6px;
+  padding: 6px 12px;
+  font-size: 12px;
+  border-radius: 4px;
+  background-color: var(--vscode-charts-green);
+  color: var(--vscode-editor-background);
+}
+
+.configured-badge .codicon { font-size: 12px; }
+.active-badge .codicon { font-size: 14px; }
+
+</style>

--- a/webviews/QuickLinksApp.vue
+++ b/webviews/QuickLinksApp.vue
@@ -8,10 +8,21 @@ const systemReadinessIcon = ref('');
 const systemReadinessDescription = ref('');
 const showSystemReadiness = ref(false);
 
+// Active provider state
+const activeProviderName = ref('');
+const isProviderConnected = ref(false);
+
 // System status check
 const updateAnsibleCreatorAvailabilityStatus = () => {
   vscodeApi.postMessage({
     message: 'set-system-status-view',
+  });
+};
+
+// Get active provider info
+const getActiveProviderInfo = () => {
+  vscodeApi.postMessage({
+    command: 'getActiveProvider',
   });
 };
 
@@ -49,11 +60,15 @@ const handleMessage = (event: MessageEvent) => {
         </p>`;
       showSystemReadiness.value = true;
     }
+  } else if (message.command === 'activeProviderInfo') {
+    activeProviderName.value = message.providerDisplayName || '';
+    isProviderConnected.value = message.isConnected || false;
   }
 };
 
 onMounted(() => {
   updateAnsibleCreatorAvailabilityStatus();
+  getActiveProviderInfo();
   window.addEventListener('message', handleMessage);
 });
 </script>
@@ -102,6 +117,46 @@ onMounted(() => {
         <h3>
           <a href="command:ansible.extension-settings.open" title="Ansible extension settings">
             <span class="codicon codicon-settings-gear"></span> Settings
+          </a>
+        </h3>
+      </div>
+
+      <h3>GENERATIVE AI</h3>
+      <div class="catalogue">
+        <h3>
+          <a href="command:ansible.lightspeed.openLlmProviderSettings" title="Configure LLM provider for Ansible Lightspeed">
+            <span class="codicon codicon-settings-gear"></span> LLM Provider
+            <span v-if="activeProviderName && isProviderConnected" class="active-provider-badge connected">
+              : {{ activeProviderName }}
+            </span>
+          </a>
+        </h3>
+      </div>
+      <div class="catalogue">
+        <h3>
+          <a href="command:ansible.lightspeed.playbookGeneration" title="Generate a playbook with Ansible Lightspeed">
+            <span class="codicon codicon-sparkle"></span> Generate Playbook
+          </a>
+        </h3>
+      </div>
+      <div class="catalogue">
+        <h3>
+          <a href="command:ansible.lightspeed.playbookExplanation" title="Explain the current playbook">
+            <span class="codicon codicon-sparkle"></span> Explain Playbook
+          </a>
+        </h3>
+      </div>
+      <div class="catalogue">
+        <h3>
+          <a href="command:ansible.lightspeed.roleGeneration" title="Generate a role with Ansible Lightspeed">
+            <span class="codicon codicon-sparkle"></span> Generate Role
+          </a>
+        </h3>
+      </div>
+      <div class="catalogue">
+        <h3>
+          <a href="command:ansible.lightspeed.roleExplanation" title="Explain the current role">
+            <span class="codicon codicon-sparkle"></span> Explain Role
           </a>
         </h3>
       </div>
@@ -162,14 +217,6 @@ onMounted(() => {
           <a href="command:ansible.content-creator.create-role" title="Create a role and add it to an existing Ansible collection">
             <span class="codicon codicon-new-file"></span> Role
             <span class="new-badge">NEW</span>
-          </a>
-        </h3>
-      </div>
-      <div class="catalogue">
-        <h3>
-          <a href="command:ansible.lightspeed.playbookGeneration" title="Generate a playbook with Ansible Lightspeed">
-            <span class="codicon codicon-new-file"></span> Playbook
-            <img class="category-icon icon-widget" src="/media/quickLinks/lightspeed.png" alt="Lightspeed">
           </a>
         </h3>
       </div>

--- a/webviews/lightspeed/src/components/ProviderConfigForm.vue
+++ b/webviews/lightspeed/src/components/ProviderConfigForm.vue
@@ -1,0 +1,196 @@
+<script setup lang="ts">
+import '@vscode/codicons/dist/codicon.css';
+import type { ProviderInfo } from './llmProviderState';
+
+defineProps<{
+  provider: ProviderInfo;
+  getConfigValue: (providerType: string, fieldKey: string) => string;
+  hasChanges: boolean;
+}>();
+
+const emit = defineEmits<{
+  'update:field': [fieldKey: string, value: string];
+  save: [];
+  cancel: [];
+}>();
+</script>
+
+<template>
+  <div class="provider-config">
+    <div
+      v-for="field in provider.configSchema"
+      :key="field.key"
+      class="config-field"
+    >
+      <label :for="`${field.key}-${provider.type}`" class="field-label">
+        {{ field.label }}
+        <span v-if="field.required" class="required-indicator">*</span>
+      </label>
+      <input
+        :id="`${field.key}-${provider.type}`"
+        :value="getConfigValue(provider.type, field.key)"
+        @input="emit('update:field', field.key, ($event.target as HTMLInputElement).value)"
+        :type="field.type === 'password' ? 'password' : 'text'"
+        class="text-input"
+        :placeholder="field.placeholder || ''"
+      />
+      <p v-if="field.description" class="field-description">
+        {{ field.description }}
+      </p>
+    </div>
+
+    <!-- Save and Cancel Buttons -->
+    <div class="config-actions">
+      <button
+        class="action-btn save-btn"
+        :class="{ 'has-changes': hasChanges }"
+        @click="emit('save')"
+        title="Save configuration"
+      >
+        <span class="codicon codicon-save"></span>
+        Save
+      </button>
+      <button
+        class="action-btn cancel-btn"
+        @click="emit('cancel')"
+        title="Cancel and close"
+      >
+        Cancel
+      </button>
+      <span v-if="hasChanges" class="unsaved-indicator">
+        Unsaved changes
+      </span>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+/* Config panel */
+.provider-config {
+  padding: 0 16px 16px;
+  border-top: 1px solid var(--vscode-widget-border);
+  background-color: var(--vscode-sideBar-background);
+  animation: slideDown 0.2s ease;
+}
+
+@keyframes slideDown {
+  from { opacity: 0; transform: translateY(-8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+/* Form fields */
+.config-field {
+  margin-top: 16px;
+}
+
+.field-label {
+  display: block;
+  font-size: 12px;
+  font-weight: 600;
+  margin-bottom: 6px;
+}
+
+.required-indicator {
+  color: var(--vscode-errorForeground, #f44336);
+  margin-left: 2px;
+  font-weight: normal;
+}
+
+.text-input {
+  width: 100%;
+  padding: 8px 12px;
+  background-color: var(--vscode-input-background);
+  color: var(--vscode-input-foreground);
+  border: 1px solid var(--vscode-input-border, var(--vscode-widget-border));
+  border-radius: 4px;
+  font-size: 13px;
+  box-sizing: border-box;
+  transition: border-color 0.15s ease;
+}
+
+.text-input:hover,
+.text-input:focus {
+  border-color: var(--vscode-focusBorder);
+}
+
+.text-input:focus {
+  outline: 1px solid var(--vscode-focusBorder);
+  outline-offset: -1px;
+}
+
+.text-input::placeholder {
+  color: var(--vscode-input-placeholderForeground);
+}
+
+.field-description {
+  font-size: 11px;
+  color: var(--vscode-descriptionForeground);
+  margin-top: 6px;
+  line-height: 1.4;
+}
+
+/* Config actions */
+.config-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-top: 20px;
+  padding-top: 16px;
+  border-top: 1px solid var(--vscode-widget-border);
+}
+
+/* Button styles for save/cancel */
+.action-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  font-size: 12px;
+  font-weight: 500;
+  border-radius: 4px;
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+  background-color: var(--vscode-button-secondaryBackground);
+  color: var(--vscode-button-secondaryForeground);
+}
+
+.action-btn:hover {
+  background-color: var(--vscode-button-secondaryHoverBackground);
+}
+
+.action-btn .codicon {
+  font-size: 14px;
+}
+
+.save-btn {
+  background-color: var(--vscode-button-background);
+  color: var(--vscode-button-foreground);
+}
+
+.save-btn:hover {
+  background-color: var(--vscode-button-hoverBackground);
+}
+
+.save-btn.has-changes {
+  background-color: var(--vscode-inputValidation-warningBackground);
+  border-color: var(--vscode-inputValidation-warningBorder);
+  color: var(--vscode-inputValidation-warningForeground, var(--vscode-foreground));
+}
+
+.cancel-btn {
+  background-color: var(--vscode-button-secondaryBackground);
+  color: var(--vscode-button-secondaryForeground);
+  margin-left: 8px;
+}
+
+.cancel-btn:hover {
+  background-color: var(--vscode-button-secondaryHoverBackground);
+}
+
+.unsaved-indicator {
+  font-size: 12px;
+  color: var(--vscode-inputValidation-warningForeground, var(--vscode-editorWarning-foreground));
+  font-style: italic;
+}
+</style>

--- a/webviews/lightspeed/src/components/SpinnerLoading.vue
+++ b/webviews/lightspeed/src/components/SpinnerLoading.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+import '@vscode/codicons/dist/codicon.css';
+
+defineProps<{
+  message?: string;
+}>();
+</script>
+
+<template>
+  <div class="loading">
+    <span class="codicon codicon-loading codicon-modifier-spin"></span>
+    {{ message || 'Loading...' }}
+  </div>
+</template>
+
+<style scoped>
+.loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 48px 20px;
+  color: var(--vscode-descriptionForeground);
+}
+
+.codicon-modifier-spin {
+  animation: spin 1.5s linear infinite;
+}
+
+@keyframes spin {
+  100% { transform: rotate(360deg); }
+}
+</style>

--- a/webviews/lightspeed/src/components/ToastNotification.vue
+++ b/webviews/lightspeed/src/components/ToastNotification.vue
@@ -1,0 +1,40 @@
+<script setup lang="ts">
+import '@vscode/codicons/dist/codicon.css';
+
+defineProps<{
+  visible: boolean;
+  message: string;
+}>();
+</script>
+
+<template>
+  <div :class="['toast-notification', { visible }]">
+    <span class="codicon codicon-check"></span> {{ message }}
+  </div>
+</template>
+
+<style scoped>
+.toast-notification {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px;
+  background-color: var(--vscode-charts-green);
+  color: var(--vscode-editor-background);
+  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 500;
+  opacity: 0;
+  transform: translateY(8px);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  pointer-events: none;
+}
+
+.toast-notification.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+</style>

--- a/webviews/lightspeed/src/components/llmProviderState.ts
+++ b/webviews/lightspeed/src/components/llmProviderState.ts
@@ -1,0 +1,272 @@
+import { onMounted, ref } from "vue";
+import { vscodeApi } from "../utils";
+
+// Types
+export interface ConfigSchemaField {
+  key: string;
+  label: string;
+  type: string;
+  required: boolean;
+  placeholder: string;
+  description: string;
+}
+
+export interface ProviderInfo {
+  type: string;
+  name: string;
+  displayName: string;
+  description: string;
+  defaultEndpoint: string;
+  configSchema: ConfigSchemaField[];
+  usesOAuth?: boolean;
+  requiresApiKey?: boolean;
+}
+
+type ProviderConfig = Record<string, string>;
+
+export function useProviderSettings() {
+  const providers = ref<ProviderInfo[]>([]);
+  const activeProvider = ref<string>("wca");
+  const editingProvider = ref<string | null>(null);
+  const isLoading = ref<boolean>(true);
+  const saveIndicatorVisible = ref<boolean>(false);
+  const connectingProvider = ref<string | null>(null);
+
+  const providerConfigs = ref<Record<string, ProviderConfig>>({});
+
+  const originalConfigs = ref<Record<string, ProviderConfig>>({});
+
+  const connectionStatuses = ref<Record<string, boolean>>({});
+
+  // Computed helpers
+  const getProviderInfo = (type: string) => {
+    return providers.value.find((p) => p.type === type);
+  };
+
+  const isConnected = (providerType: string) => {
+    return connectionStatuses.value[providerType] ?? false;
+  };
+
+  const isConnecting = (providerType: string) => {
+    return connectingProvider.value === providerType;
+  };
+
+  // Compare all fields from configSchema to detect changes
+  const hasUnsavedChanges = (providerType: string) => {
+    const provider = getProviderInfo(providerType);
+    const current = providerConfigs.value[providerType];
+    const original = originalConfigs.value[providerType];
+
+    if (!provider || !original || !current) return false;
+
+    for (const field of provider.configSchema) {
+      if ((current[field.key] || "") !== (original[field.key] || "")) {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  // Get config value for a field
+  const getConfigValue = (providerType: string, fieldKey: string): string => {
+    return providerConfigs.value[providerType]?.[fieldKey] || "";
+  };
+
+  // Set config value for a field
+  const setConfigValue = (
+    providerType: string,
+    fieldKey: string,
+    value: string,
+  ): void => {
+    if (!providerConfigs.value[providerType]) {
+      providerConfigs.value[providerType] = {};
+    }
+    providerConfigs.value[providerType][fieldKey] = value;
+  };
+
+  // Methods
+  const loadProviderSettings = () => {
+    vscodeApi.postMessage({
+      command: "getProviderSettings",
+    });
+  };
+
+  const showSaveIndicator = () => {
+    saveIndicatorVisible.value = true;
+    setTimeout(() => {
+      saveIndicatorVisible.value = false;
+    }, 2000);
+  };
+
+  const setActiveProvider = (providerType: string) => {
+    activeProvider.value = providerType;
+
+    // Only activate the provider
+    vscodeApi.postMessage({
+      command: "activateProvider",
+      provider: providerType,
+    });
+
+    showSaveIndicator();
+  };
+
+  const toggleEdit = (providerType: string) => {
+    if (editingProvider.value === providerType) {
+      // Closing edit panel
+      if (originalConfigs.value[providerType]) {
+        providerConfigs.value[providerType] = {
+          ...originalConfigs.value[providerType],
+        };
+      }
+      editingProvider.value = null;
+    } else {
+      // If switching from another provider's edit, discard that provider's unsaved changes
+      if (
+        editingProvider.value &&
+        originalConfigs.value[editingProvider.value]
+      ) {
+        providerConfigs.value[editingProvider.value] = {
+          ...originalConfigs.value[editingProvider.value],
+        };
+      }
+
+      editingProvider.value = providerType;
+      const providerInfo = getProviderInfo(providerType);
+
+      // Initialize config from configSchema if not already loaded
+      if (!providerConfigs.value[providerType]) {
+        const config: ProviderConfig = {};
+        providerInfo?.configSchema.forEach((field) => {
+          // Use defaultEndpoint for apiEndpoint field, empty string for others
+          config[field.key] =
+            field.key === "apiEndpoint"
+              ? providerInfo?.defaultEndpoint || ""
+              : "";
+        });
+        providerConfigs.value[providerType] = config;
+      }
+
+      // Store original values to compare against for change detection
+      originalConfigs.value[providerType] = {
+        ...providerConfigs.value[providerType],
+      };
+    }
+  };
+
+  const saveProviderConfig = (providerType: string) => {
+    const config = providerConfigs.value[providerType];
+    const provider = getProviderInfo(providerType);
+    if (!config || !provider) return;
+
+    // Check if there are actual changes before saving
+    const hadChanges = hasUnsavedChanges(providerType);
+
+    // Build config object from configSchema fields
+    const configToSend: Record<string, string> = {};
+    provider.configSchema.forEach((field) => {
+      configToSend[field.key] = config[field.key] || "";
+    });
+
+    vscodeApi.postMessage({
+      command: "saveProviderSettings",
+      provider: providerType,
+      config: configToSend,
+    });
+
+    // Update original config to match saved values
+    originalConfigs.value[providerType] = { ...config };
+
+    // Reset connection status if config actually changed
+    if (hadChanges) {
+      connectionStatuses.value[providerType] = false;
+    }
+
+    showSaveIndicator();
+  };
+
+  const connectProvider = (providerType: string) => {
+    connectingProvider.value = providerType;
+    activeProvider.value = providerType;
+
+    vscodeApi.postMessage({
+      command: "connectProvider",
+      provider: providerType,
+    });
+  };
+
+  // Message handler
+  const handleMessage = (event: MessageEvent) => {
+    const message = event.data;
+
+    switch (message.command) {
+      case "providerSettings": {
+        providers.value = message.providers || [];
+        activeProvider.value = message.currentProvider || "wca";
+        connectionStatuses.value = message.connectionStatuses || {};
+
+        // Load configs for ALL providers from backend, using configSchema as the field source
+        const backendConfigs = message.providerConfigs || {};
+
+        providers.value.forEach((provider) => {
+          const backendConfig = backendConfigs[provider.type] || {};
+          const config: ProviderConfig = {};
+
+          // Initialize each field from configSchema with backend value or default
+          provider.configSchema.forEach((field) => {
+            if (field.key === "apiEndpoint") {
+              config[field.key] =
+                backendConfig[field.key] || provider.defaultEndpoint || "";
+            } else {
+              config[field.key] = backendConfig[field.key] || "";
+            }
+          });
+
+          providerConfigs.value[provider.type] = config;
+
+          originalConfigs.value[provider.type] = { ...config };
+        });
+
+        isLoading.value = false;
+        connectingProvider.value = null;
+        break;
+      }
+
+      case "connectionResult":
+        connectingProvider.value = null;
+        if (message.connected) {
+          connectionStatuses.value[message.provider] = true;
+        } else {
+          connectionStatuses.value[message.provider] = false;
+          console.error(
+            `Connection failed for ${message.provider}: ${message.error}`,
+          );
+        }
+        break;
+    }
+  };
+
+  onMounted(() => {
+    loadProviderSettings();
+    window.addEventListener("message", handleMessage);
+  });
+
+  return {
+    // State
+    providers,
+    activeProvider,
+    editingProvider,
+    isLoading,
+    saveIndicatorVisible,
+    // Helpers
+    isConnected,
+    isConnecting,
+    hasUnsavedChanges,
+    getConfigValue,
+    setConfigValue,
+    // Actions
+    setActiveProvider,
+    toggleEdit,
+    saveProviderConfig,
+    connectProvider,
+  };
+}

--- a/webviews/llm-provider.html
+++ b/webviews/llm-provider.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>LLM Provider</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="./llm-provider.ts"></script>
+  </body>
+</html>

--- a/webviews/llm-provider.ts
+++ b/webviews/llm-provider.ts
@@ -1,0 +1,6 @@
+import { createApp } from "vue";
+import App from "./LlmProviderApp.vue";
+
+const app = createApp(App);
+
+app.mount("#app");


### PR DESCRIPTION
This PR migrates the existing LLM explorer side panel view into a new webview page. 
This removes fetching existing configuration management for LLM provider from setting.json. 
It adds the support to store the provider configuration into VSCode globalState and secrets for persistance . 

Jira: [ACA-4979](https://issues.redhat.com/browse/ACA-4979)
ANSTRAT: [ANSTRAT-1828](https://issues.redhat.com/browse/ANSTRAT-1828)
Figma:  [UX](https://www.figma.com/proto/Uzf3aMNZ4SCH4FvDxSvj0Y/VSCode-Extention?page-id=6130%3A751&node-id=6482-4156&viewport=225%2C96%2C0.06&t=nWRAanH2xdkIqfyp-1&scaling=min-zoom&content-scaling=fixed&starting-point-node-id=6130%3A1203)
Depends-On: https://github.com/ansible/vscode-ansible/pull/2600