### PR TITLE
fix: allow publish for release event and manual trigger, fix vsix path

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -552,7 +552,7 @@ jobs:
           slack_webhook_url: ${{ secrets.DEVTOOLS_CI_SLACK_URL }}
 
   publish:
-    if: github.ref_type == 'tag' || github.event.inputs.publish == 'true'
+    if: github.ref_type == 'tag' || (github.event_name == 'release' && github.event.action == 'published') || github.event.inputs.publish == 'true' || github.event.inputs.publish == true
     runs-on: ubuntu-latest
     environment: release
     needs:
@@ -588,7 +588,7 @@ jobs:
 
       - run: |
           yarn install --immutable
-          ls -la *.vsix
+          ls -la out/*.vsix
 
       - name: Publish extension to marketplaces
         run: |
@@ -605,7 +605,7 @@ jobs:
 
   publish-npm:
     environment: release
-    if: needs.build.outputs.can_release_to_npm == 'true' && (github.ref_type == 'tag' || github.event.inputs.publish == 'true')
+    if: needs.build.outputs.can_release_to_npm == 'true' && (github.ref_type == 'tag' || (github.event_name == 'release' && github.event.action == 'published') || github.event.inputs.publish == 'true' || github.event.inputs.publish == true)
     runs-on: ubuntu-latest
     needs:
       - build


### PR DESCRIPTION
This PR fixes the CI workflow so the VS Code extension publishes correctly.

- Updated publish and publish-npm jobs to run for:
  - Tag push
  - GitHub "Publish release" events
  - Manual workflow runs with "Publish a pre-release" = true
- Fixed VSIX path to point to the correct `out/` folder

After merging, triggering the workflow by any of the above methods will publish the extension and update the Marketplace.