### PR TITLE
fix: fix artifact paths in publish and publish-npm jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -587,13 +587,14 @@ jobs:
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: ansible-extension-build-${{ github.event.number || github.run_id }}.zip
+          path: out
 
       - name: Attach vsix to Github release
         # cspell: ignore softprops
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
         if: github.ref_type == 'tag'
         with:
-          files: "*.vsix"
+          files: "out/*.vsix"
 
       - run: |
           yarn install --immutable
@@ -624,14 +625,18 @@ jobs:
       issues: write
       checks: read
     steps:
+      - name: Checkout Source
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
       - name: Download the artifact
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
-          name: "@ansible-ansible-language-server-build-${{ github.event.number || github.run_id }}.tgz"
+          name: ansible-extension-build-${{ github.event.number || github.run_id }}.zip
+          path: out
 
       - uses: jdx/mise-action@6d1e696aa24c1aa1bcc1adea0212707c71ab78a8 # v3.6.1
 
-      - run: npm publish --access public @ansible-ansible-language-server-*.tgz
+      - run: npm publish --access public out/@ansible-ansible-language-server-*.tgz
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
## Summary

Fixes two broken CI jobs that prevented releases from completing.

## Failures

### 1. `publish` job — `ls: cannot access 'out/*.vsix'`

`download-artifact` without `path:` strips the `out/` prefix, so vsix
files landed in workspace root instead of `out/`. Both `ls -la out/*.vsix`
and `./tools/helper --publish` (which globs `out/ansible-*.vsix`) failed.

Also fixes `files: "*.vsix"` → `files: "out/*.vsix"` in the GitHub release
attachment step for consistency.

### 2. `publish-npm` job — Artifact not found

The job requested artifact `@ansible-ansible-language-server-build-<id>.tgz`
which was never uploaded. The `.tgz` is bundled inside the main artifact
`ansible-extension-build-<id>.zip`. Fixed to download the correct artifact.

### 3. `publish-npm` job — `.github/actions/report` not found

Missing checkout step caused the local report action to be unresolvable.
Added `actions/checkout` before the report step.

## Changes

- `publish`: add `path: out` to download step
- `publish`: `files: "*.vsix"` → `files: "out/*.vsix"`
- `publish-npm`: fix artifact name to use the main build artifact
- `publish-npm`: add `path: out` to download step
- `publish-npm`: fix npm publish glob to `out/@ansible-ansible-language-server-*.tgz`
- `publish-npm`: add checkout step so `.github/actions/report` resolves
