### PR TITLE
fix: Remove ansible-creator version checks from devfile/devcontainer views

### DIFF
--- a/src/features/contentCreator/vue/views/createDevcontainerPanel.ts
+++ b/src/features/contentCreator/vue/views/createDevcontainerPanel.ts
@@ -5,7 +5,6 @@ import {
   disposePanelResources,
   createOrRevealPanel,
 } from "@src/features/contentCreator/vue/views/panelUtils";
-import { checkContentCreatorRequirements } from "@src/features/contentCreator/utils";
 
 export class MainPanel {
   public static currentPanel: MainPanel | undefined;
@@ -14,20 +13,6 @@ export class MainPanel {
 
   private constructor(panel: WebviewPanel, context: ExtensionContext) {
     this._panel = panel;
-
-    this._panel.webview.onDidReceiveMessage(
-      async (msg) => {
-        if (msg && msg.type === "request-requirements-status") {
-          const status = await checkContentCreatorRequirements();
-          this._panel.webview.postMessage({
-            type: "requirements-status",
-            ...status,
-          });
-        }
-      },
-      null,
-      this._disposables,
-    );
 
     setupPanelLifecycle(
       this._panel,

--- a/src/features/contentCreator/vue/views/createDevfilePanel.ts
+++ b/src/features/contentCreator/vue/views/createDevfilePanel.ts
@@ -5,7 +5,6 @@ import {
   disposePanelResources,
   createOrRevealPanel,
 } from "@src/features/contentCreator/vue/views/panelUtils";
-import { checkContentCreatorRequirements } from "@src/features/contentCreator/utils";
 
 export class MainPanel {
   public static currentPanel: MainPanel | undefined;
@@ -14,20 +13,6 @@ export class MainPanel {
 
   private constructor(panel: WebviewPanel, context: ExtensionContext) {
     this._panel = panel;
-
-    this._panel.webview.onDidReceiveMessage(
-      async (msg) => {
-        if (msg && msg.type === "request-requirements-status") {
-          const status = await checkContentCreatorRequirements();
-          this._panel.webview.postMessage({
-            type: "requirements-status",
-            ...status,
-          });
-        }
-      },
-      null,
-      this._disposables,
-    );
 
     setupPanelLifecycle(
       this._panel,

--- a/webviews/CreateDevcontainerApp.vue
+++ b/webviews/CreateDevcontainerApp.vue
@@ -26,8 +26,6 @@ const projectUrl = ref("");
 const openDevcontainerButtonDisabled = ref(true);
 const createButtonDisabled = ref(true);
 const defaultDestinationPath = ref("");
-const requirementsMet = ref(true);
-const requirementFailures = ref([]);
 
 const isFormValid = createFormValidator({
   destinationPath: () => {
@@ -117,13 +115,6 @@ watch([destinationPath, isCreating], () => {
 });
 
 onMounted(() => {
-  vscodeApi.postMessage({ type: "request-requirements-status" });
-  window.addEventListener("message", (event) => {
-    if (event.data && event.data.type === "requirements-status") {
-      requirementsMet.value = event.data.met;
-      requirementFailures.value = event.data.failures || [];
-    }
-  });
   setupMessageHandler({
     onHomeDirectory: (data) => {
       homeDir.value = data;
@@ -165,7 +156,6 @@ const descriptionHtml = `Devcontainers are json files used for building containe
     title="Create a devcontainer"
     subtitle="Build containerized development environments"
     :description="descriptionHtml"
-    :requirementsMet="requirementsMet"
   >
     <form id="devcontainer-form">
       <section class="component-container">

--- a/webviews/CreateDevfileApp.vue
+++ b/webviews/CreateDevfileApp.vue
@@ -31,8 +31,6 @@ const createButtonDisabled = ref(true);
 const clearLogsButtonDisabled = ref(true);
 const defaultDestinationPath = ref("");
 const defaultProjectName = ref("");
-const requirementsMet = ref(true);
-const requirementFailures = ref([]);
 
 const isFormValid = computed(() => {
   const currentPath =
@@ -148,14 +146,6 @@ const onClear = () => {
 };
 
 onMounted(() => {
-  vscodeApi.postMessage({ type: "request-requirements-status" });
-  window.addEventListener("message", (event) => {
-    if (event.data && event.data.type === "requirements-status") {
-      requirementsMet.value = event.data.met;
-      requirementFailures.value = event.data.failures || [];
-    }
-  });
-
   setupMessageHandler({
     onHomeDirectory: (data) => {
       console.log("onHomeDirectory called with:", data);
@@ -228,7 +218,6 @@ const descriptionHtml = `Devfiles are yaml files used for development environmen
     title="Create a devfile"
     subtitle="Leverage Red Hat Openshift Dev Spaces"
     :description="descriptionHtml"
-    :requirementsMet="requirementsMet"
   >
     <form id="devfile-form">
       <section class="component-container">


### PR DESCRIPTION
Fixes #2781.

Removes the ansible-creator checks from the devcontainer/devfile webviews since they are intended to work without ansible-creator present.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Removed ansible-creator version checks from devcontainer and devfile webviews because these views are designed to work without ansible-creator installed locally. The scaffolding functionality exists within the extension and doesn't require external dependencies, allowing users to use these features even when ansible-creator is unavailable.

- Removed `checkContentCreatorRequirements` import and message handler from `createDevcontainerPanel.ts`
- Removed `checkContentCreatorRequirements` import and message handler from `createDevfilePanel.ts`
- Removed requirements status state and message listener from `CreateDevcontainerApp.vue`
- Removed requirements status state and message listener from `CreateDevfileApp.vue`

fixes: #2781

<!-- end of auto-generated comment: release notes by coderabbit.ai -->