### PR TITLE
fix(als): Change path for ALS binary installation to CJS instead of ESM

### DIFF
--- a/packages/ansible-language-server/package.json
+++ b/packages/ansible-language-server/package.json
@@ -3,7 +3,7 @@
     "onLanguage:ansible"
   ],
   "all": true,
-  "bin": "dist/cli.js",
+  "bin": "dist/cli.cjs",
   "categories": [
     "Programming Languages"
   ],


### PR DESCRIPTION
Binary installed by ALS package fails to launch ESM bundle `dist/cli.js` with error 'Dynamic require of "util" is not supported'. CJS entrypoint is provided in a package, and works correctly if executed directly, but it was not referenced by "bin" field in
`packages/ansible-language-server/package.json`.

This restores usage of installed `ansible-language-server` binary, and eliminates the need to manually change entrypoint in every app which may use it (for example, https://github.com/ganeshrn/claude-ansible-lsp/commit/209b2e538ae90de93af5a096969c3406f00335db#diff-037fda53525563fb89230704794a06db1150204ca28ce80697a637121c3ed3f9R13, or https://github.com/kartikvashistha/zed-ansible/issues/26#issuecomment-4269429657, etc).

Fixes: https://github.com/ansible/vscode-ansible/issues/2754


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated the Ansible Language Server binary entrypoint from the ESM build to the CommonJS build. The ESM bundle (`dist/cli.js`) fails when Node treats files as ESM modules due to dynamic require() calls for Node built-ins. The CJS bundle (`dist/cli.cjs`) works correctly, so the package.json `"bin"` field now references it, eliminating the need for downstream manual fixes.

- `packages/ansible-language-server/package.json`: Updated `"bin"` field from `dist/cli.js` to `dist/cli.cjs`

fixes: #2754

<!-- end of auto-generated comment: release notes by coderabbit.ai -->