### PR TITLE
chore: enable retries for mise install

### DIFF
--- a/.config/mise.toml
+++ b/.config/mise.toml
@@ -26,6 +26,7 @@ _.path = ["./node_modules/.bin"]
 experimental = true
 idiomatic_version_file_enable_tools = ["python"]
 lockfile = true
+http_retries = 5
 
 [tools]
 gh = "latest"


### PR DESCRIPTION
This should make it less likely to see `mise install` failures, like
the ones we ween with konflux.
