### PR TITLE
fix(ci): remove root-owned files before git clean on WSL

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -307,6 +307,14 @@ jobs:
         if: matrix.runs-on == 'self-hosted'
         run: |
           set -euxo pipefail
+          # Rootless Podman overlays under .cache/containers/ use user
+          # namespace remapping; remove them with podman or sudo.
+          if [ -d .cache/containers ]; then
+            podman unshare rm -rf -- .cache/containers 2>/dev/null \
+              || sudo rm -rf -- .cache/containers \
+              || true
+          fi
+          sudo find . -not -user "$(id -u)" -delete 2>/dev/null || true
           git reset --hard HEAD
           git clean -ffdx -e out/als/tmp/
 

--- a/packages/ansible-language-server/test/utils/getAnsibleMetaData.test.ts
+++ b/packages/ansible-language-server/test/utils/getAnsibleMetaData.test.ts
@@ -15,6 +15,7 @@ import {
   getDoc,
   resolveDocUri,
   setFixtureAnsibleCollectionPathEnv,
+  skipEE,
 } from "@test/helper.js";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -302,6 +303,10 @@ describe("getAnsibleMetaData()", function () {
 
   describe("@ee", function () {
     beforeAll(async () => {
+      if (skipEE()) {
+        return;
+      }
+
       if (docSettings) {
         await enableExecutionEnvironmentSettings(docSettings, context);
       }


### PR DESCRIPTION
## Summary
- Adds `sudo find . -not -user "$(id -u)" -delete` before `git clean` on the self-hosted WSL runner to remove root-owned artifacts left by previous Podman/container builds.
- Fixes the "Clean workspace on self-hosted runner" step failing with exit code 1 because `git clean` cannot delete files owned by root.

Closes: #2739



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Adds cleanup steps to the CI workflow's "Clean workspace on self-hosted runner" step to remove root-owned artifacts before `git clean` on the WSL runner. This prevents git clean from failing when encountering files owned by root from prior Podman/container builds.

- Remove Podman rootless overlay artifacts from `.cache/containers/` using `podman unshare rm -rf` with fallback to `sudo rm -rf`
- Delete workspace files not owned by current user via `sudo find . -not -user "$(id -u)" -delete`
- Execute cleanup before `git reset --hard HEAD` and `git clean` to prevent exit code 1 failures

closes: #2739

<!-- end of auto-generated comment: release notes by coderabbit.ai -->