### PR TITLE
chore: extract api.ready timeout to a named constant (canary)

### DIFF
--- a/src/services/PythonEnvironmentService.ts
+++ b/src/services/PythonEnvironmentService.ts
@@ -27,6 +27,9 @@ import {
 
 const PYTHON_EXT_ID = "ms-python.python";
 
+/** Max time (ms) to wait for the Python extension to finish discovery. */
+const API_READY_TIMEOUT_MS = 5000;
+
 export class PythonEnvironmentService implements vscode.Disposable {
   private static _instance: PythonEnvironmentService | undefined;
   private _pythonEnvApi: PythonEnvironmentApi | undefined;
@@ -170,16 +173,15 @@ export class PythonEnvironmentService implements vscode.Disposable {
 
       const api = await PythonExtension.api();
 
-      const READY_TIMEOUT_MS = 5000;
       await Promise.race([
         api.ready,
         new Promise<void>((resolve) => {
           setTimeout(() => {
             console.warn(
-              `[Ansible] Python extension api.ready timed out after ${READY_TIMEOUT_MS}ms — proceeding with partial discovery`,
+              `[Ansible] Python extension api.ready timed out after ${API_READY_TIMEOUT_MS}ms — proceeding with partial discovery`,
             );
             resolve();
-          }, READY_TIMEOUT_MS);
+          }, API_READY_TIMEOUT_MS);
         }),
       ]);
 


### PR DESCRIPTION
## Summary

- Promote the inline `READY_TIMEOUT_MS` magic number in
  `PythonEnvironmentService` to a module-level `API_READY_TIMEOUT_MS`
  constant with a doc comment.

## Test plan

- [ ] CI passes (no functional change)

related: #2731

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Extracted the `READY_TIMEOUT_MS` magic number (5000ms) from `PythonEnvironmentService._initFromPythonExtension` to a module-level constant `API_READY_TIMEOUT_MS`. This centralizes the configuration and improves code maintainability by eliminating inline magic numbers. No functional changes are introduced.

- Introduced module-level constant `API_READY_TIMEOUT_MS = 5000` with documentation
- Removed local `READY_TIMEOUT_MS` variable declaration from `_initFromPythonExtension` method
- Updated timeout references in warning message and `setTimeout` call to use the new constant

related: #2731

<!-- end of auto-generated comment: release notes by coderabbit.ai -->