### PR TITLE
fix: skip LLM initialization when Lightspeed is disabled

### DIFF
--- a/src/features/lightspeed/lightspeedUser.ts
+++ b/src/features/lightspeed/lightspeedUser.ts
@@ -94,6 +94,9 @@ export class LightspeedUser {
   }
 
   private async logAuthProviderDebugHints(): Promise<void> {
+    if (!this._settingsManager.settings.lightSpeedService.enabled) {
+      return;
+    }
     const provider = this._settingsManager.settings.lightSpeedService.provider;
     const lightspeedUri = await getBaseUri(this._settingsManager);
     this._logger.info(
@@ -263,7 +266,12 @@ export class LightspeedUser {
         return [AuthProviderType.rhsso, AuthProviderType.lightspeed];
       }
     }
-    const lightspeedUri = await getBaseUri(this._settingsManager);
+    let lightspeedUri: string;
+    try {
+      lightspeedUri = await getBaseUri(this._settingsManager);
+    } catch {
+      return [AuthProviderType.lightspeed, AuthProviderType.rhsso];
+    }
     // Prefer RHSSO when we know Lightspeed auth will be broken.
     // Prefer Lightspeed auth all other times.
     if (


### PR DESCRIPTION
## Summary

Fixes #2769

The extension throws `LLM provider settings not initialized` errors during activation when `ansible.lightspeed.enabled` is set to `false`. Two unguarded code paths in `lightspeedUser.ts` called `getBaseUri()` without checking if Lightspeed was enabled:

- `logAuthProviderDebugHints()` — fired from the constructor with no enabled check, always calling `getBaseUri()` which throws when the global `lightSpeedManager` hasn't been assigned yet (race condition during constructor)
- `getAuthProviderOrder()` — called `getBaseUri()` without a try-catch, crashing if LLM provider settings weren't initialized

## Changes

- Added `lightSpeedService.enabled` guard to `logAuthProviderDebugHints()` to skip logging when Lightspeed is disabled
- Wrapped `getBaseUri()` call in `getAuthProviderOrder()` with try-catch, falling back to the default provider order when settings aren't available

## Test plan

- [x] Build VSIX from `main` — confirmed error appears in Output panel with `ansible.lightspeed.enabled: false`
- [x] Build VSIX from this branch — confirmed error is gone
- [x] TypeScript compiles cleanly (`pnpm run compile`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Fixes errors when Lightspeed is disabled by adding guards to prevent LLM initialization code paths from executing when Lightspeed is not enabled. Two unprotected calls to LightSpeed services in lightspeedUser.ts are now safeguarded, preventing "LLM provider settings not initialized" errors during extension activation.

- Added lightSpeedService.enabled check to logAuthProviderDebugHints() to skip debug logging when Lightspeed is disabled
- Wrapped getBaseUri() call in getAuthProviderOrder() with try-catch to handle missing LLM provider settings and fall back to default provider order

fixes: #2769

<!-- end of auto-generated comment: release notes by coderabbit.ai -->