### PR TITLE
fix: resolve content creator webview rendering and interaction issues

### DIFF
--- a/src/features/contentCreator/utils.ts
+++ b/src/features/contentCreator/utils.ts
@@ -106,7 +106,8 @@ export async function checkContentCreatorRequirements() {
         current: "not found",
       });
     } else {
-      const parsed = semver.valid(creatorVersion) ?? semver.coerce(creatorVersion)?.version;
+      const parsed =
+        semver.valid(creatorVersion) ?? semver.coerce(creatorVersion)?.version;
       if (!parsed || !semver.gte(parsed, ANSIBLE_CREATOR_VERSION_MIN)) {
         failures.push({
           type: "ansible-creator",

--- a/src/features/contentCreator/utils.ts
+++ b/src/features/contentCreator/utils.ts
@@ -16,7 +16,11 @@ export async function getBinDetail(cmd: string, arg: string) {
       env: env,
     });
     return result;
-  } catch {
+  } catch (error) {
+    console.error(
+      `[Ansible] Failed to run "${command}":`,
+      error instanceof Error ? error.message : error,
+    );
     return "failed";
   }
 }
@@ -94,19 +98,32 @@ export async function checkContentCreatorRequirements() {
   let creatorVersion: string;
   try {
     creatorVersion = await getCreatorVersion();
-    if (!semver.gte(creatorVersion, ANSIBLE_CREATOR_VERSION_MIN)) {
+
+    if (creatorVersion === "failed") {
       failures.push({
         type: "ansible-creator",
         required: ANSIBLE_CREATOR_VERSION_MIN,
-        current: creatorVersion,
+        current: "not found",
       });
+    } else {
+      const parsed = semver.valid(creatorVersion) ?? semver.coerce(creatorVersion)?.version;
+      if (!parsed || !semver.gte(parsed, ANSIBLE_CREATOR_VERSION_MIN)) {
+        failures.push({
+          type: "ansible-creator",
+          required: ANSIBLE_CREATOR_VERSION_MIN,
+          current: parsed ?? creatorVersion,
+        });
+      }
     }
-  } catch {
-    creatorVersion = "not found";
+  } catch (error) {
+    console.error(
+      "[Ansible] ansible-creator requirements check error:",
+      error instanceof Error ? error.message : error,
+    );
     failures.push({
       type: "ansible-creator",
       required: ANSIBLE_CREATOR_VERSION_MIN,
-      current: creatorVersion,
+      current: "not found",
     });
   }
   return {

--- a/src/features/contentCreator/vue/views/addPluginPagePanel.ts
+++ b/src/features/contentCreator/vue/views/addPluginPagePanel.ts
@@ -14,13 +14,6 @@ export class MainPanel {
 
   private constructor(panel: WebviewPanel, context: ExtensionContext) {
     this._panel = panel;
-    setupPanelLifecycle(
-      this._panel,
-      context,
-      "add-plugin",
-      this._disposables,
-      () => this.dispose(),
-    );
 
     this._panel.webview.onDidReceiveMessage(
       async (msg) => {
@@ -34,6 +27,14 @@ export class MainPanel {
       },
       null,
       this._disposables,
+    );
+
+    setupPanelLifecycle(
+      this._panel,
+      context,
+      "add-plugin",
+      this._disposables,
+      () => this.dispose(),
     );
   }
 

--- a/src/features/contentCreator/vue/views/createAnsibleCollectionPanel.ts
+++ b/src/features/contentCreator/vue/views/createAnsibleCollectionPanel.ts
@@ -14,13 +14,6 @@ export class MainPanel {
 
   private constructor(panel: WebviewPanel, context: ExtensionContext) {
     this._panel = panel;
-    setupPanelLifecycle(
-      this._panel,
-      context,
-      "create-ansible-collection",
-      this._disposables,
-      () => this.dispose(),
-    );
 
     this._panel.webview.onDidReceiveMessage(
       async (msg) => {
@@ -34,6 +27,14 @@ export class MainPanel {
       },
       null,
       this._disposables,
+    );
+
+    setupPanelLifecycle(
+      this._panel,
+      context,
+      "create-ansible-collection",
+      this._disposables,
+      () => this.dispose(),
     );
   }
 

--- a/src/features/contentCreator/vue/views/createAnsibleProjectPanel.ts
+++ b/src/features/contentCreator/vue/views/createAnsibleProjectPanel.ts
@@ -14,13 +14,6 @@ export class MainPanel {
 
   private constructor(panel: WebviewPanel, context: ExtensionContext) {
     this._panel = panel;
-    setupPanelLifecycle(
-      this._panel,
-      context,
-      "create-ansible-project",
-      this._disposables,
-      () => this.dispose(),
-    );
 
     this._panel.webview.onDidReceiveMessage(
       async (msg) => {
@@ -34,6 +27,14 @@ export class MainPanel {
       },
       null,
       this._disposables,
+    );
+
+    setupPanelLifecycle(
+      this._panel,
+      context,
+      "create-ansible-project",
+      this._disposables,
+      () => this.dispose(),
     );
   }
 

--- a/src/features/contentCreator/vue/views/createDevcontainerPanel.ts
+++ b/src/features/contentCreator/vue/views/createDevcontainerPanel.ts
@@ -14,13 +14,6 @@ export class MainPanel {
 
   private constructor(panel: WebviewPanel, context: ExtensionContext) {
     this._panel = panel;
-    setupPanelLifecycle(
-      this._panel,
-      context,
-      "create-devcontainer",
-      this._disposables,
-      () => this.dispose(),
-    );
 
     this._panel.webview.onDidReceiveMessage(
       async (msg) => {
@@ -34,6 +27,14 @@ export class MainPanel {
       },
       null,
       this._disposables,
+    );
+
+    setupPanelLifecycle(
+      this._panel,
+      context,
+      "create-devcontainer",
+      this._disposables,
+      () => this.dispose(),
     );
   }
 

--- a/src/features/contentCreator/vue/views/createDevfilePanel.ts
+++ b/src/features/contentCreator/vue/views/createDevfilePanel.ts
@@ -14,13 +14,6 @@ export class MainPanel {
 
   private constructor(panel: WebviewPanel, context: ExtensionContext) {
     this._panel = panel;
-    setupPanelLifecycle(
-      this._panel,
-      context,
-      "create-devfile",
-      this._disposables,
-      () => this.dispose(),
-    );
 
     this._panel.webview.onDidReceiveMessage(
       async (msg) => {
@@ -34,6 +27,14 @@ export class MainPanel {
       },
       null,
       this._disposables,
+    );
+
+    setupPanelLifecycle(
+      this._panel,
+      context,
+      "create-devfile",
+      this._disposables,
+      () => this.dispose(),
     );
   }
 

--- a/src/features/contentCreator/vue/views/createRolePanel.ts
+++ b/src/features/contentCreator/vue/views/createRolePanel.ts
@@ -14,13 +14,6 @@ export class MainPanel {
 
   private constructor(panel: WebviewPanel, context: ExtensionContext) {
     this._panel = panel;
-    setupPanelLifecycle(
-      this._panel,
-      context,
-      "create-role",
-      this._disposables,
-      () => this.dispose(),
-    );
 
     this._panel.webview.onDidReceiveMessage(
       async (msg) => {
@@ -34,6 +27,14 @@ export class MainPanel {
       },
       null,
       this._disposables,
+    );
+
+    setupPanelLifecycle(
+      this._panel,
+      context,
+      "create-role",
+      this._disposables,
+      () => this.dispose(),
     );
   }
 

--- a/src/features/contentCreator/vue/views/panelUtils.ts
+++ b/src/features/contentCreator/vue/views/panelUtils.ts
@@ -1,5 +1,5 @@
 import type { Disposable, ExtensionContext, WebviewPanel } from "vscode";
-import { ViewColumn, window } from "vscode";
+import { Uri, ViewColumn, window } from "vscode";
 import { ContentCreatorWebviewHelper } from "@src/features/contentCreator/vue/views/helper";
 
 /**
@@ -13,15 +13,15 @@ export function setupPanelLifecycle(
   disposeCallback: () => void,
 ): void {
   panel.onDidDispose(disposeCallback, null, disposables);
-  panel.webview.html = ContentCreatorWebviewHelper.setupHtml(
-    panel.webview,
-    context,
-    htmlEntryPoint,
-  );
   ContentCreatorWebviewHelper.setupWebviewHooks(
     panel.webview,
     disposables,
     context,
+  );
+  panel.webview.html = ContentCreatorWebviewHelper.setupHtml(
+    panel.webview,
+    context,
+    htmlEntryPoint,
   );
 }
 
@@ -74,6 +74,10 @@ export function createOrRevealPanel<T>(
         enableScripts: true,
         enableCommandUris: true,
         retainContextWhenHidden: true,
+        localResourceRoots: [
+          Uri.joinPath(options.context.extensionUri, "dist"),
+          Uri.joinPath(options.context.extensionUri, "media"),
+        ],
       },
     );
     const newPanelInstance = options.panelConstructor(panel, options.context);

--- a/src/features/lightspeed/vue/views/ansibleCreatorUtils.ts
+++ b/src/features/lightspeed/vue/views/ansibleCreatorUtils.ts
@@ -30,8 +30,7 @@ export class AnsibleCreatorOperations {
   ): { isGte: boolean; userMessage?: string } {
     try {
       const parsed =
-        semver.valid(currentVersion) ??
-        semver.coerce(currentVersion)?.version;
+        semver.valid(currentVersion) ?? semver.coerce(currentVersion)?.version;
       if (!parsed) {
         return {
           isGte: false,

--- a/src/features/lightspeed/vue/views/ansibleCreatorUtils.ts
+++ b/src/features/lightspeed/vue/views/ansibleCreatorUtils.ts
@@ -478,7 +478,7 @@ export class AnsibleCreatorOperations {
     );
 
     let command: string;
-    if (versionCheck.isGte || versionCheck.userMessage) {
+    if (versionCheck.isGte) {
       command = `ansible-creator init collection ${namespaceName}.${collectionName} ${initPathUrl} --no-ansi`;
     } else {
       command = `ansible-creator init ${namespaceName}.${collectionName} --init-path=${initPathUrl} --no-ansi`;
@@ -507,7 +507,7 @@ export class AnsibleCreatorOperations {
       ANSIBLE_CREATOR_VERSION_MIN,
     );
 
-    if (versionCheck.isGte || versionCheck.userMessage) {
+    if (versionCheck.isGte) {
       return `ansible-creator init playbook ${namespace}.${collection} ${url} --no-ansi`;
     } else {
       return `ansible-creator init --project=ansible-project --init-path=${url} --scm-org=${namespace} --scm-project=${collection} --no-ansi`;

--- a/src/features/lightspeed/vue/views/ansibleCreatorUtils.ts
+++ b/src/features/lightspeed/vue/views/ansibleCreatorUtils.ts
@@ -29,11 +29,20 @@ export class AnsibleCreatorOperations {
     requiredVersion: string,
   ): { isGte: boolean; userMessage?: string } {
     try {
-      return { isGte: semver.gte(currentVersion, requiredVersion) };
+      const parsed =
+        semver.valid(currentVersion) ??
+        semver.coerce(currentVersion)?.version;
+      if (!parsed) {
+        return {
+          isGte: false,
+          userMessage: `Invalid version format: ${currentVersion}.\n`,
+        };
+      }
+      return { isGte: semver.gte(parsed, requiredVersion) };
     } catch {
       return {
         isGte: false,
-        userMessage: `Invalid version format: ${currentVersion}. This appears to be a development version.\n`,
+        userMessage: `Invalid version format: ${currentVersion}.\n`,
       };
     }
   }

--- a/webviews/FormPageLayout.vue
+++ b/webviews/FormPageLayout.vue
@@ -1,12 +1,15 @@
 <script setup lang="ts">
 import { computed } from "vue";
 
-const props = defineProps<{
-  title: string;
-  subtitle: string;
-  description?: string;
-  requirementsMet?: boolean;
-}>();
+const props = withDefaults(
+  defineProps<{
+    title: string;
+    subtitle: string;
+    description?: string;
+    requirementsMet?: boolean;
+  }>(),
+  { requirementsMet: true },
+);
 
 const isDisabled = computed(() => props.requirementsMet === false);
 </script>
@@ -34,8 +37,8 @@ const isDisabled = computed(() => props.requirementsMet === false);
 body {
   display: flex;
   flex-direction: column;
-  justify-content: center;
   align-items: center;
+  padding-top: 20px;
 }
 
 .title-div {
@@ -213,7 +216,7 @@ vscode-checkbox i {
 }
 
 .disabled-content {
-  opacity: 0.4;
+  opacity: 0.6;
   pointer-events: none;
 }
 </style>

--- a/webviews/RequirementsBanner.vue
+++ b/webviews/RequirementsBanner.vue
@@ -7,7 +7,8 @@
         <template
           v-if="failures.length === 1 && failures[0].type === 'ansible-creator'"
         >
-          This feature requires ansible-creator version <b>25.0.1</b> or higher.
+          This feature requires ansible-creator version
+          <b>{{ failures[0].required }}</b> or higher.
           To upgrade or install ansible-creator, please refer to the official
           installation and upgrade
           <a href="https://docs.ansible.com/projects/creator/installing/"
@@ -54,6 +55,9 @@ defineProps<{
   margin-bottom: 20px;
   box-shadow: 0 1px 4px 0 rgba(0, 0, 0, 0.04);
   gap: 18px;
+  width: 100%;
+  max-width: 650px;
+  box-sizing: border-box;
 }
 .banner-icon {
   font-size: 2em;


### PR DESCRIPTION
- Add localResourceRoots to content creator panels so webview assets load
- Default requirementsMet prop to true to prevent Vue boolean casting from
  disabling forms that don't use the requirements check
- Use semver.coerce() to handle Python-style dev versions (e.g. 26.3.3.dev0)
- Register message handlers before setting webview HTML to prevent race
  condition with request-requirements-status
- Fix banner layout overlap and use dynamic version in RequirementsBanner