### PR TITLE
test(mcp): add tests to catch MCP server activation regression

### DIFF
--- a/test/e2e/mcp/mcpActivation.test.ts
+++ b/test/e2e/mcp/mcpActivation.test.ts
@@ -37,51 +37,38 @@ describe("MCP server activation and availability (AAP-64488)", function () {
   });
 
   describe("MCP server CLI availability", function () {
-    it("should have MCP server package resolvable via module resolution", function () {
+    it("should have MCP server CLI resolvable", function () {
       const extension = extensions.getExtension("redhat.ansible");
       assert.ok(extension, "Extension should be found");
 
       const extensionPath = extension.extensionPath;
 
-      // The MCP server should be resolvable via Node.js module resolution
-      // from the extension's context
+      // Try module resolution first (works in development)
       try {
         const require = createRequire(path.join(extensionPath, "package.json"));
         const serverPath = require.resolve("@ansible/ansible-mcp-server");
         assert.ok(serverPath, "MCP server package should be resolvable");
 
-        // CLI should be in the same directory as the main module
-        const cliPath = path.join(path.dirname(serverPath), "cli.js");
+        const cliPath = path.join(path.dirname(serverPath), "cli.cjs");
         assert.ok(existsSync(cliPath), `MCP CLI should exist at: ${cliPath}`);
-      } catch (error) {
-        // If module resolution fails, check for legacy paths as fallback
-        const packagedCliPath = path.join(
-          extensionPath,
-          "out",
-          "mcp",
-          "cli.js",
-        );
-        const devCliPath = path.join(
-          extensionPath,
-          "packages",
-          "ansible-mcp-server",
-          "out",
-          "server",
-          "src",
-          "cli.js",
-        );
-
-        const hasPackagedCli = existsSync(packagedCliPath);
-        const hasDevCli = existsSync(devCliPath);
-
-        assert.ok(
-          hasPackagedCli || hasDevCli,
-          `MCP CLI should be resolvable via module resolution or exist at:\n` +
-            `  - Packaged: ${packagedCliPath} (exists: ${hasPackagedCli})\n` +
-            `  - Development: ${devCliPath} (exists: ${hasDevCli})\n` +
-            `  - Module resolution error: ${error}`,
-        );
+        return;
+      } catch {
+        // Module resolution fails in packaged extension - check fallback
       }
+
+      // Fallback: packaged extension path
+      const packagedCliPath = path.join(
+        extensionPath,
+        "packages",
+        "ansible-mcp-server",
+        "dist",
+        "cli.cjs",
+      );
+
+      assert.ok(
+        existsSync(packagedCliPath),
+        `MCP CLI should exist at packaged path: ${packagedCliPath}`,
+      );
     });
   });
 

--- a/test/unit/mcp/mcpPackaging.test.ts
+++ b/test/unit/mcp/mcpPackaging.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const projectRoot = path.resolve(__dirname, "..", "..", "..");
+
+describe("MCP server packaging", function () {
+  describe(".vscodeignore includes MCP server files", function () {
+    const vscodeignore = fs.readFileSync(
+      path.join(projectRoot, ".vscodeignore"),
+      "utf8",
+    );
+
+    it("should whitelist MCP server dist files", function () {
+      expect(vscodeignore).toContain("!packages/ansible-mcp-server/dist/**/*");
+    });
+
+    it("should whitelist MCP server package.json", function () {
+      expect(vscodeignore).toContain(
+        "!packages/ansible-mcp-server/package.json",
+      );
+    });
+
+    it("should whitelist MCP server resource data files", function () {
+      expect(vscodeignore).toContain(
+        "!packages/ansible-mcp-server/src/resources/data/**/*",
+      );
+    });
+  });
+
+  describe("MCP server package structure", function () {
+    const mcpPackageDir = path.join(
+      projectRoot,
+      "packages",
+      "ansible-mcp-server",
+    );
+
+    it("should have package.json with correct main entry", function () {
+      const pkg = JSON.parse(
+        fs.readFileSync(path.join(mcpPackageDir, "package.json"), "utf8"),
+      );
+      expect(pkg.name).toBe("@ansible/ansible-mcp-server");
+      expect(pkg.main).toMatch(/dist\/cli/);
+    });
+
+    it("should have dist/cli.js after build", function () {
+      const cliPath = path.join(mcpPackageDir, "dist", "cli.js");
+      if (!fs.existsSync(cliPath)) {
+        console.warn(
+          "MCP server not built yet (dist/cli.js missing) - run 'pnpm build' first",
+        );
+        return;
+      }
+      expect(fs.statSync(cliPath).isFile()).toBe(true);
+    });
+  });
+});

--- a/test/unit/mcp/mcpProvider.test.ts
+++ b/test/unit/mcp/mcpProvider.test.ts
@@ -218,7 +218,7 @@ describe("AnsibleMcpServerProvider", function () {
       const resolvedServerPath =
         "/mock/extension/path/node_modules/@ansible/ansible-mcp-server/out/server/src/server.js";
       const expectedCliPath =
-        "/mock/extension/path/node_modules/@ansible/ansible-mcp-server/out/server/src/cli.js";
+        "/mock/extension/path/node_modules/@ansible/ansible-mcp-server/out/server/src/cli.cjs";
 
       // Mock require.resolve to return the server module path
       mockRequireResolve.mockReturnValue(resolvedServerPath);
@@ -239,15 +239,39 @@ describe("AnsibleMcpServerProvider", function () {
       );
     });
 
-    it("should return null when package cannot be resolved", function () {
+    it("should return null when package cannot be resolved and no fallback exists", function () {
       // Mock require.resolve to throw (package not found)
       mockRequireResolve.mockImplementation(() => {
         throw new Error("Cannot find module '@ansible/ansible-mcp-server'");
       });
 
+      // No fallback CLI file exists either
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const result = (provider as any).findCliPath();
       expect(result).toBeNull();
+    });
+
+    it("should fall back to packaged extension path when module resolution fails", function () {
+      // Simulate packaged extension: createRequire().resolve() fails
+      mockRequireResolve.mockImplementation(() => {
+        throw new Error("Cannot find module '@ansible/ansible-mcp-server'");
+      });
+
+      const expectedPackagedCliPath = `${mockExtensionPath}/packages/ansible-mcp-server/dist/cli.cjs`;
+
+      // The fallback packaged CLI path exists
+      vi.mocked(fs.existsSync).mockImplementation(
+        (filePath) => filePath.toString() === expectedPackagedCliPath,
+      );
+      vi.mocked(fs.statSync).mockReturnValue({
+        isFile: () => true,
+      } as fs.Stats);
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = (provider as any).findCliPath();
+      expect(result).toBe(expectedPackagedCliPath);
     });
 
     it("should return null when CLI file does not exist at resolved path", function () {
@@ -268,7 +292,7 @@ describe("AnsibleMcpServerProvider", function () {
       const resolvedServerPath =
         "/mock/extension/path/node_modules/@ansible/ansible-mcp-server/out/server/src/server.js";
       const expectedCliPath =
-        "/mock/extension/path/node_modules/@ansible/ansible-mcp-server/out/server/src/cli.js";
+        "/mock/extension/path/node_modules/@ansible/ansible-mcp-server/out/server/src/cli.cjs";
 
       mockRequireResolve.mockReturnValue(resolvedServerPath);
       vi.mocked(fs.existsSync).mockImplementation(
@@ -287,7 +311,7 @@ describe("AnsibleMcpServerProvider", function () {
       const resolvedServerPath =
         "/mock/extension/path/node_modules/@ansible/ansible-mcp-server/out/server/src/server.js";
       const expectedCliPath =
-        "/mock/extension/path/node_modules/@ansible/ansible-mcp-server/out/server/src/cli.js";
+        "/mock/extension/path/node_modules/@ansible/ansible-mcp-server/out/server/src/cli.cjs";
 
       mockRequireResolve.mockReturnValue(resolvedServerPath);
       vi.mocked(fs.existsSync).mockImplementation(

--- a/test/unit/mcp/mcpServerIntegration.test.ts
+++ b/test/unit/mcp/mcpServerIntegration.test.ts
@@ -179,9 +179,7 @@ describe("MCP server integration — packaged extension simulation", function ()
     expect(stderr).not.toContain("Dynamic require");
     expect(initResponses.length).toBeGreaterThanOrEqual(1);
 
-    const initResult = initResponses.find(
-      (msg) => "id" in msg && msg.id === 1,
-    );
+    const initResult = initResponses.find((msg) => "id" in msg && msg.id === 1);
     expect(initResult).toBeDefined();
     expect(initResult).toHaveProperty("result");
 

--- a/test/unit/mcp/mcpServerIntegration.test.ts
+++ b/test/unit/mcp/mcpServerIntegration.test.ts
@@ -86,7 +86,11 @@ describe("MCP server integration — packaged extension simulation", function ()
 
     fs.mkdirSync(distDest, { recursive: true });
     for (const file of fs.readdirSync(distSrc)) {
-      fs.copyFileSync(path.join(distSrc, file), path.join(distDest, file));
+      const srcFile = path.join(distSrc, file);
+      const stat = fs.statSync(srcFile);
+      if (stat.isFile()) {
+        fs.copyFileSync(srcFile, path.join(distDest, file));
+      }
     }
 
     // Copy package.json (needed for module resolution)

--- a/test/unit/mcp/mcpServerIntegration.test.ts
+++ b/test/unit/mcp/mcpServerIntegration.test.ts
@@ -205,6 +205,7 @@ describe("MCP server integration — packaged extension simulation", function ()
     expect(toolResult).toBeDefined();
     expect(toolResult).toHaveProperty("result");
 
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const result = toolResult!.result as { tools: { name: string }[] };
     expect(result.tools).toBeInstanceOf(Array);
     expect(result.tools.length).toBeGreaterThan(0);

--- a/test/unit/mcp/mcpServerIntegration.test.ts
+++ b/test/unit/mcp/mcpServerIntegration.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+import { spawn } from "node:child_process";
+import * as path from "node:path";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import { AnsibleMcpServerProvider } from "@src/utils/mcpProvider";
+
+/**
+ * Send a JSON-RPC message over MCP stdio transport (newline-delimited JSON).
+ */
+function sendMessage(
+  stdin: NodeJS.WritableStream,
+  message: Record<string, unknown>,
+): void {
+  stdin.write(JSON.stringify(message) + "\n");
+}
+
+/**
+ * Read JSON-RPC responses from stdout, collecting all complete messages
+ * within a timeout window.
+ */
+function readMessages(
+  stdout: NodeJS.ReadableStream,
+  timeout: number,
+): Promise<Record<string, unknown>[]> {
+  return new Promise((resolve) => {
+    const messages: Record<string, unknown>[] = [];
+    let buffer = "";
+
+    const onData = (chunk: Buffer) => {
+      buffer += chunk.toString();
+      const lines = buffer.split("\n");
+      buffer = lines.pop() ?? "";
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (trimmed) {
+          try {
+            messages.push(JSON.parse(trimmed));
+          } catch {
+            // skip non-JSON lines
+          }
+        }
+      }
+    };
+
+    stdout.on("data", onData);
+    setTimeout(() => {
+      stdout.removeListener("data", onData);
+      resolve(messages);
+    }, timeout);
+  });
+}
+
+const projectRoot = path.resolve(__dirname, "..", "..", "..");
+const mcpServerSrc = path.join(projectRoot, "packages", "ansible-mcp-server");
+
+describe("MCP server integration — packaged extension simulation", function () {
+  let tempDir: string;
+
+  beforeAll(() => {
+    // Create a temp directory that mimics the packaged vsix layout.
+    // NO node_modules/ — just the files .vscodeignore should whitelist.
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "mcp-vsix-sim-"));
+
+    const distSrc = path.join(mcpServerSrc, "dist");
+    const resourcesSrc = path.join(mcpServerSrc, "src", "resources", "data");
+
+    if (!fs.existsSync(distSrc)) {
+      return;
+    }
+
+    const distDest = path.join(
+      tempDir,
+      "packages",
+      "ansible-mcp-server",
+      "dist",
+    );
+    const resourcesDest = path.join(
+      tempDir,
+      "packages",
+      "ansible-mcp-server",
+      "src",
+      "resources",
+      "data",
+    );
+
+    fs.mkdirSync(distDest, { recursive: true });
+    for (const file of fs.readdirSync(distSrc)) {
+      fs.copyFileSync(path.join(distSrc, file), path.join(distDest, file));
+    }
+
+    // Copy package.json (needed for module resolution)
+    fs.copyFileSync(
+      path.join(mcpServerSrc, "package.json"),
+      path.join(tempDir, "packages", "ansible-mcp-server", "package.json"),
+    );
+
+    // Copy a minimal root package.json so createRequire has an anchor
+    fs.writeFileSync(
+      path.join(tempDir, "package.json"),
+      JSON.stringify({ name: "fake-extension", version: "0.0.1" }),
+    );
+
+    if (fs.existsSync(resourcesSrc)) {
+      fs.mkdirSync(resourcesDest, { recursive: true });
+      for (const file of fs.readdirSync(resourcesSrc)) {
+        fs.copyFileSync(
+          path.join(resourcesSrc, file),
+          path.join(resourcesDest, file),
+        );
+      }
+    }
+  });
+
+  afterAll(() => {
+    if (tempDir && fs.existsSync(tempDir)) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+    vi.restoreAllMocks();
+  });
+
+  it("findCliPath() should resolve the CLI in a packaged extension layout (no node_modules)", function () {
+    if (!fs.existsSync(path.join(mcpServerSrc, "dist", "cli.cjs"))) {
+      console.warn("MCP server not built — skipping");
+      return;
+    }
+
+    // Point the provider at the simulated vsix directory — no node_modules/
+    // exists there, so createRequire().resolve() will fail. The provider
+    // must fall back to the direct packaged path to find the CLI.
+    const provider = new AnsibleMcpServerProvider(tempDir);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const cliPath = (provider as any).findCliPath();
+
+    expect(cliPath).not.toBeNull();
+    expect(cliPath).toContain("cli.cjs");
+    expect(fs.existsSync(cliPath)).toBe(true);
+  });
+
+  it("MCP server should start and list tools from the packaged extension path", async function () {
+    if (!fs.existsSync(path.join(mcpServerSrc, "dist", "cli.cjs"))) {
+      console.warn("MCP server not built — skipping");
+      return;
+    }
+
+    const provider = new AnsibleMcpServerProvider(tempDir);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const cliPath = (provider as any).findCliPath() as string | null;
+
+    // If findCliPath() can't find it, fail immediately — this is the bug
+    expect(cliPath).not.toBeNull();
+    if (!cliPath) return;
+
+    const child = spawn(process.execPath, [cliPath, "--stdio"], {
+      env: { ...process.env, WORKSPACE_ROOT: projectRoot },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    let stderr = "";
+    child.stderr.on("data", (data: Buffer) => {
+      stderr += data.toString();
+    });
+
+    // Step 1: Initialize
+    sendMessage(child.stdin, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-03-26",
+        capabilities: {},
+        clientInfo: { name: "integration-test", version: "0.0.1" },
+      },
+    });
+
+    const initResponses = await readMessages(child.stdout, 3000);
+    expect(stderr).not.toContain("Dynamic require");
+    expect(initResponses.length).toBeGreaterThanOrEqual(1);
+
+    const initResult = initResponses.find(
+      (msg) => "id" in msg && msg.id === 1,
+    );
+    expect(initResult).toBeDefined();
+    expect(initResult).toHaveProperty("result");
+
+    // Step 2: Send initialized notification
+    sendMessage(child.stdin, {
+      jsonrpc: "2.0",
+      method: "notifications/initialized",
+    });
+
+    // Step 3: List tools
+    sendMessage(child.stdin, {
+      jsonrpc: "2.0",
+      id: 2,
+      method: "tools/list",
+    });
+
+    const toolResponses = await readMessages(child.stdout, 3000);
+
+    const toolResult = toolResponses.find(
+      (msg) => "id" in msg && msg.id === 2,
+    ) as Record<string, unknown> | undefined;
+
+    expect(toolResult).toBeDefined();
+    expect(toolResult).toHaveProperty("result");
+
+    const result = toolResult!.result as { tools: { name: string }[] };
+    expect(result.tools).toBeInstanceOf(Array);
+    expect(result.tools.length).toBeGreaterThan(0);
+
+    const toolNames = result.tools.map((t) => t.name);
+    expect(toolNames).toContain("zen_of_ansible");
+
+    child.kill("SIGTERM");
+  });
+});

--- a/test/unit/mcp/mcpStartup.test.ts
+++ b/test/unit/mcp/mcpStartup.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { spawn } from "node:child_process";
+import * as path from "node:path";
+import * as fs from "node:fs";
+
+const projectRoot = path.resolve(__dirname, "..", "..", "..");
+const mcpServerDir = path.join(projectRoot, "packages", "ansible-mcp-server");
+
+describe("MCP server process startup", function () {
+  const cliCjsPath = path.join(mcpServerDir, "dist", "cli.cjs");
+
+  it("should have cli.cjs built", function () {
+    if (!fs.existsSync(cliCjsPath)) {
+      console.warn("cli.cjs not built yet - run 'pnpm build' first");
+      return;
+    }
+    expect(fs.statSync(cliCjsPath).isFile()).toBe(true);
+  });
+
+  it("should start cli.cjs without 'Dynamic require' errors", async function () {
+    if (!fs.existsSync(cliCjsPath)) {
+      console.warn("cli.cjs not built yet - skipping startup test");
+      return;
+    }
+
+    const result = await new Promise<{ exitCode: number; stderr: string }>(
+      (resolve) => {
+        const child = spawn(process.execPath, [cliCjsPath, "--stdio"], {
+          env: { ...process.env, WORKSPACE_ROOT: projectRoot },
+          stdio: ["pipe", "pipe", "pipe"],
+          timeout: 5000,
+        });
+
+        let stderr = "";
+        child.stderr.on("data", (data: Buffer) => {
+          stderr += data.toString();
+        });
+
+        // Send a valid JSON-RPC initialize then close stdin to trigger clean exit
+        child.stdin.write(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "initialize",
+            params: {
+              protocolVersion: "2025-03-26",
+              capabilities: {},
+              clientInfo: { name: "test", version: "0.0.1" },
+            },
+          }) + "\n",
+        );
+
+        setTimeout(() => {
+          child.stdin.end();
+          child.kill("SIGTERM");
+        }, 2000);
+
+        child.on("close", (code) => {
+          resolve({ exitCode: code ?? 1, stderr });
+        });
+      },
+    );
+
+    expect(result.stderr).not.toContain("Dynamic require");
+    expect(result.stderr).not.toContain(
+      'Dynamic require of "process" is not supported',
+    );
+  });
+});


### PR DESCRIPTION
## Purpose

**Tests only — no fixes.** This PR proves the new tests can catch the broken MCP server activation on current main.

### Expected failures

| Test | Why it fails |
|------|-------------|
| `mcpPackaging` — "should whitelist MCP server dist files" | `.vscodeignore` is missing `!packages/ansible-mcp-server/dist/**/*` |
| `mcpPackaging` — "should whitelist MCP server package.json" | `.vscodeignore` is missing `!packages/ansible-mcp-server/package.json` |
| `mcpPackaging` — "should whitelist MCP server resource data files" | `.vscodeignore` is missing `!packages/ansible-mcp-server/src/resources/data/**/*` |
| `mcpProvider` — "should fall back to packaged extension path" | `findCliPath()` has no fallback — returns null when `createRequire` fails |

### Tests that should pass

| Test | Why |
|------|-----|
| `mcpStartup` — "should start cli.cjs without Dynamic require errors" | `cli.cjs` (CJS build) works fine, the crash only happens with `cli.js` (ESM) |
| `mcpProvider` — "should return null when no fallback exists" | Current behavior — returns null on resolution failure |

Once the fix PR #2766 lands, all these tests will pass.