### PR TITLE
fix(mcp): use CJS entry point for bin

### DIFF
--- a/packages/ansible-mcp-server/package.json
+++ b/packages/ansible-mcp-server/package.json
@@ -1,5 +1,5 @@
 {
-  "bin": "dist/cli.js",
+  "bin": "dist/cli.cjs",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
     "ajv": "^8.18.0",

--- a/packages/ansible-mcp-server/test/cli.test.ts
+++ b/packages/ansible-mcp-server/test/cli.test.ts
@@ -1,0 +1,28 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync, existsSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it, expect } from "vitest";
+
+const pkgRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const pkg = JSON.parse(readFileSync(resolve(pkgRoot, "package.json"), "utf8"));
+
+describe("CLI entry point", () => {
+  const binPath = resolve(pkgRoot, pkg.bin);
+
+  it("bin field points to a file that exists after build", () => {
+    expect(
+      existsSync(binPath),
+      `bin target "${pkg.bin}" not found at ${binPath}`,
+    ).toBe(true);
+  });
+
+  it("bin entry starts and prints usage without errors", () => {
+    const output = execFileSync(process.execPath, [binPath], {
+      timeout: 10_000,
+      encoding: "utf8",
+      env: { ...process.env, NODE_NO_WARNINGS: "1" },
+    });
+    expect(output).toContain("Usage:");
+  });
+});

--- a/test/e2e/mcp/mcpActivation.test.ts
+++ b/test/e2e/mcp/mcpActivation.test.ts
@@ -51,7 +51,7 @@ describe("MCP server activation and availability (AAP-64488)", function () {
         assert.ok(serverPath, "MCP server package should be resolvable");
 
         // CLI should be in the same directory as the main module
-        const cliPath = path.join(path.dirname(serverPath), "cli.js");
+        const cliPath = path.join(path.dirname(serverPath), "cli.cjs");
         assert.ok(existsSync(cliPath), `MCP CLI should exist at: ${cliPath}`);
       } catch (error) {
         // If module resolution fails, check for legacy paths as fallback
@@ -59,7 +59,7 @@ describe("MCP server activation and availability (AAP-64488)", function () {
           extensionPath,
           "out",
           "mcp",
-          "cli.js",
+          "cli.cjs",
         );
         const devCliPath = path.join(
           extensionPath,
@@ -68,7 +68,7 @@ describe("MCP server activation and availability (AAP-64488)", function () {
           "out",
           "server",
           "src",
-          "cli.js",
+          "cli.cjs",
         );
 
         const hasPackagedCli = existsSync(packagedCliPath);


### PR DESCRIPTION
## Summary
- The `bin` field in `packages/ansible-mcp-server/package.json` pointed to `dist/cli.js` (ESM), which contains CJS `require()` shims injected by tsup bundling. Node rejects `Dynamic require of "process"` inside ESM modules, causing `npx @ansible/ansible-mcp-server` to crash on startup.
- Changed `bin` to `dist/cli.cjs` which works correctly as a CJS module.

## Test plan
- [ ] Run `npx @ansible/ansible-mcp-server --stdio` and verify the server starts without errors
- [ ] Verify MCP client (Cursor, Cline) can connect to the server
- [ ] Run `task mcp:test` to confirm tests pass

closes: #2779

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

The package.json bin field for the MCP server package was updated to point to the CommonJS build instead of the ESM build. This fixes a startup failure where Node.js rejected dynamic require() calls within the ESM module, causing `npx @ansible/ansible-mcp-server` to crash. The bin entry now aligns with the main export pointing to dist/cli.cjs.

- Updated `"bin"` field in packages/ansible-mcp-server/package.json from `"dist/cli.js"` to `"dist/cli.cjs"`

closes: #2779

<!-- end of auto-generated comment: release notes by coderabbit.ai -->