### PR TITLE
fix(ci): bump e2e download timeout to 60s

### DIFF
--- a/.vscode-test.mjs
+++ b/.vscode-test.mjs
@@ -10,6 +10,7 @@ export default defineConfig({
   files: "test/e2e/**/*.test.ts",
   extensionDevelopmentPath: ".", // package.json location
   workspaceFolder: "test/testFixtures",
+  download: { timeout: 60_000 },
   launchArgs: [
     // cannot rely on vscode-test ability to install extensions because it does
     // implicitly use --force and the server can respond with 503 errors.

--- a/package.json
+++ b/package.json
@@ -1134,6 +1134,9 @@
     "overrides": {
       "rollup": "npm:@rollup/wasm-node@*"
     },
+    "patchedDependencies": {
+      "@vscode/test-cli@0.0.12": "patches/@vscode__test-cli@0.0.12.patch"
+    },
     "packageExtensions": {
       "cypress-multi-reporters@*": {
         "dependencies": {

--- a/patches/@vscode__test-cli@0.0.12.patch
+++ b/patches/@vscode__test-cli@0.0.12.patch
@@ -1,0 +1,14 @@
+diff --git a/out/cli/platform/desktop.mjs b/out/cli/platform/desktop.mjs
+index b901849..50b5bcc 100644
+--- a/out/cli/platform/desktop.mjs
++++ b/out/cli/platform/desktop.mjs
+@@ -126,7 +126,8 @@ class PreparedDesktopRun {
+             return;
+         }
+         const opts = this.baseCliOptions();
+-        const vscodePath = await electron.downloadAndUnzipVSCode(opts.version, opts.platform, opts.reporter);
++        // https://github.com/microsoft/vscode-test-cli/issues/106
++        const vscodePath = await electron.downloadAndUnzipVSCode(opts);
+         const [cli, ...cliArgs] = electron.resolveCliArgsFromVSCodeExecutablePath(vscodePath, opts);
+         for (const extension of exts.value) {
+             cliArgs.push('--install-extension', extension);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,11 @@ overrides:
 
 packageExtensionsChecksum: sha256-aFRaYtZLvfkyedP3TSQbgNuU5y3GOl4Ou/9gmySVprU=
 
+patchedDependencies:
+  '@vscode/test-cli@0.0.12':
+    hash: e13bd8d1cf6524096a6c3fd50b9e914526c46186f440e041139203de06f23ea2
+    path: patches/@vscode__test-cli@0.0.12.patch
+
 importers:
 
   .:
@@ -133,7 +138,7 @@ importers:
         version: 4.1.2(vitest@4.1.2)
       '@vscode/test-cli':
         specifier: ^0.0.12
-        version: 0.0.12
+        version: 0.0.12(patch_hash=e13bd8d1cf6524096a6c3fd50b9e914526c46186f440e041139203de06f23ea2)
       '@vscode/test-electron':
         specifier: ^2.5.2
         version: 2.5.2
@@ -7073,7 +7078,7 @@ snapshots:
 
   '@vscode/python-extension@1.0.5': {}
 
-  '@vscode/test-cli@0.0.12':
+  '@vscode/test-cli@0.0.12(patch_hash=e13bd8d1cf6524096a6c3fd50b9e914526c46186f440e041139203de06f23ea2)':
     dependencies:
       '@types/mocha': 10.0.10
       c8: 10.1.3


### PR DESCRIPTION
## Summary

- Patches `@vscode/test-cli@0.0.12` to pass the full options object (including `timeout`) to `downloadAndUnzipVSCode` instead of positional args that drop the timeout
- Sets `download.timeout` to 60s in `.vscode-test.mjs` as a belt-and-suspenders defense

## Root cause

`@vscode/test-cli`'s `installDependentExtensions()` in `desktop.mjs` calls:

```js
electron.downloadAndUnzipVSCode(opts.version, opts.platform, opts.reporter);
```

This uses positional args, so `opts.timeout` (from `baseCliOptions()`) is never forwarded. `@vscode/test-electron` defaults to 15s, which is too short on CI runners under load.

The patch changes the call to `electron.downloadAndUnzipVSCode(opts)`, which passes the object form and preserves `timeout`.

Upstream bug: microsoft/vscode-test-cli#106

## Test plan

- [ ] CI `e2e` step passes on Linux without `@vscode/test-electron request timeout out after 15000ms`
- [ ] No regressions on macOS/Windows e2e jobs