### PR TITLE
feat: use local HTTP server for OAuth callback - AAP-70006

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -78,6 +78,10 @@ export default defineConfig(
       "@typescript-eslint/no-non-null-assertion": "error",
       "@typescript-eslint/no-base-to-string": "error",
       "@typescript-eslint/no-require-imports": "off",
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
+      ],
       "local/node-DEP0190": "error",
       "no-case-declarations": "error",
       "no-constant-condition": "error",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -497,6 +497,8 @@ export async function activate(context: ExtensionContext): Promise<void> {
         providerManager: lightSpeedManager.providerManager,
         llmProviderSettings: llmProviderSettings,
         lightspeedUser: lightSpeedManager.lightspeedAuthenticatedUser,
+        lightSpeedAuthenticationProvider:
+          lightSpeedManager.lightSpeedAuthenticationProvider,
         quickLinksProvider: quickLinksHome,
       });
     },

--- a/src/features/lightspeed/ansibleContext.ts
+++ b/src/features/lightspeed/ansibleContext.ts
@@ -141,7 +141,7 @@ Generate Ansible inventory content with:
    */
   private static preprocessAnsibleContent(
     content: string,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+
     _fileType: string,
   ): string {
     try {

--- a/src/features/lightspeed/commands/providerCommands.ts
+++ b/src/features/lightspeed/commands/providerCommands.ts
@@ -97,10 +97,24 @@ export class ProviderCommands {
   }
 
   /**
+   * Remove all OAuth sessions (equivalent to "Sign Out" in VSCode accounts menu).
+   */
+  private async signOutOAuthSessions(): Promise<void> {
+    const sessions =
+      await this.lightSpeedManager.lightSpeedAuthenticationProvider.getSessions();
+    for (const session of sessions) {
+      await this.lightSpeedManager.lightSpeedAuthenticationProvider.removeSession(
+        session.id,
+      );
+    }
+  }
+
+  /**
    * Configure LLM provider through guided setup
    */
   private async configureLlmProvider(): Promise<void> {
     try {
+      const previousProvider = this.llmProviderSettings.getProvider();
       const supportedProviders = providerFactory.getSupportedProviders();
 
       // Step 1: Select provider type
@@ -127,6 +141,11 @@ export class ProviderCommands {
       await this.llmProviderSettings.setProvider(
         selectedProvider.provider.type,
       );
+
+      // Sign out OAuth sessions if provider changed
+      if (selectedProvider.provider.type !== previousProvider) {
+        await this.signOutOAuthSessions();
+      }
 
       const providerType = selectedProvider.provider.type;
 
@@ -277,10 +296,17 @@ export class ProviderCommands {
     }
 
     try {
+      const previousProvider = this.llmProviderSettings.getProvider();
+
       // Switch to selected provider using LlmProviderSettings
       await this.llmProviderSettings.setProvider(
         selectedProvider.provider.type,
       );
+
+      // Sign out OAuth sessions if provider changed
+      if (selectedProvider.provider.type !== previousProvider) {
+        await this.signOutOAuthSessions();
+      }
 
       // Enable lightspeed in VS Code settings
       const config = vscode.workspace.getConfiguration("ansible.lightspeed");

--- a/src/features/lightspeed/explorerWebviewViewProvider.ts
+++ b/src/features/lightspeed/explorerWebviewViewProvider.ts
@@ -21,9 +21,9 @@ export class LightspeedExplorerWebviewViewProvider implements WebviewViewProvide
 
   public async resolveWebviewView(
     webviewView: WebviewView,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+
     _resolveContext: WebviewViewResolveContext,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+
     _token: CancellationToken,
   ) {
     this._view = webviewView;

--- a/src/features/lightspeed/lightSpeedOAuthProvider.ts
+++ b/src/features/lightspeed/lightSpeedOAuthProvider.ts
@@ -318,8 +318,8 @@ export class LightSpeedAuthenticationProvider
       const escapeHtml = (value: string) =>
         value.replace(/[&<>"']/g, (char) => entities[char] ?? char);
 
-      res.writeHead(200, { "Content-Type": "text/html" });
       if (code) {
+        res.writeHead(200, { "Content-Type": "text/html" });
         res.end(
           "<html><body><h1>Authorization received</h1><p>Return to your editor to finish signing in.</p></body></html>",
         );
@@ -327,6 +327,7 @@ export class LightSpeedAuthenticationProvider
       } else {
         const errorMsg =
           error || "No authorization code received from the server";
+        res.writeHead(400, { "Content-Type": "text/html" });
         res.end(
           `<html><body><h1>Authentication failed</h1><p>${escapeHtml(errorMsg)}</p></body></html>`,
         );

--- a/src/features/lightspeed/lightSpeedOAuthProvider.ts
+++ b/src/features/lightspeed/lightSpeedOAuthProvider.ts
@@ -346,7 +346,7 @@ export class LightSpeedAuthenticationProvider
   ];
 
   /* Log in to the Ansible Lightspeed auth service */
-  private async login(scopes: string[] = []) {
+  private async login(_scopes: string[] = []) {
     this._logger.debug("[ansible-lightspeed-oauth] Logging in...");
 
     await this.setExternalRedirectUri();

--- a/src/features/lightspeed/lightSpeedOAuthProvider.ts
+++ b/src/features/lightspeed/lightSpeedOAuthProvider.ts
@@ -169,13 +169,15 @@ export class LightSpeedAuthenticationProvider
 
   /**
    * Create a new auth session
-   * @param scopes - Scopes
+   * @param _scopes - Scopes
    * @returns
    */
-  public async createSession(scopes: string[]): Promise<LightspeedAuthSession> {
+  public async createSession(
+    _scopes: string[],
+  ): Promise<LightspeedAuthSession> {
     try {
       lightSpeedManager.currentModelValue = undefined;
-      const account = await this.login(scopes);
+      const account = await this.login();
 
       if (!account) {
         throw new Error(`Ansible Lightspeed login failure`);
@@ -346,7 +348,7 @@ export class LightSpeedAuthenticationProvider
   ];
 
   /* Log in to the Ansible Lightspeed auth service */
-  private async login(_scopes: string[] = []) {
+  private async login() {
     this._logger.debug("[ansible-lightspeed-oauth] Logging in...");
 
     await this.setExternalRedirectUri();

--- a/src/features/lightspeed/lightSpeedOAuthProvider.ts
+++ b/src/features/lightspeed/lightSpeedOAuthProvider.ts
@@ -14,6 +14,8 @@ import {
 } from "vscode";
 import { v4 as uuid } from "uuid";
 import crypto from "crypto";
+import http from "http";
+import { AddressInfo } from "net";
 import {
   PromiseAdapter,
   promiseFromEvent,
@@ -90,6 +92,7 @@ export class LightSpeedAuthenticationProvider
   private _authId: string;
   private _authName: string;
   private _externalRedirectUri: string;
+  private _activeRedirectUri: string | undefined;
 
   constructor(
     private readonly context: ExtensionContext,
@@ -276,19 +279,78 @@ export class LightSpeedAuthenticationProvider
     }
   }
 
+  /**
+   * Start a local HTTP server to receive the OAuth callback.
+   * Returns a promise that resolves with the authorization code and
+   * a cleanup function to shut down the server.
+   */
+  private async startLocalCallbackServer(): Promise<{
+    redirectUri: string;
+    codePromise: Promise<string>;
+    close: () => void;
+  }> {
+    let resolveCode: (code: string) => void;
+    let rejectCode: (err: Error) => void;
+    const codePromise = new Promise<string>((resolve, reject) => {
+      resolveCode = resolve;
+      rejectCode = reject;
+    });
+
+    const server = http.createServer((req, res) => {
+      const url = new URL(req.url || "/", `http://${req.headers.host}`);
+      if (url.pathname !== "/callback") {
+        res.writeHead(404);
+        res.end("Not found");
+        return;
+      }
+
+      const code = url.searchParams.get("code");
+      const error = url.searchParams.get("error");
+
+      res.writeHead(200, { "Content-Type": "text/html" });
+      if (code) {
+        res.end(
+          "<html><body><h1>Authentication successful</h1><p>You can close this tab and return to your editor.</p></body></html>",
+        );
+        resolveCode(code);
+      } else {
+        const errorMsg =
+          error || "No authorization code received from the server";
+        res.end(
+          `<html><body><h1>Authentication failed</h1><p>${errorMsg}</p></body></html>`,
+        );
+        rejectCode(new Error(errorMsg));
+      }
+    });
+
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", () => resolve());
+    });
+
+    const port = (server.address() as AddressInfo).port;
+    const redirectUri = `http://127.0.0.1:${port}/callback`;
+
+    this._logger.debug(
+      `[ansible-lightspeed-oauth] Local callback server listening on ${redirectUri}`,
+    );
+
+    const close = () => {
+      server.close();
+    };
+
+    return { redirectUri, codePromise, close };
+  }
+
+  private static readonly LOOPBACK_CALLBACK_HOSTS = [
+    "https://c.ai.ansible.redhat.com",
+    "https://stage.ai.ansible.redhat.com",
+  ];
+
   /* Log in to the Ansible Lightspeed auth service */
   private async login(scopes: string[] = []) {
     this._logger.debug("[ansible-lightspeed-oauth] Logging in...");
 
     await this.setExternalRedirectUri();
-
-    const searchParams = new URLSearchParams([
-      ["response_type", "code"],
-      ["code_challenge", getCodeChallenge()],
-      ["code_challenge_method", "S256"],
-      ["client_id", LIGHTSPEED_CLIENT_ID],
-      ["redirect_uri", this._externalRedirectUri],
-    ]);
 
     const base_uri = await getBaseUri(this.settingsManager);
     if (!base_uri) {
@@ -297,13 +359,48 @@ export class LightSpeedAuthenticationProvider
       );
     }
 
+    const useLoopback =
+      LightSpeedAuthenticationProvider.LOOPBACK_CALLBACK_HOSTS.includes(
+        base_uri,
+      );
+
+    let localServer:
+      | Awaited<ReturnType<typeof this.startLocalCallbackServer>>
+      | undefined;
+    let redirectUri: string;
+
+    if (useLoopback) {
+      localServer = await this.startLocalCallbackServer();
+      redirectUri = localServer.redirectUri;
+      this._logger.debug(
+        `[ansible-lightspeed-oauth] Using local callback redirect URI: ${redirectUri}`,
+      );
+    } else {
+      redirectUri = this._externalRedirectUri;
+      this._logger.debug(
+        `[ansible-lightspeed-oauth] Using external redirect URI: ${redirectUri}`,
+      );
+    }
+
+    const searchParams = new URLSearchParams([
+      ["response_type", "code"],
+      ["code_challenge", getCodeChallenge()],
+      ["code_challenge_method", "S256"],
+      ["client_id", LIGHTSPEED_CLIENT_ID],
+      ["redirect_uri", redirectUri],
+    ]);
+
     const query = searchParams.toString();
     const uri = Uri.parse(base_uri).with({ path: "/o/authorize/", query });
 
+    // Also listen on the vscode:// URI handler as a fallback
     const {
       promise: receivedRedirectUrl,
       cancel: cancelWaitingForRedirectUrl,
     } = promiseFromEvent(this._uriHandler.event, this.handleUriForCode(scopes));
+
+    // Store the redirect URI used for the token exchange
+    this._activeRedirectUri = redirectUri;
 
     await env.openExternal(uri);
 
@@ -315,7 +412,7 @@ export class LightSpeedAuthenticationProvider
       },
       async (_, token): Promise<OAuthAccount> => {
         try {
-          return await Promise.race<OAuthAccount>([
+          const candidates: Promise<OAuthAccount>[] = [
             receivedRedirectUrl,
             new Promise<OAuthAccount>((_, reject) => {
               setTimeout(() => {
@@ -329,9 +426,21 @@ export class LightSpeedAuthenticationProvider
             promiseFromEvent(token.onCancellationRequested, (_, __, reject) => {
               reject("User Cancelled");
             }).promise as Promise<OAuthAccount>,
-          ]);
+          ];
+
+          if (localServer) {
+            candidates.push(
+              localServer.codePromise.then(async (code) => {
+                return await this.requestOAuthAccountFromCode(code);
+              }) as Promise<OAuthAccount>,
+            );
+          }
+
+          return await Promise.race<OAuthAccount>(candidates);
         } finally {
+          localServer?.close();
           cancelWaitingForRedirectUrl.fire();
+          this._activeRedirectUri = undefined;
         }
       },
     );
@@ -387,7 +496,7 @@ export class LightSpeedAuthenticationProvider
         {
           method: "POST",
           signal: AbortSignal.timeout(ANSIBLE_LIGHTSPEED_API_TIMEOUT),
-          body: `client_id=${encodeURIComponent(LIGHTSPEED_CLIENT_ID)}&code_verifier=${encodeURIComponent(getCodeVerifier())}&grant_type=authorization_code&code=${code}&redirect_uri=${encodeURIComponent(this._externalRedirectUri)}`,
+          body: `client_id=${encodeURIComponent(LIGHTSPEED_CLIENT_ID)}&code_verifier=${encodeURIComponent(getCodeVerifier())}&grant_type=authorization_code&code=${code}&redirect_uri=${encodeURIComponent(this._activeRedirectUri || this._externalRedirectUri)}`,
           headers,
         },
       );

--- a/src/features/lightspeed/lightSpeedOAuthProvider.ts
+++ b/src/features/lightspeed/lightSpeedOAuthProvider.ts
@@ -308,24 +308,45 @@ export class LightSpeedAuthenticationProvider
       const code = url.searchParams.get("code");
       const error = url.searchParams.get("error");
 
+      const entities: Record<string, string> = {
+        "&": "&amp;",
+        "<": "&lt;",
+        ">": "&gt;",
+        '"': "&quot;",
+        "'": "&#39;",
+      };
+      const escapeHtml = (value: string) =>
+        value.replace(/[&<>"']/g, (char) => entities[char] ?? char);
+
       res.writeHead(200, { "Content-Type": "text/html" });
       if (code) {
         res.end(
-          "<html><body><h1>Authentication successful</h1><p>You can close this tab and return to your editor.</p></body></html>",
+          "<html><body><h1>Authorization received</h1><p>Return to your editor to finish signing in.</p></body></html>",
         );
         resolveCode(code);
       } else {
+        const errorMsg =
+          error || "No authorization code received from the server";
         res.end(
-          "<html><body><h1>Authentication failed</h1><p>Something went wrong. Return to your editor for details.</p></body></html>",
+          `<html><body><h1>Authentication failed</h1><p>${escapeHtml(errorMsg)}</p></body></html>`,
         );
-        rejectCode(
-          new Error(error || "No authorization code received from the server"),
-        );
+        rejectCode(new Error(errorMsg));
       }
     });
 
-    await new Promise<void>((resolve) => {
-      server.listen(0, "127.0.0.1", () => resolve());
+    await new Promise<void>((resolve, reject) => {
+      const onError = (err: Error) => {
+        server.off("listening", onListening);
+        reject(err);
+      };
+      const onListening = () => {
+        server.off("error", onError);
+        resolve();
+      };
+
+      server.once("error", onError);
+      server.once("listening", onListening);
+      server.listen(0, "127.0.0.1");
     });
 
     const port = (server.address() as AddressInfo).port;
@@ -394,13 +415,17 @@ export class LightSpeedAuthenticationProvider
     const query = searchParams.toString();
     const uri = Uri.parse(base_uri).with({ path: "/o/authorize/", query });
 
-    const {
-      promise: receivedRedirectUrl,
-      cancel: cancelWaitingForRedirectUrl,
-    } = promiseFromEvent(
-      this._uriHandler.event,
-      this.handleUriForCode(redirectUri),
-    );
+    let receivedRedirectUrl: Promise<OAuthAccount> | undefined;
+    let cancelWaitingForRedirectUrl: EventEmitter<void> | undefined;
+
+    if (!useLoopback) {
+      const result = promiseFromEvent(
+        this._uriHandler.event,
+        this.handleUriForCode(redirectUri),
+      );
+      receivedRedirectUrl = result.promise;
+      cancelWaitingForRedirectUrl = result.cancel;
+    }
 
     await env.openExternal(uri);
 
@@ -413,7 +438,6 @@ export class LightSpeedAuthenticationProvider
       async (_, token): Promise<OAuthAccount> => {
         try {
           const candidates: Promise<OAuthAccount>[] = [
-            receivedRedirectUrl,
             new Promise<OAuthAccount>((_, reject) => {
               setTimeout(() => {
                 reject(
@@ -436,10 +460,16 @@ export class LightSpeedAuthenticationProvider
             );
           }
 
+          if (receivedRedirectUrl) {
+            candidates.push(receivedRedirectUrl);
+          }
+
           return await Promise.race<OAuthAccount>(candidates);
         } finally {
           localServer?.close();
-          cancelWaitingForRedirectUrl.fire();
+          if (cancelWaitingForRedirectUrl) {
+            cancelWaitingForRedirectUrl.fire();
+          }
         }
       },
     );

--- a/src/features/lightspeed/lightSpeedOAuthProvider.ts
+++ b/src/features/lightspeed/lightSpeedOAuthProvider.ts
@@ -92,7 +92,6 @@ export class LightSpeedAuthenticationProvider
   private _authId: string;
   private _authName: string;
   private _externalRedirectUri: string;
-  private _activeRedirectUri: string | undefined;
 
   constructor(
     private readonly context: ExtensionContext,
@@ -314,12 +313,12 @@ export class LightSpeedAuthenticationProvider
         );
         resolveCode(code);
       } else {
-        const errorMsg =
-          error || "No authorization code received from the server";
         res.end(
-          `<html><body><h1>Authentication failed</h1><p>${errorMsg}</p></body></html>`,
+          "<html><body><h1>Authentication failed</h1><p>Something went wrong. Return to your editor for details.</p></body></html>",
         );
-        rejectCode(new Error(errorMsg));
+        rejectCode(
+          new Error(error || "No authorization code received from the server"),
+        );
       }
     });
 
@@ -393,14 +392,13 @@ export class LightSpeedAuthenticationProvider
     const query = searchParams.toString();
     const uri = Uri.parse(base_uri).with({ path: "/o/authorize/", query });
 
-    // Also listen on the vscode:// URI handler as a fallback
     const {
       promise: receivedRedirectUrl,
       cancel: cancelWaitingForRedirectUrl,
-    } = promiseFromEvent(this._uriHandler.event, this.handleUriForCode(scopes));
-
-    // Store the redirect URI used for the token exchange
-    this._activeRedirectUri = redirectUri;
+    } = promiseFromEvent(
+      this._uriHandler.event,
+      this.handleUriForCode(redirectUri),
+    );
 
     await env.openExternal(uri);
 
@@ -430,9 +428,9 @@ export class LightSpeedAuthenticationProvider
 
           if (localServer) {
             candidates.push(
-              localServer.codePromise.then(async (code) => {
-                return await this.requestOAuthAccountFromCode(code);
-              }) as Promise<OAuthAccount>,
+              localServer.codePromise.then((code) =>
+                this.requestOAuthAccountFromCode(code, redirectUri),
+              ) as Promise<OAuthAccount>,
             );
           }
 
@@ -440,7 +438,6 @@ export class LightSpeedAuthenticationProvider
         } finally {
           localServer?.close();
           cancelWaitingForRedirectUrl.fire();
-          this._activeRedirectUri = undefined;
         }
       },
     );
@@ -450,9 +447,9 @@ export class LightSpeedAuthenticationProvider
 
   /* Handle the redirect to VS Code (after sign in from the Ansible Lightspeed auth service) */
   private handleUriForCode: (
-    scopes: readonly string[],
+    redirectUri: string,
   ) => PromiseAdapter<Uri, OAuthAccount> =
-    () => async (uri, resolve, reject) => {
+    (redirectUri) => async (uri, resolve, reject) => {
       const query = new URLSearchParams(uri.query);
       const code = query.get("code");
 
@@ -465,7 +462,7 @@ export class LightSpeedAuthenticationProvider
         return;
       }
 
-      const account = await this.requestOAuthAccountFromCode(code);
+      const account = await this.requestOAuthAccountFromCode(code, redirectUri);
 
       if (!account) {
         reject(new Error("Unable to form account"));
@@ -478,6 +475,7 @@ export class LightSpeedAuthenticationProvider
   /* Request access token from server using code */
   private async requestOAuthAccountFromCode(
     code: string,
+    redirectUri: string,
   ): Promise<OAuthAccount | undefined> {
     const headers = {
       "Cache-Control": "no-cache",
@@ -496,7 +494,7 @@ export class LightSpeedAuthenticationProvider
         {
           method: "POST",
           signal: AbortSignal.timeout(ANSIBLE_LIGHTSPEED_API_TIMEOUT),
-          body: `client_id=${encodeURIComponent(LIGHTSPEED_CLIENT_ID)}&code_verifier=${encodeURIComponent(getCodeVerifier())}&grant_type=authorization_code&code=${code}&redirect_uri=${encodeURIComponent(this._activeRedirectUri || this._externalRedirectUri)}`,
+          body: `client_id=${encodeURIComponent(LIGHTSPEED_CLIENT_ID)}&code_verifier=${encodeURIComponent(getCodeVerifier())}&grant_type=authorization_code&code=${code}&redirect_uri=${encodeURIComponent(redirectUri)}`,
           headers,
         },
       );

--- a/src/features/lightspeed/providers/rhcustom.ts
+++ b/src/features/lightspeed/providers/rhcustom.ts
@@ -253,7 +253,6 @@ export class RHCustomProvider extends BaseLLMProvider<RHCustomConfig> {
   }
 
   async completionRequest(
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     _params: CompletionRequestParams,
   ): Promise<CompletionResponseParams> {
     // Inline suggestions are out of scope for the Red Hat AI provider currently

--- a/src/features/lightspeed/vue/views/llmProviderMessageHandlers.ts
+++ b/src/features/lightspeed/vue/views/llmProviderMessageHandlers.ts
@@ -6,6 +6,7 @@ import { ProviderManager } from "@src/features/lightspeed/providerManager";
 import { LlmProviderSettings } from "@src/features/lightspeed/llmProviderSettings";
 import { LightSpeedCommands, ProviderType } from "@src/definitions/lightspeed";
 import { LightspeedUser } from "@src/features/lightspeed/lightspeedUser";
+import { LightSpeedAuthenticationProvider } from "@src/features/lightspeed/lightSpeedOAuthProvider";
 import { QuickLinksWebviewViewProvider } from "@src/features/quickLinks/utils/quickLinksViewProvider";
 import { ProviderInfo } from "@src/interfaces/lightspeed";
 
@@ -23,6 +24,7 @@ export interface LlmProviderDependencies {
   providerManager: ProviderManager;
   llmProviderSettings: LlmProviderSettings;
   lightspeedUser: LightspeedUser;
+  lightSpeedAuthenticationProvider: LightSpeedAuthenticationProvider;
   quickLinksProvider?: QuickLinksWebviewViewProvider;
 }
 
@@ -35,6 +37,7 @@ export class LlmProviderMessageHandlers {
   private readonly providerManager: ProviderManager;
   private readonly llmProviderSettings: LlmProviderSettings;
   private readonly lightspeedUser: LightspeedUser;
+  private readonly lightSpeedAuthenticationProvider: LightSpeedAuthenticationProvider;
   private readonly quickLinksProvider?: QuickLinksWebviewViewProvider;
   private webview?: Webview;
 
@@ -43,6 +46,8 @@ export class LlmProviderMessageHandlers {
     this.providerManager = deps.providerManager;
     this.llmProviderSettings = deps.llmProviderSettings;
     this.lightspeedUser = deps.lightspeedUser;
+    this.lightSpeedAuthenticationProvider =
+      deps.lightSpeedAuthenticationProvider;
     this.quickLinksProvider = deps.quickLinksProvider;
   }
 
@@ -127,6 +132,16 @@ export class LlmProviderMessageHandlers {
   }
 
   /**
+   * Remove all OAuth sessions (equivalent to "Sign Out" in VSCode accounts menu).
+   */
+  private async signOutOAuthSessions(): Promise<void> {
+    const sessions = await this.lightSpeedAuthenticationProvider.getSessions();
+    for (const session of sessions) {
+      await this.lightSpeedAuthenticationProvider.removeSession(session.id);
+    }
+  }
+
+  /**
    * Common pattern for updating UI and refreshing providers after changes.
    */
   private async updateAndNotify(): Promise<void> {
@@ -151,6 +166,13 @@ export class LlmProviderMessageHandlers {
     if (!message.provider || !message.config) return;
 
     try {
+      // Detect provider or endpoint change to sign out stale OAuth sessions
+      const previousProvider = this.llmProviderSettings.getProvider();
+      const previousEndpoint = await this.llmProviderSettings.get(
+        message.provider,
+        "apiEndpoint",
+      );
+
       const providerInfo = this.getProviderInfo(message.provider);
 
       // Update active provider
@@ -173,6 +195,18 @@ export class LlmProviderMessageHandlers {
         }
       }
 
+      // Sign out if provider or endpoint changed
+      const newEndpoint = message.config["apiEndpoint"];
+      if (
+        message.provider !== previousProvider ||
+        (newEndpoint !== undefined && newEndpoint !== previousEndpoint)
+      ) {
+        console.log(
+          `[LlmProviderMessageHandlers] Provider or endpoint changed, signing out OAuth sessions`,
+        );
+        await this.signOutOAuthSessions();
+      }
+
       // Reset connection status when settings are changed (require re-connect)
       await this.llmProviderSettings.setConnectionStatus(
         false,
@@ -190,7 +224,16 @@ export class LlmProviderMessageHandlers {
    */
   private async handleActivateProvider(providerType: string): Promise<void> {
     try {
+      const previousProvider = this.llmProviderSettings.getProvider();
       await this.llmProviderSettings.setProvider(providerType);
+
+      if (providerType !== previousProvider) {
+        console.log(
+          `[LlmProviderMessageHandlers] Provider activated: ${previousProvider} -> ${providerType}, signing out OAuth sessions`,
+        );
+        await this.signOutOAuthSessions();
+      }
+
       await this.updateAndNotify();
     } catch (error) {
       console.error("Failed to activate provider:", error);
@@ -208,7 +251,16 @@ export class LlmProviderMessageHandlers {
     );
 
     try {
+      const previousProvider = this.llmProviderSettings.getProvider();
       await this.llmProviderSettings.setProvider(providerType);
+
+      if (providerType !== previousProvider) {
+        console.log(
+          `[LlmProviderMessageHandlers] Provider connecting: ${previousProvider} -> ${providerType}, signing out OAuth sessions`,
+        );
+        await this.signOutOAuthSessions();
+      }
+
       const providerInfo = this.getProviderInfo(providerType);
 
       if (providerInfo?.usesOAuth) {

--- a/src/features/quickLinks/utils/quickLinksViewProvider.ts
+++ b/src/features/quickLinks/utils/quickLinksViewProvider.ts
@@ -28,7 +28,7 @@ export class QuickLinksWebviewViewProvider implements WebviewViewProvider {
     webviewView: WebviewView,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     context: WebviewViewResolveContext,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+
     _token: CancellationToken,
   ) {
     this._webviewView = webviewView;

--- a/test/unit/lightspeed/commands/providerCommands.test.ts
+++ b/test/unit/lightspeed/commands/providerCommands.test.ts
@@ -82,6 +82,10 @@ describe("ProviderCommands", () => {
       lightspeedExplorerProvider: {
         refreshWebView: vi.fn(),
       },
+      lightSpeedAuthenticationProvider: {
+        getSessions: vi.fn().mockResolvedValue([]),
+        removeSession: vi.fn().mockResolvedValue(undefined),
+      },
     } as unknown as LightSpeedManager;
 
     // Setup mock LLM provider settings

--- a/test/unit/lightspeed/providers/base.test.ts
+++ b/test/unit/lightspeed/providers/base.test.ts
@@ -114,28 +114,22 @@ class TestProvider extends BaseLLMProvider {
   }
 
   async completionRequest(
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     _params: CompletionRequestParams,
   ): Promise<CompletionResponseParams> {
     throw new Error("Not implemented in test provider");
   }
 
-  async chatRequest(
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    _params: ChatRequestParams,
-  ): Promise<ChatResponseParams> {
+  async chatRequest(_params: ChatRequestParams): Promise<ChatResponseParams> {
     throw new Error("Not implemented in test provider");
   }
 
   async generatePlaybook(
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     _params: GenerationRequestParams,
   ): Promise<GenerationResponseParams> {
     throw new Error("Not implemented in test provider");
   }
 
   async generateRole(
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     _params: GenerationRequestParams,
   ): Promise<GenerationResponseParams> {
     throw new Error("Not implemented in test provider");

--- a/test/unit/lightspeed/providers/rhcustom.test.ts
+++ b/test/unit/lightspeed/providers/rhcustom.test.ts
@@ -68,7 +68,7 @@ const { mockChatCompletion, MockOpenAICompatibleClient } = vi.hoisted(() => {
   const mockChatCompletion = vi.fn();
   const MockOpenAICompatibleClient = vi.fn().mockImplementation(function (
     this: { chatCompletion: ReturnType<typeof vi.fn> },
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+
     _config: unknown,
   ) {
     this.chatCompletion = mockChatCompletion;

--- a/test/unit/lightspeed/views/llmProviderMessageHandlers.test.ts
+++ b/test/unit/lightspeed/views/llmProviderMessageHandlers.test.ts
@@ -184,6 +184,10 @@ describe("LlmProviderMessageHandlers", () => {
       providerManager: mockProviderManager,
       llmProviderSettings: mockLlmProviderSettings,
       lightspeedUser: mockLightspeedUser,
+      lightSpeedAuthenticationProvider: {
+        getSessions: vi.fn().mockResolvedValue([]),
+        removeSession: vi.fn().mockResolvedValue(undefined),
+      } as unknown as import("@src/features/lightspeed/lightSpeedOAuthProvider").LightSpeedAuthenticationProvider,
       quickLinksProvider: mockQuickLinksProvider,
     };
 

--- a/test/unit/lightspeed/views/llmProviderPanel.test.ts
+++ b/test/unit/lightspeed/views/llmProviderPanel.test.ts
@@ -131,6 +131,10 @@ describe("LlmProviderPanel", () => {
       lightspeedUser: {
         isAuthenticated: vi.fn().mockResolvedValue(true),
       } as unknown as LightspeedUser,
+      lightSpeedAuthenticationProvider: {
+        getSessions: vi.fn().mockResolvedValue([]),
+        removeSession: vi.fn().mockResolvedValue(undefined),
+      } as unknown as import("@src/features/lightspeed/lightSpeedOAuthProvider").LightSpeedAuthenticationProvider,
     };
   });
 


### PR DESCRIPTION
Replace reliance on the `vscode://` URI scheme handler (which is not
always functional at OS level) with a local HTTP server on a random
port to receive the OAuth redirect. This behaviour is only enabled
for the Lightspeed / SAAS endpoint.

## Changes

- **Local loopback OAuth callback**: start an ephemeral HTTP server on
  `127.0.0.1:<random-port>/callback` and use it as the `redirect_uri`
  when the base URI matches SAAS hosts. The `vscode://` URI handler is
  used for all other endpoints.
- **Redirect URI threading**: pass the actual `redirectUri` through the
  call chain (`handleUriForCode` → `requestOAuthAccountFromCode`)
  instead of storing it in a mutable field, avoiding cross-request
  race conditions.
- **Sign-out on config change**: sign out the current OAuth session when
  the provider or API endpoint setting changes, so stale tokens are
  not reused.
- **Server listen error handling**: properly reject the listen promise
  on startup failure instead of hanging indefinitely.
- **Callback page improvements**: use a neutral "Authorization received"
  message (token exchange hasn't completed yet), escape HTML in error
  messages to prevent reflected markup, and return HTTP 400 on error.
- **ESLint config**: allow underscore-prefixed unused vars/args
  (`argsIgnorePattern: "^_"`, `varsIgnorePattern: "^_"`) and remove
  now-redundant `eslint-disable-next-line` comments.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>