### PR TITLE
chore(mcp): add IBM Bob, Claude Code, and Gemini CLI client configs

### DIFF
--- a/docs/development/mcp.md
+++ b/docs/development/mcp.md
@@ -418,9 +418,11 @@ npm exec -- ansible-mcp-server --stdio
 }
 ```
 
-#### Testing with Cursor / Claude Desktop
+#### Testing with MCP Clients
 
-- Add MCP server config
+The server works with any MCP-compatible client, including Cursor, Claude Desktop, Claude Code, IBM Bob, and Gemini CLI.
+
+- Add MCP server config (see [Getting Started](../mcp/README.md#starting-the-server))
 - Restart client
 - Trigger tools via chat
 - Validate formatting, errors, and output correctness

--- a/docs/mcp/README.md
+++ b/docs/mcp/README.md
@@ -64,10 +64,56 @@ Add the following configuration to your Claude Desktop settings:
 {
   "mcpServers": {
     "ansible": {
-      "command": "node",
-      "args": [
-        "ansible-mcp-server"
-      ],
+      "command": "npx",
+      "args": ["-y", "@ansible/ansible-mcp-server", "--stdio"],
+      "env": {
+        "WORKSPACE_ROOT": "/path/to/your/ansible/project"
+      }
+    }
+  }
+}
+```
+
+**For Claude Code:**
+
+```bash
+claude mcp add ansible -- npx -y @ansible/ansible-mcp-server --stdio
+```
+
+> **Note:** Set `WORKSPACE_ROOT` by passing `--env WORKSPACE_ROOT=/path/to/project` or it defaults to the current directory.
+
+**For IBM Bob IDE:**
+
+Add to `~/.bob/mcp_settings.json` (global) or `.bob/mcp.json` (project-level):
+
+```json
+{
+  "mcpServers": {
+    "ansible": {
+      "command": "npx",
+      "args": ["-y", "@ansible/ansible-mcp-server", "--stdio"],
+      "env": {
+        "WORKSPACE_ROOT": "/path/to/your/ansible/project"
+      }
+    }
+  }
+}
+```
+
+**For IBM Bob Shell:**
+
+Same configuration format as IBM Bob IDE. Add to `~/.bob/mcp_settings.json` or `.bob/mcp.json`.
+
+**For Gemini CLI:**
+
+Add to `.gemini/settings.json`:
+
+```json
+{
+  "mcpServers": {
+    "ansible": {
+      "command": "npx",
+      "args": ["-y", "@ansible/ansible-mcp-server", "--stdio"],
       "env": {
         "WORKSPACE_ROOT": "/path/to/your/ansible/project"
       }


### PR DESCRIPTION
## Summary

- Fix the existing Claude Desktop MCP config to use `npx @ansible/ansible-mcp-server` instead of `node ansible-mcp-server`, which doesn't work for most users
- Add client configuration instructions for Claude Code, IBM Bob IDE, IBM Bob Shell, and Gemini CLI
- Update the developer guide's manual testing section to reference all supported MCP clients

## Test plan

- [ ] Verify Claude Desktop config example works with `npx -y @ansible/ansible-mcp-server --stdio`
- [ ] Verify Claude Code CLI command works: `claude mcp add ansible -- npx -y @ansible/ansible-mcp-server --stdio`
- [ ] Verify IBM Bob config path and format are correct
- [ ] Verify Gemini CLI config path and format are correct
- [ ] Confirm all JSON examples are valid JSON
- [ ] Confirm docs render correctly in GitHub markdown preview

Follows up on #2779 (comment by @cross-logic suggesting multi-client documentation).

Assisted by Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updates MCP documentation to support multiple MCP clients with corrected configuration examples. Fixes Claude Desktop config to use `npx @ansible/ansible-mcp-server` instead of direct node invocation, and adds configuration instructions for Claude Code, IBM Bob IDE/Shell, and Gemini CLI. Updates the developer guide's manual testing section to reference all supported MCP clients.

- Fix Claude Desktop MCP configuration in docs/mcp/README.md to use `npx @ansible/ansible-mcp-server` instead of `node ansible-mcp-server`
- Add MCP client configuration examples for Claude Code, IBM Bob IDE, IBM Bob Shell, and Gemini CLI
- Replace narrow "Testing with Cursor / Claude Desktop" section with broader "Testing with MCP Clients" section in docs/development/mcp.md
- Update configuration examples to use `npx -y @ansible/ansible-mcp-server --stdio` command format

related: #2779

<!-- end of auto-generated comment: release notes by coderabbit.ai -->