### PR TITLE
chore: use OIDC for npmjs publishing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,7 +61,7 @@ jobs:
           cache: true
           run_install: |
             - recursive: true
-              args: [--frozen-lockfile, --silent]
+              args: [--frozen-lockfile]
 
       # needed by our prek systems hooks like biome
       - name: Install node (cache)
@@ -666,9 +666,10 @@ jobs:
       - build
       - check
     permissions:
-      contents: write
-      issues: write
       checks: read
+      contents: write
+      id-token: write # Required for OIDC
+      issues: write
     steps:
       - name: Checkout Source
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -693,10 +694,8 @@ jobs:
       - name: Publish npm packages to npmjs.com
         run: |
           for file in out/ansible-*.tgz; do
-            npm publish --access public "$file"
+            npm publish "$file"
           done
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Report unexpected failures
         if: ${{ always() && failure() }}

--- a/Taskfile.base.yml
+++ b/Taskfile.base.yml
@@ -9,7 +9,7 @@ vars:
 tasks:
   pnpm:
     cmds:
-      - pnpm install --frozen-lockfile --silent
+      - pnpm -r install --frozen-lockfile
     deps:
       - mise
     dir: "{{ .TASKFILE_DIR }}"

--- a/packages/ansible-language-server/package.json
+++ b/packages/ansible-language-server/package.json
@@ -91,6 +91,9 @@
   "types": "lib/server.d.ts",
   "module": "lib/cli.js",
   "name": "@ansible/ansible-language-server",
+  "publishConfig": {
+    "access": "public"
+  },
   "publisher": "RedHat Inc.",
   "repository": {
     "type": "git",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Migrates npm publishing to OIDC in GitHub Actions to eliminate long-lived NPM tokens; updates workflow permissions and centralizes publish settings in package.json for safer, more maintainable publishing.

- Add id-token: write permission for OIDC in CI workflow
- Remove NODE_AUTH_TOKEN environment injection from publish step
- Move npm access config to package.json (publishConfig.access: public)
- Use recursive pnpm install and drop --silent flag
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fixes: #2421