### PR TITLE
fix(als): debounce config change invalidation

### DIFF
--- a/packages/ansible-language-server/src/services/workspaceManager.ts
+++ b/packages/ansible-language-server/src/services/workspaceManager.ts
@@ -141,6 +141,7 @@ export class WorkspaceFolderContext {
   private _ansibleInventory: Thenable<AnsibleInventory> | undefined;
   private _ansibleLint: AnsibleLint | undefined;
   private _ansiblePlaybook: AnsiblePlaybook | undefined;
+  private _configChangeTimer: ReturnType<typeof setTimeout> | undefined;
 
   constructor(
     connection: Connection,
@@ -158,12 +159,19 @@ export class WorkspaceFolderContext {
     this.documentSettings.onConfigurationChanged(
       this.workspaceFolder.uri,
       () => {
-        // in case the configuration changes for this folder, we should
-        // invalidate the services that rely on it in initialization
-        this._executionEnvironment = undefined;
-        this._ansibleConfig = undefined;
-        this._docsLibrary = undefined;
-        this._ansibleInventory = undefined;
+        // Debounce: multiple didChangeConfiguration notifications can arrive
+        // in rapid succession (e.g. when several settings are updated at once).
+        // Without debouncing, each fires the invalidation callback while a
+        // previous docsLibrary.initialize() may still be in flight, orphaning
+        // its result and leaving subsequent requests with an empty module index.
+        if (this._configChangeTimer) {
+          clearTimeout(this._configChangeTimer);
+          this._configChangeTimer = undefined;
+        }
+        this._configChangeTimer = setTimeout(() => {
+          this.clearCachedServices();
+          this._configChangeTimer = undefined;
+        }, 500);
       },
     );
   }


### PR DESCRIPTION
## Summary

Multiple `didChangeConfiguration` notifications arriving in rapid
succession (e.g. when several settings are updated at once) each
cleared `_docsLibrary` while a previous `initialize()` was still
in flight. This orphaned the initialization result and left
subsequent hover requests with an empty module index.

Add a 500ms debounce to the `onConfigurationChanged` callback so
rapid-fire config changes coalesce into a single service
invalidation cycle.

## Root cause

The `docsLibraryReady` notification test in #2749 proved
`initialize()` ran to completion, yet module hovers returned
empty results. The sequence:

1. Three setting updates fire concurrently (`Promise.all`)
2. ALS receives three `didChangeConfiguration` notifications
3. Notification 1 clears `_docsLibrary`, triggering a new `initialize()`
4. Notification 2 clears `_docsLibrary` again while init is in flight
5. The orphaned init completes (sends `docsLibraryReady`) but its
   result is discarded
6. A fresh `initialize()` starts but finds a stale cache, producing
   an empty module index

## Test plan

- [ ] `hover-with-EE` e2e tests pass
- [ ] No regression in non-EE hover or completion

related: #2746, #2749

Made with [Cursor](https://cursor.com)