### PR TITLE
fix: refactor mcp package building

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -395,7 +395,6 @@ jobs:
             out/e2e
             out/junit
             out/log
-            out/mcp
             out/ui*
             out/unit
             out/server

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -80,8 +80,9 @@ repos:
           - --format=gha
           - --fix
           - --max-warnings=0
-          - --cache
-          - --cache-strategy=content
+          - --concurrency=2
+          # - --cache
+          # - --cache-strategy=content
         pass_filenames: false
         always_run: true
   - repo: https://github.com/pre-commit/pre-commit-hooks.git

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -30,7 +30,6 @@
 !out/client/webview/apps/contentCreator/addPluginPageApp.js
 !out/client/webview/apps/quickLinks/quickLinksApp.js
 !out/client/webview/apps/welcomePage/welcomePageApp.js
-!out/mcp/**/*
 !out/server/src/server.js
 !out/vitebuild/extension/**/*
 !out/vitebuild/webview/style.css

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -56,8 +56,8 @@ tasks:
     deps:
       - setup
     cmds:
-      - for: sources
-        cmd: echo {{ .ITEM }}
+      # - for: sources
+      #   cmd: echo {{ .ITEM }}
       - yarn workspaces foreach --all -tv run clean
       - yarn run build
       - yarn run vite-build
@@ -152,7 +152,7 @@ tasks:
     desc: Lint the project
     interactive: true
     cmds:
-      - "{{.VIRTUAL_ENV}}/bin/prek run -a -v"
+      - "{{.VIRTUAL_ENV}}/bin/prek run -a -v --color=always"
       - defer: { task: finish }
     silent: true
     sources:

--- a/docs/development/mcp.md
+++ b/docs/development/mcp.md
@@ -287,20 +287,6 @@ server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
 
 ---
 
-### Step 4: Update Build Script (if needed)
-
-If your resource needs to be copied during build, the existing `copy-resources` script in `package.json` handles this:
-
-```json
-{
-  "scripts": {
-    "copy-resources": "mkdir -p out/server/src/resources/data && cp -r src/resources/data/* out/server/src/resources/data/"
-  }
-}
-```
-
----
-
 ### Best Practices for Resources
 
 - Keep resource files in `src/resources/data/`.
@@ -402,7 +388,7 @@ npm run dev:stdio
 Or after building:
 
 ```bash
-node out/server/src/cli.js --stdio
+npm exec -- ansible-mcp-server --stdio
 ```
 
 #### Send Manual JSON-RPC Requests

--- a/docs/mcp/README.md
+++ b/docs/mcp/README.md
@@ -66,7 +66,7 @@ Add the following configuration to your Claude Desktop settings:
     "ansible": {
       "command": "node",
       "args": [
-        "/path/to/vscode-ansible/out/mcp/index.js"
+        "ansible-mcp-server"
       ],
       "env": {
         "WORKSPACE_ROOT": "/path/to/your/ansible/project"

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -23,6 +23,9 @@ export default defineConfig(
   includeIgnoreFile(gitignorePath, "Imported .gitignore patterns"),
   {
     ignores: [
+      "**/dist/**/*",
+      "**/lib/**/*",
+      "packages/**/tsup.config.ts",
       // do not add ignores here, .yarn is special case as is not our code
       ".yarn/*",
       ".venv/*",

--- a/knip.ts
+++ b/knip.ts
@@ -42,7 +42,7 @@ const config: KnipConfig = {
         "test/**/*.ts",
         "webviews/**/*.{ts,tsx,vue,js,html}",
       ],
-      ignore: [".yarn/**"],
+      ignore: [".yarn/**", "**/dist/**", "**/lib/**"],
       project: ["{src,test,webviews}/**/*.{mjs,js,json,ts,tsx}"],
     },
     "packages/ansible-language-server": {

--- a/package.json
+++ b/package.json
@@ -1095,6 +1095,7 @@
     "sinon": "^21.0.2",
     "ts-loader": "^9.5.4",
     "ts-node": "^10.9.2",
+    "tsup": "^8.5.1",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.57.0",
@@ -1139,7 +1140,7 @@
   },
   "scripts": {
     "build": "yarn workspaces foreach --all -tvv run compile",
-    "clean": "rimraf out/client out/server out/mcp out/tsconfig.tsbuildinfo out/syntaxHighlighter coverage .nyc_output",
+    "clean": "rimraf out/client out/server out/tsconfig.tsbuildinfo out/syntaxHighlighter coverage .nyc_output",
     "compile": "tsc -b --sourceMap && tsc -p ./packages/ansible-language-server/tsconfig.json --outDir ./out/server --sourceMap",
     "knip": "knip",
     "package": "./tools/helper --package",

--- a/packages/ansible-mcp-server/Taskfile.yml
+++ b/packages/ansible-mcp-server/Taskfile.yml
@@ -33,7 +33,8 @@ tasks:
     cmds:
       - npm run compile
     generates:
-      - out/server/**/*.*
+      - lib/**/*.*
+      - dist/**/*.*
     sources:
       - ../../vitest.config.ts
       - package-lock.json
@@ -88,5 +89,4 @@ tasks:
     desc: Clean build artifacts
     dir: "{{ .TASKFILE_DIR }}"
     cmds:
-      - rm -rf out/server
       - rm -rf node_modules/.cache

--- a/packages/ansible-mcp-server/package.json
+++ b/packages/ansible-mcp-server/package.json
@@ -1,5 +1,5 @@
 {
-  "bin": "out/server/src/cli.js",
+  "bin": "dist/cli.js",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",
     "ajv": "^8.18.0",
@@ -20,7 +20,8 @@
     "node": ">=24.0"
   },
   "files": [
-    "./out/server/src/**/*",
+    "lib",
+    "dist",
     "./src/resources/data/**/*"
   ],
   "keywords": [
@@ -35,19 +36,20 @@
     "ai-assistant"
   ],
   "license": "MIT",
-  "main": "./out/server/src/server.js",
+  "main": "lib/cli.js",
+  "types": "lib/cli.d.ts",
+  "module": "lib/cli.js",
   "name": "@ansible/ansible-mcp-server",
   "publishConfig": {
     "access": "public"
   },
   "scripts": {
     "build": "npm run clean && npm run compile",
-    "clean": "rimraf out/server && rimraf lib",
-    "compile": "tsc -p . && npm run copy-resources",
-    "copy-resources": "mkdir -p out/server/src/resources/data && cp -r src/resources/data/* out/server/src/resources/data/ 2>/dev/null || true",
+    "clean": "rimraf dist lib",
+    "compile": "tsc -p . && tsup",
     "dev:stdio": "tsx src/cli.ts --stdio",
-    "prepack": "npm run compile",
-    "test": "vitest run --project=mcp",
+    "prepack": "npm run compile && rimraf dist && env NODE_ENV=production tsup",
+    "test": "vitest run --project=mcp --coverage.reportsDirectory=../../out/coverage/mcp",
     "test:ade": "vitest run --project=mcp test/adeTools.ts test/adeIntegration.ts",
     "test:ci": "vitest run --coverage --reporter=verbose",
     "test:integration": "vitest run --project=mcp test/server.ts test/integration.ts test/adeIntegration.ts",
@@ -57,6 +59,8 @@
     "test:watch": "vitest --project=mcp"
   },
   "type": "module",
-  "types": "./out/server/src/server.d.ts",
+  "sideEffects": [
+    "dist/*"
+  ],
   "version": "0.1.0"
 }

--- a/packages/ansible-mcp-server/src/utils/resourcePath.ts
+++ b/packages/ansible-mcp-server/src/utils/resourcePath.ts
@@ -71,7 +71,7 @@ export async function resolveResourcePath(
   const baseDir = getResourceBaseDir(callerUrl);
 
   // Resources are in data/ relative to base directory:
-  // - Dev: out/server/src/resources/agents.js -> out/server/src/resources/data/
+  // - Dev: src/resources/agents.js -> src/resources/data/
   const resourcePath = path.join(baseDir, "data", relativePath);
 
   try {
@@ -93,7 +93,7 @@ export async function resolveResourcePath(
       }
     }
 
-    // Fallback: if in out/server/src/utils/, try out/server/src/resources/data/
+    // Fallback: if in src/utils/, try src/resources/data/
     if (
       baseDir.includes(
         "out" + path.sep + "server" + path.sep + "src" + path.sep + "utils",

--- a/packages/ansible-mcp-server/tsconfig.json
+++ b/packages/ansible-mcp-server/tsconfig.json
@@ -1,9 +1,10 @@
 {
   "compilerOptions": {
+    "allowJs": true,
     "baseUrl": ".",
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "outDir": "./out/server",
+    "outDir": "lib",
     "paths": {
       "@src/*": ["./src/*"],
       "@test/*": ["./test/*"]
@@ -12,5 +13,6 @@
     "target": "ES2022"
   },
   "exclude": ["node_modules", "out", "coverage"],
-  "extends": "../../tsconfig.base.json"
+  "extends": "../../tsconfig.base.json",
+  "include": ["src/**/*.ts", "test/**/*.ts", "*.ts"]
 }

--- a/packages/ansible-mcp-server/tsup.config.ts
+++ b/packages/ansible-mcp-server/tsup.config.ts
@@ -1,0 +1,23 @@
+import type { Options } from 'tsup';
+
+const env = process.env.NODE_ENV;
+
+export const tsup: Options = {
+    clean: true,
+    dts: {
+        compilerOptions: {
+            composite: false,
+          },
+    },
+    entryPoints: [
+        "src/server.ts",
+    ],
+    minify: env === 'production',
+    bundle: env === 'production',
+    entry: ['src/**/*.ts'],
+    format: ['esm'],
+    outDir: env === 'production' ? 'dist' : 'lib',
+    splitting: false,
+    watch: env === 'development',
+    skipNodeModulesBundle: true,
+};

--- a/tools/helper
+++ b/tools/helper
@@ -147,14 +147,7 @@ def cli() -> None:
         run("yarn run webpack")
         # --no-dependencies and --no-yarn needed due to https://github.com/microsoft/vscode-vsce/issues/439
         run("yarn run vite-build")
-        # Build and stage the MCP server into out/mcp so it is included in the VSIX
-        # We only need to copy the resource data files that are loaded at runtime
-        # The bundled code uses __dirname which will be out/mcp/, so resources should be at out/mcp/data/
         run("task build")
-        run("mkdir -p out/mcp/data")
-        run(
-            "cp -r packages/ansible-mcp-server/src/resources/data/* out/mcp/data/ 2>/dev/null || true"
-        )
 
         # most options are supposed to be loaded from package.json but --no-update-package-json apparently is still needed
         vsix_file = f"out/ansible-{version}.vsix"

--- a/yarn.lock
+++ b/yarn.lock
@@ -61,7 +61,7 @@ __metadata:
     yaml: "npm:^2.8.2"
     zod: "npm:^3.23.8"
   bin:
-    ansible-mcp-server: out/server/src/cli.js
+    ansible-mcp-server: dist/cli.js
   languageName: unknown
   linkType: soft
 
@@ -3622,6 +3622,7 @@ __metadata:
     sinon: "npm:^21.0.2"
     ts-loader: "npm:^9.5.4"
     ts-node: "npm:^10.9.2"
+    tsup: "npm:^8.5.1"
     tsx: "npm:^4.21.0"
     typescript: "npm:^5.9.3"
     typescript-eslint: "npm:^8.57.0"
@@ -11317,7 +11318,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tsup@npm:^8.5.0":
+"tsup@npm:^8.5.0, tsup@npm:^8.5.1":
   version: 8.5.1
   resolution: "tsup@npm:8.5.1"
   dependencies:


### PR DESCRIPTION
- use tsup to build the package as both cjs/esm with bundling (this will be needed later for when we replace vite build with tsup for extension).
- add 'ansible-mcp-server' bin
- use standard/default lib/dist out directories
- remove manual copy-resources