### PR TITLE
feat(mcp): publish container image on ghcr.io

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -605,7 +605,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v6
         with:
-          images: ghcr.io/ansible/ansible-mcp-server
+          images: ghcr.io/ansible/devtools-mcp-server
           tags: |
             type=ref,event=branch
             type=semver,pattern={{version}}
@@ -618,13 +618,13 @@ jobs:
           context: packages/ansible-mcp-server
           file: packages/ansible-mcp-server/Containerfile
           load: true
-          tags: ghcr.io/ansible/ansible-mcp-server:smoke
+          tags: ghcr.io/ansible/devtools-mcp-server:smoke
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Smoke test MCP server container
         run: |
           INIT='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"smoke","version":"0.1"}}}'
-          RESPONSE=$(echo "$INIT" | timeout 10 docker run --rm -i ghcr.io/ansible/ansible-mcp-server:smoke --stdio)
+          RESPONSE=$(echo "$INIT" | timeout 10 docker run --rm -i ghcr.io/ansible/devtools-mcp-server:smoke --stdio || true)
           echo "$RESPONSE"
           echo "$RESPONSE" | grep -q '"ansible-mcp-server"' || { echo "Smoke test failed: server did not respond with expected name"; exit 1; }
           echo "Smoke test passed"
@@ -634,7 +634,7 @@ jobs:
         run: |
           while IFS= read -r tag; do
             [ -z "$tag" ] && continue
-            docker tag ghcr.io/ansible/ansible-mcp-server:smoke "$tag"
+            docker tag ghcr.io/ansible/devtools-mcp-server:smoke "$tag"
             docker push "$tag"
           done <<< "${{ steps.meta.outputs.tags }}"
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -570,12 +570,81 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./tools/builder.sh ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' && '--push' || '' }}
 
+  mcp-server-image:
+    runs-on: ubuntu-24.04
+    needs: [preflight, lint]
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          show-progress: false
+
+      - name: Download MCP server package
+        uses: actions/download-artifact@v8
+        with:
+          pattern: ansible-ansible-mcp-server-*.tgz
+          merge-multiple: true
+
+      - name: Extract MCP server build artifacts
+        run: |
+          ls -la ansible-ansible-mcp-server-*.tgz
+          tar xzf ansible-ansible-mcp-server-*.tgz -C packages/ansible-mcp-server --strip-components=1
+          ls -la packages/ansible-mcp-server/dist/
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract container metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ghcr.io/ansible/ansible-mcp-server
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+
+      - name: Build MCP server container
+        uses: docker/build-push-action@v6
+        with:
+          context: packages/ansible-mcp-server
+          file: packages/ansible-mcp-server/Containerfile
+          load: true
+          tags: ghcr.io/ansible/ansible-mcp-server:smoke
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Smoke test MCP server container
+        run: |
+          INIT='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"smoke","version":"0.1"}}}'
+          RESPONSE=$(echo "$INIT" | timeout 10 docker run --rm -i ghcr.io/ansible/ansible-mcp-server:smoke --stdio)
+          echo "$RESPONSE"
+          echo "$RESPONSE" | grep -q '"ansible-mcp-server"' || { echo "Smoke test failed: server did not respond with expected name"; exit 1; }
+          echo "Smoke test passed"
+
+      - name: Tag and push MCP server container
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' || github.ref_type == 'tag' || (github.event_name == 'release' && github.event.action == 'published') }}
+        run: |
+          while IFS= read -r tag; do
+            [ -z "$tag" ] && continue
+            docker tag ghcr.io/ansible/ansible-mcp-server:smoke "$tag"
+            docker push "$tag"
+          done <<< "${{ steps.meta.outputs.tags }}"
+
   check: # This job does nothing and is only used for the branch protection
     needs:
       - lint
       - preflight
       - build
       - builder-image
+      - mcp-server-image
     if: always() && !cancelled() && needs.build.result == 'success' && (needs.builder-image.result == 'success' || needs.builder-image.result == 'skipped')
 
     permissions:
@@ -643,7 +712,7 @@ jobs:
         uses: re-actors/alls-green@release/v1 # that is a branch, not a tag
         id: alls-green
         with:
-          allowed-skips: builder-image
+          allowed-skips: builder-image, mcp-server-image
           jobs: ${{ toJSON(needs) }}
 
       - name: Report unexpected failures

--- a/packages/ansible-mcp-server/.dockerignore
+++ b/packages/ansible-mcp-server/.dockerignore
@@ -1,0 +1,3 @@
+*
+!dist/**
+!package.json

--- a/packages/ansible-mcp-server/Containerfile
+++ b/packages/ansible-mcp-server/Containerfile
@@ -1,0 +1,14 @@
+FROM registry.access.redhat.com/ubi10/nodejs-24-minimal:latest
+
+LABEL org.opencontainers.image.source="https://github.com/ansible/vscode-ansible"
+LABEL org.opencontainers.image.description="Ansible MCP server for AI-assisted automation development"
+LABEL org.opencontainers.image.vendor="Red Hat"
+LABEL org.opencontainers.image.licenses="MIT"
+
+WORKDIR /app
+COPY dist/ dist/
+COPY package.json .
+
+USER 1001
+ENTRYPOINT ["node", "dist/cli.cjs"]
+CMD ["--stdio"]

--- a/packages/ansible-mcp-server/Taskfile.yml
+++ b/packages/ansible-mcp-server/Taskfile.yml
@@ -91,7 +91,7 @@ tasks:
     deps:
       - package
     cmds:
-      - docker build -f Containerfile -t ghcr.io/ansible/ansible-mcp-server:local .
+      - docker build -f Containerfile -t ghcr.io/ansible/devtools-mcp-server:local .
   clean:
     desc: Clean build artifacts
     dir: "{{ .TASKFILE_DIR }}"

--- a/packages/ansible-mcp-server/Taskfile.yml
+++ b/packages/ansible-mcp-server/Taskfile.yml
@@ -85,6 +85,13 @@ tasks:
       - npm pack --silent --pack-destination '{{ .GIT_ROOT }}/out'
       - defer: npm version 0.0.0 --no-git-tag-version
     silent: false
+  container:
+    desc: Build the MCP server container image
+    dir: "{{ .TASKFILE_DIR }}"
+    deps:
+      - package
+    cmds:
+      - docker build -f Containerfile -t ghcr.io/ansible/ansible-mcp-server:local .
   clean:
     desc: Clean build artifacts
     dir: "{{ .TASKFILE_DIR }}"


### PR DESCRIPTION
## Summary
- Adds UBI 10 container packaging for the MCP server using `ubi10/nodejs-24-minimal` as the base image
- New `mcp-server-image` CI job builds, smoke tests, and pushes to `ghcr.io/ansible/devtools-mcp-server` on main/tags/releases
- Smoke test sends a JSON-RPC `initialize` request to the container and validates the response
- Adds `task mcp:container` for local container builds

## Test plan
- [ ] CI `mcp-server-image` job builds the container successfully
- [ ] Smoke test passes (server responds to MCP initialize via stdio)
- [ ] Push step is skipped on PRs
- [ ] Container publishes on push to main with correct tags

## Usage

```bash
docker run --rm -i ghcr.io/ansible/devtools-mcp-server:latest --stdio
```

Or in an MCP client config:

```json
{
  "mcpServers": {
    "ansible": {
      "command": "docker",
      "args": ["run", "--rm", "-i", "ghcr.io/ansible/devtools-mcp-server:latest", "--stdio"]
    }
  }
}
```

related: AAP-64488

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Adds UBI 10 container packaging for the MCP server, a CI job that builds and smoke-tests the image, and publishing to GHCR on main/tag/release. Needed to provide a reproducible, distributable MCP server image; implemented via a Containerfile, CI job, and local build task.

- Added `mcp-server-image` CI job in `.github/workflows/ci.yaml` to build, smoke-test, and publish the container image
- Added `packages/ansible-mcp-server/.dockerignore` to include only `dist/` and `package.json` in build context
- Added `packages/ansible-mcp-server/Containerfile` using `ubi10/nodejs-24-minimal` and non-root user, ENTRYPOINT `node dist/cli.cjs`
- Added `container` task to `packages/ansible-mcp-server/Taskfile.yml` for local image builds
- Updated `check` job to depend on `mcp-server-image`
- Updated `re-actors/alls-green` allowed-skips to include `mcp-server-image`

related: AAP-64488
<!-- end of auto-generated comment: release notes by coderabbit.ai -->