### PR TITLE
fix: add type to workflow_dispatch input and clean up publish conditions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,8 @@ on:
       publish:
         description: "Publish a pre-release"
         required: false
-        default: "false"
+        type: boolean
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.ref }}-${{ github.event.pull_request.number || github.sha }}
@@ -536,7 +537,7 @@ jobs:
           args: ${{ env.SONAR_ARGS }}
         # Temporarily ignore errors if the pull request is from a fork due to lack of upload secrets access
         # See https://issues.redhat.com/browse/AAP-52660
-        continue-on-error: ${{ github.event_name == 'pull_request' && github.repository != github.event.pull_request.head.repo.full_name || github.ref_type == 'tag' || (github.event_name == 'release' && github.event.action == 'published') || github.event.inputs.publish == 'true' || github.event.inputs.publish == true }}
+        continue-on-error: ${{ github.event_name == 'pull_request' && github.repository != github.event.pull_request.head.repo.full_name || startsWith(github.ref, 'refs/tags/') || github.event_name == 'release' || github.event.inputs.publish == true }}
       - name: Decide whether the needed jobs succeeded or failed
         uses: re-actors/alls-green@release/v1 # that is a branch, not a tag
         id: alls-green
@@ -551,7 +552,7 @@ jobs:
           slack_webhook_url: ${{ secrets.DEVTOOLS_CI_SLACK_URL }}
 
   publish:
-    if: github.ref_type == 'tag' || (github.event_name == 'release' && github.event.action == 'published') || github.event.inputs.publish == 'true' || github.event.inputs.publish == true
+    if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'release' || github.event.inputs.publish == true
     runs-on: ubuntu-latest
     environment: release
     needs:
@@ -604,7 +605,7 @@ jobs:
 
   publish-npm:
     environment: release
-    if: needs.build.outputs.can_release_to_npm == 'true' && (github.ref_type == 'tag' || (github.event_name == 'release' && github.event.action == 'published') || github.event.inputs.publish == 'true' || github.event.inputs.publish == true)
+    if: needs.build.outputs.can_release_to_npm == 'true' && (startsWith(github.ref, 'refs/tags/') || github.event_name == 'release' || github.event.inputs.publish == true)
     runs-on: ubuntu-latest
     needs:
       - build


### PR DESCRIPTION
## Summary

Fixes the publish job being skipped during releases by using more reliable tag detection and properly typing the workflow_dispatch input.

## Changes

- **Use `startsWith(github.ref, 'refs/tags/')` instead of `github.ref_type == 'tag'`** for more reliable tag detection
- Added `type: boolean` to the `publish` workflow_dispatch input (was missing, causing GitHub to send `inputs: null`)
- Simplified `github.event_name == 'release'` condition (removed redundant `&& github.event.action == 'published'`)
- Removed redundant `== 'true'` string checks (input is now properly typed as boolean)
- Applied changes consistently across publish, publish-npm, and Sonar continue-on-error conditions

## Testing

Will test with v26.3.2 tag after merge.

Fixes the issue where publish job was being skipped even though all conditions should evaluate to true.