### PR TITLE
chore: Run precheck in CI only

### DIFF
--- a/Taskfile.base.yml
+++ b/Taskfile.base.yml
@@ -52,7 +52,7 @@ tasks:
     dir: "{{ .TASKFILE_DIR }}"
     cmds:
       - bash ./tools/test-setup.sh
-      - ./tools/precheck.sh
+      - task: precheck
     sources:
       - ./tools/precheck.sh
       - pyproject.toml
@@ -61,6 +61,13 @@ tasks:
       - out/log/manifest-*.json
     run: once
     interactive: true
+  precheck:
+    desc: Run precheck validations (CI only)
+    internal: true
+    status:
+      - '[ "$CI" != "true" ]'
+    cmds:
+      - ./tools/precheck.sh
   mise:
     desc: Check if mise is installed and working
     internal: true


### PR DESCRIPTION
Changes the `precheck` task to run only in CI=true environments.

This is due to local environments often having multiple versions of tools in PATH (common on development machines), which would result in failed task runs.