### PR TITLE
fix(e2e): batch EE settings to avoid ALS race

### DIFF
--- a/packages/ansible-language-server/src/services/docsLibrary.ts
+++ b/packages/ansible-language-server/src/services/docsLibrary.ts
@@ -62,6 +62,9 @@ export class DocsLibrary {
       for (const collectionsPath of ansibleConfig.collections_paths) {
         await this.findDocumentationInCollectionsPath(collectionsPath);
       }
+      this.connection.sendNotification("ansible/docsLibraryReady", {
+        modulesCount: this.modules.size,
+      });
     } catch (error) {
       if (error instanceof Error) {
         this.connection.window.showErrorMessage(error.message);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1196,6 +1196,32 @@ const startClient = async (
   try {
     await client.start();
 
+    // Level-triggered gate: resolves immediately if docsLibrary is already
+    // ready, otherwise waits for the next ansible/docsLibraryReady notification.
+    // Re-armed only when ansible.* config changes invalidate the library.
+    let docsReady = newDocsReadyGate();
+    let docsLibraryIsReady = false;
+    client.onNotification(
+      new NotificationType("ansible/docsLibraryReady"),
+      () => {
+        docsLibraryIsReady = true;
+        docsReady.resolve();
+      },
+    );
+    context.subscriptions.push(
+      workspace.onDidChangeConfiguration((e) => {
+        if (e.affectsConfiguration("ansible")) {
+          docsLibraryIsReady = false;
+          docsReady = newDocsReadyGate();
+        }
+      }),
+    );
+    context.subscriptions.push(
+      vscode.commands.registerCommand("ansible.awaitDocsLibraryReady", () =>
+        docsLibraryIsReady ? Promise.resolve() : docsReady.promise,
+      ),
+    );
+
     // If the extensions change, fire this notification again to pick up on any association changes
     extensions.onDidChange(() => {
       notifyAboutConflicts();
@@ -1339,4 +1365,12 @@ async function updateDocumentInRoleContext() {
     "redhat.ansible.isDocumentInRole",
     isInRole,
   );
+}
+
+function newDocsReadyGate(): { resolve: () => void; promise: Promise<void> } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => {
+    resolve = r;
+  });
+  return { resolve, promise };
 }

--- a/test/e2e/e2e.utils.ts
+++ b/test/e2e/e2e.utils.ts
@@ -162,17 +162,21 @@ export function unSetFixtureAnsibleCollectionPathEnv(): void {
 }
 
 export async function enableExecutionEnvironmentSettings(): Promise<void> {
-  await updateSettings("trace.server", "verbose", "ansibleServer");
-  await updateSettings("executionEnvironment.enabled", true);
-
   const volumeMounts = [
     {
       src: ANSIBLE_COLLECTIONS_FIXTURES_BASE_PATH,
       dest: ANSIBLE_COLLECTIONS_FIXTURES_BASE_PATH,
-      options: "ro", // read-only option for volume mounts
+      options: "ro",
     },
   ];
-  await updateSettings("executionEnvironment.volumeMounts", volumeMounts);
+
+  // Fire all three updates concurrently to minimize the window between
+  // the first and last didChangeConfiguration the ALS receives.
+  await Promise.all([
+    updateSettings("trace.server", "verbose", "ansibleServer"),
+    updateSettings("executionEnvironment.enabled", true),
+    updateSettings("executionEnvironment.volumeMounts", volumeMounts),
+  ]);
 }
 
 export async function disableExecutionEnvironmentSettings(): Promise<void> {

--- a/test/e2e/hover/withEE.test.ts
+++ b/test/e2e/hover/withEE.test.ts
@@ -33,11 +33,17 @@ describe("ee", function () {
     const docUri1 = getDocUri("hover/with_ee/1.yml");
 
     before(async function () {
+      this.timeout(60_000);
       await vscode.commands.executeCommand("workbench.action.closeAllEditors");
       await activate(docUri1);
       setFixtureAnsibleCollectionPathEnv(
         "/home/runner/.ansible/collections:/usr/share/ansible/collections",
       );
+    });
+
+    it("should receive docsLibraryReady from ALS", async function () {
+      this.timeout(60_000);
+      await vscode.commands.executeCommand("ansible.awaitDocsLibraryReady");
     });
 
     describe("Hover for play keywords", function () {


### PR DESCRIPTION
## Summary

E2E `hover-ee` tests were flaky due to a race between settings
updates and ALS `docsLibrary` initialization. Hover requests
arrived before EE docs were indexed, returning empty results.

### Fix

- ALS sends `ansible/docsLibraryReady` after `docsLibrary.initialize()`
- Client extension exposes `ansible.awaitDocsLibraryReady` command
- Tests await the notification before running hover assertions
- EE settings fired concurrently via `Promise.all`

## Test plan

- [ ] `hover-with-EE` e2e tests pass reliably
- [ ] No regression in non-EE hover tests

related: #2746, #2748