### PR TITLE
fix(ci): remove Podman overlays before checkout on WSL

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -30,6 +30,7 @@ Towncrier
 WSLENV
 antsibull
 bfnrt
+buildah
 charliermarsh
 checode
 codeclimate

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -282,15 +282,26 @@ jobs:
               SKIP_PODMAN: 1
               SKIP_DOCKER: 1
     steps:
-      # Self-hosted runners may retain root-owned files from previous
-      # container builds (e.g. Podman overlays under out/als/tmp/).
-      # Disable checkout's built-in clean so it does not fail with
-      # EACCES when it cannot remove those files.
+      # Self-hosted runners retain root-owned files from rootless Podman
+      # (overlay storage under out/als/tmp/).  These files live inside a
+      # user-namespace so normal rm fails with EACCES and sudo is
+      # unavailable.  `podman unshare` re-enters the same namespace,
+      # letting us delete them before checkout touches the workspace.
+      - name: Remove Podman overlay files on self-hosted runner
+        if: matrix.runs-on == 'self-hosted'
+        run: |
+          target="${GITHUB_WORKSPACE}/out/als/tmp/home/.local/share/containers"
+          if [ -d "$target" ]; then
+            podman unshare rm -rf -- "$target" \
+              || buildah unshare rm -rf -- "$target" \
+              || echo "::warning::Could not remove $target — checkout may fail"
+          fi
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0 # we need tags for dynamic versioning
           show-progress: false
-          clean: ${{ matrix.runs-on != 'self-hosted' }}
+          clean: ${{ (matrix.runs-on || '') != 'self-hosted' }}
 
       - name: Clean workspace on self-hosted runner
         if: matrix.runs-on == 'self-hosted'


### PR DESCRIPTION
## Summary

- The `clean: false` approach from #2733 is insufficient because
  `actions/checkout` v6 still validates the existing repo, encounters
  EACCES on root-owned Podman overlay files, and then tries to
  `rmRF` the entire workspace — which also fails.
- Add a pre-checkout step that uses `podman unshare` to re-enter the
  rootless Podman user-namespace and remove the container storage
  directory before checkout runs.  Falls back to `buildah unshare`
  and emits a `::warning` if neither is available.
- All existing safety nets (`clean: false`, `git clean -e` exclusion)
  are preserved so non-self-hosted runners (linux, macos) are
  completely unaffected.


related: #2733