### PR TITLE
fix(mcp): copy resource data files to build output directory

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -25,7 +25,6 @@
 !packages/ansible-language-server/dist/cli.cjs
 !packages/ansible-mcp-server/dist/**/*
 !packages/ansible-mcp-server/package.json
-!packages/ansible-mcp-server/src/resources/data/**/*
 !package.json
 !package.nls.json
 !syntaxes/**/*

--- a/packages/ansible-mcp-server/package.json
+++ b/packages/ansible-mcp-server/package.json
@@ -23,8 +23,7 @@
   },
   "files": [
     "lib",
-    "dist",
-    "./src/resources/data/**/*"
+    "dist"
   ],
   "keywords": [
     "mcp",

--- a/packages/ansible-mcp-server/tsup.config.ts
+++ b/packages/ansible-mcp-server/tsup.config.ts
@@ -1,7 +1,9 @@
 import type { Options } from "tsup";
+import { cpSync } from "node:fs";
 import { builtinModules } from "node:module";
 
 const env = process.env.NODE_ENV;
+const outDir = env === "production" ? "dist" : "lib";
 
 export const tsup: Options = {
   clean: true,
@@ -15,10 +17,15 @@ export const tsup: Options = {
   bundle: env === "production",
   entry: ["src/**/*.ts"],
   format: ["esm", "cjs"],
-  outDir: env === "production" ? "dist" : "lib",
+  outDir,
   splitting: false,
   watch: env === "development",
   skipNodeModulesBundle: false,
   noExternal: [/./],
   external: [...builtinModules],
+  async onSuccess() {
+    const dataTarget =
+      env === "production" ? `${outDir}/data` : `${outDir}/resources/data`;
+    cpSync("src/resources/data", dataTarget, { recursive: true });
+  },
 };

--- a/test/unit/mcp/mcpPackaging.test.ts
+++ b/test/unit/mcp/mcpPackaging.test.ts
@@ -21,10 +21,8 @@ describe("MCP server packaging", function () {
       );
     });
 
-    it("should whitelist MCP server resource data files", function () {
-      expect(vscodeignore).toContain(
-        "!packages/ansible-mcp-server/src/resources/data/**/*",
-      );
+    it("should whitelist MCP server dist files which include resource data", function () {
+      expect(vscodeignore).toContain("!packages/ansible-mcp-server/dist/**/*");
     });
   });
 

--- a/test/unit/mcp/mcpPackaging.test.ts
+++ b/test/unit/mcp/mcpPackaging.test.ts
@@ -3,6 +3,14 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 
 const projectRoot = path.resolve(__dirname, "..", "..", "..");
+const mcpPackageDir = path.join(projectRoot, "packages", "ansible-mcp-server");
+
+const resourceDataFiles = [
+  "agents.md",
+  "ee-rules.md",
+  "execution-environment-schema.json",
+  "execution-environment-sample.yml",
+];
 
 describe("MCP server packaging", function () {
   describe(".vscodeignore includes MCP server files", function () {
@@ -20,19 +28,9 @@ describe("MCP server packaging", function () {
         "!packages/ansible-mcp-server/package.json",
       );
     });
-
-    it("should whitelist MCP server dist files which include resource data", function () {
-      expect(vscodeignore).toContain("!packages/ansible-mcp-server/dist/**/*");
-    });
   });
 
   describe("MCP server package structure", function () {
-    const mcpPackageDir = path.join(
-      projectRoot,
-      "packages",
-      "ansible-mcp-server",
-    );
-
     it("should have package.json with correct main entry", function () {
       const pkg = JSON.parse(
         fs.readFileSync(path.join(mcpPackageDir, "package.json"), "utf8"),
@@ -50,6 +48,48 @@ describe("MCP server packaging", function () {
         return;
       }
       expect(fs.statSync(cliPath).isFile()).toBe(true);
+    });
+  });
+
+  describe("resource data files are present in build output", function () {
+    const distDataDir = path.join(mcpPackageDir, "dist", "data");
+    const sourceDataDir = path.join(mcpPackageDir, "src", "resources", "data");
+
+    it("should have source resource data files", function () {
+      for (const file of resourceDataFiles) {
+        expect(
+          fs.existsSync(path.join(sourceDataDir, file)),
+          `source file missing: src/resources/data/${file}`,
+        ).toBe(true);
+      }
+    });
+
+    it("should have resource data files copied to dist/data/ after build", function () {
+      if (!fs.existsSync(path.join(mcpPackageDir, "dist", "cli.js"))) {
+        console.warn(
+          "MCP server not built yet (dist/cli.js missing) - run 'pnpm build' first",
+        );
+        return;
+      }
+      for (const file of resourceDataFiles) {
+        expect(
+          fs.existsSync(path.join(distDataDir, file)),
+          `dist/data/${file} missing — tsup onSuccess copy may have failed`,
+        ).toBe(true);
+      }
+    });
+
+    it("should have non-empty resource data files in dist/data/", function () {
+      if (!fs.existsSync(distDataDir)) {
+        console.warn("dist/data/ not found - run 'pnpm build' first");
+        return;
+      }
+      for (const file of resourceDataFiles) {
+        const filePath = path.join(distDataDir, file);
+        if (!fs.existsSync(filePath)) continue;
+        const stat = fs.statSync(filePath);
+        expect(stat.size, `dist/data/${file} is empty`).toBeGreaterThan(0);
+      }
     });
   });
 });


### PR DESCRIPTION
# Fix: MCP server resource files missing from VSIX

## The Problem

The MCP server has 4 data files that tools need at runtime:

- `agents.md` — best practices guidelines used by `ansible_content_best_practices`
- `ee-rules.md` — execution environment rules used by `define_and_build_execution_env`
- `execution-environment-schema.json` — JSON schema for EE validation
- `execution-environment-sample.yml` — sample EE config

These files live at `packages/ansible-mcp-server/src/resources/data/`.

**How the code finds them:** When a tool like `define_and_build_execution_env` runs, it calls `resolveResourcePath("ee-rules.md", import.meta.url)` in `src/utils/resourcePath.ts`. This function figures out which directory the running code lives in (using `__dirname` for CJS or `import.meta.url` for ESM), then appends `/data/ee-rules.md` to that directory.

**What happens in the packaged extension:** The build tool (tsup) bundles all TypeScript into `dist/cli.cjs`. When this bundled file runs, `__dirname` resolves to `dist/`. So the code looks for `dist/data/ee-rules.md`.

**But `dist/data/` didn't exist.** tsup only compiles `.ts` files — it has no built-in mechanism to copy non-code assets like `.md` or `.json` files. The data files stayed in `src/resources/data/` and were never copied to the build output.

The `.vscodeignore` had a line `!packages/ansible-mcp-server/src/resources/data/**/*` which did ship the source data files inside the VSIX — but it didn't matter because the runtime code never looks in `src/resources/data/`. It only looks relative to where the compiled code runs from (`dist/`).

## The Fix

**1. `packages/ansible-mcp-server/tsup.config.ts`** — Added an `onSuccess` callback that runs after each tsup build and copies the data files to the right location:

- Production build (`dist/`): copies to `dist/data/` — because the bundled `cli.cjs` has `__dirname = dist/`
- Dev build (`lib/`): copies to `lib/resources/data/` — because non-bundled files like `lib/resources/eeSchema.js` have `__dirname = lib/resources/`

The `onSuccess` hook runs after tsup finishes (and after `clean: true` wipes the output dir), so the copied files survive in the final output.

**2. `.vscodeignore`** — Removed the `!packages/ansible-mcp-server/src/resources/data/**/*` line. Since data files are now properly in `dist/data/`, the existing `!packages/ansible-mcp-server/dist/**/*` line already includes them. This avoids shipping duplicate copies of the data files in the VSIX.

**3. `packages/ansible-mcp-server/package.json`** — Removed `"./src/resources/data/**/*"` from the `files` array. Same reasoning — `"dist"` and `"lib"` already cover the data files for npm publishing now.