### PR TITLE
feat(als): integrate apme as diagnostics provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,11 @@
         "title": "Migrate with apme"
       },
       {
+        "category": "Ansible",
+        "command": "ansible.apme.restartDaemon",
+        "title": "Restart apme Daemon"
+      },
+      {
         "command": "extension.resync-ansible-inventory",
         "title": "Resync Ansible Inventory"
       },

--- a/package.json
+++ b/package.json
@@ -30,6 +30,11 @@
   "contributes": {
     "commands": [
       {
+        "category": "Ansible",
+        "command": "ansible.apme.migrate",
+        "title": "Migrate with apme"
+      },
+      {
         "command": "extension.resync-ansible-inventory",
         "title": "Resync Ansible Inventory"
       },
@@ -341,6 +346,46 @@
             "markdownDescription": "Path to the ansible-lint executable.",
             "order": 2,
             "scope": "machine-overridable",
+            "type": "string"
+          },
+          "ansible.validation.apme.enabled": {
+            "default": false,
+            "markdownDescription": "Enables `apme` static analysis. Runs alongside ansible-lint when both are enabled.",
+            "order": 5,
+            "scope": "resource",
+            "type": "boolean"
+          },
+          "ansible.validation.apme.path": {
+            "default": "apme",
+            "markdownDescription": "Path to the apme executable.",
+            "order": 6,
+            "scope": "machine-overridable",
+            "type": "string"
+          },
+          "ansible.validation.apme.arguments": {
+            "default": "",
+            "markdownDescription": "Command line arguments to be passed to apme.",
+            "order": 7,
+            "scope": "resource",
+            "type": "string"
+          },
+          "ansible.validation.apme.autoFixOnSave": {
+            "default": false,
+            "markdownDescription": "Specifies whether apme should auto-fix deterministic (Tier 1) violations when you save a file.",
+            "order": 8,
+            "scope": "resource",
+            "type": "boolean"
+          },
+          "ansible.validation.diagnosticPrecedence": {
+            "default": "both",
+            "enum": [
+              "both",
+              "apme",
+              "lint"
+            ],
+            "markdownDescription": "When both apme and ansible-lint report diagnostics on the same line, which tool's diagnostic to keep. `both` shows all diagnostics, `apme` prefers apme, `lint` prefers ansible-lint.",
+            "order": 9,
+            "scope": "resource",
             "type": "string"
           }
         },
@@ -745,6 +790,11 @@
           "command": "extension.buildExecutionEnvironment",
           "group": "navigation",
           "when": "resourceFilename == 'execution-environment.yml' || resourceFilename == 'execution-environment.yaml'"
+        },
+        {
+          "command": "ansible.apme.migrate",
+          "group": "2_main@2",
+          "when": "explorerResourceIsFolder && config.ansible.validation.apme.enabled"
         }
       ],
       "view/title": []

--- a/packages/ansible-language-server/src/ansibleLanguageService.ts
+++ b/packages/ansible-language-server/src/ansibleLanguageService.ts
@@ -8,6 +8,8 @@ import {
   TextDocumentSyncKind,
 } from "vscode-languageserver";
 import { TextDocument } from "vscode-languageserver-textdocument";
+import { URI } from "vscode-uri";
+import { provideCodeActions } from "@src/providers/codeActionProvider.js";
 import {
   doCompletion,
   doCompletionResolve,
@@ -75,6 +77,9 @@ export class AnsibleLanguageService {
             },
           },
           hoverProvider: true,
+          codeActionProvider: {
+            codeActionKinds: ["quickfix"],
+          },
           completionProvider: {
             resolveProvider: true,
           },
@@ -139,6 +144,39 @@ export class AnsibleLanguageService {
               "will require a server restart to take effect.",
           );
         });
+
+      // Trigger async workspace-level apme scan on startup
+      this.triggerApmeWorkspaceScan();
+    });
+  }
+
+  private triggerApmeWorkspaceScan(): void {
+    this.workspaceManager.forEachContext(async (context) => {
+      try {
+        const settings = await context.documentSettings.get(
+          context.workspaceFolder.uri,
+        );
+        if (!settings.validation?.enabled || !settings.validation?.apme?.enabled) {
+          return;
+        }
+        this.connection.console.log(
+          "[apme] Triggering workspace scan on startup...",
+        );
+        const diagnosticsByFile =
+          await context.ansibleApme.doValidateWorkspace();
+
+        for (const [fileUri, fileDiagnostics] of diagnosticsByFile) {
+          this.connection.sendDiagnostics({
+            uri: fileUri,
+            diagnostics: fileDiagnostics,
+          });
+        }
+        this.connection.console.log(
+          `[apme] Workspace scan complete: ${diagnosticsByFile.size} file(s) with violations`,
+        );
+      } catch (error) {
+        this.handleError(error, "apmeWorkspaceScan");
+      }
     });
   }
 
@@ -357,6 +395,68 @@ export class AnsibleLanguageService {
       }
       return null;
     });
+
+    this.connection.onCodeAction(async (params) => {
+      try {
+        const context = this.workspaceManager.getContext(
+          params.textDocument.uri,
+        );
+        return await provideCodeActions(params, context, this.connection);
+      } catch (error) {
+        this.handleError(error, "onCodeAction");
+        return [];
+      }
+    });
+
+    this.connection.onRequest(
+      "ansible/apme/remediate",
+      async (filePath: string): Promise<{ success: boolean; filesUpdated: number }> => {
+        try {
+          const fileUri = `file://${filePath}`;
+          const context = this.workspaceManager.getContext(fileUri);
+          if (!context) {
+            return { success: false, filesUpdated: 0 };
+          }
+          const result = await context.ansibleApme.doRemediate(filePath);
+
+          if (result.success) {
+            const document = this.documents.get(fileUri);
+            if (document) {
+              await doValidate(
+                document,
+                this.validationManager,
+                false,
+                context,
+                this.connection,
+                this.schemaService,
+              );
+            }
+          }
+          return result;
+        } catch (error) {
+          this.handleError(error, "ansible/apme/remediate");
+          return { success: false, filesUpdated: 0 };
+        }
+      },
+    );
+
+    this.connection.onRequest(
+      "ansible/apme/remediateWorkspace",
+      async (): Promise<{ success: boolean; filesUpdated: number }> => {
+        try {
+          let totalUpdated = 0;
+          await this.workspaceManager.forEachContext(async (context) => {
+            const workspacePath = URI.parse(context.workspaceFolder.uri).path;
+            const result = await context.ansibleApme.doRemediate(workspacePath);
+            totalUpdated += result.filesUpdated;
+          });
+          return { success: true, filesUpdated: totalUpdated };
+        } catch (error) {
+          this.handleError(error, "ansible/apme/remediateWorkspace");
+          return { success: false, filesUpdated: 0 };
+        }
+      },
+    );
 
     // Custom actions that are performed on receiving special notifications from the client
     // Resync ansible inventory service by clearing the cached items

--- a/packages/ansible-language-server/src/ansibleLanguageService.ts
+++ b/packages/ansible-language-server/src/ansibleLanguageService.ts
@@ -58,7 +58,26 @@ export class AnsibleLanguageService {
 
   private initializeConnection() {
     this.connection.onInitialize((params: InitializeParams) => {
-      this.workspaceManager.setWorkspaceFolders(params.workspaceFolders || []);
+      this.connection.console.log(
+        `[debug] onInitialize: workspaceFolders=${JSON.stringify(params.workspaceFolders)}`,
+      );
+      this.connection.console.log(
+        `[debug] onInitialize: capabilities.workspace.configuration=${params.capabilities?.workspace?.configuration}`,
+      );
+      this.connection.console.log(
+        `[debug] onInitialize: capabilities.workspace.workspaceFolders=${JSON.stringify(params.capabilities?.workspace?.workspaceFolders)}`,
+      );
+      this.connection.console.log(
+        `[debug] onInitialize: initializationOptions=${JSON.stringify(params.initializationOptions)}`,
+      );
+      let workspaceFolders = params.workspaceFolders || [];
+      if (workspaceFolders.length === 0 && params.rootUri) {
+        this.connection.console.log(
+          `[debug] No workspaceFolders provided, falling back to rootUri: ${params.rootUri}`,
+        );
+        workspaceFolders = [{ uri: params.rootUri, name: "root" }];
+      }
+      this.workspaceManager.setWorkspaceFolders(workspaceFolders);
       this.workspaceManager.setCapabilities(params.capabilities);
 
       const result: InitializeResult = {
@@ -101,6 +120,7 @@ export class AnsibleLanguageService {
     });
 
     this.connection.onInitialized(() => {
+      this.connection.console.log("[debug] onInitialized fired");
       if (this.workspaceManager.clientCapabilities.workspace?.configuration) {
         this.connection.client
           .register(DidChangeConfigurationNotification.type, {
@@ -151,7 +171,7 @@ export class AnsibleLanguageService {
   }
 
   private triggerApmeWorkspaceScan(): void {
-    this.workspaceManager.forEachContext(async (context) => {
+    this.workspaceManager.forEachWorkspaceFolder(async (context) => {
       try {
         const settings = await context.documentSettings.get(
           context.workspaceFolder.uri,
@@ -159,6 +179,14 @@ export class AnsibleLanguageService {
         if (!settings.validation?.enabled || !settings.validation?.apme?.enabled) {
           return;
         }
+
+        const started = await context.apmeDaemonManager.startDaemon();
+        if (!started) {
+          this.connection.console.warn(
+            "[apme] Daemon failed to start; workspace scan may fail",
+          );
+        }
+
         this.connection.console.log(
           "[apme] Triggering workspace scan on startup...",
         );
@@ -412,7 +440,7 @@ export class AnsibleLanguageService {
       "ansible/apme/remediate",
       async (filePath: string): Promise<{ success: boolean; filesUpdated: number }> => {
         try {
-          const fileUri = `file://${filePath}`;
+          const fileUri = URI.file(filePath).toString();
           const context = this.workspaceManager.getContext(fileUri);
           if (!context) {
             return { success: false, filesUpdated: 0 };
@@ -430,6 +458,16 @@ export class AnsibleLanguageService {
                 this.connection,
                 this.schemaService,
               );
+            }
+            if (result.filesUpdated > 1) {
+              const wsDiags =
+                await context.ansibleApme.doValidateWorkspace();
+              for (const [uri, diags] of wsDiags) {
+                this.connection.sendDiagnostics({
+                  uri,
+                  diagnostics: diags,
+                });
+              }
             }
           }
           return result;
@@ -457,6 +495,41 @@ export class AnsibleLanguageService {
         }
       },
     );
+
+    this.connection.onRequest(
+      "ansible/apme/restartDaemon",
+      async (): Promise<{ success: boolean; message: string }> => {
+        try {
+          let allRestarted = true;
+          await this.workspaceManager.forEachContext(async (context) => {
+            const settings = await context.documentSettings.get(
+              context.workspaceFolder.uri,
+            );
+            if (settings.validation?.apme?.enabled) {
+              const restarted =
+                await context.apmeDaemonManager.restartDaemon();
+              if (!restarted) allRestarted = false;
+            }
+          });
+          return {
+            success: allRestarted,
+            message: allRestarted
+              ? "Daemon restarted successfully"
+              : "Daemon restart failed",
+          };
+        } catch (error) {
+          this.handleError(error, "ansible/apme/restartDaemon");
+          return {
+            success: false,
+            message:
+              error instanceof Error ? error.message : String(error),
+          };
+        }
+      },
+    );
+
+    // apme daemon persists across editor sessions (startup is expensive ~10s).
+    // Use "Ansible: Restart apme Daemon" command to restart it explicitly.
 
     // Custom actions that are performed on receiving special notifications from the client
     // Resync ansible inventory service by clearing the cached items

--- a/packages/ansible-language-server/src/interfaces/extensionSettings.ts
+++ b/packages/ansible-language-server/src/interfaces/extensionSettings.ts
@@ -38,6 +38,13 @@ export interface ExtensionSettings extends ExtensionSettingsType {
       arguments: string;
       autoFixOnSave: boolean;
     };
+    apme: {
+      enabled: boolean;
+      path: string;
+      arguments: string;
+      autoFixOnSave: boolean;
+    };
+    diagnosticPrecedence: "both" | "apme" | "lint";
   };
   executionEnvironment: {
     enabled: boolean;
@@ -165,5 +172,27 @@ interface ValidationSettingsWithDescription extends SettingsEntry {
       default: boolean;
       description: string;
     };
+  };
+  apme: {
+    enabled: {
+      default: boolean;
+      description: string;
+    };
+    path: {
+      default: string;
+      description: string;
+    };
+    arguments: {
+      default: string;
+      description: string;
+    };
+    autoFixOnSave: {
+      default: boolean;
+      description: string;
+    };
+  };
+  diagnosticPrecedence: {
+    default: string;
+    description: string;
   };
 }

--- a/packages/ansible-language-server/src/interfaces/extensionSettings.ts
+++ b/packages/ansible-language-server/src/interfaces/extensionSettings.ts
@@ -15,6 +15,7 @@ interface ExtensionSettingsType {
     | ExtensionSettingsType
     | string
     | boolean
+    | number
     | string[]
     | IContainerEngine
     | IPullPolicy
@@ -43,6 +44,7 @@ export interface ExtensionSettings extends ExtensionSettingsType {
       path: string;
       arguments: string;
       autoFixOnSave: boolean;
+      timeout: number;
     };
     diagnosticPrecedence: "both" | "apme" | "lint";
   };
@@ -69,12 +71,13 @@ export interface IVolumeMounts {
 export interface SettingsEntry {
   [name: string]:
     | {
-        default: string | boolean;
+        default: string | boolean | number;
         description: string;
       }
     | SettingsEntry
     | string
     | boolean
+    | number
     | Array<IVolumeMounts>;
 }
 
@@ -188,6 +191,10 @@ interface ValidationSettingsWithDescription extends SettingsEntry {
     };
     autoFixOnSave: {
       default: boolean;
+      description: string;
+    };
+    timeout: {
+      default: number;
       description: string;
     };
   };

--- a/packages/ansible-language-server/src/providers/codeActionProvider.ts
+++ b/packages/ansible-language-server/src/providers/codeActionProvider.ts
@@ -21,7 +21,8 @@ export async function provideCodeActions(
   const apmeFixableDiagnostics = params.context.diagnostics.filter(
     (d) =>
       d.source === "Ansible [apme]" &&
-      d.data &&
+      d.data != null &&
+      typeof d.data === "object" &&
       (d.data as { fixable?: boolean }).fixable === true,
   );
 

--- a/packages/ansible-language-server/src/providers/codeActionProvider.ts
+++ b/packages/ansible-language-server/src/providers/codeActionProvider.ts
@@ -1,0 +1,46 @@
+import {
+  CodeAction,
+  CodeActionKind,
+  CodeActionParams,
+  Command,
+  Connection,
+  Diagnostic,
+} from "vscode-languageserver";
+import { WorkspaceFolderContext } from "@src/services/workspaceManager.js";
+import { URI } from "vscode-uri";
+
+export async function provideCodeActions(
+  params: CodeActionParams,
+  context: WorkspaceFolderContext | undefined,
+  connection: Connection,
+): Promise<(CodeAction | Command)[]> {
+  if (!context) {
+    return [];
+  }
+
+  const apmeFixableDiagnostics = params.context.diagnostics.filter(
+    (d) =>
+      d.source === "Ansible [apme]" &&
+      d.data &&
+      (d.data as { fixable?: boolean }).fixable === true,
+  );
+
+  if (apmeFixableDiagnostics.length === 0) {
+    return [];
+  }
+
+  const docPath = URI.parse(params.textDocument.uri).path;
+
+  const codeAction: CodeAction = {
+    title: `Fix all apme violations (${apmeFixableDiagnostics.length} fixable)`,
+    kind: CodeActionKind.QuickFix,
+    diagnostics: apmeFixableDiagnostics,
+    command: {
+      title: "Fix all apme violations",
+      command: "ansible.apme.remediate",
+      arguments: [docPath],
+    },
+  };
+
+  return [codeAction];
+}

--- a/packages/ansible-language-server/src/providers/validationProvider.ts
+++ b/packages/ansible-language-server/src/providers/validationProvider.ts
@@ -42,6 +42,9 @@ export async function doValidate(
     // full validation with ansible-lint or ansible syntax-check (if ansible-lint is not installed or disabled)
 
     const settings = await context.documentSettings.get(textDocument.uri);
+    connection?.console.log(
+      `[debug] doValidate: uri=${textDocument.uri} quick=${quick} validation.enabled=${settings.validation.enabled} lint.enabled=${settings.validation.lint.enabled} apme.enabled=${settings.validation.apme?.enabled} apme.path=${settings.validation.apme?.path}`,
+    );
     if (!settings.validation.enabled) {
       connection?.console.log("Validation disabled");
 
@@ -65,7 +68,15 @@ export async function doValidate(
 
       if (lintAvailability) {
         connection?.console.log("Validating using ansible-lint");
+        connection?.sendNotification("ansible/apme/scanStatus", {
+          scanning: true,
+          tool: "ansible-lint",
+        });
         diagnosticsByFile = await context.ansibleLint.doValidate(textDocument);
+        connection?.sendNotification("ansible/apme/scanStatus", {
+          scanning: false,
+          tool: "ansible-lint",
+        });
       } else {
         connection?.window.showErrorMessage(
           "Ansible-lint is not available. Kindly check the path or disable validation using ansible-lint",
@@ -221,7 +232,7 @@ async function getSchemaValidation(
   }
 }
 
-function mergeDiagnostics(
+export function mergeDiagnostics(
   lintDiagnostics: Map<string, Diagnostic[]>,
   apmeDiagnostics: Map<string, Diagnostic[]>,
   precedence: "both" | "apme" | "lint",

--- a/packages/ansible-language-server/src/providers/validationProvider.ts
+++ b/packages/ansible-language-server/src/providers/validationProvider.ts
@@ -87,6 +87,32 @@ export async function doValidate(
       }
     }
 
+    // validation using apme (runs alongside lint, not as fallback)
+    if (settings.validation.apme?.enabled) {
+      const commandRunner = new CommandRunner(connection, context, settings);
+      const apmeExecutable = settings.executionEnvironment.enabled
+        ? "apme"
+        : settings.validation.apme.path;
+      const apmeAvailability =
+        await commandRunner.getExecutablePath(apmeExecutable);
+
+      if (apmeAvailability) {
+        connection?.console.log("Validating using apme");
+        const apmeDiagnostics =
+          await context.ansibleApme.doValidate(textDocument);
+
+        diagnosticsByFile = mergeDiagnostics(
+          diagnosticsByFile,
+          apmeDiagnostics,
+          settings.validation.diagnosticPrecedence ?? "both",
+        );
+      } else {
+        connection?.console.log(
+          "apme is not available. Install apme or disable apme validation.",
+        );
+      }
+    }
+
     if (!diagnosticsByFile.has(textDocument.uri)) {
       // In case there are no diagnostics for the file that triggered the
       // validation, set an empty array in order to clear the validation.
@@ -193,4 +219,65 @@ async function getSchemaValidation(
     connection?.console.error(`Schema validation error: ${err}`);
     return [];
   }
+}
+
+function mergeDiagnostics(
+  lintDiagnostics: Map<string, Diagnostic[]>,
+  apmeDiagnostics: Map<string, Diagnostic[]>,
+  precedence: "both" | "apme" | "lint",
+): Map<string, Diagnostic[]> {
+  if (precedence === "both") {
+    for (const [fileUri, apmeFileDiags] of apmeDiagnostics) {
+      const existing = lintDiagnostics.get(fileUri) ?? [];
+      existing.push(...apmeFileDiags);
+      lintDiagnostics.set(fileUri, existing);
+    }
+    return lintDiagnostics;
+  }
+
+  const merged = new Map<string, Diagnostic[]>();
+
+  const allFileUris = new Set([
+    ...lintDiagnostics.keys(),
+    ...apmeDiagnostics.keys(),
+  ]);
+
+  for (const fileUri of allFileUris) {
+    const lintFileDiags = lintDiagnostics.get(fileUri) ?? [];
+    const apmeFileDiags = apmeDiagnostics.get(fileUri) ?? [];
+
+    if (lintFileDiags.length === 0) {
+      merged.set(fileUri, apmeFileDiags);
+      continue;
+    }
+    if (apmeFileDiags.length === 0) {
+      merged.set(fileUri, lintFileDiags);
+      continue;
+    }
+
+    const apmeLines = new Set(apmeFileDiags.map((d) => d.range.start.line));
+    const lintLines = new Set(lintFileDiags.map((d) => d.range.start.line));
+
+    const result: Diagnostic[] = [];
+
+    if (precedence === "apme") {
+      result.push(...apmeFileDiags);
+      for (const d of lintFileDiags) {
+        if (!apmeLines.has(d.range.start.line)) {
+          result.push(d);
+        }
+      }
+    } else {
+      result.push(...lintFileDiags);
+      for (const d of apmeFileDiags) {
+        if (!lintLines.has(d.range.start.line)) {
+          result.push(d);
+        }
+      }
+    }
+
+    merged.set(fileUri, result);
+  }
+
+  return merged;
 }

--- a/packages/ansible-language-server/src/services/ansibleApme.ts
+++ b/packages/ansible-language-server/src/services/ansibleApme.ts
@@ -43,6 +43,13 @@ export class AnsibleApme {
   private context: WorkspaceFolderContext;
   private useProgressTracker = false;
   private remediationInFlight: Set<string> = new Set();
+  private workspaceScanInFlight: Promise<Map<string, Diagnostic[]>> | null =
+    null;
+  private cachedDiagnostics: Map<string, Diagnostic[]> | null = null;
+  private scanDebounceTimer: ReturnType<typeof setTimeout> | undefined;
+  private pendingScanResolvers: Array<{
+    resolve: (v: Map<string, Diagnostic[]>) => void;
+  }> = [];
 
   constructor(connection: Connection, context: WorkspaceFolderContext) {
     this.connection = connection;
@@ -54,97 +61,92 @@ export class AnsibleApme {
   public async doValidate(
     textDocument: TextDocument,
   ): Promise<Map<string, Diagnostic[]>> {
-    const diagnostics: Map<string, Diagnostic[]> = new Map();
+    const docUri = textDocument.uri;
+
+    // If a project scan is already running, wait for it
+    if (this.workspaceScanInFlight) {
+      this.connection.console.log(
+        "[apme] Project scan in progress, waiting for results...",
+      );
+      const wsResults = await this.workspaceScanInFlight;
+      return this.extractFileResults(docUri, wsResults);
+    }
+
     const settings = await this.context.documentSettings.get(textDocument.uri);
-
     if (!settings.validation?.enabled || !settings.validation?.apme?.enabled) {
-      this.connection.console.log("[apme] Validation disabled, skipping");
-      return diagnostics;
-    }
-
-    const docPath = URI.parse(textDocument.uri).path;
-    const workingDirectory = URI.parse(this.context.workspaceFolder.uri).path;
-    const mountPaths = new Set([workingDirectory, path.dirname(docPath)]);
-
-    this.connection.console.log(`[apme] Validating file: ${docPath}`);
-
-    let apmeArguments = settings.validation.apme.arguments ?? "";
-    apmeArguments = `check "${docPath}" --json ${apmeArguments}`;
-
-    if (settings.validation.apme.autoFixOnSave) {
-      if (this.remediationInFlight.has(docPath)) {
-        this.connection.console.log(
-          `[apme] Skipping auto-fix: remediation already in flight for ${docPath}`,
-        );
-        return diagnostics;
-      }
-      return this.doRemediateAndValidate(textDocument);
-    }
-
-    const progressTracker = this.useProgressTracker
-      ? await this.connection.window.createWorkDoneProgress()
-      : { begin: () => {}, done: () => {} };
-
-    progressTracker.begin("apme", undefined, "Checking...");
-
-    const commandRunner = new CommandRunner(
-      this.connection,
-      this.context,
-      settings,
-    );
-
-    const apmeExecutable = settings.executionEnvironment.enabled
-      ? "apme"
-      : settings.validation.apme.path;
-
-    try {
-      this.connection.console.log(
-        `[apme] Running: ${apmeExecutable} ${apmeArguments}`,
-      );
-      const result = await commandRunner.runCommand(
-        apmeExecutable,
-        apmeArguments,
-        workingDirectory,
-        mountPaths,
-      );
-
-      const diagnosticResult = this.parseApmeOutput(result.stdout, workingDirectory);
-      this.connection.console.log(
-        `[apme] Check complete: ${this.countDiagnostics(diagnosticResult)} violation(s) found`,
-      );
-      return diagnosticResult;
-    } catch (error) {
-      if (error instanceof Error) {
-        const execError = error as ExecException & {
-          stdout: string;
-          stderr: string;
-        };
-
-        // Exit code 1 = violations found (not an error)
-        if (execError.stdout) {
-          const diagnosticResult = this.parseApmeOutput(execError.stdout, workingDirectory);
-          this.connection.console.log(
-            `[apme] Check complete (exit 1): ${this.countDiagnostics(diagnosticResult)} violation(s) found`,
-          );
-          return diagnosticResult;
-        }
-
-        if (execError.stderr) {
-          this.connection.console.warn(`[apme] stderr: ${execError.stderr}`);
-        }
-        this.connection.console.error(`[apme] Command failed: ${execError.message}`);
-      } else {
-        this.connection.console.error(
-          `[apme] Unexpected error: ${JSON.stringify(error)}`,
-        );
-      }
       return new Map();
+    }
+
+    // Return cached results immediately and schedule a background re-scan
+    if (this.cachedDiagnostics) {
+      this.connection.console.log(
+        "[apme] Returning cached diagnostics, scheduling background re-scan...",
+      );
+      this.scheduleProjectScan();
+      return this.extractFileResults(docUri, this.cachedDiagnostics);
+    }
+
+    // No cache, no scan in flight — run a full project scan now
+    return this.extractFileResults(docUri, await this.runProjectScan());
+  }
+
+  private scheduleProjectScan(): void {
+    if (this.scanDebounceTimer) clearTimeout(this.scanDebounceTimer);
+    this.scanDebounceTimer = setTimeout(() => {
+      this.scanDebounceTimer = undefined;
+      this.runProjectScan().then((results) => {
+        // Publish updated diagnostics for all files with violations
+        for (const [fileUri, fileDiags] of results) {
+          this.connection.sendDiagnostics({
+            uri: fileUri,
+            diagnostics: fileDiags,
+          });
+        }
+        // Clear diagnostics for files that no longer have violations
+        if (this.cachedDiagnostics) {
+          for (const prevUri of this.cachedDiagnostics.keys()) {
+            if (!results.has(prevUri)) {
+              this.connection.sendDiagnostics({
+                uri: prevUri,
+                diagnostics: [],
+              });
+            }
+          }
+        }
+        this.connection.console.log(
+          `[apme] Background re-scan complete: ${this.countDiagnostics(results)} violation(s)`,
+        );
+      });
+    }, 2000);
+  }
+
+  private async runProjectScan(): Promise<Map<string, Diagnostic[]>> {
+    if (this.workspaceScanInFlight) {
+      return this.workspaceScanInFlight;
+    }
+
+    this.connection.sendNotification("ansible/apme/scanStatus", {
+      scanning: true,
+      tool: "apme",
+    });
+
+    const scanPromise = this._runProjectScanInternal();
+    this.workspaceScanInFlight = scanPromise;
+    try {
+      const result = await scanPromise;
+      this.cachedDiagnostics = result;
+      return result;
     } finally {
-      progressTracker.done();
+      this.workspaceScanInFlight = null;
+      this.connection.sendNotification("ansible/apme/scanStatus", {
+        scanning: false,
+        tool: "apme",
+        violations: this.countDiagnostics(this.cachedDiagnostics ?? new Map()),
+      });
     }
   }
 
-  public async doValidateWorkspace(): Promise<Map<string, Diagnostic[]>> {
+  private async _runProjectScanInternal(): Promise<Map<string, Diagnostic[]>> {
     const workspaceUri = this.context.workspaceFolder.uri;
     const settings = await this.context.documentSettings.get(workspaceUri);
 
@@ -153,19 +155,10 @@ export class AnsibleApme {
     }
 
     const workingDirectory = URI.parse(workspaceUri).path;
-    this.connection.console.log(
-      `[apme] Starting workspace scan: ${workingDirectory}`,
-    );
     const mountPaths = new Set([workingDirectory]);
 
     let apmeArguments = settings.validation.apme.arguments ?? "";
     apmeArguments = `check "${workingDirectory}" --json ${apmeArguments}`;
-
-    const progressTracker = this.useProgressTracker
-      ? await this.connection.window.createWorkDoneProgress()
-      : { begin: () => {}, done: () => {} };
-
-    progressTracker.begin("apme", undefined, "Scanning workspace...");
 
     const commandRunner = new CommandRunner(
       this.connection,
@@ -177,32 +170,104 @@ export class AnsibleApme {
       ? "apme"
       : settings.validation.apme.path;
 
+    const timeoutMs =
+      (settings.validation.apme.timeout ?? 120) * 1000 || undefined;
+
     try {
+      this.connection.console.log(
+        `[apme] Running project scan: ${apmeExecutable} ${apmeArguments}`,
+      );
       const result = await commandRunner.runCommand(
         apmeExecutable,
         apmeArguments,
         workingDirectory,
         mountPaths,
+        timeoutMs,
       );
 
-      return this.parseApmeOutput(result.stdout, workingDirectory);
+      const diagnosticResult = this.parseApmeOutput(
+        result.stdout,
+        workingDirectory,
+      );
+      this.connection.console.log(
+        `[apme] Project scan complete: ${this.countDiagnostics(diagnosticResult)} violation(s) found`,
+      );
+      return diagnosticResult;
     } catch (error) {
       if (error instanceof Error) {
         const execError = error as ExecException & {
           stdout: string;
           stderr: string;
         };
-
         if (execError.stdout) {
-          return this.parseApmeOutput(execError.stdout, workingDirectory);
+          const diagnosticResult = this.parseApmeOutput(
+            execError.stdout,
+            workingDirectory,
+          );
+          this.connection.console.log(
+            `[apme] Project scan complete (exit 1): ${this.countDiagnostics(diagnosticResult)} violation(s) found`,
+          );
+          return diagnosticResult;
         }
-
-        this.connection.console.error(`[apme] Workspace scan error: ${execError.message}`);
+        this.connection.console.error(
+          `[apme] Project scan failed: ${execError.message}`,
+        );
       }
-      return new Map();
-    } finally {
-      progressTracker.done();
+
+      if (this.context.apmeDaemonManager.isDaemonCrashError(error)) {
+        this.connection.console.warn(
+          "[apme] Detected daemon crash, attempting restart and retry...",
+        );
+        const restarted = await this.context.apmeDaemonManager.restartDaemon();
+        if (restarted) {
+          try {
+            const retryResult = await commandRunner.runCommand(
+              apmeExecutable,
+              apmeArguments,
+              workingDirectory,
+              mountPaths,
+              timeoutMs,
+            );
+            return this.parseApmeOutput(retryResult.stdout, workingDirectory);
+          } catch (retryError) {
+            if (retryError instanceof Error) {
+              const retryExec = retryError as ExecException & {
+                stdout: string;
+              };
+              if (retryExec.stdout) {
+                return this.parseApmeOutput(
+                  retryExec.stdout,
+                  workingDirectory,
+                );
+              }
+            }
+          }
+        }
+      }
+
+      return this.cachedDiagnostics ?? new Map();
     }
+  }
+
+  private extractFileResults(
+    docUri: string,
+    allResults: Map<string, Diagnostic[]>,
+  ): Map<string, Diagnostic[]> {
+    const result: Map<string, Diagnostic[]> = new Map();
+    const fileDiags = allResults.get(docUri);
+    result.set(docUri, fileDiags ?? []);
+    return result;
+  }
+
+  public async doValidateWorkspace(): Promise<Map<string, Diagnostic[]>> {
+    const daemonReady = await this.context.apmeDaemonManager.ensureHealthy();
+    if (!daemonReady) {
+      this.connection.console.error(
+        "[apme] Daemon is unhealthy and could not be restarted; skipping workspace scan",
+      );
+      return new Map();
+    }
+    return this.runProjectScan();
   }
 
   public async doRemediate(
@@ -218,30 +283,34 @@ export class AnsibleApme {
     this.connection.console.log(`[apme] Starting remediation: ${filePath}`);
     this.remediationInFlight.add(filePath);
 
+    const workspaceUri = this.context.workspaceFolder.uri;
+    const settings = await this.context.documentSettings.get(workspaceUri);
+    const workingDirectory = URI.parse(workspaceUri).path;
+    const mountPaths = new Set([workingDirectory, path.dirname(filePath)]);
+
+    let apmeArguments = settings.validation.apme.arguments ?? "";
+    apmeArguments = `remediate "${filePath}" --json ${apmeArguments}`;
+
+    const commandRunner = new CommandRunner(
+      this.connection,
+      this.context,
+      settings,
+    );
+
+    const apmeExecutable = settings.executionEnvironment.enabled
+      ? "apme"
+      : settings.validation.apme.path;
+
+    const timeoutMs =
+      (settings.validation.apme.timeout ?? 120) * 1000 || undefined;
+
     try {
-      const workspaceUri = this.context.workspaceFolder.uri;
-      const settings = await this.context.documentSettings.get(workspaceUri);
-      const workingDirectory = URI.parse(workspaceUri).path;
-      const mountPaths = new Set([workingDirectory, path.dirname(filePath)]);
-
-      let apmeArguments = settings.validation.apme.arguments ?? "";
-      apmeArguments = `remediate "${filePath}" --json ${apmeArguments}`;
-
-      const commandRunner = new CommandRunner(
-        this.connection,
-        this.context,
-        settings,
-      );
-
-      const apmeExecutable = settings.executionEnvironment.enabled
-        ? "apme"
-        : settings.validation.apme.path;
-
       const result = await commandRunner.runCommand(
         apmeExecutable,
         apmeArguments,
         workingDirectory,
         mountPaths,
+        timeoutMs,
       );
 
       try {
@@ -259,7 +328,6 @@ export class AnsibleApme {
           stdout: string;
           stderr: string;
         };
-        // Exit code 1 = remaining violations (remediation ran but didn't fix everything)
         if (execError.stdout) {
           try {
             const output = JSON.parse(execError.stdout);
@@ -271,8 +339,42 @@ export class AnsibleApme {
             // fall through
           }
         }
-        this.connection.console.error(`[apme] Remediation error: ${execError.message}`);
+        this.connection.console.error(
+          `[apme] Remediation error: ${execError.message}`,
+        );
       }
+
+      if (this.context.apmeDaemonManager.isDaemonCrashError(error)) {
+        this.connection.console.warn(
+          "[apme] Detected daemon crash during remediation, attempting restart...",
+        );
+        const restarted = await this.context.apmeDaemonManager.restartDaemon();
+        if (restarted) {
+          try {
+            const retryResult = await commandRunner.runCommand(
+              apmeExecutable,
+              apmeArguments,
+              workingDirectory,
+              mountPaths,
+              timeoutMs,
+            );
+            try {
+              const output = JSON.parse(retryResult.stdout);
+              return {
+                success: true,
+                filesUpdated: output.files_updated ?? 0,
+              };
+            } catch {
+              return { success: true, filesUpdated: 0 };
+            }
+          } catch {
+            this.connection.console.error(
+              "[apme] Remediation retry after daemon restart also failed",
+            );
+          }
+        }
+      }
+
       return { success: false, filesUpdated: 0 };
     } finally {
       this.remediationInFlight.delete(filePath);
@@ -303,12 +405,16 @@ export class AnsibleApme {
       ? "apme"
       : settings.validation.apme.path;
 
+    const timeoutMs =
+      (settings.validation.apme.timeout ?? 120) * 1000 || undefined;
+
     try {
       const result = await commandRunner.runCommand(
         apmeExecutable,
         apmeArguments,
         workingDirectory,
         mountPaths,
+        timeoutMs,
       );
       return this.parseApmeOutput(result.stdout, workingDirectory);
     } catch (error) {
@@ -406,10 +512,19 @@ export class AnsibleApme {
           },
         });
       }
+
+      // Log remediation summary so users see what apme can auto-fix
+      const summary = output.remediation_summary;
+      if (summary && (summary.auto_fixable > 0 || summary.ai_candidate > 0)) {
+        this.connection.console.log(
+          `[apme] Remediation summary: ${summary.auto_fixable} auto-fixable, ` +
+            `${summary.ai_candidate} AI-candidate, ${summary.manual_review} manual-review`,
+        );
+      }
     } catch (error) {
       this.connection.console.error(
         `[apme] Failed to parse output: ${error instanceof Error ? error.message : String(error)}` +
-          `\nTried to parse:\n${stdout.substring(0, 500)}`,
+          `\nTried to parse:\n${stdout.substring(0, 2000)}`,
       );
     }
 

--- a/packages/ansible-language-server/src/services/ansibleApme.ts
+++ b/packages/ansible-language-server/src/services/ansibleApme.ts
@@ -1,0 +1,426 @@
+import { ExecException } from "child_process";
+import * as path from "path";
+import { URI } from "vscode-uri";
+import {
+  Connection,
+  Diagnostic,
+  DiagnosticSeverity,
+  integer,
+  Position,
+  Range,
+} from "vscode-languageserver";
+import { TextDocument } from "vscode-languageserver-textdocument";
+import { WorkspaceFolderContext } from "@src/services/workspaceManager.js";
+import { CommandRunner } from "@src/utils/commandRunner.js";
+
+interface ApmeViolation {
+  rule_id: string;
+  severity: string;
+  message: string;
+  file: string;
+  line: number;
+  path?: string;
+  remediation_class?: string;
+  remediation_resolution?: string;
+  scope?: string;
+}
+
+interface ApmeCheckOutput {
+  violations: ApmeViolation[];
+  count: number;
+  scan_id?: string;
+  remediation_summary?: {
+    auto_fixable: number;
+    ai_candidate: number;
+    manual_review: number;
+  };
+  diffs?: Array<{ path: string; diff: string }>;
+  files_updated?: number;
+}
+
+export class AnsibleApme {
+  private connection: Connection;
+  private context: WorkspaceFolderContext;
+  private useProgressTracker = false;
+  private remediationInFlight: Set<string> = new Set();
+
+  constructor(connection: Connection, context: WorkspaceFolderContext) {
+    this.connection = connection;
+    this.context = context;
+    this.useProgressTracker =
+      !!context.clientCapabilities.window?.workDoneProgress;
+  }
+
+  public async doValidate(
+    textDocument: TextDocument,
+  ): Promise<Map<string, Diagnostic[]>> {
+    const diagnostics: Map<string, Diagnostic[]> = new Map();
+    const settings = await this.context.documentSettings.get(textDocument.uri);
+
+    if (!settings.validation?.enabled || !settings.validation?.apme?.enabled) {
+      this.connection.console.log("[apme] Validation disabled, skipping");
+      return diagnostics;
+    }
+
+    const docPath = URI.parse(textDocument.uri).path;
+    const workingDirectory = URI.parse(this.context.workspaceFolder.uri).path;
+    const mountPaths = new Set([workingDirectory, path.dirname(docPath)]);
+
+    this.connection.console.log(`[apme] Validating file: ${docPath}`);
+
+    let apmeArguments = settings.validation.apme.arguments ?? "";
+    apmeArguments = `check "${docPath}" --json ${apmeArguments}`;
+
+    if (settings.validation.apme.autoFixOnSave) {
+      if (this.remediationInFlight.has(docPath)) {
+        this.connection.console.log(
+          `[apme] Skipping auto-fix: remediation already in flight for ${docPath}`,
+        );
+        return diagnostics;
+      }
+      return this.doRemediateAndValidate(textDocument);
+    }
+
+    const progressTracker = this.useProgressTracker
+      ? await this.connection.window.createWorkDoneProgress()
+      : { begin: () => {}, done: () => {} };
+
+    progressTracker.begin("apme", undefined, "Checking...");
+
+    const commandRunner = new CommandRunner(
+      this.connection,
+      this.context,
+      settings,
+    );
+
+    const apmeExecutable = settings.executionEnvironment.enabled
+      ? "apme"
+      : settings.validation.apme.path;
+
+    try {
+      this.connection.console.log(
+        `[apme] Running: ${apmeExecutable} ${apmeArguments}`,
+      );
+      const result = await commandRunner.runCommand(
+        apmeExecutable,
+        apmeArguments,
+        workingDirectory,
+        mountPaths,
+      );
+
+      const diagnosticResult = this.parseApmeOutput(result.stdout, workingDirectory);
+      this.connection.console.log(
+        `[apme] Check complete: ${this.countDiagnostics(diagnosticResult)} violation(s) found`,
+      );
+      return diagnosticResult;
+    } catch (error) {
+      if (error instanceof Error) {
+        const execError = error as ExecException & {
+          stdout: string;
+          stderr: string;
+        };
+
+        // Exit code 1 = violations found (not an error)
+        if (execError.stdout) {
+          const diagnosticResult = this.parseApmeOutput(execError.stdout, workingDirectory);
+          this.connection.console.log(
+            `[apme] Check complete (exit 1): ${this.countDiagnostics(diagnosticResult)} violation(s) found`,
+          );
+          return diagnosticResult;
+        }
+
+        if (execError.stderr) {
+          this.connection.console.warn(`[apme] stderr: ${execError.stderr}`);
+        }
+        this.connection.console.error(`[apme] Command failed: ${execError.message}`);
+      } else {
+        this.connection.console.error(
+          `[apme] Unexpected error: ${JSON.stringify(error)}`,
+        );
+      }
+      return new Map();
+    } finally {
+      progressTracker.done();
+    }
+  }
+
+  public async doValidateWorkspace(): Promise<Map<string, Diagnostic[]>> {
+    const workspaceUri = this.context.workspaceFolder.uri;
+    const settings = await this.context.documentSettings.get(workspaceUri);
+
+    if (!settings.validation?.enabled || !settings.validation?.apme?.enabled) {
+      return new Map();
+    }
+
+    const workingDirectory = URI.parse(workspaceUri).path;
+    this.connection.console.log(
+      `[apme] Starting workspace scan: ${workingDirectory}`,
+    );
+    const mountPaths = new Set([workingDirectory]);
+
+    let apmeArguments = settings.validation.apme.arguments ?? "";
+    apmeArguments = `check "${workingDirectory}" --json ${apmeArguments}`;
+
+    const progressTracker = this.useProgressTracker
+      ? await this.connection.window.createWorkDoneProgress()
+      : { begin: () => {}, done: () => {} };
+
+    progressTracker.begin("apme", undefined, "Scanning workspace...");
+
+    const commandRunner = new CommandRunner(
+      this.connection,
+      this.context,
+      settings,
+    );
+
+    const apmeExecutable = settings.executionEnvironment.enabled
+      ? "apme"
+      : settings.validation.apme.path;
+
+    try {
+      const result = await commandRunner.runCommand(
+        apmeExecutable,
+        apmeArguments,
+        workingDirectory,
+        mountPaths,
+      );
+
+      return this.parseApmeOutput(result.stdout, workingDirectory);
+    } catch (error) {
+      if (error instanceof Error) {
+        const execError = error as ExecException & {
+          stdout: string;
+          stderr: string;
+        };
+
+        if (execError.stdout) {
+          return this.parseApmeOutput(execError.stdout, workingDirectory);
+        }
+
+        this.connection.console.error(`[apme] Workspace scan error: ${execError.message}`);
+      }
+      return new Map();
+    } finally {
+      progressTracker.done();
+    }
+  }
+
+  public async doRemediate(
+    filePath: string,
+  ): Promise<{ success: boolean; filesUpdated: number }> {
+    if (this.remediationInFlight.has(filePath)) {
+      this.connection.console.warn(
+        `[apme] Skipping remediate: already in flight for ${filePath}`,
+      );
+      return { success: false, filesUpdated: 0 };
+    }
+
+    this.connection.console.log(`[apme] Starting remediation: ${filePath}`);
+    this.remediationInFlight.add(filePath);
+
+    try {
+      const workspaceUri = this.context.workspaceFolder.uri;
+      const settings = await this.context.documentSettings.get(workspaceUri);
+      const workingDirectory = URI.parse(workspaceUri).path;
+      const mountPaths = new Set([workingDirectory, path.dirname(filePath)]);
+
+      let apmeArguments = settings.validation.apme.arguments ?? "";
+      apmeArguments = `remediate "${filePath}" --json ${apmeArguments}`;
+
+      const commandRunner = new CommandRunner(
+        this.connection,
+        this.context,
+        settings,
+      );
+
+      const apmeExecutable = settings.executionEnvironment.enabled
+        ? "apme"
+        : settings.validation.apme.path;
+
+      const result = await commandRunner.runCommand(
+        apmeExecutable,
+        apmeArguments,
+        workingDirectory,
+        mountPaths,
+      );
+
+      try {
+        const output = JSON.parse(result.stdout);
+        return {
+          success: true,
+          filesUpdated: output.files_updated ?? 0,
+        };
+      } catch {
+        return { success: true, filesUpdated: 0 };
+      }
+    } catch (error) {
+      if (error instanceof Error) {
+        const execError = error as ExecException & {
+          stdout: string;
+          stderr: string;
+        };
+        // Exit code 1 = remaining violations (remediation ran but didn't fix everything)
+        if (execError.stdout) {
+          try {
+            const output = JSON.parse(execError.stdout);
+            return {
+              success: true,
+              filesUpdated: output.files_updated ?? 0,
+            };
+          } catch {
+            // fall through
+          }
+        }
+        this.connection.console.error(`[apme] Remediation error: ${execError.message}`);
+      }
+      return { success: false, filesUpdated: 0 };
+    } finally {
+      this.remediationInFlight.delete(filePath);
+    }
+  }
+
+  private async doRemediateAndValidate(
+    textDocument: TextDocument,
+  ): Promise<Map<string, Diagnostic[]>> {
+    const docPath = URI.parse(textDocument.uri).path;
+
+    await this.doRemediate(docPath);
+
+    const workingDirectory = URI.parse(this.context.workspaceFolder.uri).path;
+    const mountPaths = new Set([workingDirectory, path.dirname(docPath)]);
+    const settings = await this.context.documentSettings.get(textDocument.uri);
+
+    let apmeArguments = settings.validation.apme.arguments ?? "";
+    apmeArguments = `check "${docPath}" --json ${apmeArguments}`;
+
+    const commandRunner = new CommandRunner(
+      this.connection,
+      this.context,
+      settings,
+    );
+
+    const apmeExecutable = settings.executionEnvironment.enabled
+      ? "apme"
+      : settings.validation.apme.path;
+
+    try {
+      const result = await commandRunner.runCommand(
+        apmeExecutable,
+        apmeArguments,
+        workingDirectory,
+        mountPaths,
+      );
+      return this.parseApmeOutput(result.stdout, workingDirectory);
+    } catch (error) {
+      if (error instanceof Error) {
+        const execError = error as ExecException & { stdout: string };
+        if (execError.stdout) {
+          return this.parseApmeOutput(execError.stdout, workingDirectory);
+        }
+      }
+      return new Map();
+    }
+  }
+
+  private parseApmeOutput(
+    stdout: string,
+    workingDirectory: string,
+  ): Map<string, Diagnostic[]> {
+    const diagnostics: Map<string, Diagnostic[]> = new Map();
+
+    if (!stdout) {
+      return diagnostics;
+    }
+
+    try {
+      const output: ApmeCheckOutput = JSON.parse(stdout);
+      const violations = output.violations ?? [];
+
+      if (!Array.isArray(violations)) {
+        return diagnostics;
+      }
+
+      for (const violation of violations) {
+        if (!violation.rule_id || !violation.file) {
+          continue;
+        }
+
+        const lineNum = Math.max(0, (violation.line ?? 1) - 1);
+        const start: Position = { line: lineNum, character: 0 };
+        const end: Position = { line: lineNum, character: integer.MAX_VALUE };
+        const range: Range = { start, end };
+
+        let severity: DiagnosticSeverity;
+        switch (violation.severity) {
+          case "high":
+          case "error":
+            severity = DiagnosticSeverity.Error;
+            break;
+          case "medium":
+          case "warning":
+            severity = DiagnosticSeverity.Warning;
+            break;
+          default:
+            severity = DiagnosticSeverity.Information;
+            break;
+        }
+
+        const remClass = violation.remediation_class ?? "manual-review";
+        const fixable = remClass === "auto-fixable";
+        const aiProposable = remClass === "ai-candidate";
+        const tier = fixable ? 1 : aiProposable ? 2 : 3;
+
+        const filePath = violation.file.startsWith("/")
+          ? violation.file
+          : `${workingDirectory}/${violation.file}`;
+        const locationUri = URI.file(filePath).toString();
+
+        let fileDiagnostics = diagnostics.get(locationUri);
+        if (!fileDiagnostics) {
+          fileDiagnostics = [];
+          diagnostics.set(locationUri, fileDiagnostics);
+        }
+
+        const tierLabel =
+          tier === 1
+            ? " [auto-fixable]"
+            : tier === 2
+              ? " [ai-candidate]"
+              : "";
+
+        fileDiagnostics.push({
+          message: `${violation.rule_id}: ${violation.message}${tierLabel}`,
+          range: range,
+          severity: severity,
+          source: "Ansible [apme]",
+          code: violation.rule_id,
+          codeDescription: {
+            href: `https://apme.readthedocs.io/rules/${violation.rule_id.toLowerCase()}/`,
+          },
+          data: {
+            tier,
+            fixable,
+            ai_proposable: aiProposable,
+            remediation_class: remClass,
+            rule_id: violation.rule_id,
+          },
+        });
+      }
+    } catch (error) {
+      this.connection.console.error(
+        `[apme] Failed to parse output: ${error instanceof Error ? error.message : String(error)}` +
+          `\nTried to parse:\n${stdout.substring(0, 500)}`,
+      );
+    }
+
+    return diagnostics;
+  }
+
+  private countDiagnostics(diagnostics: Map<string, Diagnostic[]>): number {
+    let count = 0;
+    for (const fileDiags of diagnostics.values()) {
+      count += fileDiags.length;
+    }
+    return count;
+  }
+}

--- a/packages/ansible-language-server/src/services/apmeDaemonManager.ts
+++ b/packages/ansible-language-server/src/services/apmeDaemonManager.ts
@@ -1,0 +1,191 @@
+import { Connection } from "vscode-languageserver";
+import { WorkspaceFolderContext } from "@src/services/workspaceManager.js";
+import { CommandRunner } from "@src/utils/commandRunner.js";
+
+const DAEMON_START_TIMEOUT = 30_000;
+const DAEMON_STOP_TIMEOUT = 10_000;
+const HEALTH_CHECK_TIMEOUT = 10_000;
+const PORT_RELEASE_DELAY = 3_000;
+
+const CRASH_PATTERNS = [
+  "connection refused",
+  "econnreset",
+  "econnrefused",
+  "epipe",
+  "daemon is not running",
+  "grpc",
+  "unavailable",
+  "spawn",
+  "enoent",
+];
+
+export class ApmeDaemonManager {
+  private connection: Connection;
+  private context: WorkspaceFolderContext;
+
+  constructor(connection: Connection, context: WorkspaceFolderContext) {
+    this.connection = connection;
+    this.context = context;
+  }
+
+  public async startDaemon(): Promise<boolean> {
+    try {
+      const { executable, runner } = await this.getRunner();
+      this.connection.console.log("[apme] Starting daemon...");
+      await runner.runCommand(
+        executable,
+        "daemon start",
+        undefined,
+        undefined,
+        DAEMON_START_TIMEOUT,
+      );
+      this.connection.console.log("[apme] Daemon started successfully");
+      return true;
+    } catch (error) {
+      if (error instanceof Error) {
+        const msg = error.message || "";
+        const stderr = (error as { stderr?: string }).stderr || "";
+        const combined = msg + stderr;
+
+        if (combined.includes("already running")) {
+          this.connection.console.log("[apme] Daemon already running");
+          return true;
+        }
+
+        if (combined.includes("Port") && combined.includes("in use")) {
+          this.connection.console.warn(
+            "[apme] Port conflict detected, waiting for ports to free...",
+          );
+          await this.sleep(PORT_RELEASE_DELAY);
+          return this.startDaemonRetry();
+        }
+
+        this.connection.console.warn(`[apme] Daemon start failed: ${msg}`);
+      }
+      return false;
+    }
+  }
+
+  private async startDaemonRetry(): Promise<boolean> {
+    try {
+      const { executable, runner } = await this.getRunner();
+      await runner.runCommand(
+        executable,
+        "daemon start",
+        undefined,
+        undefined,
+        DAEMON_START_TIMEOUT,
+      );
+      this.connection.console.log("[apme] Daemon started after port retry");
+      return true;
+    } catch (error) {
+      if (error instanceof Error) {
+        const combined =
+          (error.message || "") +
+          ((error as { stderr?: string }).stderr || "");
+        if (combined.includes("already running")) {
+          this.connection.console.log("[apme] Daemon already running");
+          return true;
+        }
+        this.connection.console.warn(
+          `[apme] Daemon start retry failed: ${error.message}`,
+        );
+      }
+      return false;
+    }
+  }
+
+  public async stopDaemon(): Promise<void> {
+    try {
+      const { executable, runner } = await this.getRunner();
+      this.connection.console.log("[apme] Stopping daemon...");
+      await runner.runCommand(
+        executable,
+        "daemon stop",
+        undefined,
+        undefined,
+        DAEMON_STOP_TIMEOUT,
+      );
+      this.connection.console.log("[apme] Daemon stopped");
+    } catch (error) {
+      if (error instanceof Error) {
+        this.connection.console.warn(
+          `[apme] Daemon stop failed (best-effort): ${error.message}`,
+        );
+      }
+    }
+  }
+
+  public async restartDaemon(): Promise<boolean> {
+    await this.stopDaemon();
+    await this.sleep(PORT_RELEASE_DELAY);
+    return this.startDaemon();
+  }
+
+  public async isHealthy(): Promise<boolean> {
+    try {
+      const { executable, runner } = await this.getRunner();
+      const result = await runner.runCommand(
+        executable,
+        "health-check --json",
+        undefined,
+        undefined,
+        HEALTH_CHECK_TIMEOUT,
+      );
+      try {
+        const health = JSON.parse(result.stdout);
+        const services = Object.values(health) as Array<{
+          status?: string;
+        }>;
+        return services.every((s) => s.status === "ok");
+      } catch {
+        return result.stdout.includes("ok");
+      }
+    } catch {
+      return false;
+    }
+  }
+
+  public async ensureHealthy(): Promise<boolean> {
+    // Try starting first — if already running, this is a no-op
+    const started = await this.startDaemon();
+    if (started && (await this.isHealthy())) {
+      return true;
+    }
+    this.connection.console.warn(
+      "[apme] Daemon unhealthy after start, attempting full restart...",
+    );
+    const restarted = await this.restartDaemon();
+    if (!restarted) {
+      return false;
+    }
+    return this.isHealthy();
+  }
+
+  public isDaemonCrashError(error: unknown): boolean {
+    if (!(error instanceof Error)) return false;
+    const msg = (
+      (error.message || "") +
+      ((error as { stderr?: string }).stderr || "")
+    ).toLowerCase();
+    return CRASH_PATTERNS.some((p) => msg.includes(p));
+  }
+
+  private async getRunner(): Promise<{
+    executable: string;
+    runner: CommandRunner;
+  }> {
+    const settings = await this.context.documentSettings.get(
+      this.context.workspaceFolder.uri,
+    );
+    const executable = settings.executionEnvironment.enabled
+      ? "apme"
+      : settings.validation.apme.path;
+    const runner = new CommandRunner(this.connection, this.context, settings);
+    return { executable, runner };
+  }
+
+  private sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+}

--- a/packages/ansible-language-server/src/services/settingsManager.ts
+++ b/packages/ansible-language-server/src/services/settingsManager.ts
@@ -118,7 +118,7 @@ export class SettingsManager {
       },
       apme: {
         enabled: {
-          default: false,
+          default: true,
           description: "Toggle usage of apme for static analysis",
         },
         path: {
@@ -134,6 +134,11 @@ export class SettingsManager {
           default: false,
           description:
             "Specifies whether apme should auto-fix deterministic violations when you save a file.",
+        },
+        timeout: {
+          default: 120,
+          description:
+            "Maximum time in seconds to allow apme to run before aborting. 0 means no timeout.",
         },
       },
       diagnosticPrecedence: {
@@ -175,10 +180,24 @@ export class SettingsManager {
     }
     let result = this.documentSettings.get(uri);
     if (!result && this.connection) {
-      const clientSettings = await this.connection.workspace.getConfiguration({
-        scopeUri: uri,
-        section: "ansible",
-      });
+      let clientSettings;
+      try {
+        clientSettings = await Promise.race([
+          this.connection.workspace.getConfiguration({
+            scopeUri: uri,
+            section: "ansible",
+          }),
+          new Promise<null>((resolve) => setTimeout(() => resolve(null), 5000)),
+        ]);
+      } catch {
+        clientSettings = null;
+      }
+      if (!clientSettings) {
+        this.connection.console?.log(
+          "Client did not respond to configuration request, using defaults",
+        );
+        clientSettings = {};
+      }
       // Recursively merge globalSettings with clientSettings to use:
       //  - setting from client when provided
       //  - default value of setting otherwise

--- a/packages/ansible-language-server/src/services/settingsManager.ts
+++ b/packages/ansible-language-server/src/services/settingsManager.ts
@@ -116,6 +116,31 @@ export class SettingsManager {
             "Specifies whether `ansible-lint --fix` should run automatically when you save a file.",
         },
       },
+      apme: {
+        enabled: {
+          default: false,
+          description: "Toggle usage of apme for static analysis",
+        },
+        path: {
+          default: "apme",
+          description: "Path to the apme executable",
+        },
+        arguments: {
+          default: "",
+          description:
+            "Optional command line arguments to be appended to apme invocation",
+        },
+        autoFixOnSave: {
+          default: false,
+          description:
+            "Specifies whether apme should auto-fix deterministic violations when you save a file.",
+        },
+      },
+      diagnosticPrecedence: {
+        default: "both",
+        description:
+          "When both apme and ansible-lint report diagnostics on the same line, which to keep. 'both' shows all, 'apme' keeps apme, 'lint' keeps ansible-lint.",
+      },
     },
   };
 

--- a/packages/ansible-language-server/src/services/workspaceManager.ts
+++ b/packages/ansible-language-server/src/services/workspaceManager.ts
@@ -7,6 +7,7 @@ import {
   WorkspaceFoldersChangeEvent,
 } from "vscode-languageserver";
 import { AnsibleConfig } from "@src/services/ansibleConfig.js";
+import { AnsibleApme } from "@src/services/ansibleApme.js";
 import { AnsibleLint } from "@src/services/ansibleLint.js";
 import { AnsiblePlaybook } from "@src/services/ansiblePlaybook.js";
 import { DocsLibrary } from "@src/services/docsLibrary.js";
@@ -139,6 +140,7 @@ export class WorkspaceFolderContext {
   private _docsLibrary: Thenable<DocsLibrary> | undefined;
   private _ansibleConfig: Thenable<AnsibleConfig> | undefined;
   private _ansibleInventory: Thenable<AnsibleInventory> | undefined;
+  private _ansibleApme: AnsibleApme | undefined;
   private _ansibleLint: AnsibleLint | undefined;
   private _ansiblePlaybook: AnsiblePlaybook | undefined;
   private _configChangeTimer: ReturnType<typeof setTimeout> | undefined;
@@ -228,6 +230,13 @@ export class WorkspaceFolderContext {
     this._ansibleConfig = undefined;
     this._docsLibrary = undefined;
     this._ansibleInventory = undefined;
+  }
+
+  public get ansibleApme(): AnsibleApme {
+    if (!this._ansibleApme) {
+      this._ansibleApme = new AnsibleApme(this.connection, this);
+    }
+    return this._ansibleApme;
   }
 
   public get ansibleLint(): AnsibleLint {

--- a/packages/ansible-language-server/src/services/workspaceManager.ts
+++ b/packages/ansible-language-server/src/services/workspaceManager.ts
@@ -8,6 +8,7 @@ import {
 } from "vscode-languageserver";
 import { AnsibleConfig } from "@src/services/ansibleConfig.js";
 import { AnsibleApme } from "@src/services/ansibleApme.js";
+import { ApmeDaemonManager } from "@src/services/apmeDaemonManager.js";
 import { AnsibleLint } from "@src/services/ansibleLint.js";
 import { AnsiblePlaybook } from "@src/services/ansiblePlaybook.js";
 import { DocsLibrary } from "@src/services/docsLibrary.js";
@@ -66,6 +67,24 @@ export class WorkspaceManager {
         callbackfn(folder),
       ),
     );
+  }
+
+  /**
+   * Iterates over all registered workspace folders, creating a context for each
+   * if one does not already exist, then invokes the callback.
+   */
+  public async forEachWorkspaceFolder(
+    callbackfn: (value: WorkspaceFolderContext) => Promise<void> | void,
+  ): Promise<void> {
+    const contexts = this.sortedWorkspaceFolders.map((folder) => {
+      let context = this.folderContexts.get(folder.uri);
+      if (!context) {
+        context = new WorkspaceFolderContext(this.connection, folder, this);
+        this.folderContexts.set(folder.uri, context);
+      }
+      return context;
+    });
+    await Promise.all(contexts.map((ctx) => callbackfn(ctx)));
   }
 
   /**
@@ -141,6 +160,7 @@ export class WorkspaceFolderContext {
   private _ansibleConfig: Thenable<AnsibleConfig> | undefined;
   private _ansibleInventory: Thenable<AnsibleInventory> | undefined;
   private _ansibleApme: AnsibleApme | undefined;
+  private _apmeDaemonManager: ApmeDaemonManager | undefined;
   private _ansibleLint: AnsibleLint | undefined;
   private _ansiblePlaybook: AnsiblePlaybook | undefined;
   private _configChangeTimer: ReturnType<typeof setTimeout> | undefined;
@@ -230,6 +250,10 @@ export class WorkspaceFolderContext {
     this._ansibleConfig = undefined;
     this._docsLibrary = undefined;
     this._ansibleInventory = undefined;
+    this._ansibleApme = undefined;
+    this._apmeDaemonManager = undefined;
+    this._ansibleLint = undefined;
+    this._ansiblePlaybook = undefined;
   }
 
   public get ansibleApme(): AnsibleApme {
@@ -237,6 +261,13 @@ export class WorkspaceFolderContext {
       this._ansibleApme = new AnsibleApme(this.connection, this);
     }
     return this._ansibleApme;
+  }
+
+  public get apmeDaemonManager(): ApmeDaemonManager {
+    if (!this._apmeDaemonManager) {
+      this._apmeDaemonManager = new ApmeDaemonManager(this.connection, this);
+    }
+    return this._apmeDaemonManager;
   }
 
   public get ansibleLint(): AnsibleLint {

--- a/packages/ansible-language-server/src/utils/commandRunner.ts
+++ b/packages/ansible-language-server/src/utils/commandRunner.ts
@@ -25,6 +25,7 @@ export class CommandRunner {
     args: string,
     workingDirectory?: string,
     mountPaths?: Set<string>,
+    timeout?: number,
   ): Promise<{
     stdout: string;
     stderr: string;
@@ -82,6 +83,7 @@ export class CommandRunner {
       cwd: currentWorkingDirectory,
       env: runEnv,
       maxBuffer: 10 * 1000 * 1000,
+      timeout: timeout,
     });
 
     return result;

--- a/packages/ansible-language-server/test/providers/validationProvider.test.ts
+++ b/packages/ansible-language-server/test/providers/validationProvider.test.ts
@@ -4,6 +4,7 @@ import { Diagnostic, Position, integer } from "vscode-languageserver";
 import {
   doValidate,
   getYamlValidation,
+  mergeDiagnostics,
 } from "@src/providers/validationProvider.js";
 import { WorkspaceFolderContext } from "@src/services/workspaceManager.js";
 import {
@@ -899,4 +900,125 @@ describe("doValidate()", function () {
       }
     });
   }
+});
+
+describe("mergeDiagnostics()", () => {
+  const fileUri = "file:///workspace/test.yml";
+
+  function makeDiag(
+    line: number,
+    source: string,
+    message: string,
+  ): Diagnostic {
+    return {
+      message,
+      range: {
+        start: { line, character: 0 } as Position,
+        end: { line, character: integer.MAX_VALUE } as Position,
+      },
+      severity: 1,
+      source,
+    };
+  }
+
+  it('should concatenate all diagnostics when precedence is "both"', () => {
+    const lint = new Map<string, Diagnostic[]>();
+    lint.set(fileUri, [makeDiag(5, "ansible-lint", "lint issue on line 5")]);
+
+    const apme = new Map<string, Diagnostic[]>();
+    apme.set(fileUri, [makeDiag(5, "Ansible [apme]", "apme issue on line 5")]);
+
+    const result = mergeDiagnostics(lint, apme, "both");
+    expect(result.get(fileUri)!.length).toBe(2);
+  });
+
+  it('should keep apme and drop lint on same line when precedence is "apme"', () => {
+    const lint = new Map<string, Diagnostic[]>();
+    lint.set(fileUri, [
+      makeDiag(5, "ansible-lint", "lint on 5"),
+      makeDiag(10, "ansible-lint", "lint on 10"),
+    ]);
+
+    const apme = new Map<string, Diagnostic[]>();
+    apme.set(fileUri, [makeDiag(5, "Ansible [apme]", "apme on 5")]);
+
+    const result = mergeDiagnostics(lint, apme, "apme");
+    const diags = result.get(fileUri)!;
+    expect(diags.length).toBe(2);
+    expect(diags.find((d) => d.source === "Ansible [apme]")).toBeDefined();
+    expect(
+      diags.find(
+        (d) => d.source === "ansible-lint" && d.range.start.line === 10,
+      ),
+    ).toBeDefined();
+    expect(
+      diags.find(
+        (d) => d.source === "ansible-lint" && d.range.start.line === 5,
+      ),
+    ).toBeUndefined();
+  });
+
+  it('should keep lint and drop apme on same line when precedence is "lint"', () => {
+    const lint = new Map<string, Diagnostic[]>();
+    lint.set(fileUri, [makeDiag(5, "ansible-lint", "lint on 5")]);
+
+    const apme = new Map<string, Diagnostic[]>();
+    apme.set(fileUri, [
+      makeDiag(5, "Ansible [apme]", "apme on 5"),
+      makeDiag(20, "Ansible [apme]", "apme on 20"),
+    ]);
+
+    const result = mergeDiagnostics(lint, apme, "lint");
+    const diags = result.get(fileUri)!;
+    expect(diags.length).toBe(2);
+    expect(diags.find((d) => d.source === "ansible-lint")).toBeDefined();
+    expect(
+      diags.find(
+        (d) => d.source === "Ansible [apme]" && d.range.start.line === 20,
+      ),
+    ).toBeDefined();
+    expect(
+      diags.find(
+        (d) => d.source === "Ansible [apme]" && d.range.start.line === 5,
+      ),
+    ).toBeUndefined();
+  });
+
+  it("should return all apme diagnostics when lint map is empty", () => {
+    const lint = new Map<string, Diagnostic[]>();
+    const apme = new Map<string, Diagnostic[]>();
+    apme.set(fileUri, [makeDiag(1, "Ansible [apme]", "apme only")]);
+
+    const result = mergeDiagnostics(lint, apme, "apme");
+    expect(result.get(fileUri)!.length).toBe(1);
+  });
+
+  it("should return all lint diagnostics when apme map is empty", () => {
+    const lint = new Map<string, Diagnostic[]>();
+    lint.set(fileUri, [makeDiag(1, "ansible-lint", "lint only")]);
+    const apme = new Map<string, Diagnostic[]>();
+
+    const result = mergeDiagnostics(lint, apme, "lint");
+    expect(result.get(fileUri)!.length).toBe(1);
+  });
+
+  it("should return empty map when both inputs are empty", () => {
+    const result = mergeDiagnostics(new Map(), new Map(), "both");
+    expect(result.size).toBe(0);
+  });
+
+  it("should merge diagnostics across different files", () => {
+    const fileA = "file:///workspace/a.yml";
+    const fileB = "file:///workspace/b.yml";
+
+    const lint = new Map<string, Diagnostic[]>();
+    lint.set(fileA, [makeDiag(1, "ansible-lint", "lint in a")]);
+
+    const apme = new Map<string, Diagnostic[]>();
+    apme.set(fileB, [makeDiag(2, "Ansible [apme]", "apme in b")]);
+
+    const result = mergeDiagnostics(lint, apme, "apme");
+    expect(result.get(fileA)!.length).toBe(1);
+    expect(result.get(fileB)!.length).toBe(1);
+  });
 });

--- a/packages/ansible-language-server/test/services/ansibleApme.test.ts
+++ b/packages/ansible-language-server/test/services/ansibleApme.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { DiagnosticSeverity } from "vscode-languageserver";
 import { AnsibleApme } from "@src/services/ansibleApme.js";
 
@@ -326,13 +326,115 @@ describe("AnsibleApme.parseApmeOutput", () => {
   });
 });
 
-describe("AnsibleApme.mergeDiagnostics via validationProvider", () => {
-  // mergeDiagnostics is tested indirectly through validationProvider
-  // These tests verify the dedup logic directly
+describe("AnsibleApme.doValidate", () => {
+  function createMockContext(
+    overrides: {
+      validationEnabled?: boolean;
+      apmeEnabled?: boolean;
+      autoFixOnSave?: boolean;
+      apmePath?: string;
+    } = {},
+  ) {
+    const {
+      validationEnabled = true,
+      apmeEnabled = true,
+      autoFixOnSave = false,
+      apmePath = "apme",
+    } = overrides;
 
+    return {
+      documentSettings: {
+        get: () =>
+          Promise.resolve({
+            validation: {
+              enabled: validationEnabled,
+              apme: {
+                enabled: apmeEnabled,
+                path: apmePath,
+                arguments: "",
+                autoFixOnSave,
+              },
+            },
+            executionEnvironment: { enabled: false },
+          }),
+      },
+      workspaceFolder: { uri: "file:///workspace/project" },
+      clientCapabilities: { window: {} },
+    };
+  }
+
+  const mockConnection = {
+    console: {
+      log: () => {},
+      warn: () => {},
+      error: () => {},
+    },
+    window: {
+      createWorkDoneProgress: () =>
+        Promise.resolve({ begin: () => {}, done: () => {} }),
+    },
+  };
+
+  it("should return empty map when validation is disabled", async () => {
+    const ctx = createMockContext({ validationEnabled: false });
+    const apme = new AnsibleApme(mockConnection as any, ctx as any);
+    const doc = { uri: "file:///workspace/project/test.yml" } as any;
+    const result = await apme.doValidate(doc);
+    expect(result.size).toBe(0);
+  });
+
+  it("should return empty map when apme is disabled", async () => {
+    const ctx = createMockContext({ apmeEnabled: false });
+    const apme = new AnsibleApme(mockConnection as any, ctx as any);
+    const doc = { uri: "file:///workspace/project/test.yml" } as any;
+    const result = await apme.doValidate(doc);
+    expect(result.size).toBe(0);
+  });
+});
+
+describe("AnsibleApme.doRemediate concurrency guard", () => {
+  const mockConnection = {
+    console: {
+      log: () => {},
+      warn: vi.fn(),
+      error: () => {},
+    },
+  };
+
+  const mockContext = {
+    documentSettings: {
+      get: () =>
+        Promise.resolve({
+          validation: {
+            enabled: true,
+            apme: { enabled: true, path: "apme", arguments: "" },
+          },
+          executionEnvironment: { enabled: false },
+          python: { interpreterPath: "python3", activationScript: "" },
+        }),
+    },
+    workspaceFolder: { uri: "file:///workspace/project" },
+    clientCapabilities: { window: {} },
+  };
+
+  it("should reject second concurrent call for same path", async () => {
+    const apme = new AnsibleApme(mockConnection as any, mockContext as any);
+
+    // Access remediationInFlight to simulate in-flight state
+    (apme as any).remediationInFlight.add("/workspace/project/test.yml");
+
+    const result = await apme.doRemediate("/workspace/project/test.yml");
+    expect(result.success).toBe(false);
+    expect(result.filesUpdated).toBe(0);
+    expect(mockConnection.console.warn).toHaveBeenCalled();
+  });
+});
+
+describe("AnsibleApme.mergeDiagnostics via validationProvider", () => {
   it("should be importable from validationProvider", async () => {
     const mod = await import("@src/providers/validationProvider.js");
     expect(mod.doValidate).toBeDefined();
     expect(mod.getYamlValidation).toBeDefined();
+    expect(mod.mergeDiagnostics).toBeDefined();
   });
 });

--- a/packages/ansible-language-server/test/services/ansibleApme.test.ts
+++ b/packages/ansible-language-server/test/services/ansibleApme.test.ts
@@ -1,0 +1,338 @@
+import { describe, it, expect } from "vitest";
+import { DiagnosticSeverity } from "vscode-languageserver";
+import { AnsibleApme } from "@src/services/ansibleApme.js";
+
+// Access the private parseApmeOutput via prototype for testing
+const parseApmeOutput = (AnsibleApme.prototype as any)["parseApmeOutput"].bind({
+  connection: { console: { error: () => {}, log: () => {}, warn: () => {} } },
+});
+
+describe("AnsibleApme.parseApmeOutput", () => {
+  const workDir = "/workspace/project";
+
+  it("should parse violations with correct fields", () => {
+    const json = JSON.stringify({
+      violations: [
+        {
+          rule_id: "L003",
+          severity: "low",
+          message: "Deprecated module found",
+          file: "site.yml",
+          line: 5,
+          remediation_class: "manual-review",
+        },
+      ],
+      count: 1,
+    });
+
+    const result = parseApmeOutput(json, workDir);
+    const diags = result.get("file:///workspace/project/site.yml");
+
+    expect(diags).toBeDefined();
+    expect(diags!.length).toBe(1);
+    expect(diags![0].message).toContain("L003");
+    expect(diags![0].message).toContain("Deprecated module found");
+    expect(diags![0].source).toBe("Ansible [apme]");
+    expect(diags![0].code).toBe("L003");
+    expect(diags![0].range.start.line).toBe(4); // 0-indexed
+    expect(diags![0].severity).toBe(DiagnosticSeverity.Information);
+  });
+
+  it("should map severity correctly", () => {
+    const json = JSON.stringify({
+      violations: [
+        {
+          rule_id: "R108",
+          severity: "high",
+          message: "Risky permission",
+          file: "play.yml",
+          line: 1,
+          remediation_class: "ai-candidate",
+        },
+        {
+          rule_id: "M010",
+          severity: "medium",
+          message: "Migration needed",
+          file: "play.yml",
+          line: 2,
+          remediation_class: "auto-fixable",
+        },
+        {
+          rule_id: "L067",
+          severity: "info",
+          message: "Set verbosity",
+          file: "play.yml",
+          line: 3,
+          remediation_class: "manual-review",
+        },
+      ],
+      count: 3,
+    });
+
+    const result = parseApmeOutput(json, workDir);
+    const diags = result.get("file:///workspace/project/play.yml")!;
+
+    expect(diags[0].severity).toBe(DiagnosticSeverity.Error);
+    expect(diags[1].severity).toBe(DiagnosticSeverity.Warning);
+    expect(diags[2].severity).toBe(DiagnosticSeverity.Information);
+  });
+
+  it("should classify tiers from remediation_class", () => {
+    const json = JSON.stringify({
+      violations: [
+        {
+          rule_id: "M009",
+          severity: "low",
+          message: "Auto-fixable issue",
+          file: "a.yml",
+          line: 1,
+          remediation_class: "auto-fixable",
+        },
+        {
+          rule_id: "L026",
+          severity: "low",
+          message: "AI candidate issue",
+          file: "a.yml",
+          line: 2,
+          remediation_class: "ai-candidate",
+        },
+        {
+          rule_id: "R401",
+          severity: "info",
+          message: "Manual review issue",
+          file: "a.yml",
+          line: 3,
+          remediation_class: "manual-review",
+        },
+      ],
+      count: 3,
+    });
+
+    const result = parseApmeOutput(json, workDir);
+    const diags = result.get("file:///workspace/project/a.yml")!;
+
+    expect(diags[0].data.tier).toBe(1);
+    expect(diags[0].data.fixable).toBe(true);
+    expect(diags[0].data.ai_proposable).toBe(false);
+    expect(diags[0].message).toContain("[auto-fixable]");
+
+    expect(diags[1].data.tier).toBe(2);
+    expect(diags[1].data.fixable).toBe(false);
+    expect(diags[1].data.ai_proposable).toBe(true);
+    expect(diags[1].message).toContain("[ai-candidate]");
+
+    expect(diags[2].data.tier).toBe(3);
+    expect(diags[2].data.fixable).toBe(false);
+    expect(diags[2].data.ai_proposable).toBe(false);
+    expect(diags[2].message).not.toContain("[auto-fixable]");
+    expect(diags[2].message).not.toContain("[ai-candidate]");
+  });
+
+  it("should handle empty violations array", () => {
+    const json = JSON.stringify({
+      violations: [],
+      count: 0,
+    });
+
+    const result = parseApmeOutput(json, workDir);
+    expect(result.size).toBe(0);
+  });
+
+  it("should handle empty string input", () => {
+    const result = parseApmeOutput("", workDir);
+    expect(result.size).toBe(0);
+  });
+
+  it("should handle malformed JSON gracefully", () => {
+    const result = parseApmeOutput("not valid json {{{", workDir);
+    expect(result.size).toBe(0);
+  });
+
+  it("should handle violations with absolute file paths", () => {
+    const json = JSON.stringify({
+      violations: [
+        {
+          rule_id: "L005",
+          severity: "low",
+          message: "Community module",
+          file: "/absolute/path/to/play.yml",
+          line: 10,
+          remediation_class: "ai-candidate",
+        },
+      ],
+      count: 1,
+    });
+
+    const result = parseApmeOutput(json, workDir);
+    const diags = result.get("file:///absolute/path/to/play.yml");
+    expect(diags).toBeDefined();
+    expect(diags!.length).toBe(1);
+  });
+
+  it("should handle violations with relative file paths", () => {
+    const json = JSON.stringify({
+      violations: [
+        {
+          rule_id: "L024",
+          severity: "low",
+          message: "Some issue",
+          file: "roles/myrole/tasks/main.yml",
+          line: 4,
+          remediation_class: "ai-candidate",
+        },
+      ],
+      count: 1,
+    });
+
+    const result = parseApmeOutput(json, workDir);
+    const diags = result.get(
+      "file:///workspace/project/roles/myrole/tasks/main.yml",
+    );
+    expect(diags).toBeDefined();
+    expect(diags!.length).toBe(1);
+  });
+
+  it("should distribute violations across multiple files", () => {
+    const json = JSON.stringify({
+      violations: [
+        {
+          rule_id: "L003",
+          severity: "low",
+          message: "Issue in file A",
+          file: "a.yml",
+          line: 1,
+          remediation_class: "manual-review",
+        },
+        {
+          rule_id: "L005",
+          severity: "low",
+          message: "Issue in file B",
+          file: "b.yml",
+          line: 2,
+          remediation_class: "ai-candidate",
+        },
+        {
+          rule_id: "L024",
+          severity: "low",
+          message: "Another issue in file A",
+          file: "a.yml",
+          line: 5,
+          remediation_class: "ai-candidate",
+        },
+      ],
+      count: 3,
+    });
+
+    const result = parseApmeOutput(json, workDir);
+    expect(result.size).toBe(2);
+    expect(result.get("file:///workspace/project/a.yml")!.length).toBe(2);
+    expect(result.get("file:///workspace/project/b.yml")!.length).toBe(1);
+  });
+
+  it("should skip violations missing rule_id", () => {
+    const json = JSON.stringify({
+      violations: [
+        {
+          severity: "low",
+          message: "No rule ID",
+          file: "a.yml",
+          line: 1,
+        },
+      ],
+      count: 1,
+    });
+
+    const result = parseApmeOutput(json, workDir);
+    expect(result.size).toBe(0);
+  });
+
+  it("should skip violations missing file", () => {
+    const json = JSON.stringify({
+      violations: [
+        {
+          rule_id: "L003",
+          severity: "low",
+          message: "No file",
+          line: 1,
+        },
+      ],
+      count: 1,
+    });
+
+    const result = parseApmeOutput(json, workDir);
+    expect(result.size).toBe(0);
+  });
+
+  it("should handle line 0 (role/project-level violations)", () => {
+    const json = JSON.stringify({
+      violations: [
+        {
+          rule_id: "L027",
+          severity: "low",
+          message: "Role-level issue",
+          file: "roles/broken_role",
+          line: 0,
+          remediation_class: "ai-candidate",
+        },
+      ],
+      count: 1,
+    });
+
+    const result = parseApmeOutput(json, workDir);
+    const diags = result.get("file:///workspace/project/roles/broken_role")!;
+    expect(diags[0].range.start.line).toBe(0);
+  });
+
+  it("should include codeDescription href for rule docs", () => {
+    const json = JSON.stringify({
+      violations: [
+        {
+          rule_id: "L003",
+          severity: "low",
+          message: "Test",
+          file: "a.yml",
+          line: 1,
+          remediation_class: "manual-review",
+        },
+      ],
+      count: 1,
+    });
+
+    const result = parseApmeOutput(json, workDir);
+    const diag = result.get("file:///workspace/project/a.yml")![0];
+    expect(diag.codeDescription).toBeDefined();
+    expect(diag.codeDescription!.href).toContain("l003");
+  });
+
+  it("should default missing remediation_class to manual-review (tier 3)", () => {
+    const json = JSON.stringify({
+      violations: [
+        {
+          rule_id: "L099",
+          severity: "low",
+          message: "No remediation class",
+          file: "a.yml",
+          line: 1,
+        },
+      ],
+      count: 1,
+    });
+
+    const result = parseApmeOutput(json, workDir);
+    const diag = result.get("file:///workspace/project/a.yml")![0];
+    expect(diag.data.tier).toBe(3);
+    expect(diag.data.fixable).toBe(false);
+    expect(diag.data.ai_proposable).toBe(false);
+  });
+});
+
+describe("AnsibleApme.mergeDiagnostics via validationProvider", () => {
+  // mergeDiagnostics is tested indirectly through validationProvider
+  // These tests verify the dedup logic directly
+
+  it("should be importable from validationProvider", async () => {
+    const mod = await import("@src/providers/validationProvider.js");
+    expect(mod.doValidate).toBeDefined();
+    expect(mod.getYamlValidation).toBeDefined();
+  });
+});

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -172,6 +172,101 @@ export async function activate(context: ExtensionContext): Promise<void> {
 
   notifyAboutConflicts();
 
+  // Register apme migrate command
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "ansible.apme.migrate",
+      async (folderUri?: vscode.Uri) => {
+        const targetUri =
+          folderUri ??
+          vscode.workspace.workspaceFolders?.[0]?.uri;
+        if (!targetUri) {
+          vscode.window.showErrorMessage(
+            "No workspace folder found for apme migration.",
+          );
+          return;
+        }
+        const targetPath = targetUri.fsPath;
+
+        await vscode.window.withProgress(
+          {
+            location: vscode.ProgressLocation.Notification,
+            title: "Migrating with apme...",
+            cancellable: false,
+          },
+          async () => {
+            try {
+              const result = await client.sendRequest<{
+                success: boolean;
+                filesUpdated: number;
+              }>("ansible/apme/remediateWorkspace");
+
+              if (result.success) {
+                vscode.window.showInformationMessage(
+                  `apme migration complete: ${result.filesUpdated} file(s) updated.`,
+                );
+              } else {
+                vscode.window.showWarningMessage(
+                  "apme migration finished with errors. Check the Ansible Server output.",
+                );
+              }
+            } catch (err) {
+              vscode.window.showErrorMessage(
+                `apme migration failed: ${err instanceof Error ? err.message : String(err)}`,
+              );
+            }
+          },
+        );
+      },
+    ),
+  );
+
+  // apme status bar indicator
+  const apmeStatusBar = vscode.window.createStatusBarItem(
+    vscode.StatusBarAlignment.Right,
+    99,
+  );
+  apmeStatusBar.command = "workbench.actions.view.problems";
+  context.subscriptions.push(apmeStatusBar);
+
+  const updateApmeStatusBar = () => {
+    const apmeEnabled = vscode.workspace
+      .getConfiguration("ansible.validation.apme")
+      .get<boolean>("enabled", false);
+    if (!apmeEnabled) {
+      apmeStatusBar.hide();
+      return;
+    }
+
+    const allDiagnostics = vscode.languages.getDiagnostics();
+    let apmeCount = 0;
+    for (const [, diags] of allDiagnostics) {
+      for (const d of diags) {
+        if (d.source === "Ansible [apme]") {
+          apmeCount++;
+        }
+      }
+    }
+
+    if (apmeCount === 0) {
+      apmeStatusBar.text = "$(check) apme";
+      apmeStatusBar.backgroundColor = undefined;
+      apmeStatusBar.tooltip = "apme: no violations";
+    } else {
+      apmeStatusBar.text = `$(warning) apme: ${apmeCount}`;
+      apmeStatusBar.backgroundColor = new vscode.ThemeColor(
+        "statusBarItem.warningBackground",
+      );
+      apmeStatusBar.tooltip = `apme: ${apmeCount} violation(s) — click to open Problems`;
+    }
+    apmeStatusBar.show();
+  };
+
+  context.subscriptions.push(
+    vscode.languages.onDidChangeDiagnostics(() => updateApmeStatusBar()),
+  );
+  updateApmeStatusBar();
+
   new AnsiblePlaybookRunProvider(context, extSettings, telemetry);
 
   // handle metadata status bar

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -221,51 +221,142 @@ export async function activate(context: ExtensionContext): Promise<void> {
     ),
   );
 
-  // apme status bar indicator
-  const apmeStatusBar = vscode.window.createStatusBarItem(
+  // Register apme remediate command (used by code actions)
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "ansible.apme.remediate",
+      async (filePath: string) => {
+        try {
+          const result = await client.sendRequest<{
+            success: boolean;
+            filesUpdated: number;
+          }>("ansible/apme/remediate", filePath);
+
+          if (result.success) {
+            vscode.window.showInformationMessage(
+              `apme remediation complete: ${result.filesUpdated} file(s) updated.`,
+            );
+          } else {
+            vscode.window.showWarningMessage(
+              "apme remediation finished with errors. Check the Ansible Server output.",
+            );
+          }
+        } catch (err) {
+          vscode.window.showErrorMessage(
+            `apme remediation failed: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      },
+    ),
+  );
+
+  // Register apme daemon restart command
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "ansible.apme.restartDaemon",
+      async () => {
+        await vscode.window.withProgress(
+          {
+            location: vscode.ProgressLocation.Notification,
+            title: "Restarting apme daemon...",
+            cancellable: false,
+          },
+          async () => {
+            try {
+              const result = await client.sendRequest<{
+                success: boolean;
+                message: string;
+              }>("ansible/apme/restartDaemon");
+
+              if (result.success) {
+                vscode.window.showInformationMessage(
+                  "apme daemon restarted successfully.",
+                );
+              } else {
+                vscode.window.showWarningMessage(
+                  `apme daemon restart issue: ${result.message}`,
+                );
+              }
+            } catch (err) {
+              vscode.window.showErrorMessage(
+                `apme daemon restart failed: ${err instanceof Error ? err.message : String(err)}`,
+              );
+            }
+          },
+        );
+      },
+    ),
+  );
+
+  // Scan status bar — shows scanning state for apme and ansible-lint
+  const scanStatusBar = vscode.window.createStatusBarItem(
     vscode.StatusBarAlignment.Right,
     99,
   );
-  apmeStatusBar.command = "workbench.actions.view.problems";
-  context.subscriptions.push(apmeStatusBar);
+  scanStatusBar.command = "workbench.actions.view.problems";
+  context.subscriptions.push(scanStatusBar);
 
-  const updateApmeStatusBar = () => {
-    const apmeEnabled = vscode.workspace
-      .getConfiguration("ansible.validation.apme")
-      .get<boolean>("enabled", false);
-    if (!apmeEnabled) {
-      apmeStatusBar.hide();
+  const activeScans = new Set<string>();
+
+  const updateScanStatusBar = () => {
+    if (activeScans.size > 0) {
+      const tools = Array.from(activeScans).join(", ");
+      scanStatusBar.text = `$(sync~spin) ${tools}`;
+      scanStatusBar.tooltip = `Scanning with ${tools}...`;
+      scanStatusBar.backgroundColor = undefined;
+      scanStatusBar.show();
       return;
     }
 
     const allDiagnostics = vscode.languages.getDiagnostics();
     let apmeCount = 0;
+    let lintCount = 0;
     for (const [, diags] of allDiagnostics) {
       for (const d of diags) {
-        if (d.source === "Ansible [apme]") {
-          apmeCount++;
-        }
+        if (d.source === "Ansible [apme]") apmeCount++;
+        else if (d.source === "Ansible [ansible-lint]") lintCount++;
       }
     }
 
-    if (apmeCount === 0) {
-      apmeStatusBar.text = "$(check) apme";
-      apmeStatusBar.backgroundColor = undefined;
-      apmeStatusBar.tooltip = "apme: no violations";
+    const total = apmeCount + lintCount;
+    if (total === 0) {
+      scanStatusBar.text = "$(check) apme";
+      scanStatusBar.backgroundColor = undefined;
+      scanStatusBar.tooltip = "No violations found";
     } else {
-      apmeStatusBar.text = `$(warning) apme: ${apmeCount}`;
-      apmeStatusBar.backgroundColor = new vscode.ThemeColor(
+      const parts: string[] = [];
+      if (apmeCount > 0) parts.push(`apme: ${apmeCount}`);
+      if (lintCount > 0) parts.push(`lint: ${lintCount}`);
+      scanStatusBar.text = `$(warning) ${parts.join(" | ")}`;
+      scanStatusBar.backgroundColor = new vscode.ThemeColor(
         "statusBarItem.warningBackground",
       );
-      apmeStatusBar.tooltip = `apme: ${apmeCount} violation(s) — click to open Problems`;
+      scanStatusBar.tooltip = `${total} violation(s) — click to open Problems`;
     }
-    apmeStatusBar.show();
+    scanStatusBar.show();
   };
 
-  context.subscriptions.push(
-    vscode.languages.onDidChangeDiagnostics(() => updateApmeStatusBar()),
+  // Listen for scan status notifications from the language server
+  client.onNotification(
+    "ansible/apme/scanStatus",
+    (params: { scanning: boolean; tool: string; violations?: number }) => {
+      if (params.scanning) {
+        activeScans.add(params.tool);
+      } else {
+        activeScans.delete(params.tool);
+      }
+      updateScanStatusBar();
+    },
   );
-  updateApmeStatusBar();
+
+  let scanStatusBarTimer: ReturnType<typeof setTimeout> | undefined;
+  context.subscriptions.push(
+    vscode.languages.onDidChangeDiagnostics(() => {
+      if (scanStatusBarTimer) clearTimeout(scanStatusBarTimer);
+      scanStatusBarTimer = setTimeout(updateScanStatusBar, 200);
+    }),
+  );
+  updateScanStatusBar();
 
   new AnsiblePlaybookRunProvider(context, extSettings, telemetry);
 


### PR DESCRIPTION
## Summary

- Integrates [apme](https://github.com/ansible/apme) (Ansible Policy & Modernization Engine) as a third diagnostics tool in the Ansible Language Server
- Surfaces apme's three-tier violation model (auto-fixable, ai-candidate, manual-review) as LSP diagnostics with code actions
- Adds "Migrate with apme" command for bulk project remediation
- Includes status bar indicator, clickable rule links, and configurable dedup with ansible-lint

## Changes

**New files:**
- `packages/ansible-language-server/src/services/ansibleApme.ts` — AnsibleApme service (validation, workspace scan, remediation with per-file lock)
- `packages/ansible-language-server/src/providers/codeActionProvider.ts` — Quick fix code actions for Tier 1 violations
- `packages/ansible-language-server/test/services/ansibleApme.test.ts` — 15 unit tests for JSON parser

**Modified files:**
- `package.json` — apme settings, "Migrate with apme" command, explorer context menu
- `src/extension.ts` — Migrate command handler, status bar indicator
- `packages/ansible-language-server/src/ansibleLanguageService.ts` — Code action handler, remediate request handlers, workspace scan on startup
- `packages/ansible-language-server/src/interfaces/extensionSettings.ts` — apme settings types
- `packages/ansible-language-server/src/providers/validationProvider.ts` — apme validation step + diagnostic dedup
- `packages/ansible-language-server/src/services/settingsManager.ts` — apme setting defaults
- `packages/ansible-language-server/src/services/workspaceManager.ts` — ansibleApme lazy getter

## New settings

| Setting | Default | Description |
|---------|---------|-------------|
| `ansible.validation.apme.enabled` | `false` | Enable apme static analysis |
| `ansible.validation.apme.path` | `"apme"` | Path to apme executable |
| `ansible.validation.apme.arguments` | `""` | Extra CLI arguments |
| `ansible.validation.apme.autoFixOnSave` | `false` | Auto-fix Tier 1 violations on save |
| `ansible.validation.diagnosticPrecedence` | `"both"` | Dedup: `both`, `apme`, or `lint` |

## Test plan

- [x] apme diagnostics appear as squiggles in editor
- [x] Problems panel shows violations with tier labels
- [x] Hover shows rule ID + message
- [x] "Migrate with apme" works from command palette and right-click context menu
- [x] Status bar shows violation count
- [x] Rule IDs are clickable links
- [x] Workspace auto-scan on open
- [x] 15 unit tests pass
- [ ] Auto-fix on save end-to-end test
- [ ] Integration tests with apme daemon


🤖 Generated with [Claude Code](https://claude.com/claude-code)