### PR TITLE
chore: prevent running LS tests when core one fails

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dev = [
   "prek>=0.3.4",
   "pygithub>=2.8.1",
   "pytest-coverage>=0.0",
+  "pytest-dependency>=0.6",
   "pytest-github-actions-annotate-failures>=0.4.0",
   "pytest-rerunfailures>=16.1",
   "selenium>=4.40.0",
@@ -64,6 +65,7 @@ exclude = "(.ansible|out|syntaxes).*"
 # integration like vscode or pycharm
 # keep -rA to know what is skipped, failed and passed as these are scenarios
 #  and we do not expect to have too many of them.
+#
 addopts = ["--durations-min=10", "--durations=10", "-n0", "-rA", "-v"]
 filterwarnings = [
   "error",
@@ -74,6 +76,7 @@ junit_logging = "all"
 log_cli = true
 log_cli_level = "INFO"
 markers = [
+  "dependency: mark test as having dependencies (pytest-dependency)",
   "lightspeed: mark tests related to lightspeed that require backend credentials",
   "modify_settings: modify vscode settings.json before/after test",
   "vscode_trial: mark tests related to lightspeed trial",
@@ -100,6 +103,7 @@ norecursedirs = [
 strict_markers = true
 # strict_xfail = true
 testpaths = ["test/ui"]
+automark_dependency = true
 
 [tool.ruff]
 cache-dir = "./.cache/.ruff"

--- a/test/ui/conftest.py
+++ b/test/ui/conftest.py
@@ -9,11 +9,13 @@ import shutil
 import subprocess
 from functools import lru_cache
 from pathlib import Path
-
-import pytest
+from typing import TYPE_CHECKING
 
 from test.ui.const import CONTAINER_NAME
 from test.ui.utils.ui_utils import LIGHTSPEED_PASSWORD, LIGHTSPEED_USER
+
+if TYPE_CHECKING:
+    import pytest
 
 # Project root (vscode-ansible), assuming conftest at test/selenium/conftest.py
 _PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
@@ -42,21 +44,9 @@ def skip_if_missing_lightspeed_credentials() -> bool:
     return skip
 
 
-def pytest_collection_modifyitems(
-    config: pytest.Config, items: list[pytest.Item]
-) -> None:
-    """Automatically skip tests marked with 'lightspeed' if credentials are missing."""
-    if skip_if_missing_lightspeed_credentials():  # pragma: no cover
-        skip_marker = pytest.mark.skip(
-            reason="LIGHTSPEED_PASSWORD or LIGHTSPEED_USER environment variables are not defined."
-        )
-        for item in items:
-            if "lightspeed" in item.keywords:
-                item.add_marker(skip_marker)
-
-
 def pytest_sessionstart(session: pytest.Session) -> None:
     """Prepare dirs and settings for UI/Selenium tests (replaces Taskfile rimraf/mkdir/cp)."""
+    os.chdir(_PROJECT_ROOT)
     for dir_path in (
         _PROJECT_ROOT / "out" / "ui" / "logs",
         _PROJECT_ROOT / "out" / "ui" / "coder-logs",
@@ -82,6 +72,7 @@ def pytest_sessionfinish(
     """Teardown the selenium server after tests on CI."""
     result = subprocess.run(
         f"podman-compose stats --no-stream --no-reset {CONTAINER_NAME}",
+        cwd=_PROJECT_ROOT,
         text=True,
         capture_output=True,
         check=False,
@@ -94,6 +85,7 @@ def pytest_sessionfinish(
             f"podman stop {CONTAINER_NAME} 2>/dev/null || true",
             # Apparently compose down can fail with various errors but stopping container works
             # "podman-compose down",
+            cwd=_PROJECT_ROOT,
             capture_output=True,
             check=False,
             shell=True,

--- a/test/ui/fixtures/ui_fixtures.py
+++ b/test/ui/fixtures/ui_fixtures.py
@@ -16,6 +16,7 @@ from selenium import webdriver
 from selenium.common import WebDriverException
 from selenium.webdriver.remote.webdriver import WebDriver
 
+from test.ui.conftest import _PROJECT_ROOT
 from test.ui.const import CONTAINER_NAME
 
 if TYPE_CHECKING:
@@ -77,6 +78,7 @@ def browser_setup(
                     f"podman-compose up --force-recreate --quiet-pull --remove-orphans --timeout 5 -d {CONTAINER_NAME}",
                     check=True,
                     shell=True,
+                    cwd=_PROJECT_ROOT,
                 )
             count = 0
             while True:

--- a/test/ui/test_80_lightspeed.py
+++ b/test/ui/test_80_lightspeed.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import pytest
 
+from test.ui.conftest import skip_if_missing_lightspeed_credentials
 from test.ui.utils.ui_utils import (
     find_element_across_iframes,
     vscode_explanation,
@@ -45,8 +46,21 @@ def vscode_login_wrapper(driver: Any) -> None:
     logged_in_flag = True
 
 
-# @pytest.mark.flaky(reruns=6, reruns_delay=10)
-@pytest.mark.xfail(reason="Broken")
+def test_has_ls_credentials() -> None:
+    """Test that the user has LS credentials."""
+    assert skip_if_missing_lightspeed_credentials(), "User has no LS credentials"
+
+
+def pytest_collection_modifyitems(
+    config: pytest.Config, items: list[pytest.Item]
+) -> None:
+    """Automatically skip tests marked with 'lightspeed' if credentials are missing."""
+    assert skip_if_missing_lightspeed_credentials(), (
+        "LIGHTSPEED_PASSWORD or LIGHTSPEED_USER environment variables are not defined."
+    )
+
+
+@pytest.mark.dependency(depends=["test_has_ls_credentials"])
 def test_vscode_widget(
     browser_setup: Any,
     screenshot_on_fail: Any,
@@ -74,7 +88,7 @@ def test_vscode_widget(
     )
 
 
-@pytest.mark.xfail(reason="Broken")
+@pytest.mark.dependency(depends=["test_vscode_widget"])
 def test_vscode_playbook_explanation(
     browser_setup: Any,
     screenshot_on_fail: Any,
@@ -105,7 +119,7 @@ def test_vscode_playbook_explanation(
         assert phrase in explanation, msg
 
 
-@pytest.mark.xfail(reason="Broken")
+@pytest.mark.dependency(depends=["test_vscode_widget"])
 def test_vscode_playbook_generation(
     browser_setup: Any,
     screenshot_on_fail: Any,
@@ -127,7 +141,7 @@ def test_vscode_playbook_generation(
     assert all(txt in playbook for txt in expected_playbook), "Error- bad playbook"
 
 
-@pytest.mark.xfail(reason="Broken")
+@pytest.mark.dependency(depends=["test_vscode_widget"])
 def test_vscode_role_generation(
     browser_setup: Any,
     screenshot_on_fail: Any,
@@ -144,7 +158,7 @@ def test_vscode_role_generation(
     assert "ansible.builtin.package" in tasks
 
 
-@pytest.mark.xfail(reason="Broken")
+@pytest.mark.dependency(depends=["test_vscode_widget"])
 def test_vscode_lightspeed_explorer(
     browser_setup: Any,
     screenshot_on_fail: Any,

--- a/test/ui/test_81_login.py
+++ b/test/ui/test_81_login.py
@@ -37,7 +37,7 @@ tasks:
   - name: Install dnsutils"""
 
 
-@pytest.mark.xfail(reason="Broken")
+@pytest.mark.dependency(depends=["test_vscode_widget"])
 def test_unsubed_login(
     browser_setup: Any,
     lightspeed_logout_teardown: Any,
@@ -83,7 +83,7 @@ def test_unsubed_login(
     assert body[i + 2].text == username
 
 
-@pytest.mark.xfail(reason="Broken")
+@pytest.mark.dependency(depends=["test_vscode_widget"])
 def test_unsubed_admin_login(
     browser_setup: Any,
     lightspeed_logout_teardown: Any,
@@ -133,7 +133,7 @@ def test_unsubed_admin_login(
     assert body[i + 3].text == "Role: administrator"
 
 
-@pytest.mark.xfail(reason="Broken")
+@pytest.mark.dependency(depends=["test_vscode_widget"])
 def test_no_wca_user_login(
     browser_setup: Any,
     lightspeed_logout_teardown: Any,
@@ -202,7 +202,7 @@ def test_no_wca_user_login(
         assert body[i + 4].text == "Role: licensed user"
 
 
-@pytest.mark.xfail(reason="Broken")
+@pytest.mark.dependency(depends=["test_vscode_widget"])
 def test_no_wca_admin_login(
     browser_setup: Any,
     lightspeed_logout_teardown: Any,
@@ -256,7 +256,7 @@ def test_no_wca_admin_login(
         assert body[i + 2].text == "Role: administrator, licensed user"
 
 
-@pytest.mark.xfail(reason="Broken")
+@pytest.mark.dependency(depends=["test_vscode_widget"])
 def test_login_page(
     browser_setup: Any,
     screenshot_on_fail: Any,
@@ -300,7 +300,7 @@ def test_login_page(
         assert button.is_enabled()
 
 
-@pytest.mark.xfail(reason="Broken")
+@pytest.mark.dependency(depends=["test_vscode_widget"])
 def test_sso_auth_flow(
     browser_setup: Any,
     screenshot_on_fail: Any,
@@ -337,7 +337,7 @@ def test_sso_auth_flow(
     assert rh_button.is_enabled()
 
 
-@pytest.mark.xfail(reason="Broken")
+@pytest.mark.dependency(depends=["test_vscode_widget"])
 def test_admin_portal_error(
     browser_setup: Any,
     screenshot_on_fail: Any,
@@ -382,7 +382,7 @@ def test_admin_portal_error(
     admin_portal_logout(driver)
 
 
-@pytest.mark.xfail(reason="Broken")
+@pytest.mark.dependency(depends=["test_vscode_widget"])
 def test_vscode_rhsso_auth_flow(
     browser_setup: Any,
     screenshot_on_fail: Any,

--- a/test/ui/utils/ui_utils.py
+++ b/test/ui/utils/ui_utils.py
@@ -185,7 +185,7 @@ def user_is_auth(driver: WebDriver) -> bool:
     return bool(elts)
 
 
-@pytest.mark.xfail(reason="Broken")
+@pytest.mark.dependency(depends=["test_vscode_widget"])
 def sso_auth_flow(  # noqa: PLR0913
     driver: WebDriver,
     username: str = LIGHTSPEED_USER,

--- a/uv.lock
+++ b/uv.lock
@@ -2101,6 +2101,16 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-dependency"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "setuptools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c2/ea/84509533e0f6477960b8a9179d240d93c909c6543e4dd8209932026d7815/pytest_dependency-0.6.1.tar.gz", hash = "sha256:246c24d2a5fc743a942cec4408853640e56a05ba58d46e5b213a1d4b738a2464", size = 20837, upload-time = "2026-02-15T18:08:43.927Z" }
+
+[[package]]
 name = "pytest-github-actions-annotate-failures"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2998,6 +3008,7 @@ dev = [
     { name = "prek" },
     { name = "pygithub" },
     { name = "pytest-coverage" },
+    { name = "pytest-dependency" },
     { name = "pytest-github-actions-annotate-failures" },
     { name = "pytest-rerunfailures" },
     { name = "selenium" },
@@ -3032,6 +3043,7 @@ dev = [
     { name = "prek", specifier = ">=0.3.4" },
     { name = "pygithub", specifier = ">=2.8.1" },
     { name = "pytest-coverage", specifier = ">=0.0" },
+    { name = "pytest-dependency", specifier = ">=0.6" },
     { name = "pytest-github-actions-annotate-failures", specifier = ">=0.4.0" },
     { name = "pytest-rerunfailures", specifier = ">=16.1" },
     { name = "selenium", specifier = ">=4.40.0" },


### PR DESCRIPTION
- cuts tests execution on CI in half as there is no point on trying
  10+ tests that we known to fail with extra delays.
- use pytest-dependency to decide which tests need to be skipped
- allow execution of tests from subdirectories

Related: AAP-67210