### PR TITLE
fix: add auto-detection for common Ansible content files (#2782)

### DIFF
--- a/package.json
+++ b/package.json
@@ -679,11 +679,33 @@
           "**/*playbook*.yml",
           "**/*playbook*.yaml",
           "**/roles/**/main.yml",
-          "**/roles/**/main.yaml"
+          "**/roles/**/main.yaml",
+          "**/tasks/**/*.yml",
+          "**/tasks/**/*.yaml",
+          "**/handlers/**/*.yml",
+          "**/handlers/**/*.yaml",
+          "**/defaults/**/*.yml",
+          "**/defaults/**/*.yaml",
+          "**/vars/**/*.yml",
+          "**/vars/**/*.yaml",
+          "**/meta/*.yml",
+          "**/meta/*.yaml",
+          "**/host_vars/**/*.yml",
+          "**/host_vars/**/*.yaml",
+          "**/group_vars/**/*.yml",
+          "**/group_vars/**/*.yaml",
+          "**/molecule/*/molecule.yml",
+          "**/molecule/*/molecule.yaml"
         ],
         "filenames": [
           "site.yml",
-          "site.yaml"
+          "site.yaml",
+          "galaxy.yml",
+          "galaxy.yaml",
+          "execution-environment.yml",
+          "execution-environment.yaml",
+          "requirements.yml",
+          "requirements.yaml"
         ],
         "firstLine": "# code: language=ansible",
         "icon": {
@@ -929,13 +951,15 @@
     "yamlValidation": [
       {
         "fileMatch": [
-          "execution-environment.yml"
+          "execution-environment.yml",
+          "execution-environment.yaml"
         ],
         "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/execution-environment.json"
       },
       {
         "fileMatch": [
-          "meta/runtime.yml"
+          "meta/runtime.yml",
+          "meta/runtime.yaml"
         ],
         "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/meta-runtime.json"
       },
@@ -949,11 +973,17 @@
         "url": "https://raw.githubusercontent.com/ansible/ansible-navigator/main/src/ansible_navigator/data/ansible-navigator.json"
       },
       {
-        "fileMatch": "requirements.yml",
+        "fileMatch": [
+          "requirements.yml",
+          "requirements.yaml"
+        ],
         "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/requirements.json"
       },
       {
-        "fileMatch": "meta/main.yml",
+        "fileMatch": [
+          "meta/main.yml",
+          "meta/main.yaml"
+        ],
         "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/meta.json"
       },
       {
@@ -974,19 +1004,22 @@
       {
         "fileMatch": [
           ".ansible-lint",
-          ".config/ansible-lint.yml"
+          ".config/ansible-lint.yml",
+          ".config/ansible-lint.yaml"
         ],
         "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/ansible-lint-config.json"
       },
       {
         "fileMatch": [
-          "molecule/*/molecule.yml"
+          "molecule/*/molecule.yml",
+          "molecule/*/molecule.yaml"
         ],
         "url": "https://raw.githubusercontent.com/ansible-community/molecule/main/src/molecule/data/molecule.json"
       },
       {
         "fileMatch": [
-          "galaxy.yml"
+          "galaxy.yml",
+          "galaxy.yaml"
         ],
         "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/galaxy.json"
       },

--- a/packages/ansible-language-server/src/services/schemaService.ts
+++ b/packages/ansible-language-server/src/services/schemaService.ts
@@ -14,8 +14,18 @@ const SCHEMA_MAPPINGS = [
     pattern: /[/\\]meta[/\\]runtime\.ya?ml$/i,
     url: "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/meta-runtime.json",
   },
-  // Add more official schemas here as needed:
-  // galaxy.yml, requirements.yml, execution-environment.yml, etc.
+  {
+    pattern: /[/\\]galaxy\.ya?ml$/i,
+    url: "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/galaxy.json",
+  },
+  {
+    pattern: /[/\\]requirements\.ya?ml$/i,
+    url: "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/requirements.json",
+  },
+  {
+    pattern: /[/\\]execution-environment\.ya?ml$/i,
+    url: "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/execution-environment.json",
+  },
 ];
 
 /**


### PR DESCRIPTION
  ## fix: add auto-detection for common Ansible content files                                                                  
                                                                                                                               
  Fixes #2782                                                                                                                  
                                                                                                                               
  ### Problem                                                     

  The extension only auto-detects a small subset of Ansible files (playbooks, `site.yml`, `roles/**/main.yml`). Common files   
  like `galaxy.yml`, `execution-environment.yml`, `requirements.yml`, and task/handler files outside the recognized patterns
  default to plain YAML mode, which means users lose Ansible-specific features like syntax highlighting, linting, and the      
  Python environment selector.                                    

  ### Changes

  **Language auto-detection (`package.json` → `contributes.languages`):**                                                      
  - Added `galaxy.yml/yaml`, `execution-environment.yml/yaml`, and `requirements.yml/yaml` as recognized filenames
  - Added patterns for `tasks/`, `handlers/`, `defaults/`, `vars/`, `meta/`, `host_vars/`, `group_vars/`, and                  
  `molecule/*/molecule.yml` directories                                                                                        
                                                                                                                               
  **Schema mappings (`schemaService.ts`):**                                                                                    
  - Added schema mappings for `galaxy.yml`, `requirements.yml`, and `execution-environment.yml` in the language server
  (resolves the existing TODO comment)                                                                                         
                                                                  
  **YAML validation consistency (`package.json` → `yamlValidation`):**                                                         
  - Added missing `.yaml` variants for `execution-environment`, `meta/runtime`, `requirements`, `meta/main`, `molecule`,
  `galaxy`, and `ansible-lint` config entries that previously only matched `.yml`                                              
                                                                  
  ### How to test                                                                                                              
                                                                  
  1. Open a file like `galaxy.yml` or `execution-environment.yml` in VS Code — it should show as **Ansible** in the status bar,
   not YAML                                                       
  2. Open a task file outside of `roles/` (e.g. `tasks/install.yml`) — should also show as Ansible                             
  3. Rename any of the above files to use `.yaml` extension — should still be detected                                         
  4. Open a non-Ansible YAML file (e.g. `docker-compose.yml`) — should still show as YAML  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
The PR expands Ansible file auto-detection and schema mappings so common Ansible YAML files (including .yml and .yaml) and typical task/role paths are recognized, restoring language features (highlighting, linting, schemas) by adding filename/path patterns and schema mappings.

- Add filename detection for galaxy, execution-environment, and requirements (both .yml and .yaml)
- Add path patterns for tasks/, handlers/, defaults/, vars/, meta/, host_vars/, group_vars/, and molecule/*/molecule.yml
- Extend SCHEMA_MAPPINGS with galaxy.yml, requirements.yml, and execution-environment.yml
- Add .yaml variants to yamlValidation fileMatch entries for consistent validation

fixes: #2782
<!-- end of auto-generated comment: release notes by coderabbit.ai -->