### PR TITLE
fix: trim textfields in collection and project webviews

### DIFF
--- a/test/unit/webviews/CreateAnsibleCollectionApp.test.ts
+++ b/test/unit/webviews/CreateAnsibleCollectionApp.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount } from "@vue/test-utils";
+import CreateAnsibleCollectionApp from "../../../webviews/CreateAnsibleCollectionApp.vue";
+
+const { mockPostMessage } = vi.hoisted(() => ({
+  mockPostMessage: vi.fn(),
+}));
+
+vi.mock("../../../webviews/lightspeed/src/utils/vscode", () => ({
+  vscodeApi: {
+    postMessage: mockPostMessage,
+    post: vi.fn(),
+    on: vi.fn(),
+    postAndReceive: vi.fn().mockResolvedValue([]),
+  },
+}));
+
+vi.mock("@vscode/codicons/dist/codicon.css", () => ({}));
+
+vi.mock(
+  "../../../src/features/contentCreator/webviewUtils",
+  async (importOriginal) => {
+    const actual = await importOriginal();
+    return {
+      // @ts-expect-error - importOriginal returns unknown
+      ...actual,
+      initializeUI: vi.fn(),
+      setupMessageHandler: vi.fn(),
+      checkADEPresence: vi.fn(),
+      openFolderExplorer: vi.fn(),
+      openFileExplorer: vi.fn(),
+      clearLogs: vi.fn(),
+      copyLogs: vi.fn(),
+      openLogFile: vi.fn(),
+      openScaffoldedFolder: vi.fn(),
+    };
+  },
+);
+
+describe("CreateAnsibleCollectionApp", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("trims whitespace from text fields in payload", async () => {
+    const wrapper = mount(CreateAnsibleCollectionApp);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const vm = wrapper.vm as any;
+
+    vm.namespace = "  mynamespace  ";
+    vm.collectionName = "  mycollection  ";
+    vm.initPath = "  /home/test/path  ";
+
+    await wrapper.find("#create-button").trigger("click");
+
+    expect(mockPostMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "init-create",
+        payload: expect.objectContaining({
+          namespaceName: "mynamespace",
+          collectionName: "mycollection",
+          initPath: "/home/test/path",
+        }),
+      }),
+    );
+  });
+
+  it("disables create button when namespace or collection is 2 chars or less", () => {
+    const wrapper = mount(CreateAnsibleCollectionApp);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const vm = wrapper.vm as any;
+
+    vm.namespace = "ss";
+    vm.collectionName = "ss";
+    vm.initPath = "/home/test";
+
+    const button = wrapper.find("#create-button");
+    expect(button.attributes("disabled")).toBeDefined();
+  });
+});

--- a/test/unit/webviews/CreateAnsibleProjectApp.test.ts
+++ b/test/unit/webviews/CreateAnsibleProjectApp.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount } from "@vue/test-utils";
+import CreateAnsibleProjectApp from "../../../webviews/CreateAnsibleProjectApp.vue";
+
+const { mockPostMessage } = vi.hoisted(() => ({
+  mockPostMessage: vi.fn(),
+}));
+
+vi.mock("../../../webviews/lightspeed/src/utils/vscode", () => ({
+  vscodeApi: {
+    postMessage: mockPostMessage,
+    post: vi.fn(),
+    on: vi.fn(),
+    postAndReceive: vi.fn().mockResolvedValue([]),
+  },
+}));
+
+vi.mock("@vscode/codicons/dist/codicon.css", () => ({}));
+
+vi.mock(
+  "../../../src/features/contentCreator/webviewUtils",
+  async (importOriginal) => {
+    const actual = await importOriginal();
+    return {
+      // @ts-expect-error - importOriginal returns unknown
+      ...actual,
+      initializeUI: vi.fn(),
+      setupMessageHandler: vi.fn(),
+      openFolderExplorer: vi.fn(),
+      openFileExplorer: vi.fn(),
+      clearLogs: vi.fn(),
+      copyLogs: vi.fn(),
+      openLogFile: vi.fn(),
+      openScaffoldedFolder: vi.fn(),
+    };
+  },
+);
+
+describe("CreateAnsibleProjectApp", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("trims whitespace from text fields in payload", async () => {
+    const wrapper = mount(CreateAnsibleProjectApp);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const vm = wrapper.vm as any;
+
+    vm.namespace = "  mynamespace  ";
+    vm.collectionName = "  mycollection  ";
+    vm.initPath = "  /home/test/path  ";
+
+    await wrapper.find("#create-button").trigger("click");
+
+    expect(mockPostMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "init-create",
+        payload: expect.objectContaining({
+          namespaceName: "mynamespace",
+          collectionName: "mycollection",
+          destinationPath: "/home/test/path",
+        }),
+      }),
+    );
+  });
+
+  it("disables create button when namespace or collection is 2 chars or less", () => {
+    const wrapper = mount(CreateAnsibleProjectApp);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const vm = wrapper.vm as any;
+
+    vm.namespace = "ss";
+    vm.collectionName = "ss";
+
+    const button = wrapper.find("#create-button");
+    expect(button.attributes("disabled")).toBeDefined();
+  });
+});

--- a/webviews/CreateAnsibleCollectionApp.vue
+++ b/webviews/CreateAnsibleCollectionApp.vue
@@ -45,8 +45,8 @@ const requirementFailures = ref([]);
 
 const isFormValid = computed(() => {
   return (
-    namespace.value.trim() !== "" &&
-    collectionName.value.trim() !== "" &&
+    namespace.value.trim().length > 2 &&
+    collectionName.value.trim().length > 2 &&
     (initPath.value.trim() !== "" || defaultInitPath.value.trim() !== "")
   );
 });
@@ -79,12 +79,12 @@ const handleCreate = createActionWrapper(
   commonState.createButtonDisabled,
   () => {
     const actualInitPath = initPath.value.trim() || defaultInitPath.value;
-    const actualLogFilePath = commonState.logFilePath.value || commonState.defaultLogFilePath.value;
+    const actualLogFilePath = (commonState.logFilePath.value || commonState.defaultLogFilePath.value || '').trim();
 
     const payload = {
       initPath: actualInitPath,
-      namespaceName: namespace.value,
-      collectionName: collectionName.value,
+      namespaceName: namespace.value.trim(),
+      collectionName: collectionName.value.trim(),
       verbosity: verbosity.value,
       logToFile: logToFile.value,
       logFileAppend: logFileAppend.value,

--- a/webviews/CreateAnsibleProjectApp.vue
+++ b/webviews/CreateAnsibleProjectApp.vue
@@ -41,8 +41,8 @@ const projectUrl = ref("");
 
 const canCreate = computed(() => {
   return (
-    namespace.value.trim() !== "" &&
-    collectionName.value.trim() !== ""
+    namespace.value.trim().length > 2 &&
+    collectionName.value.trim().length > 2
   );
 });
 
@@ -70,14 +70,14 @@ const handleCreate = createActionWrapper(
   commonState.createButtonDisabled,
   () => {
     const payload = {
-      destinationPath: initPath.value,
-      namespaceName: namespace.value,
-      collectionName: collectionName.value,
+      destinationPath: initPath.value.trim(),
+      namespaceName: namespace.value.trim(),
+      collectionName: collectionName.value.trim(),
       verbosity: verbosity.value,
       logToFile: logToFile.value,
       logFileAppend: logFileAppend.value,
       isEditableModeInstall: isEditableModeInstall.value,
-      logFilePath: commonState.logFilePath.value || commonState.defaultLogFilePath.value,
+      logFilePath: (commonState.logFilePath.value || commonState.defaultLogFilePath.value || '').trim(),
       logLevel: logLevel.value,
       isOverwritten: isOverwritten.value,
     };


### PR DESCRIPTION
Fixes AAP-54044

Trim text field inputs in Collection and Project webviews before validation 
and payload creation to avoid issues caused by leading/trailing whitespace.

Also fixed validation logic - fields now require a trimmed length of > 2 
characters instead of checking for an empty string, because ansible-creator needs a collection name and namespace name should be greater than 2 characters.