### PR TITLE
chore: release drafter v7 workaround

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,6 +1,6 @@
 ---
 # see https://github.com/ansible/team-devtools
-_extends: ansible/team-devtools
+_extends: github:ansible/team-devtools:/.github/release-drafter.yml
 tag-template: 'v$RESOLVED_VERSION'
 category-template: '### $TITLE'
 template: '$CHANGES'


### PR DESCRIPTION
Related: https://github.com/release-drafter/release-drafter/issues/1576


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Update the release-drafter configuration to use an explicit GitHub path reference instead of shorthand notation for template resolution. This change addresses compatibility requirements with release-drafter v7 while maintaining existing changelog and tag templating behavior.

- Modified `.github/release-drafter.yml` `_extends` field from `ansible/team-devtools` to `github:ansible/team-devtools:/.github/release-drafter.yml`

related: #1576

<!-- end of auto-generated comment: release notes by coderabbit.ai -->