### PR TITLE
fix(test): increase Selenium UI test timeouts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,11 +20,15 @@ services:
       - ./out/ui/logs:/home/selenium/.local/share/code-server/logs:rw
     restart: "no"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:4444"]
+      test:
+        [
+          "CMD-SHELL",
+          "curl -sf http://localhost:4444 && curl -sf http://localhost:8080",
+        ]
       interval: 10s
       timeout: 5s
       retries: 10
-      start_period: 10s
+      start_period: 30s
     deploy:
       resources:
         limits:

--- a/test/ui/fixtures/ui_fixtures.py
+++ b/test/ui/fixtures/ui_fixtures.py
@@ -89,6 +89,10 @@ def browser_setup(
                 log.info(
                     "Waiting for container %s to be healthy: %s", CONTAINER_NAME, count
                 )
+            log.info(
+                "Container healthy, waiting for code-server extension activation..."
+            )
+            time.sleep(30)
 
         browser = os.environ.get("BROWSER_TYPE")
         options: FirefoxOptions | ChromeOptions

--- a/test/ui/test_00_commands.py
+++ b/test/ui/test_00_commands.py
@@ -43,7 +43,7 @@ def test_terminal(
     ensure_vscode_ready(driver)
     vscode_run_command(driver, ">workbench.action.terminal.new")
     vscode_run_command(driver, ">workbench.action.terminal.focus")
-    time.sleep(3)  # allow terminal to start before sending input
+    time.sleep(5)  # allow terminal to start before sending input
     vscode_run_command(
         driver, ">workbench.action.terminal.sendSequence", "adt --version\\n"
     )
@@ -60,7 +60,7 @@ def test_terminal(
 
     errors = [NoSuchElementException, ElementNotInteractableException]
     wait = WebDriverWait(
-        driver, timeout=10, poll_frequency=0.5, ignored_exceptions=errors
+        driver, timeout=30, poll_frequency=1, ignored_exceptions=errors
     )
     wait.until(lambda _: check_output())
 
@@ -85,10 +85,10 @@ def test_create_empty_playbook(
     wait_displayed(
         driver,
         "//div[contains(@class, 'tab') and contains(., 'Untitled')]",
-        timeout=2,
+        timeout=10,
     )
 
-    time.sleep(1)
+    time.sleep(2)
     view_lines = driver.find_elements("xpath", "//div[@class='view-line']")
 
     # Extract text from the lines (checking first 10 lines is sufficient)

--- a/test/ui/test_01_dev_webviews.py
+++ b/test/ui/test_01_dev_webviews.py
@@ -24,7 +24,7 @@ def test_devfile_webview(
 
     vscode_run_command(driver, ">Ansible: Create a Devfile")
 
-    find_element_across_iframes(driver, "//form[@id='devfile-form']", retries=10)
+    find_element_across_iframes(driver, "//form[@id='devfile-form']", retries=20)
 
     vscode_textfield_interact(driver, "path-url", "~")
 
@@ -70,7 +70,7 @@ def test_devcontainer_webview(
     find_element_across_iframes(
         driver,
         "//form[@id='devcontainer-form']",
-        retries=10,
+        retries=20,
     )
 
     vscode_textfield_interact(driver, "path-url", "~")

--- a/test/ui/utils/ui_utils.py
+++ b/test/ui/utils/ui_utils.py
@@ -78,7 +78,16 @@ def ensure_vscode_ready(driver: WebDriver, timeout: int = 120) -> None:
     driver.switch_to.default_content()
     if "127.0.0.1:8080" not in driver.current_url:
         driver.get("http://127.0.0.1:8080")
-    wait_displayed(driver, "//a[@aria-label='Ansible']", timeout=60)
+    max_nav_attempts = 3
+    for attempt in range(max_nav_attempts):
+        try:
+            wait_displayed(driver, "//a[@aria-label='Ansible']", timeout=90)
+            break
+        except (TimeoutException, TimeOutError):
+            if attempt == max_nav_attempts - 1:
+                raise
+            driver.refresh()
+            time.sleep(10)
     vscode_run_command(driver, ">Ansible: Focus on Ansible Development Tools View")
     find_element_across_iframes(
         driver,
@@ -1039,7 +1048,7 @@ def vscode_run_command(
                 driver,
                 command_box,
                 "//input[@aria-controls='quickInput_list']",
-                timeout=2,
+                timeout=5,
             )
             break
         except (


### PR DESCRIPTION
Timeouts calibrated for local dev were too aggressive for CI runners, causing cascading TimeoutExceptions across all three non-Lightspeed UI tests.

related: #2741

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Increases Selenium UI test timeouts and retries to prevent CI flakiness caused by CI being slower than local runs; approach: raise waits, poll intervals, retry counts, and add post-healthcheck delay.

- test/ui/test_00_commands.py: longer terminal focus delay, WebDriverWait timeout/poll, “Untitled” tab wait, editor read delay
- test/ui/test_01_dev_webviews.py: iframe lookup retries increased (10→20)
- test/ui/utils/ui_utils.py: command palette input timeout increased (2s→5s)
- docker-compose.yml & fixtures: longer healthcheck/start delays and post-healthcheck sleep

related: #2741
<!-- end of auto-generated comment: release notes by coderabbit.ai -->