### PR TITLE
fix(ci): pin code-server to v4.113.1 for Selenium tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,10 @@
 # cspell: ignore healthcheck
 services:
   selenium-vscode:
-    image: ghcr.io/ansible/selenium-adt:main
-    pull_policy: missing
+    build:
+      context: .
+      dockerfile: test/ui/Containerfile.selenium
+    image: selenium-adt-pinned:local
     container_name: selenium-vscode
     shm_size: "10g"
     security_opt:

--- a/test/ui/Containerfile.selenium
+++ b/test/ui/Containerfile.selenium
@@ -1,0 +1,19 @@
+# Extends ghcr.io/ansible/selenium-adt:main with pinned code-server version
+# This is a workaround for https://github.com/coder/code-server/issues/7890
+# code-server v4.114.0 has a bug preventing extensions from loading properly.
+# Pin to v4.113.1 until the upstream fix is available.
+FROM ghcr.io/ansible/selenium-adt:main
+
+USER root
+
+# Reinstall code-server with pinned version to avoid extension loading bug
+# in v4.114.0 (released April 4, 2026)
+RUN curl -fsSL https://code-server.dev/install.sh | sh -s -- --version 4.113.1
+
+# Reinstall extensions that may have been affected
+RUN code-server --install-extension ms-python.vscode-python-envs \
+    --install-extension ms-python.python \
+    --install-extension redhat.vscode-yaml \
+    --install-extension redhat.vscode-redhat-account
+
+USER 1001

--- a/test/ui/test_00_commands.py
+++ b/test/ui/test_00_commands.py
@@ -33,7 +33,6 @@ EXPECTED_ADT_PACKAGES = [
 ]
 
 
-@pytest.mark.skip(reason="Flaky on CI - tests container image, not extension code")
 def test_terminal(
     browser_setup: Any,
     screenshot_on_fail: Any,
@@ -72,7 +71,6 @@ def test_terminal(
     assert not missing, f"Missing packages in 'adt --version' output: {missing}"
 
 
-@pytest.mark.skip(reason="Flaky on CI - extension activation timing issues")
 def test_create_empty_playbook(
     browser_setup: Any,
     screenshot_on_fail: Any,

--- a/test/ui/test_01_dev_webviews.py
+++ b/test/ui/test_01_dev_webviews.py
@@ -14,7 +14,6 @@ from test.ui.utils.ui_utils import (
 )
 
 
-@pytest.mark.skip(reason="Flaky on CI - extension activation timing issues")
 def test_devfile_webview(
     browser_setup: Any,
     screenshot_on_fail: Any,
@@ -58,7 +57,6 @@ def test_devfile_webview(
     vscode_button_click(driver, "reset-button")
 
 
-@pytest.mark.skip(reason="Flaky on CI - extension activation timing issues")
 def test_devcontainer_webview(
     browser_setup: Any,
     screenshot_on_fail: Any,

--- a/test/ui/test_02_welcome_webviews.py
+++ b/test/ui/test_02_welcome_webviews.py
@@ -12,7 +12,6 @@ from test.ui.utils.ui_utils import (
 )
 
 
-@pytest.mark.skip(reason="Flaky on CI - extension activation timing issues")
 @pytest.mark.modify_settings({"ansible.lightspeed.enabled": False})
 def test_sidebar_nav(
     browser_setup: Any,
@@ -44,7 +43,6 @@ def test_sidebar_nav(
     )
 
 
-@pytest.mark.skip(reason="Flaky on CI - extension activation timing issues")
 def test_header_and_subtitle(
     browser_setup: Any,
     screenshot_on_fail: Any,
@@ -78,7 +76,6 @@ def test_header_and_subtitle(
     )
 
 
-@pytest.mark.skip(reason="Flaky on CI - extension activation timing issues")
 def test_mcp_section(
     browser_setup: Any,
     screenshot_on_fail: Any,

--- a/test/ui/test_03_llm_provider_webview.py
+++ b/test/ui/test_03_llm_provider_webview.py
@@ -12,7 +12,6 @@ from test.ui.utils.ui_utils import (
 )
 
 
-@pytest.mark.skip(reason="Flaky on CI - extension activation timing issues")
 def test_llm_provider_webview_opens(
     browser_setup: Any,
     screenshot_on_fail: Any,
@@ -32,7 +31,6 @@ def test_llm_provider_webview_opens(
     )
 
 
-@pytest.mark.skip(reason="Flaky on CI - extension activation timing issues")
 def test_llm_provider_webview_lists_providers(
     browser_setup: Any,
     screenshot_on_fail: Any,
@@ -73,7 +71,6 @@ def test_llm_provider_webview_lists_providers(
     assert rhcustom_provider is not None, "Red Hat AI provider should be listed"
 
 
-@pytest.mark.skip(reason="Flaky on CI - extension activation timing issues")
 def test_llm_provider_webview_edit_button(
     browser_setup: Any,
     screenshot_on_fail: Any,
@@ -106,7 +103,6 @@ def test_llm_provider_webview_edit_button(
     )
 
 
-@pytest.mark.skip(reason="Flaky on CI - extension activation timing issues")
 def test_rhcustom_provider_config_fields(
     browser_setup: Any,
     screenshot_on_fail: Any,

--- a/test/ui/test_50_mcp_server.py
+++ b/test/ui/test_50_mcp_server.py
@@ -58,7 +58,6 @@ def _assert_disable_notification(driver: Any) -> None:
     )
 
 
-@pytest.mark.skip(reason="Flaky on CI - extension activation timing issues")
 def test_mcp_server_enable_via_command(
     browser_setup: Any,
     screenshot_on_fail: Any,
@@ -72,7 +71,6 @@ def test_mcp_server_enable_via_command(
     _assert_enable_notification(driver)
 
 
-@pytest.mark.skip(reason="Flaky on CI - extension activation timing issues")
 def test_mcp_server_disable(
     browser_setup: Any,
     screenshot_on_fail: Any,
@@ -86,7 +84,6 @@ def test_mcp_server_disable(
     _assert_disable_notification(driver)
 
 
-@pytest.mark.skip(reason="Flaky on CI - extension activation timing issues")
 @pytest.mark.modify_settings({"ansible.mcpServer.enabled": True})
 def test_mcp_server_enabled_via_settings(
     browser_setup: Any,
@@ -102,7 +99,6 @@ def test_mcp_server_enabled_via_settings(
     _assert_enable_notification(driver)
 
 
-@pytest.mark.skip(reason="Flaky on CI - extension activation timing issues")
 def test_mcp_server_usable(
     browser_setup: Any,
     screenshot_on_fail: Any,


### PR DESCRIPTION
## Summary

- Pin code-server to v4.113.1 in Selenium test container to fix extension activation failures
- Re-enable all 15 previously skipped Selenium UI tests
- Build custom container image locally instead of using upstream selenium-adt:main directly

## Background

code-server v4.114.0 (released April 4, 2026) has a bug preventing VS Code extensions from loading properly in the selenium-adt container. This caused all Selenium UI tests to fail with `TimeoutException` while waiting for the Ansible extension to activate.

## Changes

1. **New `test/ui/Containerfile.selenium`**: Extends `ghcr.io/ansible/selenium-adt:main` and pins code-server to v4.113.1
2. **Updated `docker-compose.yml`**: Builds from the local Containerfile instead of using the upstream image directly
3. **Removed skip markers**: All 15 Selenium tests that were previously skipped due to flakiness are now enabled

## Test plan

- [ ] CI passes with all Selenium UI tests running
- [ ] Container builds successfully with pinned code-server version
- [ ] Extension activates properly in the test environment

Fixes: #2580
Related: ansible/ansible-dev-tools#677

Made with [Cursor](https://cursor.com)