### PR TITLE
chore: Only run precheck task in CI

### DIFF
--- a/Taskfile.base.yml
+++ b/Taskfile.base.yml
@@ -52,7 +52,7 @@ tasks:
     dir: "{{ .TASKFILE_DIR }}"
     cmds:
       - bash ./tools/test-setup.sh
-      - ./tools/precheck.sh
+      - task: precheck
     sources:
       - ./tools/precheck.sh
       - pyproject.toml
@@ -61,6 +61,12 @@ tasks:
       - out/log/manifest-*.json
     run: once
     interactive: true
+  precheck:
+    desc: Check for duplicate executables (only runs when CI=true)
+    status:
+      - '[ "$CI" != "true" ]'
+    cmds:
+      - ./tools/precheck.sh
   mise:
     desc: Check if mise is installed and working
     internal: true

--- a/Taskfile.base.yml
+++ b/Taskfile.base.yml
@@ -66,7 +66,7 @@ tasks:
     status:
       - '[ "$CI" != "true" ]'
     cmds:
-      - ./tools/precheck.sh
+      - "{{.GIT_ROOT}}/tools/precheck.sh"
   mise:
     desc: Check if mise is installed and working
     internal: true

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -49,7 +49,7 @@ tasks:
       # clean up uv cache, important for CI especially for caching size reduction
       # - task: ci_clean_cache
       # we also need to be sure that at the end of build and test we do not produce undesired side effects
-      - ./tools/precheck.sh
+      - task: precheck
       # ensure that `vitest list` works and does not display any warnings (stderr)
       - vitest list 1>out/log/vitest-list-stdout.txt 2>out/log/vitest-list-stderr.txt && test ! -s out/log/vitest-list-stderr.txt || { echo "Failing because 'vitest list' should not produce any warnings:"; cat out/log/vitest-list-stderr.txt; exit 5; }
       - tools/dirty.sh


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Refactored precheck script execution by creating a new conditional `precheck` task in `Taskfile.base.yml` that runs based on the CI environment variable. This eliminates duplicate script invocations and centralizes the precheck logic.

- Added new `precheck` task in `Taskfile.base.yml` with conditional execution logic
- Updated `setup` task in `Taskfile.base.yml` to invoke the new `precheck` task
- Updated `finish` task in `Taskfile.yml` to invoke the new `precheck` task

<!-- end of auto-generated comment: release notes by coderabbit.ai -->