### PR TITLE
fix: sign out OAuth session when provider or API endpoint changes

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -497,6 +497,8 @@ export async function activate(context: ExtensionContext): Promise<void> {
         providerManager: lightSpeedManager.providerManager,
         llmProviderSettings: llmProviderSettings,
         lightspeedUser: lightSpeedManager.lightspeedAuthenticatedUser,
+        lightSpeedAuthenticationProvider:
+          lightSpeedManager.lightSpeedAuthenticationProvider,
         quickLinksProvider: quickLinksHome,
       });
     },

--- a/src/features/lightspeed/commands/providerCommands.ts
+++ b/src/features/lightspeed/commands/providerCommands.ts
@@ -97,10 +97,24 @@ export class ProviderCommands {
   }
 
   /**
+   * Remove all OAuth sessions (equivalent to "Sign Out" in VSCode accounts menu).
+   */
+  private async signOutOAuthSessions(): Promise<void> {
+    const sessions =
+      await this.lightSpeedManager.lightSpeedAuthenticationProvider.getSessions();
+    for (const session of sessions) {
+      await this.lightSpeedManager.lightSpeedAuthenticationProvider.removeSession(
+        session.id,
+      );
+    }
+  }
+
+  /**
    * Configure LLM provider through guided setup
    */
   private async configureLlmProvider(): Promise<void> {
     try {
+      const previousProvider = this.llmProviderSettings.getProvider();
       const supportedProviders = providerFactory.getSupportedProviders();
 
       // Step 1: Select provider type
@@ -127,6 +141,11 @@ export class ProviderCommands {
       await this.llmProviderSettings.setProvider(
         selectedProvider.provider.type,
       );
+
+      // Sign out OAuth sessions if provider changed
+      if (selectedProvider.provider.type !== previousProvider) {
+        await this.signOutOAuthSessions();
+      }
 
       const providerType = selectedProvider.provider.type;
 
@@ -277,10 +296,17 @@ export class ProviderCommands {
     }
 
     try {
+      const previousProvider = this.llmProviderSettings.getProvider();
+
       // Switch to selected provider using LlmProviderSettings
       await this.llmProviderSettings.setProvider(
         selectedProvider.provider.type,
       );
+
+      // Sign out OAuth sessions if provider changed
+      if (selectedProvider.provider.type !== previousProvider) {
+        await this.signOutOAuthSessions();
+      }
 
       // Enable lightspeed in VS Code settings
       const config = vscode.workspace.getConfiguration("ansible.lightspeed");

--- a/src/features/lightspeed/vue/views/llmProviderMessageHandlers.ts
+++ b/src/features/lightspeed/vue/views/llmProviderMessageHandlers.ts
@@ -6,6 +6,7 @@ import { ProviderManager } from "@src/features/lightspeed/providerManager";
 import { LlmProviderSettings } from "@src/features/lightspeed/llmProviderSettings";
 import { LightSpeedCommands, ProviderType } from "@src/definitions/lightspeed";
 import { LightspeedUser } from "@src/features/lightspeed/lightspeedUser";
+import { LightSpeedAuthenticationProvider } from "@src/features/lightspeed/lightSpeedOAuthProvider";
 import { QuickLinksWebviewViewProvider } from "@src/features/quickLinks/utils/quickLinksViewProvider";
 import { ProviderInfo } from "@src/interfaces/lightspeed";
 
@@ -23,6 +24,7 @@ export interface LlmProviderDependencies {
   providerManager: ProviderManager;
   llmProviderSettings: LlmProviderSettings;
   lightspeedUser: LightspeedUser;
+  lightSpeedAuthenticationProvider: LightSpeedAuthenticationProvider;
   quickLinksProvider?: QuickLinksWebviewViewProvider;
 }
 
@@ -35,6 +37,7 @@ export class LlmProviderMessageHandlers {
   private readonly providerManager: ProviderManager;
   private readonly llmProviderSettings: LlmProviderSettings;
   private readonly lightspeedUser: LightspeedUser;
+  private readonly lightSpeedAuthenticationProvider: LightSpeedAuthenticationProvider;
   private readonly quickLinksProvider?: QuickLinksWebviewViewProvider;
   private webview?: Webview;
 
@@ -43,6 +46,8 @@ export class LlmProviderMessageHandlers {
     this.providerManager = deps.providerManager;
     this.llmProviderSettings = deps.llmProviderSettings;
     this.lightspeedUser = deps.lightspeedUser;
+    this.lightSpeedAuthenticationProvider =
+      deps.lightSpeedAuthenticationProvider;
     this.quickLinksProvider = deps.quickLinksProvider;
   }
 
@@ -127,6 +132,16 @@ export class LlmProviderMessageHandlers {
   }
 
   /**
+   * Remove all OAuth sessions (equivalent to "Sign Out" in VSCode accounts menu).
+   */
+  private async signOutOAuthSessions(): Promise<void> {
+    const sessions = await this.lightSpeedAuthenticationProvider.getSessions();
+    for (const session of sessions) {
+      await this.lightSpeedAuthenticationProvider.removeSession(session.id);
+    }
+  }
+
+  /**
    * Common pattern for updating UI and refreshing providers after changes.
    */
   private async updateAndNotify(): Promise<void> {
@@ -151,6 +166,13 @@ export class LlmProviderMessageHandlers {
     if (!message.provider || !message.config) return;
 
     try {
+      // Detect provider or endpoint change to sign out stale OAuth sessions
+      const previousProvider = this.llmProviderSettings.getProvider();
+      const previousEndpoint = await this.llmProviderSettings.get(
+        message.provider,
+        "apiEndpoint",
+      );
+
       const providerInfo = this.getProviderInfo(message.provider);
 
       // Update active provider
@@ -173,6 +195,18 @@ export class LlmProviderMessageHandlers {
         }
       }
 
+      // Sign out if provider or endpoint changed
+      const newEndpoint = message.config["apiEndpoint"];
+      if (
+        message.provider !== previousProvider ||
+        (newEndpoint !== undefined && newEndpoint !== previousEndpoint)
+      ) {
+        console.log(
+          `[LlmProviderMessageHandlers] Provider or endpoint changed, signing out OAuth sessions`,
+        );
+        await this.signOutOAuthSessions();
+      }
+
       // Reset connection status when settings are changed (require re-connect)
       await this.llmProviderSettings.setConnectionStatus(
         false,
@@ -190,7 +224,16 @@ export class LlmProviderMessageHandlers {
    */
   private async handleActivateProvider(providerType: string): Promise<void> {
     try {
+      const previousProvider = this.llmProviderSettings.getProvider();
       await this.llmProviderSettings.setProvider(providerType);
+
+      if (providerType !== previousProvider) {
+        console.log(
+          `[LlmProviderMessageHandlers] Provider activated: ${previousProvider} -> ${providerType}, signing out OAuth sessions`,
+        );
+        await this.signOutOAuthSessions();
+      }
+
       await this.updateAndNotify();
     } catch (error) {
       console.error("Failed to activate provider:", error);
@@ -208,7 +251,16 @@ export class LlmProviderMessageHandlers {
     );
 
     try {
+      const previousProvider = this.llmProviderSettings.getProvider();
       await this.llmProviderSettings.setProvider(providerType);
+
+      if (providerType !== previousProvider) {
+        console.log(
+          `[LlmProviderMessageHandlers] Provider connecting: ${previousProvider} -> ${providerType}, signing out OAuth sessions`,
+        );
+        await this.signOutOAuthSessions();
+      }
+
       const providerInfo = this.getProviderInfo(providerType);
 
       if (providerInfo?.usesOAuth) {

--- a/test/unit/lightspeed/commands/providerCommands.test.ts
+++ b/test/unit/lightspeed/commands/providerCommands.test.ts
@@ -82,6 +82,10 @@ describe("ProviderCommands", () => {
       lightspeedExplorerProvider: {
         refreshWebView: vi.fn(),
       },
+      lightSpeedAuthenticationProvider: {
+        getSessions: vi.fn().mockResolvedValue([]),
+        removeSession: vi.fn().mockResolvedValue(undefined),
+      },
     } as unknown as LightSpeedManager;
 
     // Setup mock LLM provider settings

--- a/test/unit/lightspeed/views/llmProviderMessageHandlers.test.ts
+++ b/test/unit/lightspeed/views/llmProviderMessageHandlers.test.ts
@@ -184,6 +184,10 @@ describe("LlmProviderMessageHandlers", () => {
       providerManager: mockProviderManager,
       llmProviderSettings: mockLlmProviderSettings,
       lightspeedUser: mockLightspeedUser,
+      lightSpeedAuthenticationProvider: {
+        getSessions: vi.fn().mockResolvedValue([]),
+        removeSession: vi.fn().mockResolvedValue(undefined),
+      } as unknown as import("@src/features/lightspeed/lightSpeedOAuthProvider").LightSpeedAuthenticationProvider,
       quickLinksProvider: mockQuickLinksProvider,
     };
 

--- a/test/unit/lightspeed/views/llmProviderPanel.test.ts
+++ b/test/unit/lightspeed/views/llmProviderPanel.test.ts
@@ -131,6 +131,10 @@ describe("LlmProviderPanel", () => {
       lightspeedUser: {
         isAuthenticated: vi.fn().mockResolvedValue(true),
       } as unknown as LightspeedUser,
+      lightSpeedAuthenticationProvider: {
+        getSessions: vi.fn().mockResolvedValue([]),
+        removeSession: vi.fn().mockResolvedValue(undefined),
+      } as unknown as import("@src/features/lightspeed/lightSpeedOAuthProvider").LightSpeedAuthenticationProvider,
     };
   });
 


### PR DESCRIPTION
When the active provider or WCA API endpoint is changed through the
LLM Provider panel or provider commands, all existing OAuth sessions
are removed (equivalent to clicking "Sign Out" in VSCode), forcing a
fresh login against the new configuration.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
