### PR TITLE
chore: avoid creating temp files inside the source tree

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,7 +6,6 @@ import tsParser from "@typescript-eslint/parser";
 import prettierRecommendedConfig from "eslint-plugin-prettier/recommended";
 import globals from "globals";
 import path from "path";
-import { fileURLToPath } from "url";
 import { defineConfig } from "eslint/config";
 import { createRequire } from "module";
 import importPlugin from "eslint-plugin-import";
@@ -15,8 +14,6 @@ const require = createRequire(import.meta.url);
 /** @type {import('eslint').ESLint.Plugin} */
 const eslintPluginLocal = require("./test/eslint/eslint-plugin-local.cjs");
 
-const __filename = fileURLToPath(import.meta.url); // get the resolved path to the file
-const __dirname = path.dirname(__filename); // get the name of the directory
 const gitignorePath = path.resolve(import.meta.dirname, ".gitignore");
 
 export default defineConfig(
@@ -43,7 +40,6 @@ export default defineConfig(
       parser: tsParser,
       parserOptions: {
         projectService: true,
-        tsconfigRootDir: __dirname,
       },
     },
     plugins: {

--- a/packages/ansible-language-server/test/helper.ts
+++ b/packages/ansible-language-server/test/helper.ts
@@ -15,7 +15,7 @@ import type { ExtensionSettings } from "@src/interfaces/extensionSettings.js";
 
 import Fuse from "fuse.js";
 
-const FIXTURES_BASE_PATH = path.join(__dirname, "fixtures");
+export const FIXTURES_BASE_PATH = path.join(__dirname, "fixtures");
 const ANSIBLE_COLLECTIONS_FIXTURES_BASE_PATH = path.resolve(
   FIXTURES_BASE_PATH,
   "common",

--- a/packages/ansible-language-server/test/utils/getAnsibleMetaData.test.ts
+++ b/packages/ansible-language-server/test/utils/getAnsibleMetaData.test.ts
@@ -1,7 +1,5 @@
 import { expect, beforeAll, afterAll } from "vitest";
 import * as path from "path";
-import { fileURLToPath } from "url";
-import { dirname } from "path";
 import {
   ansibleMetaDataEntryType,
   ansibleMetaDataType,
@@ -15,32 +13,26 @@ import {
   getDoc,
   resolveDocUri,
   setFixtureAnsibleCollectionPathEnv,
+  FIXTURES_BASE_PATH,
 } from "@test/helper.js";
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
 
 function getAnsibleTestInfo() {
   const ansibleInfo: ansibleMetaDataEntryType = {};
   ansibleInfo["core version"] = ".";
   ansibleInfo["location"] = "/ansible";
   ansibleInfo["config file path"] = path.resolve(
-    __dirname,
-    "..",
-    "fixtures",
+    FIXTURES_BASE_PATH,
     "utils",
     "getAnsibleMetaData",
     "ansible.cfg",
   );
   ansibleInfo["collections location"] = [
-    path.resolve(__dirname, "..", "fixtures", "common", "collections"),
+    path.resolve(FIXTURES_BASE_PATH, "common", "collections"),
   ];
   ansibleInfo["module location"] = ["/modules"];
   ansibleInfo["default host list path"] = [
     path.resolve(
-      __dirname,
-      "..",
-      "fixtures",
+      FIXTURES_BASE_PATH,
       "utils",
       "getAnsibleMetaData",
       "inventory",

--- a/packages/ansible-language-server/test/utils/pathUtils.test.ts
+++ b/packages/ansible-language-server/test/utils/pathUtils.test.ts
@@ -1,14 +1,10 @@
 import { expect } from "vitest";
 import * as path from "path";
-import { fileURLToPath } from "url";
-import { dirname } from "path";
 import { globArray } from "@src/utils/pathUtils.js";
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
+import { FIXTURES_BASE_PATH } from "@test/helper.js";
 
 describe("docsFinder", function () {
-  const dir = path.resolve(__dirname, "..", "fixtures", "utils", "docsFinder");
+  const dir = path.resolve(FIXTURES_BASE_PATH, "utils", "docsFinder");
 
   describe("globArray()", function () {
     const tests = [

--- a/packages/ansible-mcp-server/test/tools/ansibleLint.test.ts
+++ b/packages/ansible-mcp-server/test/tools/ansibleLint.test.ts
@@ -1,17 +1,19 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { createAnsibleLintHandler } from "@src/handlers.js";
-import { join, dirname } from "node:path";
-import { writeFile, unlink } from "node:fs/promises";
-import { fileURLToPath } from "node:url";
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
+import { join } from "node:path";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 
 describe("Ansible Lint Handler", () => {
-  const testPlaybookPath = join(__dirname, "test-playbook.yml");
-  const cleanPlaybookPath = join(__dirname, "clean-playbook.yml");
+  let tempDir: string;
+  let testPlaybookPath: string;
+  let cleanPlaybookPath: string;
 
-  beforeAll(async () => {
-    // Create test files
+  beforeAll(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "vitest-ansible-lint-"));
+    testPlaybookPath = join(tempDir, "test-playbook.yml");
+    cleanPlaybookPath = join(tempDir, "clean-playbook.yml");
+
     const testPlaybookContent = `---
 - name: Test playbook with issues
   hosts: localhost
@@ -28,14 +30,12 @@ describe("Ansible Lint Handler", () => {
       ansible.builtin.debug:
         msg: hello`;
 
-    await writeFile(testPlaybookPath, testPlaybookContent, "utf8");
-    await writeFile(cleanPlaybookPath, cleanPlaybookContent, "utf8");
+    writeFileSync(testPlaybookPath, testPlaybookContent, "utf8");
+    writeFileSync(cleanPlaybookPath, cleanPlaybookContent, "utf8");
   });
 
-  afterAll(async () => {
-    // Clean up test files
-    await unlink(testPlaybookPath);
-    await unlink(cleanPlaybookPath);
+  afterAll(() => {
+    rmSync(tempDir, { recursive: true, force: true });
   });
 
   describe("Core linting functionality", () => {
@@ -70,7 +70,7 @@ describe("Ansible Lint Handler", () => {
   describe("Input validation", () => {
     it("should handle non-existent file", async () => {
       const handler = createAnsibleLintHandler();
-      const nonExistentFile = join(__dirname, "non-existent.yml");
+      const nonExistentFile = join(tempDir, "non-existent.yml");
 
       const result = await handler({
         filePath: nonExistentFile,

--- a/packages/ansible-mcp-server/test/tools/ansibleNavigator.test.ts
+++ b/packages/ansible-mcp-server/test/tools/ansibleNavigator.test.ts
@@ -1,17 +1,19 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { createAnsibleNavigatorHandler } from "@src/handlers.js";
-import { join, dirname } from "node:path";
-import { writeFile, unlink } from "node:fs/promises";
-import { fileURLToPath } from "node:url";
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
+import { join } from "node:path";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 
 describe("Ansible Navigator Handler", () => {
-  const testPlaybookPath = join(__dirname, "test-navigator-playbook.yml");
-  const cleanPlaybookPath = join(__dirname, "clean-navigator-playbook.yml");
+  let tempDir: string;
+  let testPlaybookPath: string;
+  let cleanPlaybookPath: string;
 
-  beforeAll(async () => {
-    // Create test files
+  beforeAll(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "vitest-ansible-navigator-"));
+    testPlaybookPath = join(tempDir, "test-navigator-playbook.yml");
+    cleanPlaybookPath = join(tempDir, "clean-navigator-playbook.yml");
+
     const testPlaybookContent = `---
 - name: Test playbook for ansible-navigator
   hosts: localhost
@@ -30,18 +32,12 @@ describe("Ansible Navigator Handler", () => {
       ansible.builtin.debug:
         msg: "Clean playbook"`;
 
-    await writeFile(testPlaybookPath, testPlaybookContent, "utf8");
-    await writeFile(cleanPlaybookPath, cleanPlaybookContent, "utf8");
+    writeFileSync(testPlaybookPath, testPlaybookContent, "utf8");
+    writeFileSync(cleanPlaybookPath, cleanPlaybookContent, "utf8");
   });
 
-  afterAll(async () => {
-    // Clean up test files
-    try {
-      await unlink(testPlaybookPath);
-      await unlink(cleanPlaybookPath);
-    } catch {
-      // Ignore errors if files don't exist
-    }
+  afterAll(() => {
+    rmSync(tempDir, { recursive: true, force: true });
   });
 
   describe("Core functionality", () => {
@@ -94,7 +90,7 @@ describe("Ansible Navigator Handler", () => {
   describe("Input validation", () => {
     it("should handle non-existent file", async () => {
       const handler = createAnsibleNavigatorHandler();
-      const nonExistentFile = join(__dirname, "non-existent-navigator.yml");
+      const nonExistentFile = join(tempDir, "non-existent-navigator.yml");
 
       const result = await handler({
         userMessage: "run test",


### PR DESCRIPTION
Related: AAP-65204


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Consolidates test fixture paths and prevents writing temp files into the source tree by using shared fixture roots and system temp dirs.

- Export FIXTURES_BASE_PATH from test helper for shared fixture resolution
- Remove __dirname derivations in eslint.config.mjs
- Update tests to resolve via FIXTURES_BASE_PATH
- Migrate ansibleLint/ansibleNavigator tests to mkdtempSync + writeFileSync + rmSync

related: AAP-65204
<!-- end of auto-generated comment: release notes by coderabbit.ai -->