### PR TITLE
fix(ci): clean root-owned overlays on WSL runner

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -282,6 +282,26 @@ jobs:
               SKIP_PODMAN: 1
               SKIP_DOCKER: 1
     steps:
+      - name: Remove root-owned container overlays (self-hosted)
+        if: matrix.runs-on == 'self-hosted'
+        run: |
+          target="$GITHUB_WORKSPACE/out/als/tmp/home/.local/share/containers"
+
+          if [ -e "$target" ] || [ -L "$target" ]; then
+            resolved_workspace="$(readlink -f "$GITHUB_WORKSPACE")"
+            resolved_target="$(readlink -f "$target")"
+
+            case "$resolved_target" in
+              "$resolved_workspace"/*)
+                sudo rm -rf -- "$resolved_target"
+                ;;
+              *)
+                echo "Refusing to delete path outside GITHUB_WORKSPACE: $resolved_target"
+                exit 1
+                ;;
+            esac
+          fi
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0 # we need tags for dynamic versioning


### PR DESCRIPTION
## Summary

- Add a pre-checkout step on self-hosted runners that uses `sudo` to
  remove stale root-owned container storage overlay directories under
  `out/als/tmp/home/.local/share/containers/`.
- These overlays were created by previous ALS test runs that used
  Podman/Buildah and left root-owned files the runner user cannot
  delete, causing `actions/checkout` to fail with `EACCES` on every
  subsequent run.

## Test plan

- [ ] Verify the WSL CI job passes (checkout no longer fails with
      `EACCES: permission denied, rmdir`)
- [ ] Verify Linux and macOS jobs are unaffected (the new step is
      gated on `matrix.runs-on == 'self-hosted'`)


Made with [Cursor](https://cursor.com)