### PR TITLE
feat: restore webview HMR with Vite dev server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 # about not not using or creating files from user home directory directly (~).
 !media/
 .DS_Store
+.vite-dev-server-url
+.vite-dev.pid
 .cache
 .eslintcache
 .idea

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -23,7 +23,8 @@
       "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
       "name": "Debug Extension (Vite)",
       "outFiles": ["${workspaceFolder}/dist/extension/*.js"],
-      "preLaunchTask": "npm: vite-dev",
+      "postDebugTask": "kill-vite-dev",
+      "preLaunchTask": "build-then-vite-dev",
       "request": "launch",
       "type": "extensionHost"
     },
@@ -41,8 +42,8 @@
         "${workspaceFolder}/examples"
       ],
       "name": "Launch Extension",
-      "outFiles": ["${workspaceFolder}/lib/src/**/*.js"],
-      "preLaunchTask": "npm: watch",
+      "outFiles": ["${workspaceFolder}/dist/extension/*.js"],
+      "preLaunchTask": "build:extension",
       "request": "launch",
       "runtimeExecutable": "${execPath}",
       "type": "extensionHost"
@@ -56,8 +57,8 @@
         "VSCODE_REDHAT_TELEMETRY_DEBUG": "false"
       },
       "name": "Launch Extension (packed)",
-      "outFiles": ["${workspaceFolder}/lib/src/**/*.js"],
-      "preLaunchTask": "npm: watch",
+      "outFiles": ["${workspaceFolder}/dist/extension/*.js"],
+      "preLaunchTask": "build:extension",
       "request": "launch",
       "runtimeExecutable": "${execPath}",
       "type": "extensionHost"

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -63,22 +63,49 @@
       "problemMatcher": {
         "background": {
           "activeOnStart": true,
-          "beginsPattern": "^.*extension build start*$",
-          "endsPattern": "^.*extension (build|rebuild) success.*$"
+          "beginsPattern": "^\\s*VITE v",
+          "endsPattern": "^\\s*➜\\s+Local:"
         },
         "fileLocation": "relative",
-        "owner": "typescript",
+        "owner": "vite",
         "pattern": {
-          "code": 5,
-          "column": 4,
-          "file": 1,
-          "line": 3,
-          "message": 6,
-          "regexp": "^([a-zA-Z]\\:/?([\\w\\-]/?)+\\.\\w+):(\\d+):(\\d+): (ERROR|WARNING)\\: (.*)$"
+          "regexp": "^$"
         }
       },
       "script": "vite-dev",
       "type": "npm"
+    },
+    {
+      "command": "pnpm run vite-dev",
+      "group": "build",
+      "isBackground": true,
+      "label": "build-then-vite-dev",
+      "problemMatcher": {
+        "background": {
+          "activeOnStart": true,
+          "beginsPattern": "^\\s*VITE v",
+          "endsPattern": "^\\s*➜\\s+Local:"
+        },
+        "fileLocation": "relative",
+        "owner": "vite",
+        "pattern": {
+          "regexp": "^$"
+        }
+      },
+      "type": "shell"
+    },
+    {
+      "command": "node -e \"try { const pid = require('fs').readFileSync('.vite-dev.pid','utf8').trim(); process.kill(Number(pid)); require('fs').unlinkSync('.vite-dev.pid'); console.log('Vite stopped (pid '+pid+')'); } catch(e) { console.log('No Vite process found'); }\"",
+      "label": "kill-vite-dev",
+      "presentation": { "reveal": "silent" },
+      "type": "shell"
+    },
+    {
+      "command": "pnpm run build:extension",
+      "group": "build",
+      "label": "build:extension",
+      "problemMatcher": [],
+      "type": "shell"
     },
     {
       "group": {

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -31,6 +31,8 @@ ignorePaths:
   - test/testFixtures/lightspeed/*.yml
   - tsconfig*.json
   - uv.lock
+  - .claude/settings.local.json
+  - ./src/webviewHtml.ts
 ignoreRegExpList:
   # ignore github usernames like @foo
   - "@[\\w]+"

--- a/package.json
+++ b/package.json
@@ -1158,7 +1158,7 @@
     "preinstall": "",
     "build:extension": "esbuild src/extension.ts --bundle --outfile=dist/extension/extension.js --format=cjs --platform=node --target=es2022 --external:vscode --alias:@src=./src --alias:@webviews=./webviews --alias:@root=. --sourcemap",
     "vite-build": "vue-tsc --noEmit && vite build",
-    "vite-dev": "pnpm run vite-build && vite",
+    "vite-dev": "pnpm run build:extension && vite",
     "vite-preview": "vite preview",
     "watch": "tsc -b -w"
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,15 @@ lint = [
 builtin = "clear,rare,code"
 check-filenames = true
 check-hidden = true
-ignore-words-list = ["als", "ro", "stdio", "isPlay", "afterAll", "pullrequest"]
+ignore-words-list = [
+  "als",
+  "ro",
+  "stdio",
+  "isPlay",
+  "afterAll",
+  "pullrequest",
+  "ws"
+]
 ignore-words = ".config/dictionary.txt"
 skip = ".cache,dist,out,node_modules,.mypy_cache,.ruff_cache,site,codicon.css,pnpm-lock.yaml,package-lock.json,.vscode-test,.git,dictionary.txt,settings.md,.eslintcache,.venv,media,.ansible,lib"
 

--- a/src/webviewHtml.ts
+++ b/src/webviewHtml.ts
@@ -1,7 +1,12 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as crypto from "node:crypto";
-import { type ExtensionContext, type Webview, Uri } from "vscode";
+import {
+  ExtensionMode,
+  type ExtensionContext,
+  type Webview,
+  Uri,
+} from "vscode";
 
 interface WebviewHtmlOptions {
   webview: Webview;
@@ -9,7 +14,7 @@ interface WebviewHtmlOptions {
   inputName?: string;
 }
 
-function findHtmlFile(distDir: string, inputName: string): string {
+export function findHtmlFile(distDir: string, inputName: string): string {
   const filename = `${inputName}.html`;
   // Walk dist/ recursively to find the matching HTML file
   function search(dir: string): string | undefined {
@@ -31,12 +36,74 @@ function findHtmlFile(distDir: string, inputName: string): string {
 }
 
 /**
+ * Returns the Vite dev server URL if the dev server is running, or undefined
+ * for production builds. The dev server writes its URL to a marker file.
+ */
+export function getDevServerUrl(extensionPath: string): string | undefined {
+  const markerPath = path.join(extensionPath, ".vite-dev-server-url");
+  try {
+    const raw = fs.readFileSync(markerPath, "utf8").trim();
+    const parsed = new URL(raw);
+    if (
+      parsed.protocol !== "http:" ||
+      parsed.hostname !== "localhost" ||
+      !parsed.port
+    ) {
+      return undefined;
+    }
+    return parsed.origin;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Resolves the entry script path on the Vite dev server for a given input name.
+ * Matches the multi-page input structure in vite.config.mts.
+ */
+export function resolveDevEntryScript(
+  extensionPath: string,
+  inputName: string,
+): string {
+  const lightspeedEntry = path.join(
+    extensionPath,
+    "webviews",
+    "lightspeed",
+    "src",
+    `${inputName}.ts`,
+  );
+  if (fs.existsSync(lightspeedEntry)) {
+    return `webviews/lightspeed/src/${inputName}.ts`;
+  }
+  return `webviews/${inputName}.ts`;
+}
+
+/**
  * Reads the built HTML file for a webview, injects a CSP meta tag with a
  * fresh nonce, and rewrites asset paths to use webview URIs.
+ *
+ * In dev mode (Vite dev server running), returns an HTML shell that loads
+ * directly from the dev server, enabling HMR.
  */
 export function getWebviewHtml(options: WebviewHtmlOptions): string {
   const { webview, context, inputName = "index" } = options;
   const nonce = crypto.randomBytes(16).toString("base64");
+
+  const devServerUrl = getDevServerUrl(context.extensionPath);
+  if (context.extensionMode === ExtensionMode.Development && devServerUrl) {
+    const entryScript = resolveDevEntryScript(context.extensionPath, inputName);
+    return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'nonce-${nonce}' http://localhost:*; style-src ${webview.cspSource} 'unsafe-inline' http://localhost:*; font-src ${webview.cspSource} http://localhost:*; img-src 'self' ${webview.cspSource} https: data: http://localhost:*; connect-src ws://localhost:* http://localhost:*;">
+  </head>
+  <body>
+    <div id="app"></div>
+    <script nonce="${nonce}" type="module" src="${devServerUrl}/@vite/client"></script>
+    <script nonce="${nonce}" type="module" src="${devServerUrl}/${entryScript}"></script>
+  </body>
+</html>`;
+  }
 
   const distDir = path.join(context.extensionPath, "dist");
   const htmlPath = findHtmlFile(distDir, inputName);

--- a/test/unit/vitestSetup.ts
+++ b/test/unit/vitestSetup.ts
@@ -111,9 +111,18 @@ vi.mock("vscode", () => {
     extensions: {
       getExtension: vi.fn(),
     },
+    ExtensionMode: {
+      Production: 1,
+      Development: 2,
+      Test: 3,
+    },
     Uri: {
-      file: vi.fn(),
+      file: vi.fn((path: string) => ({ fsPath: path, path })),
       parse: vi.fn(),
+      joinPath: vi.fn((base: { path: string }, ...segments: string[]) => {
+        const joined = [base.path, ...segments].join("/");
+        return { fsPath: joined, path: joined, toString: () => joined };
+      }),
     },
     ViewColumn: {
       One: 1,

--- a/test/unit/webviewHtml.test.ts
+++ b/test/unit/webviewHtml.test.ts
@@ -1,0 +1,285 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import {
+  findHtmlFile,
+  getDevServerUrl,
+  resolveDevEntryScript,
+  getWebviewHtml,
+} from "@src/webviewHtml";
+import { ExtensionMode } from "vscode";
+
+describe("findHtmlFile", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "webview-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("finds an HTML file at the top level", () => {
+    fs.writeFileSync(path.join(tmpDir, "index.html"), "<html></html>");
+    expect(findHtmlFile(tmpDir, "index")).toBe(path.join(tmpDir, "index.html"));
+  });
+
+  it("finds an HTML file in a subdirectory", () => {
+    const subDir = path.join(tmpDir, "lightspeed");
+    fs.mkdirSync(subDir);
+    fs.writeFileSync(path.join(subDir, "explorer.html"), "<html></html>");
+    expect(findHtmlFile(tmpDir, "explorer")).toBe(
+      path.join(subDir, "explorer.html"),
+    );
+  });
+
+  it("finds an HTML file in a deeply nested directory", () => {
+    const deepDir = path.join(tmpDir, "a", "b", "c");
+    fs.mkdirSync(deepDir, { recursive: true });
+    fs.writeFileSync(path.join(deepDir, "deep.html"), "<html></html>");
+    expect(findHtmlFile(tmpDir, "deep")).toBe(path.join(deepDir, "deep.html"));
+  });
+
+  it("throws when the HTML file does not exist", () => {
+    expect(() => findHtmlFile(tmpDir, "missing")).toThrow(
+      /Webview HTML file not found: missing\.html/,
+    );
+  });
+});
+
+describe("getDevServerUrl", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "webview-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns the URL when the marker file contains a valid localhost URL", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, ".vite-dev-server-url"),
+      "http://localhost:5173",
+    );
+    expect(getDevServerUrl(tmpDir)).toBe("http://localhost:5173");
+  });
+
+  it("trims whitespace from the marker file", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, ".vite-dev-server-url"),
+      "  http://localhost:5173\n",
+    );
+    expect(getDevServerUrl(tmpDir)).toBe("http://localhost:5173");
+  });
+
+  it("returns undefined when the marker file does not exist", () => {
+    expect(getDevServerUrl(tmpDir)).toBeUndefined();
+  });
+
+  it("returns undefined for a non-http protocol", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, ".vite-dev-server-url"),
+      "https://localhost:5173",
+    );
+    expect(getDevServerUrl(tmpDir)).toBeUndefined();
+  });
+
+  it("returns undefined for a non-localhost hostname", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, ".vite-dev-server-url"),
+      "http://example.com:5173",
+    );
+    expect(getDevServerUrl(tmpDir)).toBeUndefined();
+  });
+
+  it("returns undefined when URL has no port", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, ".vite-dev-server-url"),
+      "http://localhost",
+    );
+    expect(getDevServerUrl(tmpDir)).toBeUndefined();
+  });
+
+  it("returns undefined for malformed content", () => {
+    fs.writeFileSync(path.join(tmpDir, ".vite-dev-server-url"), "not-a-url");
+    expect(getDevServerUrl(tmpDir)).toBeUndefined();
+  });
+});
+
+describe("resolveDevEntryScript", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "webview-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns lightspeed path when the lightspeed entry file exists", () => {
+    const lsDir = path.join(tmpDir, "webviews", "lightspeed", "src");
+    fs.mkdirSync(lsDir, { recursive: true });
+    fs.writeFileSync(path.join(lsDir, "explorer.ts"), "");
+    expect(resolveDevEntryScript(tmpDir, "explorer")).toBe(
+      "webviews/lightspeed/src/explorer.ts",
+    );
+  });
+
+  it("returns top-level webviews path when no lightspeed entry exists", () => {
+    expect(resolveDevEntryScript(tmpDir, "add-plugin")).toBe(
+      "webviews/add-plugin.ts",
+    );
+  });
+});
+
+describe("getWebviewHtml", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "webview-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function makeContext(mode: number) {
+    return {
+      extensionPath: tmpDir,
+      extensionUri: { path: tmpDir, fsPath: tmpDir },
+      extensionMode: mode,
+    };
+  }
+
+  function makeWebview() {
+    return {
+      cspSource: "test-csp-source",
+      asWebviewUri: vi.fn((uri: { path: string }) => uri.path),
+      onDidReceiveMessage: vi.fn(),
+      postMessage: vi.fn(),
+      options: {},
+    };
+  }
+
+  describe("dev mode", () => {
+    it("returns dev HTML when in Development mode with a valid marker", () => {
+      fs.writeFileSync(
+        path.join(tmpDir, ".vite-dev-server-url"),
+        "http://localhost:5173",
+      );
+      const webview = makeWebview();
+      const context = makeContext(ExtensionMode.Development);
+
+      const html = getWebviewHtml({
+        webview: webview as never,
+        context: context as never,
+        inputName: "add-plugin",
+      });
+
+      expect(html).toContain("http://localhost:5173/@vite/client");
+      expect(html).toContain("http://localhost:5173/webviews/add-plugin.ts");
+      expect(html).toContain('<div id="app"></div>');
+      expect(html).toContain("Content-Security-Policy");
+    });
+
+    it("resolves lightspeed entry scripts in dev mode", () => {
+      fs.writeFileSync(
+        path.join(tmpDir, ".vite-dev-server-url"),
+        "http://localhost:5173",
+      );
+      const lsDir = path.join(tmpDir, "webviews", "lightspeed", "src");
+      fs.mkdirSync(lsDir, { recursive: true });
+      fs.writeFileSync(path.join(lsDir, "explorer.ts"), "");
+
+      const html = getWebviewHtml({
+        webview: makeWebview() as never,
+        context: makeContext(ExtensionMode.Development) as never,
+        inputName: "explorer",
+      });
+
+      expect(html).toContain(
+        "http://localhost:5173/webviews/lightspeed/src/explorer.ts",
+      );
+    });
+
+    it("does not use dev mode when extensionMode is Production", () => {
+      fs.writeFileSync(
+        path.join(tmpDir, ".vite-dev-server-url"),
+        "http://localhost:5173",
+      );
+      // Create a dist file so production path works
+      const distDir = path.join(tmpDir, "dist");
+      fs.mkdirSync(distDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(distDir, "index.html"),
+        '<html><head></head><body><script src="/assets/main.js"></script></body></html>',
+      );
+
+      const html = getWebviewHtml({
+        webview: makeWebview() as never,
+        context: makeContext(ExtensionMode.Production) as never,
+      });
+
+      expect(html).not.toContain("localhost:5173");
+      expect(html).toContain("Content-Security-Policy");
+    });
+  });
+
+  describe("production mode", () => {
+    it("returns production HTML with CSP, nonces, and rewritten asset paths", () => {
+      const distDir = path.join(tmpDir, "dist");
+      fs.mkdirSync(distDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(distDir, "index.html"),
+        `<html><head></head><body><script src="/assets/main.js"></script></body></html>`,
+      );
+
+      const webview = makeWebview();
+      const context = makeContext(ExtensionMode.Production);
+
+      const html = getWebviewHtml({
+        webview: webview as never,
+        context: context as never,
+      });
+
+      expect(html).toContain("Content-Security-Policy");
+      expect(html).toContain("nonce-");
+      expect(html).toContain("/assets/main.js");
+      expect(html).not.toContain('src="/assets/');
+    });
+
+    it("throws when the HTML file is missing", () => {
+      const distDir = path.join(tmpDir, "dist");
+      fs.mkdirSync(distDir, { recursive: true });
+
+      expect(() =>
+        getWebviewHtml({
+          webview: makeWebview() as never,
+          context: makeContext(ExtensionMode.Production) as never,
+          inputName: "nonexistent",
+        }),
+      ).toThrow(/Webview HTML file not found/);
+    });
+
+    it("defaults inputName to 'index'", () => {
+      const distDir = path.join(tmpDir, "dist");
+      fs.mkdirSync(distDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(distDir, "index.html"),
+        "<html><head></head><body></body></html>",
+      );
+
+      const html = getWebviewHtml({
+        webview: makeWebview() as never,
+        context: makeContext(ExtensionMode.Production) as never,
+      });
+
+      expect(html).toContain("<html>");
+    });
+  });
+});

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -1,6 +1,49 @@
+import fs from "node:fs";
 import path from "node:path";
 import vue from "@vitejs/plugin-vue";
-import { defineConfig } from "vite";
+import { defineConfig, type Plugin } from "vite";
+
+/**
+ * Writes the dev server URL to a marker file so the extension host can
+ * detect it and serve webview HTML directly from the dev server (enabling HMR).
+ */
+function viteDevServerUrl(): Plugin {
+  const markerPath = path.resolve(__dirname, ".vite-dev-server-url");
+  const pidPath = path.resolve(__dirname, ".vite-dev.pid");
+  return {
+    buildEnd() {
+      // Clean up marker file during production builds
+      try {
+        fs.unlinkSync(markerPath);
+      } catch {
+        // ignore if not present
+      }
+    },
+    configureServer(server) {
+      server.httpServer?.once("listening", () => {
+        const address = server.httpServer?.address();
+        if (address && typeof address === "object") {
+          const url = `http://localhost:${address.port}`;
+          fs.writeFileSync(markerPath, url, "utf8");
+          fs.writeFileSync(pidPath, String(process.pid), "utf8");
+        }
+      });
+      server.httpServer?.once("close", () => {
+        try {
+          fs.unlinkSync(markerPath);
+        } catch {
+          // ignore if not present
+        }
+        try {
+          fs.unlinkSync(pidPath);
+        } catch {
+          // ignore if not present
+        }
+      });
+    },
+    name: "vscode-dev-server-url",
+  };
+}
 
 export default defineConfig({
   build: {
@@ -63,6 +106,7 @@ export default defineConfig({
     },
   },
   plugins: [
+    viteDevServerUrl(),
     vue({
       template: {
         compilerOptions: {
@@ -77,5 +121,11 @@ export default defineConfig({
       "@src": path.resolve(__dirname, "src"),
       "@webviews": path.resolve(__dirname, "webviews"),
     },
+  },
+  server: {
+    cors: true,
+    origin: "http://localhost:5173",
+    port: 5173,
+    strictPort: true,
   },
 });


### PR DESCRIPTION
Add dev mode support to getWebviewHtml() that loads webview entry scripts
directly from the Vite dev server when a .vite-dev-server-url marker file
is present. A small Vite plugin writes this marker on server start.

- src/webviewHtml.ts: dev mode branch serving HTML shell from Vite dev server
- vite.config.mts: viteDevServerUrl plugin, server.cors and server.origin
- .vscode/launch.json: fix outFiles and preLaunchTask for esbuild output
- .vscode/tasks.json: update vite-dev problem matcher, add build:extension task
- package.json: vite-dev now runs build:extension then vite dev server

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR restores Hot Module Replacement (HMR) support for webviews by enabling the Vite dev server to serve webview entry scripts directly in development mode. When a `.vite-dev-server-url` marker file is present, the webview HTML loads scripts from the local Vite dev server instead of built output, enabling faster development iteration.

- Added `.vite-dev-server-url` and `.vite-dev.pid` entries to `.gitignore` to prevent Vite development artifacts from being tracked
- Created `viteDevServerUrl()` Vite plugin in `vite.config.mts` that writes the dev server URL and process PID to marker files on startup and cleans them up on shutdown
- Configured Vite server with CORS enabled, explicit port 5173, and constrained origin to `http://localhost:5173`
- Updated `getWebviewHtml()` in `src/webviewHtml.ts` to detect dev server by reading the marker file and serve HTML with scripts directly from the dev server instead of built output
- Added `resolveDevEntryScript()` helper to resolve correct entry point paths for development mode
- Updated `.vscode/launch.json` debug configurations to reference compiled `dist/extension/*.js` output and use new build task orchestration
- Modified `.vscode/tasks.json` to detect Vite server readiness with improved pattern matching and added new `build-then-vite-dev`, `kill-vite-dev`, and `build:extension` tasks
- Updated `package.json` vite-dev script to run `build:extension` before starting the Vite dev server
- Added `ws://` pattern to `cspell.config.yaml` and `ws` entry to `.config/dictionary.txt` for websocket protocol references

related: #27997

<!-- end of auto-generated comment: release notes by coderabbit.ai -->