### PR TITLE
feat: add Red Hat Custom LLM provider

### DIFF
--- a/src/definitions/lightspeed.ts
+++ b/src/definitions/lightspeed.ts
@@ -76,7 +76,7 @@ export const WCA_API_ENDPOINT_DEFAULT = "https://c.ai.ansible.redhat.com";
 export const GOOGLE_DEFAULT_MODEL = "gemini-2.5-flash";
 
 // LLM Provider Types
-export type ProviderType = "wca" | "google";
+export type ProviderType = "wca" | "google" | "rhcustom";
 
 export type LIGHTSPEED_SUGGESTION_TYPE = "SINGLE-TASK" | "MULTI-TASK";
 

--- a/src/features/lightspeed/clients/openaiCompatibleClient.ts
+++ b/src/features/lightspeed/clients/openaiCompatibleClient.ts
@@ -131,7 +131,7 @@ export class OpenAICompatibleClient {
         throw error;
       }
 
-      throw new Error("Unknown error occurred");
+      throw new Error("Unknown error occurred", { cause: error });
     }
   }
 }

--- a/src/features/lightspeed/clients/openaiCompatibleClient.ts
+++ b/src/features/lightspeed/clients/openaiCompatibleClient.ts
@@ -131,7 +131,7 @@ export class OpenAICompatibleClient {
         throw error;
       }
 
-      throw new Error("Unknown error occurred", { cause: error });
+      throw new Error("Unknown error occurred");
     }
   }
 }

--- a/src/features/lightspeed/llmProviderSettings.ts
+++ b/src/features/lightspeed/llmProviderSettings.ts
@@ -175,18 +175,21 @@ export class LlmProviderSettings {
     apiEndpoint: string;
     modelName: string | undefined;
     apiKey: string;
+    maxTokens?: string;
     connectionStatuses: Record<string, boolean>;
   }> {
     const currentProvider = this.getProvider();
     const apiEndpoint = await this.get(currentProvider, "apiEndpoint");
     const modelName = await this.get(currentProvider, "modelName");
     const apiKey = await this.get(currentProvider, "apiKey");
+    const maxTokens = await this.get(currentProvider, "maxTokens");
 
     return {
       provider: currentProvider,
       apiEndpoint,
       modelName: modelName || undefined,
       apiKey,
+      maxTokens: maxTokens || undefined,
       connectionStatuses: this.getAllConnectionStatuses(),
     };
   }

--- a/src/features/lightspeed/providers/base.ts
+++ b/src/features/lightspeed/providers/base.ts
@@ -104,6 +104,8 @@ export abstract class BaseLLMProvider<
 > implements LLMProvider {
   protected config: TConfig;
   protected timeout: number;
+  /** Set by validateConfig() on failure; used by getStatusWithValidation for the error message. */
+  protected lastValidationError?: string;
 
   constructor(config: TConfig, timeout: number = 30000) {
     this.config = config;
@@ -170,7 +172,10 @@ export abstract class BaseLLMProvider<
       if (!isValid) {
         return {
           connected: false,
-          error: lastValidationError || defaultErrorMessage,
+          error:
+            this.lastValidationError ||
+            lastValidationError ||
+            defaultErrorMessage,
         };
       }
 

--- a/src/features/lightspeed/providers/factory.ts
+++ b/src/features/lightspeed/providers/factory.ts
@@ -51,43 +51,51 @@ export class LLMProviderFactory implements ProviderFactory {
         } as GoogleConfig);
       }
 
-      case "rhcustom": {
-        if (!config.apiKey || config.apiKey.trim() === "") {
-          throw new Error(
-            "API Key is required for Red Hat Custom. Please set it in the provider settings.",
-          );
-        }
-        if (!config.modelName || config.modelName.trim() === "") {
-          throw new Error(
-            "Model name is required for Red Hat Custom. Please set it in the provider settings.",
-          );
-        }
-        if (!config.apiEndpoint || config.apiEndpoint.trim() === "") {
-          throw new Error(
-            "API endpoint is required for Red Hat Custom. Please set it in the provider settings.",
-          );
-        }
-        const maxTokens =
-          typeof config.maxTokens === "number"
-            ? config.maxTokens
-            : config.maxTokens !== undefined &&
-                config.maxTokens !== null &&
-                String(config.maxTokens).trim() !== ""
-              ? parseInt(String(config.maxTokens).trim(), 10)
-              : 1600;
-        const baseURL = config.apiEndpoint.trim().replace(/\/+$/, "");
-        return new RHCustomProvider({
-          apiKey: config.apiKey,
-          modelName: config.modelName,
-          baseURL,
-          timeout: config.timeout || 30000,
-          maxTokens,
-        } as RHCustomConfig);
-      }
+      case "rhcustom":
+        return this.createRHCustomProvider(config);
 
       default:
         throw new Error(`Unsupported provider type: ${type}`);
     }
+  }
+
+  private static parseMaxTokens(
+    value: number | string | undefined | null,
+    defaultValue = 1600,
+  ): number {
+    if (typeof value === "number") return value;
+    const trimmed =
+      value !== undefined && value !== null ? String(value).trim() : "";
+    return trimmed !== "" ? Number.parseInt(trimmed, 10) : defaultValue;
+  }
+
+  private createRHCustomProvider(
+    config: LightSpeedServiceSettings,
+  ): RHCustomProvider {
+    if (!config.apiKey || config.apiKey.trim() === "") {
+      throw new Error(
+        "API Key is required for Red Hat Custom. Please set it in the provider settings.",
+      );
+    }
+    if (!config.modelName || config.modelName.trim() === "") {
+      throw new Error(
+        "Model name is required for Red Hat Custom. Please set it in the provider settings.",
+      );
+    }
+    if (!config.apiEndpoint || config.apiEndpoint.trim() === "") {
+      throw new Error(
+        "API endpoint is required for Red Hat Custom. Please set it in the provider settings.",
+      );
+    }
+    const maxTokens = LLMProviderFactory.parseMaxTokens(config.maxTokens);
+    const baseURL = config.apiEndpoint.trim().replace(/\/+$/, "");
+    return new RHCustomProvider({
+      apiKey: config.apiKey,
+      modelName: config.modelName,
+      baseURL,
+      timeout: config.timeout || 30000,
+      maxTokens,
+    } as RHCustomConfig);
   }
 
   getSupportedProviders(): ProviderInfo[] {

--- a/src/features/lightspeed/providers/factory.ts
+++ b/src/features/lightspeed/providers/factory.ts
@@ -1,5 +1,6 @@
 import { LLMProvider } from "./base";
 import { GoogleProvider, GoogleConfig } from "./google";
+import { RHCustomProvider, RHCustomConfig } from "./rhcustom";
 import { LightSpeedServiceSettings } from "../../../interfaces/extensionSettings";
 import {
   GOOGLE_API_ENDPOINT,
@@ -36,25 +37,52 @@ export class LLMProviderFactory implements ProviderFactory {
             "API Key is required for Google Gemini. Please set 'ansible.lightspeed.apiKey' in your settings.",
           );
         }
-        // Allow localhost URLs for testing, block other custom endpoints
-        const isLocalhostUrl =
-          config.apiEndpoint?.startsWith("http://localhost");
-        if (
-          config.apiEndpoint &&
-          config.apiEndpoint !== GOOGLE_API_ENDPOINT &&
-          !isLocalhostUrl
-        ) {
-          throw new Error(
-            `Custom API endpoints are not supported for Google Gemini provider. The endpoint is automatically configured. Please remove 'ansible.lightspeed.apiEndpoint' from your settings.`,
-          );
-        }
+        // Use custom endpoint if provided (allows v2, proxies, etc.)
+        const customEndpoint =
+          config.apiEndpoint && config.apiEndpoint !== GOOGLE_API_ENDPOINT
+            ? config.apiEndpoint
+            : undefined;
 
         return new GoogleProvider({
           apiKey: config.apiKey,
           modelName: config.modelName || GOOGLE_DEFAULT_MODEL,
           timeout: config.timeout || 30000,
-          baseUrl: isLocalhostUrl ? config.apiEndpoint : undefined,
+          baseUrl: customEndpoint,
         } as GoogleConfig);
+      }
+
+      case "rhcustom": {
+        if (!config.apiKey || config.apiKey.trim() === "") {
+          throw new Error(
+            "API Key is required for Red Hat Custom. Please set it in the provider settings.",
+          );
+        }
+        if (!config.modelName || config.modelName.trim() === "") {
+          throw new Error(
+            "Model name is required for Red Hat Custom. Please set it in the provider settings.",
+          );
+        }
+        if (!config.apiEndpoint || config.apiEndpoint.trim() === "") {
+          throw new Error(
+            "API endpoint is required for Red Hat Custom. Please set it in the provider settings.",
+          );
+        }
+        const maxTokens =
+          typeof config.maxTokens === "number"
+            ? config.maxTokens
+            : config.maxTokens !== undefined &&
+                config.maxTokens !== null &&
+                String(config.maxTokens).trim() !== ""
+              ? parseInt(String(config.maxTokens).trim(), 10)
+              : 1600;
+        const baseURL = config.apiEndpoint.trim().replace(/\/+$/, "");
+        return new RHCustomProvider({
+          apiKey: config.apiKey,
+          modelName: config.modelName,
+          baseURL,
+          timeout: config.timeout || 30000,
+          maxTokens,
+        } as RHCustomConfig);
       }
 
       default:
@@ -120,6 +148,51 @@ export class LLMProviderFactory implements ProviderFactory {
             placeholder: "gemini-2.5-flash",
             description:
               "The Gemini model to use (optional, defaults to gemini-2.5-flash)",
+          },
+        ],
+      },
+      {
+        type: "rhcustom",
+        name: "rhcustom",
+        displayName: "Red Hat Custom",
+        description: "Connect to custom OpenAI-compatible Red Hat AI models",
+        defaultEndpoint: "",
+        defaultModel: undefined,
+        usesOAuth: false,
+        requiresApiKey: true,
+        configSchema: [
+          {
+            key: "apiEndpoint",
+            label: "API Endpoint",
+            type: "string",
+            required: true,
+            placeholder: "https://your-api.example.com",
+            description: "Base URL of your custom deployment",
+          },
+          {
+            key: "apiKey",
+            label: "API Key",
+            type: "password",
+            required: true,
+            placeholder: "",
+            description: "Your API key for the custom endpoint",
+          },
+          {
+            key: "modelName",
+            label: "Model Name",
+            type: "string",
+            required: true,
+            placeholder: "my-model",
+            description: "The model name to use",
+          },
+          {
+            key: "maxTokens",
+            label: "Max Tokens",
+            type: "number",
+            required: false,
+            placeholder: "1600",
+            description:
+              "Maximum tokens per response (optional, defaults to 1600)",
           },
         ],
       },

--- a/src/features/lightspeed/providers/factory.ts
+++ b/src/features/lightspeed/providers/factory.ts
@@ -88,7 +88,10 @@ export class LLMProviderFactory implements ProviderFactory {
       );
     }
     const maxTokens = LLMProviderFactory.parseMaxTokens(config.maxTokens);
-    const baseURL = config.apiEndpoint.trim().replace(/\/+$/, "");
+    let baseURL = config.apiEndpoint.trim();
+    while (baseURL.endsWith("/")) {
+      baseURL = baseURL.slice(0, -1);
+    }
     return new RHCustomProvider({
       apiKey: config.apiKey,
       modelName: config.modelName,

--- a/src/features/lightspeed/providers/google.ts
+++ b/src/features/lightspeed/providers/google.ts
@@ -143,6 +143,7 @@ export class GoogleProvider extends BaseLLMProvider<GoogleConfig> {
       );
       throw new Error(
         `Google completion failed: ${error instanceof Error ? error.message : "Unknown error"}`,
+        { cause: error },
       );
     }
   }

--- a/src/features/lightspeed/providers/google.ts
+++ b/src/features/lightspeed/providers/google.ts
@@ -40,7 +40,6 @@ export class GoogleProvider extends BaseLLMProvider<GoogleConfig> {
   private readonly client: GoogleGenAI;
   private readonly modelName: string;
   private readonly logger = getLightspeedLogger();
-  private lastValidationError?: string;
 
   constructor(config: GoogleConfig) {
     super(config, config.timeout);
@@ -80,9 +79,13 @@ export class GoogleProvider extends BaseLLMProvider<GoogleConfig> {
       this.lastValidationError = undefined; // Clear any previous error
       return true;
     } catch (error) {
-      const errorMsg = `Config validation failed: ${error instanceof Error ? error.message : "Unknown error"}`;
-      this.logger.error(`[Google Provider] ${errorMsg}`);
-      this.lastValidationError = errorMsg;
+      const formattedError = this.handleGeminiError(error, "config validation");
+      this.lastValidationError = formattedError.message;
+
+      this.logger.error(`[Google Provider] ${formattedError.message}`);
+      this.logger.error(
+        `[Google Provider] Validation error details: ${error instanceof Error ? error.stack : JSON.stringify(error)}`,
+      );
       return false;
     }
   }
@@ -91,7 +94,7 @@ export class GoogleProvider extends BaseLLMProvider<GoogleConfig> {
     return await this.getStatusWithValidation(
       this.modelName,
       this.lastValidationError,
-      "Failed to connect to Google Gemini API. Check your API key.",
+      "Failed to connect to Google Gemini API. Check your API key or endpoint.",
     );
   }
 
@@ -140,7 +143,6 @@ export class GoogleProvider extends BaseLLMProvider<GoogleConfig> {
       );
       throw new Error(
         `Google completion failed: ${error instanceof Error ? error.message : "Unknown error"}`,
-        { cause: error },
       );
     }
   }

--- a/src/features/lightspeed/providers/rhcustom.ts
+++ b/src/features/lightspeed/providers/rhcustom.ts
@@ -230,7 +230,10 @@ export class RHCustomProvider extends BaseLLMProvider<RHCustomConfig> {
       this.lastValidationError = undefined;
       return true;
     } catch (error) {
-      const formattedError = this.handleRHCustomError(error, "config validation");
+      const formattedError = this.handleRHCustomError(
+        error,
+        "config validation",
+      );
       this.lastValidationError = formattedError.message;
 
       this.logger.error(`[RHCustom Provider] ${formattedError.message}`);

--- a/src/features/lightspeed/providers/rhcustom.ts
+++ b/src/features/lightspeed/providers/rhcustom.ts
@@ -76,6 +76,7 @@ export class RHCustomProvider extends BaseLLMProvider<RHCustomConfig> {
       if (error instanceof TypeError) {
         throw new Error(
           `Invalid base URL format: ${config.baseURL}. Please provide a valid URL (e.g., https://example.com).`,
+          { cause: error },
         );
       }
       throw error;

--- a/src/features/lightspeed/providers/rhcustom.ts
+++ b/src/features/lightspeed/providers/rhcustom.ts
@@ -29,7 +29,7 @@ import {
   OpenAIClientError,
 } from "../clients/openaiCompatibleClient";
 
-interface RHCustomConfig {
+export interface RHCustomConfig {
   apiKey: string;
   modelName: string;
   baseURL: string;
@@ -45,7 +45,6 @@ export class RHCustomProvider extends BaseLLMProvider<RHCustomConfig> {
   private readonly modelName: string;
   private readonly maxTokens: number;
   private readonly logger = getLightspeedLogger();
-  private lastValidationError?: string;
 
   constructor(config: RHCustomConfig) {
     super(config, config.timeout || 30000);
@@ -77,7 +76,6 @@ export class RHCustomProvider extends BaseLLMProvider<RHCustomConfig> {
       if (error instanceof TypeError) {
         throw new Error(
           `Invalid base URL format: ${config.baseURL}. Please provide a valid URL (e.g., https://example.com).`,
-          { cause: error },
         );
       }
       throw error;
@@ -231,15 +229,13 @@ export class RHCustomProvider extends BaseLLMProvider<RHCustomConfig> {
       this.lastValidationError = undefined;
       return true;
     } catch (error) {
-      const errorMsg = `Config validation failed: ${error instanceof Error ? error.message : "Unknown error"}`;
-      console.log("[RHCustom Provider] Config validation failed:", errorMsg);
-      console.log("[RHCustom Provider] Error details:", error);
+      const formattedError = this.handleRHCustomError(error, "config validation");
+      this.lastValidationError = formattedError.message;
 
-      this.logger.error(`[RHCustom Provider] ${errorMsg}`);
+      this.logger.error(`[RHCustom Provider] ${formattedError.message}`);
       this.logger.error(
         `[RHCustom Provider] Validation error details: ${error instanceof Error ? error.stack : JSON.stringify(error)}`,
       );
-      this.lastValidationError = errorMsg;
       return false;
     }
   }

--- a/src/features/lightspeed/vue/views/llmProviderMessageHandlers.ts
+++ b/src/features/lightspeed/vue/views/llmProviderMessageHandlers.ts
@@ -4,7 +4,10 @@ import { SettingsManager } from "../../../../settings";
 import { providerFactory } from "../../providers/factory";
 import { ProviderManager } from "../../providerManager";
 import { LlmProviderSettings } from "../../llmProviderSettings";
-import { LightSpeedCommands } from "../../../../definitions/lightspeed";
+import {
+  LightSpeedCommands,
+  ProviderType,
+} from "../../../../definitions/lightspeed";
 import { LightspeedUser } from "../../lightspeedUser";
 import { QuickLinksWebviewViewProvider } from "../../../quickLinks/utils/quickLinksViewProvider";
 import { ProviderInfo } from "../../../../interfaces/lightspeed";
@@ -248,9 +251,7 @@ export class LlmProviderMessageHandlers {
     await this.llmProviderSettings.setConnectionStatus(connected, providerType);
 
     if (connected) {
-      window.showInformationMessage(
-        `Successfully connected to ${displayName}.`,
-      );
+      window.showInformationMessage(`Successfully connected to ${displayName}.`);
     } else {
       window.showErrorMessage(`Failed to connect to ${displayName}: ${error}`);
     }
@@ -275,15 +276,22 @@ export class LlmProviderMessageHandlers {
   ): Promise<void> {
     await commands.executeCommand(LightSpeedCommands.LIGHTSPEED_AUTH_REQUEST);
 
-    const isAuth = await this.lightspeedUser.isAuthenticated();
-    const displayName = providerInfo?.displayName || providerType.toUpperCase();
+    // Wait for the OAuth flow to complete, then check status
+    setTimeout(async () => {
+      const isAuth = await this.lightspeedUser.isAuthenticated();
+      const displayName =
+        providerInfo?.displayName || providerType.toUpperCase();
+      const error = isAuth
+        ? undefined
+        : "Authentication failed or was cancelled.";
 
-    await this.handleConnectionResult(
-      providerType,
-      displayName,
-      isAuth,
-      isAuth ? undefined : "Authentication failed or was cancelled.",
-    );
+      await this.handleConnectionResult(
+        providerType,
+        displayName,
+        isAuth,
+        error,
+      );
+    }, 2000);
   }
 
   /**
@@ -294,7 +302,8 @@ export class LlmProviderMessageHandlers {
     providerInfo: ProviderInfo | undefined,
   ): Promise<void> {
     const result = await this.validateProviderConnection(providerType);
-    const displayName = providerInfo?.displayName || providerType.toUpperCase();
+    const displayName =
+      providerInfo?.displayName || providerType.toUpperCase();
 
     await this.handleConnectionResult(
       providerType,
@@ -322,6 +331,10 @@ export class LlmProviderMessageHandlers {
         providerType,
         "apiEndpoint",
       );
+      const maxTokensStr = await this.llmProviderSettings.get(
+        providerType,
+        "maxTokens",
+      );
 
       if (providerInfo?.requiresApiKey && !apiKey) {
         return {
@@ -333,13 +346,17 @@ export class LlmProviderMessageHandlers {
 
       // Use stored endpoint as-is (allows custom endpoints, v2, proxies, etc.)
       const apiEndpoint = storedEndpoint || "";
+      const maxTokens = maxTokensStr?.trim()
+        ? parseInt(maxTokensStr, 10)
+        : undefined;
 
       const provider = providerFactory.createProvider(
-        providerType as "google",
+        providerType as ProviderType,
         {
           apiKey,
           modelName,
           apiEndpoint,
+          maxTokens: Number.isNaN(maxTokens) ? undefined : maxTokens,
           enabled: true,
           provider: providerType,
           timeout: 30000,

--- a/src/features/lightspeed/vue/views/llmProviderMessageHandlers.ts
+++ b/src/features/lightspeed/vue/views/llmProviderMessageHandlers.ts
@@ -251,7 +251,9 @@ export class LlmProviderMessageHandlers {
     await this.llmProviderSettings.setConnectionStatus(connected, providerType);
 
     if (connected) {
-      window.showInformationMessage(`Successfully connected to ${displayName}.`);
+      window.showInformationMessage(
+        `Successfully connected to ${displayName}.`,
+      );
     } else {
       window.showErrorMessage(`Failed to connect to ${displayName}: ${error}`);
     }
@@ -302,8 +304,7 @@ export class LlmProviderMessageHandlers {
     providerInfo: ProviderInfo | undefined,
   ): Promise<void> {
     const result = await this.validateProviderConnection(providerType);
-    const displayName =
-      providerInfo?.displayName || providerType.toUpperCase();
+    const displayName = providerInfo?.displayName || providerType.toUpperCase();
 
     await this.handleConnectionResult(
       providerType,

--- a/src/features/lightspeed/vue/views/llmProviderMessageHandlers.ts
+++ b/src/features/lightspeed/vue/views/llmProviderMessageHandlers.ts
@@ -348,7 +348,7 @@ export class LlmProviderMessageHandlers {
       // Use stored endpoint as-is (allows custom endpoints, v2, proxies, etc.)
       const apiEndpoint = storedEndpoint || "";
       const maxTokens = maxTokensStr?.trim()
-        ? parseInt(maxTokensStr, 10)
+        ? Number.parseInt(maxTokensStr, 10)
         : undefined;
 
       const provider = providerFactory.createProvider(

--- a/src/interfaces/extensionSettings.d.ts
+++ b/src/interfaces/extensionSettings.d.ts
@@ -34,10 +34,11 @@ export interface PlaybookSettings {
 // Settings appear on VS Code Settings UI
 export interface LightSpeedServiceSettings {
   enabled: boolean;
-  provider: string; // 'wca' | 'google' | 'custom'
+  provider: string; // 'wca' | 'google' | 'rhcustom'
   apiEndpoint: string;
   modelName: string | undefined;
-  apiKey: string; // For third-party providers like Google
+  apiKey: string; // For third-party providers like Google, Red Hat Custom
+  maxTokens?: number; // For Red Hat Custom and other API-key providers
   timeout: number; // Request timeout in milliseconds
   suggestions: { enabled: boolean; waitWindow: number };
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -38,6 +38,7 @@ export class SettingsManager {
           apiEndpoint: "https://c.ai.ansible.redhat.com",
           modelName: undefined,
           apiKey: "",
+          maxTokens: undefined,
         };
 
     this.settings = {
@@ -67,6 +68,9 @@ export class SettingsManager {
         apiEndpoint: llmSettings.apiEndpoint,
         modelName: llmSettings.modelName,
         apiKey: llmSettings.apiKey,
+        maxTokens: llmSettings.maxTokens
+          ? parseInt(llmSettings.maxTokens, 10)
+          : undefined,
         timeout: lightSpeedSettings.get("timeout", 30000),
         suggestions: {
           enabled:

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -69,7 +69,7 @@ export class SettingsManager {
         modelName: llmSettings.modelName,
         apiKey: llmSettings.apiKey,
         maxTokens: llmSettings.maxTokens
-          ? parseInt(llmSettings.maxTokens, 10)
+          ? Number.parseInt(llmSettings.maxTokens, 10)
           : undefined,
         timeout: lightSpeedSettings.get("timeout", 30000),
         suggestions: {

--- a/test/ui/test_03_llm_provider_webview.py
+++ b/test/ui/test_03_llm_provider_webview.py
@@ -61,6 +61,13 @@ def test_llm_provider_webview_lists_providers(
     )
     assert google_provider is not None, "Google Gemini provider should be listed"
 
+    rhcustom_provider = find_element_across_iframes(
+        driver,
+        "//*[contains(@class, 'provider-name') and contains(., 'Red Hat Custom')]",
+        retries=10,
+    )
+    assert rhcustom_provider is not None, "Red Hat Custom provider should be listed"
+
 
 def test_llm_provider_webview_edit_button(
     browser_setup: Any,
@@ -92,3 +99,37 @@ def test_llm_provider_webview_edit_button(
         "//button[contains(., 'Save')]",
         retries=10,
     )
+
+
+def test_rhcustom_provider_config_fields(
+    browser_setup: Any,
+    screenshot_on_fail: Any,
+    close_editors: Any,
+) -> None:
+    """Test that Red Hat Custom provider edit reveals config fields."""
+    driver, _ = browser_setup
+
+    ensure_vscode_ready(driver)
+
+    vscode_run_command(driver, ">Ansible Lightspeed: Open LLM Provider Settings")
+
+    find_element_across_iframes(
+        driver,
+        "//h1[text()='LLM Provider Settings']",
+        retries=15,
+    )
+
+    rhcustom_edit = find_element_across_iframes(
+        driver,
+        "//*[contains(@class, 'provider-row') and .//*[contains(text(), 'Red Hat Custom')]]"
+        "//button[contains(@class, 'edit-btn')]",
+        retries=10,
+    )
+    rhcustom_edit.click()
+
+    max_tokens_label = find_element_across_iframes(
+        driver,
+        "//*[contains(text(), 'Max Tokens')]",
+        retries=10,
+    )
+    assert max_tokens_label is not None, "Max Tokens field should be present"

--- a/test/unit/lightspeed/providers/base.test.ts
+++ b/test/unit/lightspeed/providers/base.test.ts
@@ -69,11 +69,11 @@ import {
   ChatResponseParams,
   GenerationRequestParams,
   GenerationResponseParams,
-} from "@src/features/lightspeed/providers/base.js";
+} from "../../../../src/features/lightspeed/providers/base.js";
 import {
   CompletionRequestParams,
   CompletionResponseParams,
-} from "@src/interfaces/lightspeed.js";
+} from "../../../../src/interfaces/lightspeed.js";
 import {
   TEST_PROVIDER_INFO,
   TEST_PROMPTS,
@@ -88,9 +88,25 @@ class TestProvider extends BaseLLMProvider {
   readonly name = "test";
   readonly displayName = "Test Provider";
 
-  // Minimal implementations of abstract methods - not tested here, only needed for instantiation
+  private _validateResult: boolean | undefined;
+  private _validateThrow: Error | undefined;
+
   async validateConfig(): Promise<boolean> {
+    if (this._validateThrow) {
+      throw this._validateThrow;
+    }
+    if (this._validateResult !== undefined) {
+      return this._validateResult;
+    }
     return true;
+  }
+
+  setValidateConfigResult(result: boolean) {
+    this._validateResult = result;
+  }
+
+  setValidateConfigThrow(error: Error) {
+    this._validateThrow = error;
   }
 
   async getStatus(): Promise<ProviderStatus> {
@@ -152,6 +168,26 @@ class TestProvider extends BaseLLMProvider {
     providerName?: string,
   ): Error {
     return this.handleHttpError(error, operation, providerName);
+  }
+
+  setLastValidationError(error: string | undefined) {
+    this.lastValidationError = error;
+  }
+
+  getLastValidationError() {
+    return this.lastValidationError;
+  }
+
+  testGetStatusWithValidation(
+    modelName: string,
+    lastValidationError: string | undefined,
+    defaultErrorMessage: string,
+  ) {
+    return this.getStatusWithValidation(
+      modelName,
+      lastValidationError,
+      defaultErrorMessage,
+    );
   }
 }
 
@@ -443,6 +479,119 @@ describe("BaseLLMProvider", () => {
 
       expect(result).toBeInstanceOf(Error);
       expect(result.message).toContain(TEST_OPERATIONS.GENERIC);
+    });
+  });
+
+  describe("lastValidationError", () => {
+    it("should be undefined by default", () => {
+      const provider = new TestProvider(TEST_CONFIGS.BASE_TEST);
+      expect(provider.getLastValidationError()).toBeUndefined();
+    });
+
+    it("should store validation error on the base class", () => {
+      const provider = new TestProvider(TEST_CONFIGS.BASE_TEST);
+      provider.setLastValidationError("Config validation failed: bad key");
+      expect(provider.getLastValidationError()).toBe(
+        "Config validation failed: bad key",
+      );
+    });
+
+    it("should allow clearing the validation error", () => {
+      const provider = new TestProvider(TEST_CONFIGS.BASE_TEST);
+      provider.setLastValidationError("some error");
+      provider.setLastValidationError(undefined);
+      expect(provider.getLastValidationError()).toBeUndefined();
+    });
+  });
+
+  describe("getStatusWithValidation", () => {
+    it("should return connected status when validation passes", async () => {
+      const provider = new TestProvider(TEST_CONFIGS.BASE_TEST);
+
+      const status = await provider.testGetStatusWithValidation(
+        "test-model",
+        undefined,
+        "default error",
+      );
+
+      expect(status.connected).toBe(true);
+      expect(status.modelInfo?.name).toBe("test-model");
+      expect(status.modelInfo?.capabilities).toEqual([
+        "completion",
+        "chat",
+        "generation",
+      ]);
+    });
+
+    it("should use lastValidationError from base class when validation fails", async () => {
+      const provider = new TestProvider(TEST_CONFIGS.BASE_TEST);
+      provider.setValidateConfigResult(false);
+      provider.setLastValidationError("Base class error message");
+
+      const status = await provider.testGetStatusWithValidation(
+        "test-model",
+        "param error",
+        "default error",
+      );
+
+      expect(status.connected).toBe(false);
+      expect(status.error).toBe("Base class error message");
+    });
+
+    it("should fall back to parameter lastValidationError when base class error is unset", async () => {
+      const provider = new TestProvider(TEST_CONFIGS.BASE_TEST);
+      provider.setValidateConfigResult(false);
+
+      const status = await provider.testGetStatusWithValidation(
+        "test-model",
+        "param error",
+        "default error",
+      );
+
+      expect(status.connected).toBe(false);
+      expect(status.error).toBe("param error");
+    });
+
+    it("should fall back to default error message when no validation errors set", async () => {
+      const provider = new TestProvider(TEST_CONFIGS.BASE_TEST);
+      provider.setValidateConfigResult(false);
+
+      const status = await provider.testGetStatusWithValidation(
+        "test-model",
+        undefined,
+        "default error",
+      );
+
+      expect(status.connected).toBe(false);
+      expect(status.error).toBe("default error");
+    });
+
+    it("should handle exception thrown during validation", async () => {
+      const provider = new TestProvider(TEST_CONFIGS.BASE_TEST);
+      provider.setValidateConfigThrow(new Error("Validation exploded"));
+
+      const status = await provider.testGetStatusWithValidation(
+        "test-model",
+        undefined,
+        "default error",
+      );
+
+      expect(status.connected).toBe(false);
+      expect(status.error).toBe("Validation exploded");
+    });
+
+    it("should handle non-Error exception during validation", async () => {
+      const provider = new TestProvider(TEST_CONFIGS.BASE_TEST);
+      provider.setValidateConfigThrow("string error" as unknown as Error);
+
+      const status = await provider.testGetStatusWithValidation(
+        "test-model",
+        undefined,
+        "default error",
+      );
+
+      expect(status.connected).toBe(false);
+      expect(status.error).toBe("Unknown error");
     });
   });
 });

--- a/test/unit/lightspeed/providers/factory.test.ts
+++ b/test/unit/lightspeed/providers/factory.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { LLMProviderFactory } from "@src/features/lightspeed/providers/factory.js";
-import type { ProviderType } from "@src/definitions/lightspeed.d.ts";
-import { PROVIDER_TYPES, TEST_LIGHTSPEED_SETTINGS } from "../testConstants.js";
+import { LLMProviderFactory } from "../../../../src/features/lightspeed/providers/factory.js";
+import type { ProviderType } from "../../../../src/definitions/lightspeed.d.ts";
+import {
+  PROVIDER_TYPES,
+  TEST_LIGHTSPEED_SETTINGS,
+  API_ENDPOINTS,
+} from "../testConstants.js";
 
 // Mock AnsibleContextProcessor for providers that extend BaseLLMProvider
 const mockEnhancePromptForAnsible = vi.fn(
@@ -18,7 +22,7 @@ const mockCleanAnsibleOutput = vi.fn((output: string) => {
 });
 
 // Use vi.mock for ES modules - these are hoisted
-vi.mock("../@src/features/lightspeed/ansibleContext", () => ({
+vi.mock("../../../../../src/features/lightspeed/ansibleContext", () => ({
   AnsibleContextProcessor: {
     enhancePromptForAnsible: mockEnhancePromptForAnsible,
     cleanAnsibleOutput: mockCleanAnsibleOutput,
@@ -76,18 +80,14 @@ describe("LLMProviderFactory", () => {
         }).toThrow("API Key is required for Google Gemini");
       });
 
-      it("should throw error when custom API endpoint is provided", () => {
+      it("should accept custom API endpoint for Google provider", () => {
         const factory = LLMProviderFactory.getInstance();
-        const config = {
-          ...TEST_LIGHTSPEED_SETTINGS.GOOGLE_MINIMAL,
-          apiEndpoint: "https://custom-endpoint.example.com",
-        };
+        const config = TEST_LIGHTSPEED_SETTINGS.GOOGLE_WITH_CUSTOM_ENDPOINT;
 
-        expect(() => {
-          factory.createProvider(PROVIDER_TYPES.GOOGLE, config);
-        }).toThrow(
-          "Custom API endpoints are not supported for Google Gemini provider. The endpoint is automatically configured. Please remove 'ansible.lightspeed.apiEndpoint' from your settings.",
-        );
+        const provider = factory.createProvider(PROVIDER_TYPES.GOOGLE, config);
+
+        expect(provider).toBeDefined();
+        expect(provider.name).toBe("google");
       });
     });
 
@@ -99,6 +99,125 @@ describe("LLMProviderFactory", () => {
         expect(() => {
           factory.createProvider(PROVIDER_TYPES.WCA, config);
         }).toThrow("WCA provider should be handled by existing LightSpeedAPI");
+      });
+    });
+
+    describe("RHCustom provider", () => {
+      it("should create RHCustom provider with full config", () => {
+        const factory = LLMProviderFactory.getInstance();
+        const config = TEST_LIGHTSPEED_SETTINGS.RHCUSTOM_FULL;
+
+        const provider = factory.createProvider(
+          PROVIDER_TYPES.RHCUSTOM,
+          config,
+        );
+
+        expect(provider).toBeDefined();
+        expect(provider.name).toBe("rhcustom");
+      });
+
+      it("should create RHCustom provider with minimal config", () => {
+        const factory = LLMProviderFactory.getInstance();
+        const config = TEST_LIGHTSPEED_SETTINGS.RHCUSTOM_MINIMAL;
+
+        const provider = factory.createProvider(
+          PROVIDER_TYPES.RHCUSTOM,
+          config,
+        );
+
+        expect(provider).toBeDefined();
+        expect(provider.name).toBe("rhcustom");
+      });
+
+      it("should throw error when API key is missing", () => {
+        const factory = LLMProviderFactory.getInstance();
+        const config = {
+          ...TEST_LIGHTSPEED_SETTINGS.RHCUSTOM_MINIMAL,
+          apiKey: "",
+        };
+
+        expect(() => {
+          factory.createProvider(PROVIDER_TYPES.RHCUSTOM, config);
+        }).toThrow("API Key is required for Red Hat Custom");
+      });
+
+      it("should throw error when model name is missing", () => {
+        const factory = LLMProviderFactory.getInstance();
+        const config = {
+          ...TEST_LIGHTSPEED_SETTINGS.RHCUSTOM_MINIMAL,
+          modelName: "",
+        };
+
+        expect(() => {
+          factory.createProvider(PROVIDER_TYPES.RHCUSTOM, config);
+        }).toThrow("Model name is required for Red Hat Custom");
+      });
+
+      it("should throw error when API endpoint is missing", () => {
+        const factory = LLMProviderFactory.getInstance();
+        const config = {
+          ...TEST_LIGHTSPEED_SETTINGS.RHCUSTOM_MINIMAL,
+          apiEndpoint: "",
+        };
+
+        expect(() => {
+          factory.createProvider(PROVIDER_TYPES.RHCUSTOM, config);
+        }).toThrow("API endpoint is required for Red Hat Custom");
+      });
+
+      it("should throw error when API key is only whitespace", () => {
+        const factory = LLMProviderFactory.getInstance();
+        const config = {
+          ...TEST_LIGHTSPEED_SETTINGS.RHCUSTOM_MINIMAL,
+          apiKey: "   ",
+        };
+
+        expect(() => {
+          factory.createProvider(PROVIDER_TYPES.RHCUSTOM, config);
+        }).toThrow("API Key is required for Red Hat Custom");
+      });
+
+      it("should use numeric maxTokens directly", () => {
+        const factory = LLMProviderFactory.getInstance();
+        const config = {
+          ...TEST_LIGHTSPEED_SETTINGS.RHCUSTOM_MINIMAL,
+          maxTokens: 2048,
+        };
+
+        const provider = factory.createProvider(
+          PROVIDER_TYPES.RHCUSTOM,
+          config,
+        );
+        expect(provider).toBeDefined();
+      });
+
+      it("should default maxTokens to 1600 when not provided", () => {
+        const factory = LLMProviderFactory.getInstance();
+        const config = {
+          ...TEST_LIGHTSPEED_SETTINGS.RHCUSTOM_MINIMAL,
+          maxTokens: undefined,
+        };
+
+        const provider = factory.createProvider(
+          PROVIDER_TYPES.RHCUSTOM,
+          config,
+        );
+        expect(provider).toBeDefined();
+      });
+
+      it("should strip trailing slashes from apiEndpoint", () => {
+        const factory = LLMProviderFactory.getInstance();
+        const config = {
+          ...TEST_LIGHTSPEED_SETTINGS.RHCUSTOM_MINIMAL,
+          apiEndpoint: API_ENDPOINTS.RHCUSTOM + "///",
+        };
+
+        const provider = factory.createProvider(
+          PROVIDER_TYPES.RHCUSTOM,
+          config,
+        );
+        expect(provider).toBeDefined();
+        expect(provider.name).toBe("rhcustom");
       });
     });
 
@@ -161,6 +280,53 @@ describe("LLMProviderFactory", () => {
       });
     });
 
+    it("should include RHCustom provider", () => {
+      const factory = LLMProviderFactory.getInstance();
+      const providers = factory.getSupportedProviders();
+      const rhcustomProvider = providers.find(
+        (p) => p.type === PROVIDER_TYPES.RHCUSTOM,
+      );
+
+      expect(rhcustomProvider).toBeDefined();
+      expect(rhcustomProvider?.type).toBe(PROVIDER_TYPES.RHCUSTOM);
+      expect(rhcustomProvider?.name).toBe("rhcustom");
+      expect(rhcustomProvider?.displayName).toBe("Red Hat Custom");
+    });
+
+    it("should have correct RHCustom config schema", () => {
+      const factory = LLMProviderFactory.getInstance();
+      const providers = factory.getSupportedProviders();
+      const rhcustomProvider = providers.find(
+        (p) => p.type === PROVIDER_TYPES.RHCUSTOM,
+      );
+
+      expect(rhcustomProvider?.configSchema).toHaveLength(4);
+      const schemaKeys = rhcustomProvider?.configSchema.map((f) => f.key);
+      expect(schemaKeys).toEqual([
+        "apiEndpoint",
+        "apiKey",
+        "modelName",
+        "maxTokens",
+      ]);
+
+      const maxTokensField = rhcustomProvider?.configSchema.find(
+        (f) => f.key === "maxTokens",
+      );
+      expect(maxTokensField?.type).toBe("number");
+      expect(maxTokensField?.required).toBe(false);
+    });
+
+    it("should mark RHCustom as requiring API key", () => {
+      const factory = LLMProviderFactory.getInstance();
+      const providers = factory.getSupportedProviders();
+      const rhcustomProvider = providers.find(
+        (p) => p.type === PROVIDER_TYPES.RHCUSTOM,
+      );
+
+      expect(rhcustomProvider?.requiresApiKey).toBe(true);
+      expect(rhcustomProvider?.usesOAuth).toBe(false);
+    });
+
     it("should have config schema with required fields", () => {
       const factory = LLMProviderFactory.getInstance();
       const providers = factory.getSupportedProviders();
@@ -215,6 +381,65 @@ describe("LLMProviderFactory", () => {
         );
 
         expect(isValid).toBe(true);
+      });
+    });
+
+    describe("RHCustom provider validation", () => {
+      it("should return true for valid RHCustom config", () => {
+        const factory = LLMProviderFactory.getInstance();
+        const config = TEST_LIGHTSPEED_SETTINGS.RHCUSTOM_MINIMAL;
+
+        const isValid = factory.validateProviderConfig(
+          PROVIDER_TYPES.RHCUSTOM,
+          config,
+        );
+
+        expect(isValid).toBe(true);
+      });
+
+      it("should return false when required apiKey is missing", () => {
+        const factory = LLMProviderFactory.getInstance();
+        const config = {
+          ...TEST_LIGHTSPEED_SETTINGS.RHCUSTOM_MINIMAL,
+          apiKey: "",
+        };
+
+        const isValid = factory.validateProviderConfig(
+          PROVIDER_TYPES.RHCUSTOM,
+          config,
+        );
+
+        expect(isValid).toBe(false);
+      });
+
+      it("should return false when required apiEndpoint is missing", () => {
+        const factory = LLMProviderFactory.getInstance();
+        const config = {
+          ...TEST_LIGHTSPEED_SETTINGS.RHCUSTOM_MINIMAL,
+          apiEndpoint: "",
+        };
+
+        const isValid = factory.validateProviderConfig(
+          PROVIDER_TYPES.RHCUSTOM,
+          config,
+        );
+
+        expect(isValid).toBe(false);
+      });
+
+      it("should return false when required modelName is missing", () => {
+        const factory = LLMProviderFactory.getInstance();
+        const config = {
+          ...TEST_LIGHTSPEED_SETTINGS.RHCUSTOM_MINIMAL,
+          modelName: "",
+        };
+
+        const isValid = factory.validateProviderConfig(
+          PROVIDER_TYPES.RHCUSTOM,
+          config,
+        );
+
+        expect(isValid).toBe(false);
       });
     });
 

--- a/test/unit/lightspeed/providers/google.test.ts
+++ b/test/unit/lightspeed/providers/google.test.ts
@@ -220,54 +220,6 @@ describe("GoogleProvider", () => {
       expect(mockedLogger.error).toHaveBeenCalled();
     });
 
-    it("should format validation error through handleGeminiError", async () => {
-      sharedGenerateContent.mockRejectedValue(new Error("Connection refused"));
-      const provider = new GoogleProvider({
-        apiKey: TEST_API_KEYS.GOOGLE,
-        modelName: MODEL_NAMES.GEMINI_PRO,
-      });
-
-      const isValid = await provider.validateConfig();
-      expect(isValid).toBe(false);
-
-      const status = await provider.getStatus();
-      expect(status.connected).toBe(false);
-      expect(status.error).toContain("Google Gemini error");
-      expect(status.error).toContain("config validation");
-    });
-
-    it("should clear lastValidationError on success after previous failure", async () => {
-      const provider = new GoogleProvider({
-        apiKey: TEST_API_KEYS.GOOGLE,
-        modelName: MODEL_NAMES.GEMINI_PRO,
-      });
-
-      sharedGenerateContent.mockRejectedValue(new Error("Temporary failure"));
-      await provider.validateConfig();
-      const failStatus = await provider.getStatus();
-      expect(failStatus.connected).toBe(false);
-
-      sharedGenerateContent.mockResolvedValue({ text: "ok" });
-      await provider.validateConfig();
-      const successStatus = await provider.getStatus();
-      expect(successStatus.connected).toBe(true);
-      expect(successStatus.error).toBeUndefined();
-    });
-
-    it("should include error details in validation log", async () => {
-      const errorWithStack = new Error("API key expired");
-      sharedGenerateContent.mockRejectedValue(errorWithStack);
-      const provider = new GoogleProvider({
-        apiKey: TEST_API_KEYS.GOOGLE,
-        modelName: MODEL_NAMES.GEMINI_PRO,
-      });
-
-      await provider.validateConfig();
-
-      expect(mockedLogger.error).toHaveBeenCalledWith(
-        expect.stringContaining("Validation error details:"),
-      );
-    });
   });
 
   describe("completionRequest", () => {

--- a/test/unit/lightspeed/providers/google.test.ts
+++ b/test/unit/lightspeed/providers/google.test.ts
@@ -219,6 +219,55 @@ describe("GoogleProvider", () => {
 
       expect(mockedLogger.error).toHaveBeenCalled();
     });
+
+    it("should format validation error through handleGeminiError", async () => {
+      sharedGenerateContent.mockRejectedValue(new Error("Connection refused"));
+      const provider = new GoogleProvider({
+        apiKey: TEST_API_KEYS.GOOGLE,
+        modelName: MODEL_NAMES.GEMINI_PRO,
+      });
+
+      const isValid = await provider.validateConfig();
+      expect(isValid).toBe(false);
+
+      const status = await provider.getStatus();
+      expect(status.connected).toBe(false);
+      expect(status.error).toContain("Google Gemini error");
+      expect(status.error).toContain("config validation");
+    });
+
+    it("should clear lastValidationError on success after previous failure", async () => {
+      const provider = new GoogleProvider({
+        apiKey: TEST_API_KEYS.GOOGLE,
+        modelName: MODEL_NAMES.GEMINI_PRO,
+      });
+
+      sharedGenerateContent.mockRejectedValue(new Error("Temporary failure"));
+      await provider.validateConfig();
+      const failStatus = await provider.getStatus();
+      expect(failStatus.connected).toBe(false);
+
+      sharedGenerateContent.mockResolvedValue({ text: "ok" });
+      await provider.validateConfig();
+      const successStatus = await provider.getStatus();
+      expect(successStatus.connected).toBe(true);
+      expect(successStatus.error).toBeUndefined();
+    });
+
+    it("should include error details in validation log", async () => {
+      const errorWithStack = new Error("API key expired");
+      sharedGenerateContent.mockRejectedValue(errorWithStack);
+      const provider = new GoogleProvider({
+        apiKey: TEST_API_KEYS.GOOGLE,
+        modelName: MODEL_NAMES.GEMINI_PRO,
+      });
+
+      await provider.validateConfig();
+
+      expect(mockedLogger.error).toHaveBeenCalledWith(
+        expect.stringContaining("Validation error details:"),
+      );
+    });
   });
 
   describe("completionRequest", () => {

--- a/test/unit/lightspeed/providers/rhcustom.test.ts
+++ b/test/unit/lightspeed/providers/rhcustom.test.ts
@@ -288,42 +288,6 @@ describe("RHCustomProvider", () => {
       expect(mockChatCompletion).toHaveBeenCalled();
     });
 
-    it("should return false and set lastValidationError on failure", async () => {
-      mockChatCompletion.mockRejectedValue(new Error("Connection refused"));
-      const provider = new RHCustomProvider({
-        apiKey: TEST_API_KEYS.RHCUSTOM,
-        modelName: MODEL_NAMES.RHCUSTOM_DEEPSEEK,
-        baseURL: API_ENDPOINTS.RHCUSTOM,
-      });
-
-      const isValid = await provider.validateConfig();
-      expect(isValid).toBe(false);
-
-      const status = await provider.getStatus();
-      expect(status.connected).toBe(false);
-      expect(status.error).toContain("Connection refused");
-      expect(mockedLogger.error).toHaveBeenCalledWith(
-        expect.stringContaining("Validation error details:"),
-      );
-    });
-
-    it("should clear lastValidationError on success after failure", async () => {
-      const provider = new RHCustomProvider({
-        apiKey: TEST_API_KEYS.RHCUSTOM,
-        modelName: MODEL_NAMES.RHCUSTOM_DEEPSEEK,
-        baseURL: API_ENDPOINTS.RHCUSTOM,
-      });
-
-      mockChatCompletion.mockRejectedValue(new Error("Temporary failure"));
-      await provider.validateConfig();
-
-      mockChatCompletion.mockResolvedValue({
-        message: { role: "assistant", content: "ok" },
-      });
-      const successStatus = await provider.getStatus();
-      expect(successStatus.connected).toBe(true);
-      expect(successStatus.error).toBeUndefined();
-    });
   });
 
   describe("completionRequest", () => {

--- a/test/unit/lightspeed/providers/rhcustom.test.ts
+++ b/test/unit/lightspeed/providers/rhcustom.test.ts
@@ -287,6 +287,43 @@ describe("RHCustomProvider", () => {
       ]);
       expect(mockChatCompletion).toHaveBeenCalled();
     });
+
+    it("should return false and set lastValidationError on failure", async () => {
+      mockChatCompletion.mockRejectedValue(new Error("Connection refused"));
+      const provider = new RHCustomProvider({
+        apiKey: TEST_API_KEYS.RHCUSTOM,
+        modelName: MODEL_NAMES.RHCUSTOM_DEEPSEEK,
+        baseURL: API_ENDPOINTS.RHCUSTOM,
+      });
+
+      const isValid = await provider.validateConfig();
+      expect(isValid).toBe(false);
+
+      const status = await provider.getStatus();
+      expect(status.connected).toBe(false);
+      expect(status.error).toContain("Connection refused");
+      expect(mockedLogger.error).toHaveBeenCalledWith(
+        expect.stringContaining("Validation error details:"),
+      );
+    });
+
+    it("should clear lastValidationError on success after failure", async () => {
+      const provider = new RHCustomProvider({
+        apiKey: TEST_API_KEYS.RHCUSTOM,
+        modelName: MODEL_NAMES.RHCUSTOM_DEEPSEEK,
+        baseURL: API_ENDPOINTS.RHCUSTOM,
+      });
+
+      mockChatCompletion.mockRejectedValue(new Error("Temporary failure"));
+      await provider.validateConfig();
+
+      mockChatCompletion.mockResolvedValue({
+        message: { role: "assistant", content: "ok" },
+      });
+      const successStatus = await provider.getStatus();
+      expect(successStatus.connected).toBe(true);
+      expect(successStatus.error).toBeUndefined();
+    });
   });
 
   describe("completionRequest", () => {
@@ -377,7 +414,6 @@ describe("RHCustomProvider", () => {
         metadata: { isExplanation: true },
       });
 
-      // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(mockedLogger.info).toHaveBeenCalledWith(
         expect.stringContaining("EXPLANATION"),
       );
@@ -398,7 +434,7 @@ describe("RHCustomProvider", () => {
       };
 
       await expect(provider.chatRequest(params)).rejects.toThrow();
-      // eslint-disable-next-line @typescript-eslint/unbound-method
+
       expect(mockedLogger.error).toHaveBeenCalled();
     });
   });
@@ -730,7 +766,7 @@ describe("RHCustomProvider", () => {
       };
 
       await expect(provider.generatePlaybook(params)).rejects.toThrow();
-      // eslint-disable-next-line @typescript-eslint/unbound-method
+
       expect(mockedLogger.error).toHaveBeenCalled();
     });
   });
@@ -827,7 +863,7 @@ describe("RHCustomProvider", () => {
       };
 
       await expect(provider.generateRole(params)).rejects.toThrow();
-      // eslint-disable-next-line @typescript-eslint/unbound-method
+
       expect(mockedLogger.error).toHaveBeenCalled();
     });
   });

--- a/test/unit/lightspeed/providers/rhcustom.test.ts
+++ b/test/unit/lightspeed/providers/rhcustom.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import * as Module from "module";
-import { RHCustomProvider } from "@src/features/lightspeed/providers/rhcustom.js";
-import type { CompletionRequestParams } from "@src/interfaces/lightspeed.js";
+import { RHCustomProvider } from "../../../../src/features/lightspeed/providers/rhcustom.js";
+import type { CompletionRequestParams } from "../../../../src/interfaces/lightspeed.js";
 import type {
   ChatRequestParams,
   GenerationRequestParams,
-} from "@src/features/lightspeed/providers/base.js";
+} from "../../../../src/features/lightspeed/providers/base.js";
 import {
   TEST_API_KEYS,
   MODEL_NAMES,
@@ -16,12 +16,12 @@ import {
   API_ENDPOINTS,
   DEFAULT_TIMEOUTS,
 } from "../testConstants.js";
-import { OpenAIClientError } from "@src/features/lightspeed/clients/openaiCompatibleClient.js";
-import { getLightspeedLogger } from "@src/utils/logger.js";
+import { OpenAIClientError } from "../../../../src/features/lightspeed/clients/openaiCompatibleClient.js";
+import { getLightspeedLogger } from "../../../../src/utils/logger.js";
 import {
   generateOutlineFromPlaybook,
   generateOutlineFromRole,
-} from "@src/features/lightspeed/utils/outlineGenerator.js";
+} from "../../../../src/features/lightspeed/utils/outlineGenerator.js";
 
 // Mock AnsibleContextProcessor
 const mockEnhancePromptForAnsible = vi.fn(
@@ -77,21 +77,24 @@ const { mockChatCompletion, MockOpenAICompatibleClient } = vi.hoisted(() => {
   return { mockChatCompletion, MockOpenAICompatibleClient };
 });
 
-vi.mock("@src/features/lightspeed/clients/openaiCompatibleClient", () => {
-  return {
-    OpenAICompatibleClient: MockOpenAICompatibleClient,
-    OpenAIClientError: class OpenAIClientError extends Error {
-      status: number;
-      constructor(message: string, status: number) {
-        super(message);
-        this.name = "OpenAIClientError";
-        this.status = status;
-      }
-    },
-  };
-});
+vi.mock(
+  "../../../../src/features/lightspeed/clients/openaiCompatibleClient",
+  () => {
+    return {
+      OpenAICompatibleClient: MockOpenAICompatibleClient,
+      OpenAIClientError: class OpenAIClientError extends Error {
+        status: number;
+        constructor(message: string, status: number) {
+          super(message);
+          this.name = "OpenAIClientError";
+          this.status = status;
+        }
+      },
+    };
+  },
+);
 
-vi.mock("@src/utils/logger", () => {
+vi.mock("../../../../src/utils/logger", () => {
   const loggerMock = {
     info: vi.fn(),
     error: vi.fn(),
@@ -106,7 +109,7 @@ vi.mock("@src/utils/logger", () => {
   };
 });
 
-vi.mock("@src/features/lightspeed/utils/outlineGenerator", () => ({
+vi.mock("../../../../src/features/lightspeed/utils/outlineGenerator", () => ({
   generateOutlineFromPlaybook: vi.fn(() => {
     return "1. Task one\n2. Task two";
   }),
@@ -374,6 +377,7 @@ describe("RHCustomProvider", () => {
         metadata: { isExplanation: true },
       });
 
+      // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(mockedLogger.info).toHaveBeenCalledWith(
         expect.stringContaining("EXPLANATION"),
       );
@@ -394,7 +398,7 @@ describe("RHCustomProvider", () => {
       };
 
       await expect(provider.chatRequest(params)).rejects.toThrow();
-
+      // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(mockedLogger.error).toHaveBeenCalled();
     });
   });
@@ -726,7 +730,7 @@ describe("RHCustomProvider", () => {
       };
 
       await expect(provider.generatePlaybook(params)).rejects.toThrow();
-
+      // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(mockedLogger.error).toHaveBeenCalled();
     });
   });
@@ -823,7 +827,7 @@ describe("RHCustomProvider", () => {
       };
 
       await expect(provider.generateRole(params)).rejects.toThrow();
-
+      // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(mockedLogger.error).toHaveBeenCalled();
     });
   });

--- a/test/unit/lightspeed/testConstants.ts
+++ b/test/unit/lightspeed/testConstants.ts
@@ -2,7 +2,7 @@
  * Test constants and mock data for provider factory and base provider tests
  */
 
-import type { LightSpeedServiceSettings } from "@src/interfaces/extensionSettings.js";
+import type { LightSpeedServiceSettings } from "../../../src/interfaces/extensionSettings.js";
 
 // Model names
 export const MODEL_NAMES = {
@@ -155,6 +155,13 @@ export const TEST_LIGHTSPEED_SETTINGS = {
     provider: PROVIDER_TYPES.GOOGLE,
     apiKey: "",
     apiEndpoint: "",
+  } as LightSpeedServiceSettings,
+  GOOGLE_WITH_CUSTOM_ENDPOINT: {
+    ...BASE_LIGHTSPEED_SETTINGS,
+    provider: PROVIDER_TYPES.GOOGLE,
+    apiKey: TEST_API_KEYS.GOOGLE,
+    modelName: MODEL_NAMES.GEMINI_PRO,
+    apiEndpoint: "https://custom-gemini-proxy.example.com/v1beta",
   } as LightSpeedServiceSettings,
   WCA: {
     ...BASE_LIGHTSPEED_SETTINGS,

--- a/test/unit/lightspeed/views/llmProviderMessageHandlers.test.ts
+++ b/test/unit/lightspeed/views/llmProviderMessageHandlers.test.ts
@@ -261,6 +261,7 @@ describe("LlmProviderMessageHandlers", () => {
     });
 
     it("should handle connectProvider message for OAuth provider", async () => {
+      vi.useFakeTimers();
       const message = {
         command: "connectProvider",
         provider: PROVIDER_TYPES.WCA,
@@ -272,7 +273,10 @@ describe("LlmProviderMessageHandlers", () => {
       expect(mockedCommands.executeCommand).toHaveBeenCalledWith(
         "ansible.lightspeed.oauth",
       );
+
+      await vi.advanceTimersByTimeAsync(2000);
       expect(mockIsAuthenticated).toHaveBeenCalled();
+      vi.useRealTimers();
     });
 
     it("should not process messages when webview is not set", async () => {
@@ -415,6 +419,7 @@ describe("LlmProviderMessageHandlers", () => {
     });
 
     it("should handle successful OAuth connection", async () => {
+      vi.useFakeTimers();
       mockIsAuthenticated.mockResolvedValue(true);
 
       await messageHandlers.handleMessage({
@@ -422,13 +427,17 @@ describe("LlmProviderMessageHandlers", () => {
         provider: PROVIDER_TYPES.WCA,
       });
 
+      await vi.advanceTimersByTimeAsync(2000);
+
       expect(mockSetConnectionStatus).toHaveBeenCalledWith(
         true,
         PROVIDER_TYPES.WCA,
       );
+      vi.useRealTimers();
     });
 
     it("should handle failed OAuth connection", async () => {
+      vi.useFakeTimers();
       mockIsAuthenticated.mockResolvedValue(false);
 
       await messageHandlers.handleMessage({
@@ -436,11 +445,14 @@ describe("LlmProviderMessageHandlers", () => {
         provider: PROVIDER_TYPES.WCA,
       });
 
+      await vi.advanceTimersByTimeAsync(2000);
+
       expect(mockSetConnectionStatus).toHaveBeenCalledWith(
         false,
         PROVIDER_TYPES.WCA,
       );
       expect(mockedWindow.showErrorMessage).toHaveBeenCalled();
+      vi.useRealTimers();
     });
   });
 


### PR DESCRIPTION
**Related Jira issues**: [ACA-5007](https://issues.redhat.com/browse/ACA-5007), [ACA-5008](https://issues.redhat.com/browse/ACA-5008), [ACA-5155](https://issues.redhat.com/browse/ACA-5155)


ANSTRAT: [ANSTRAT-1828](https://issues.redhat.com/browse/ANSTRAT-1828)

# PR Description
Add Red Hat Custom (rhcustom) LLM provider integration, enabling users to connect to custom OpenAI-compatible RHAI model endpoints from the LLM Provider Settings webview. This builds on the webview infrastructure merged in [#2573](https://github.com/ansible/vscode-ansible/pull/2573).

### Summary
- Wire up the Red Hat Custom (rhcustom) LLM provider into the provider factory with full configuration support (apiKey, modelName, apiEndpoint, maxTokens)
- Move `lastValidationError` to the base provider class and improve error handling across providers
- Add maxTokens support in settings, interfaces, and webview message handlers
- Add unit tests for rhcustom factory creation, base provider validation, and provider-specific logic
- Add smoke/UI test verifying Red Hat Custom provider appears in the LLM Provider Settings webview
