### PR TITLE
fix: do not fail check on Sonar for release runs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -536,8 +536,7 @@ jobs:
           args: ${{ env.SONAR_ARGS }}
         # Temporarily ignore errors if the pull request is from a fork due to lack of upload secrets access
         # See https://issues.redhat.com/browse/AAP-52660
-        continue-on-error: ${{ github.event_name == 'pull_request' && github.repository != github.event.pull_request.head.repo.full_name }}
-
+        continue-on-error: ${{ github.event_name == 'pull_request' && github.repository != github.event.pull_request.head.repo.full_name || github.ref_type == 'tag' || (github.event_name == 'release' && github.event.action == 'published') || github.event.inputs.publish == 'true' || github.event.inputs.publish == true }}
       - name: Decide whether the needed jobs succeeded or failed
         uses: re-actors/alls-green@release/v1 # that is a branch, not a tag
         id: alls-green


### PR DESCRIPTION
## Summary

Makes the SonarCloud step in the **check** job non-blocking when the workflow run is a **release** (tag push, release published, or manual publish). This prevents releases from failing because of external services (Sonar/Codecov); we assume quality checks have already passed on main/PRs.

## Problem

- The **publish** job only runs when **check** succeeds (`needs: [check]`).
- **check** was failing when the SonarCloud step failed (e.g. quality gate / coverage).
- On tag push or manual "Publish a pre-release" runs, publish was skipped because `success()` was false (check had failed).
- Releases were blocked even when the only failure was Sonar.

## Solution

Extend the SonarCloud step’s `continue-on-error` so it is **true** when the run is:

- A **tag** push (`github.ref_type == 'tag'`), or
- A **release published** event (`github.event_name == 'release' && github.event.action == 'published'`), or
- A **manual run** with "Publish a pre-release" = true (`github.event.inputs.publish == 'true'` or `== true`).

Existing behavior is kept: fork PRs still have `continue-on-error` for Sonar (AAP-52660). Normal PRs and push to main still fail the step (and thus check) if Sonar fails.

## Testing

- After merge, trigger a release via **Actions → CI → Run workflow** with "Publish a pre-release" = true, or push a release tag.
- **check** should succeed even if SonarCloud fails the step.
- **publish** should run and publish to the marketplace.

(related): AAP-52660