### PR TITLE
fix: prevent API key disclosure via settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -491,9 +491,9 @@
           "ansible.lightspeed.apiKey": {
             "type": "string",
             "default": "",
-            "markdownDescription": "API key for authentication.",
+            "markdownDescription": "**REMOVED** — API keys are now stored securely. Use the LLM Provider Settings panel.",
             "deprecated": true,
-            "deprecationMessage": "This setting is deprecated and will be removed in a future release. Use the LLM Provider Settings panel instead for secure API key storage.",
+            "deprecationMessage": "This setting is no longer read. API keys are stored in VS Code's secret storage via the LLM Provider Settings panel.",
             "order": 7,
             "scope": "resource"
           }

--- a/src/features/lightspeed/base.ts
+++ b/src/features/lightspeed/base.ts
@@ -91,6 +91,7 @@ export class LightSpeedManager {
     this.providerManager = new ProviderManager(
       this.settingsManager,
       this.apiInstance,
+      this.llmProviderSettings,
     );
 
     this.contentMatchesProvider = new ContentMatchesWebview(

--- a/src/features/lightspeed/llmProviderSettings.ts
+++ b/src/features/lightspeed/llmProviderSettings.ts
@@ -31,7 +31,7 @@ export class LlmProviderSettings {
     const cfg = vscode.workspace.getConfiguration("ansible.lightspeed");
     const inspect = (key: string) => {
       const i = cfg.inspect<string>(key);
-      return i?.workspaceValue ?? i?.globalValue;
+      return i?.workspaceFolderValue ?? i?.workspaceValue ?? i?.globalValue;
     };
 
     // Import provider first — it determines where other fields are stored
@@ -67,6 +67,10 @@ export class LlmProviderSettings {
         }
       }
     }
+
+    // Scrub sensitive values from settings.json so they no longer persist
+    // in plain text after being migrated to the secret store.
+    await LlmProviderSettings.scrubLegacySecrets(cfg);
 
     await this.context.globalState.update(
       LlmProviderSettings.MIGRATION_KEY,
@@ -126,6 +130,41 @@ export class LlmProviderSettings {
     await this.context.globalState.update(stateKey, value?.trim() ?? "");
   }
 
+  /**
+   * Remove the apiKey from settings.json at both global and workspace scopes
+   * so it no longer persists in plain text on disk.
+   */
+  private static async scrubLegacySecrets(
+    cfg: vscode.WorkspaceConfiguration,
+  ): Promise<void> {
+    const info = cfg.inspect<string>("apiKey");
+    try {
+      if (info?.globalValue !== undefined) {
+        await cfg.update(
+          "apiKey",
+          undefined,
+          vscode.ConfigurationTarget.Global,
+        );
+      }
+      if (info?.workspaceValue !== undefined) {
+        await cfg.update(
+          "apiKey",
+          undefined,
+          vscode.ConfigurationTarget.Workspace,
+        );
+      }
+      if (info?.workspaceFolderValue !== undefined) {
+        await cfg.update(
+          "apiKey",
+          undefined,
+          vscode.ConfigurationTarget.WorkspaceFolder,
+        );
+      }
+    } catch {
+      // Best-effort: workspace may be read-only or untrusted
+    }
+  }
+
   private getProviderInfo(providerType: string) {
     return providerFactory
       .getSupportedProviders()
@@ -174,21 +213,18 @@ export class LlmProviderSettings {
     provider: string;
     apiEndpoint: string;
     modelName: string | undefined;
-    apiKey: string;
     maxTokens?: string;
     connectionStatuses: Record<string, boolean>;
   }> {
     const currentProvider = this.getProvider();
     const apiEndpoint = await this.get(currentProvider, "apiEndpoint");
     const modelName = await this.get(currentProvider, "modelName");
-    const apiKey = await this.get(currentProvider, "apiKey");
     const maxTokens = await this.get(currentProvider, "maxTokens");
 
     return {
       provider: currentProvider,
       apiEndpoint,
       modelName: modelName || undefined,
-      apiKey,
       maxTokens: maxTokens || undefined,
       connectionStatuses: this.getAllConnectionStatuses(),
     };

--- a/src/features/lightspeed/providerManager.ts
+++ b/src/features/lightspeed/providerManager.ts
@@ -15,16 +15,23 @@ import {
   CompletionResponseParams,
 } from "@src/interfaces/lightspeed";
 import { isError } from "@src/features/lightspeed/utils/errors";
+import { LlmProviderSettings } from "@src/features/lightspeed/llmProviderSettings";
 
 export class ProviderManager {
   private readonly settingsManager: SettingsManager;
   private readonly wcaApi: LightSpeedAPI;
+  private readonly llmProviderSettings: LlmProviderSettings;
   private llmProvider: LLMProvider | null = null;
   private readonly providerStatus: Map<string, ProviderStatus> = new Map();
 
-  constructor(settingsManager: SettingsManager, wcaApi: LightSpeedAPI) {
+  constructor(
+    settingsManager: SettingsManager,
+    wcaApi: LightSpeedAPI,
+    llmProviderSettings: LlmProviderSettings,
+  ) {
     this.settingsManager = settingsManager;
     this.wcaApi = wcaApi;
+    this.llmProviderSettings = llmProviderSettings;
     this.initializeLlmProvider();
   }
 
@@ -41,9 +48,14 @@ export class ProviderManager {
     }
 
     try {
+      const apiKey = await this.llmProviderSettings.get(
+        lightspeedConfig.provider,
+        "apiKey",
+      );
       this.llmProvider = providerFactory.createProvider(
         lightspeedConfig.provider as ProviderType,
         lightspeedConfig,
+        apiKey || undefined,
       );
 
       // Validate the provider configuration

--- a/src/features/lightspeed/providers/base.ts
+++ b/src/features/lightspeed/providers/base.ts
@@ -195,6 +195,38 @@ export abstract class BaseLLMProvider<
   }
 
   /**
+   * Strip secrets (API keys, bearer tokens, authorization headers) from an
+   * error before it is written to a log channel.  Returns a safe string.
+   */
+  protected static sanitizeErrorForLogging(error: unknown): string {
+    const redact = (text: string): string =>
+      text
+        .replaceAll(
+          /(Authorization["']?\s*[:=]\s*["']?Bearer\s+)[^"'\s,}]+/gi,
+          "$1[REDACTED]",
+        )
+        .replaceAll(/(apiKey["']?\s*[:=]\s*["']?)[^"'\s,}]+/gi, "$1[REDACTED]")
+        .replaceAll(
+          /key["']?\s*[:=]\s*["'][A-Za-z0-9_-]{20,}["']/gi,
+          "key: [REDACTED]",
+        )
+        .replaceAll(
+          /(x-goog-api-key["']?\s*[:=]\s*["']?)[^"'\s,}&]+/gi,
+          "$1[REDACTED]",
+        )
+        .replaceAll(/([?&]x-goog-api-key=)[^&\s]+/gi, "$1[REDACTED]");
+
+    if (error instanceof Error) {
+      return redact(error.stack ?? error.message);
+    }
+    try {
+      return redact(JSON.stringify(error));
+    } catch {
+      return redact(String(error));
+    }
+  }
+
+  /**
    * Handle HTTP status code errors with comprehensive error messages
    * This method provides reusable error handling for common HTTP status codes
    */

--- a/src/features/lightspeed/providers/factory.ts
+++ b/src/features/lightspeed/providers/factory.ts
@@ -29,28 +29,28 @@ export class LLMProviderFactory implements ProviderFactory {
   createProvider(
     type: ProviderType,
     config: LightSpeedServiceSettings,
+    apiKey?: string,
   ): LLMProvider {
     switch (type) {
       case "wca":
-        // WCA provider would be handled differently (using existing LightSpeedAPI)
         throw new Error(
           "WCA provider should be handled by existing LightSpeedAPI, not factory",
         );
 
       case "google": {
-        if (!config.apiKey) {
+        const normalizedApiKey = apiKey?.trim();
+        if (!normalizedApiKey) {
           throw new Error(
-            "API Key is required for Google Gemini. Please set 'ansible.lightspeed.apiKey' in your settings.",
+            "API Key is required for Google Gemini. Please configure it in the LLM Provider Settings panel.",
           );
         }
-        // Use custom endpoint if provided (allows v2, proxies, etc.)
         const customEndpoint =
           config.apiEndpoint && config.apiEndpoint !== GOOGLE_API_ENDPOINT
             ? config.apiEndpoint
             : undefined;
 
         return new GoogleProvider({
-          apiKey: config.apiKey,
+          apiKey: normalizedApiKey,
           modelName: config.modelName || GOOGLE_DEFAULT_MODEL,
           timeout: config.timeout || 30000,
           baseUrl: customEndpoint,
@@ -58,7 +58,7 @@ export class LLMProviderFactory implements ProviderFactory {
       }
 
       case "rhcustom":
-        return this.createRHCustomProvider(config);
+        return this.createRHCustomProvider(config, apiKey);
 
       default:
         throw new Error(`Unsupported provider type: ${type}`);
@@ -79,10 +79,12 @@ export class LLMProviderFactory implements ProviderFactory {
 
   private createRHCustomProvider(
     config: LightSpeedServiceSettings,
+    apiKey?: string,
   ): RHCustomProvider {
-    if (!config.apiKey || config.apiKey.trim() === "") {
+    const normalizedApiKey = apiKey?.trim();
+    if (!normalizedApiKey) {
       throw new Error(
-        "API Key is required for Red Hat AI. Please set it in the provider settings.",
+        "API Key is required for Red Hat AI. Please configure it in the LLM Provider Settings panel.",
       );
     }
     if (!config.modelName || config.modelName.trim() === "") {
@@ -101,7 +103,7 @@ export class LLMProviderFactory implements ProviderFactory {
       baseURL = baseURL.slice(0, -1);
     }
     return new RHCustomProvider({
-      apiKey: config.apiKey,
+      apiKey: normalizedApiKey,
       modelName: config.modelName,
       baseURL,
       timeout: config.timeout || 30000,
@@ -221,6 +223,7 @@ export class LLMProviderFactory implements ProviderFactory {
   validateProviderConfig(
     type: ProviderType,
     config: LightSpeedServiceSettings,
+    apiKey?: string,
   ): boolean {
     const providerInfo = this.getSupportedProviders().find(
       (p) => p.type === type,
@@ -229,9 +232,13 @@ export class LLMProviderFactory implements ProviderFactory {
       return false;
     }
 
-    // Check required fields
     for (const field of providerInfo.configSchema) {
       if (field.required) {
+        // For password fields the value comes from the separate apiKey param
+        if (field.type === "password") {
+          if (!apiKey || apiKey.trim() === "") return false;
+          continue;
+        }
         const value = config[field.key as keyof LightSpeedServiceSettings];
         if (!value || (typeof value === "string" && value.trim() === "")) {
           return false;
@@ -239,9 +246,7 @@ export class LLMProviderFactory implements ProviderFactory {
       }
     }
 
-    // Special validation for WCA
     if (type === "wca") {
-      // WCA requires valid endpoint but no API key
       if (!config.apiEndpoint || config.apiEndpoint.trim() === "") {
         return false;
       }

--- a/src/features/lightspeed/providers/google.ts
+++ b/src/features/lightspeed/providers/google.ts
@@ -84,7 +84,7 @@ export class GoogleProvider extends BaseLLMProvider<GoogleConfig> {
 
       this.logger.error(`[Google Provider] ${formattedError.message}`);
       this.logger.error(
-        `[Google Provider] Validation error details: ${error instanceof Error ? error.stack : JSON.stringify(error)}`,
+        `[Google Provider] Validation error details: ${BaseLLMProvider.sanitizeErrorForLogging(error)}`,
       );
       return false;
     }
@@ -135,16 +135,12 @@ export class GoogleProvider extends BaseLLMProvider<GoogleConfig> {
 
       return result_data;
     } catch (error) {
-      this.logger.error(
-        `[Google Provider] Completion request failed: ${error}`,
-      );
-      this.logger.error(
-        `[Google Provider] Error stack: ${error instanceof Error ? error.stack : "No stack trace"}`,
-      );
-      throw new Error(
-        `Google completion failed: ${error instanceof Error ? error.message : "Unknown error"}`,
-        { cause: error },
-      );
+      const safeError = BaseLLMProvider.sanitizeErrorForLogging(error);
+      this.logger.error("[Google Provider] Completion request failed");
+      this.logger.error(`[Google Provider] Error details: ${safeError}`);
+      throw new Error(`Google completion failed: ${safeError}`, {
+        cause: error,
+      });
     }
   }
 
@@ -189,7 +185,9 @@ export class GoogleProvider extends BaseLLMProvider<GoogleConfig> {
         model: this.modelName,
       };
     } catch (error) {
-      this.logger.error(`[Google Provider] Chat request failed: ${error}`);
+      this.logger.error(
+        `[Google Provider] Chat request failed: ${BaseLLMProvider.sanitizeErrorForLogging(error)}`,
+      );
       throw this.handleGeminiError(error, "chat generation");
     }
   }
@@ -253,7 +251,7 @@ export class GoogleProvider extends BaseLLMProvider<GoogleConfig> {
       };
     } catch (error) {
       this.logger.error(
-        `[Google Provider] Playbook generation failed: ${error}`,
+        `[Google Provider] Playbook generation failed: ${BaseLLMProvider.sanitizeErrorForLogging(error)}`,
       );
       throw this.handleGeminiError(error, "playbook generation");
     }
@@ -307,7 +305,9 @@ export class GoogleProvider extends BaseLLMProvider<GoogleConfig> {
         model: this.modelName,
       };
     } catch (error) {
-      this.logger.error(`[Google Provider] Role generation failed: ${error}`);
+      this.logger.error(
+        `[Google Provider] Role generation failed: ${BaseLLMProvider.sanitizeErrorForLogging(error)}`,
+      );
       throw this.handleGeminiError(error, "role generation");
     }
   }

--- a/src/features/lightspeed/providers/rhcustom.ts
+++ b/src/features/lightspeed/providers/rhcustom.ts
@@ -52,7 +52,7 @@ export class RHCustomProvider extends BaseLLMProvider<RHCustomConfig> {
     // Validate required fields
     if (!config.apiKey || config.apiKey.trim() === "") {
       throw new Error(
-        "API Key is required for Red Hat AI provider. Please set 'ansible.lightspeed.apiKey' in your settings.",
+        "API Key is required for Red Hat AI provider. Please configure it in the LLM Provider Settings panel.",
       );
     }
     if (!config.modelName || config.modelName.trim() === "") {
@@ -238,7 +238,7 @@ export class RHCustomProvider extends BaseLLMProvider<RHCustomConfig> {
 
       this.logger.error(`[RHCustom Provider] ${formattedError.message}`);
       this.logger.error(
-        `[RHCustom Provider] Validation error details: ${error instanceof Error ? error.stack : JSON.stringify(error)}`,
+        `[RHCustom Provider] Validation error details: ${BaseLLMProvider.sanitizeErrorForLogging(error)}`,
       );
       return false;
     }
@@ -311,7 +311,9 @@ export class RHCustomProvider extends BaseLLMProvider<RHCustomConfig> {
         model: this.modelName,
       };
     } catch (error) {
-      this.logger.error(`[RHCustom Provider] Chat request failed: ${error}`);
+      this.logger.error(
+        `[RHCustom Provider] Chat request failed: ${BaseLLMProvider.sanitizeErrorForLogging(error)}`,
+      );
       throw this.handleRHCustomError(error, "chat generation");
     }
   }
@@ -416,7 +418,7 @@ export class RHCustomProvider extends BaseLLMProvider<RHCustomConfig> {
       };
     } catch (error) {
       this.logger.error(
-        `[RHCustom Provider] Playbook generation failed: ${error}`,
+        `[RHCustom Provider] Playbook generation failed: ${BaseLLMProvider.sanitizeErrorForLogging(error)}`,
       );
       throw this.handleRHCustomError(error, "playbook generation");
     }
@@ -549,7 +551,9 @@ export class RHCustomProvider extends BaseLLMProvider<RHCustomConfig> {
         model: this.modelName,
       };
     } catch (error) {
-      this.logger.error(`[RHCustom Provider] Role generation failed: ${error}`);
+      this.logger.error(
+        `[RHCustom Provider] Role generation failed: ${BaseLLMProvider.sanitizeErrorForLogging(error)}`,
+      );
       throw this.handleRHCustomError(error, "role generation");
     }
   }

--- a/src/features/lightspeed/vue/views/llmProviderMessageHandlers.ts
+++ b/src/features/lightspeed/vue/views/llmProviderMessageHandlers.ts
@@ -95,15 +95,17 @@ export class LlmProviderMessageHandlers {
     const settings = await this.llmProviderSettings.getAllSettings();
     const connectionStatuses = { ...settings.connectionStatuses };
 
-    // Build configs dynamically based on each provider's configSchema
+    // Build configs dynamically based on each provider's configSchema.
+    // Password fields are masked so the real secret is never sent to the webview.
     const providerConfigs: Record<string, Record<string, string>> = {};
     for (const provider of providers) {
       const config: Record<string, string> = {};
       for (const field of provider.configSchema) {
-        config[field.key] = await this.llmProviderSettings.get(
+        const raw = await this.llmProviderSettings.get(
           provider.type,
           field.key,
         );
+        config[field.key] = field.type === "password" && raw ? "••••••••" : raw;
       }
       providerConfigs[provider.type] = config;
     }
@@ -160,9 +162,13 @@ export class LlmProviderMessageHandlers {
       if (providerInfo) {
         for (const field of providerInfo.configSchema) {
           const value = message.config[field.key];
-          // Skip apiKey only if provider doesn't require it
-          // (but still save empty value to clear existing key)
           if (field.key === "apiKey" && !providerInfo.requiresApiKey) {
+            continue;
+          }
+          // The webview receives a mask ("••••••••") for password fields.
+          // Skip saving when the mask is returned unchanged so we never
+          // overwrite the real secret with the placeholder.
+          if (field.type === "password" && value === "••••••••") {
             continue;
           }
           await this.llmProviderSettings.set(
@@ -351,7 +357,6 @@ export class LlmProviderMessageHandlers {
       const provider = providerFactory.createProvider(
         providerType as ProviderType,
         {
-          apiKey,
           modelName,
           apiEndpoint,
           maxTokens: Number.isNaN(maxTokens) ? undefined : maxTokens,
@@ -360,6 +365,7 @@ export class LlmProviderMessageHandlers {
           timeout: 30000,
           suggestions: { enabled: true, waitWindow: 0 },
         },
+        apiKey || undefined,
       );
 
       const status = await provider.getStatus();

--- a/src/interfaces/extensionSettings.d.ts
+++ b/src/interfaces/extensionSettings.d.ts
@@ -37,7 +37,6 @@ interface LightSpeedServiceSettings {
   provider: string; // 'wca' | 'google' | 'rhcustom'
   apiEndpoint: string;
   modelName: string | undefined;
-  apiKey: string; // For third-party providers like Google, Red Hat AI
   maxTokens?: number; // For Red Hat AI and other API-key providers
   timeout: number; // Request timeout in milliseconds
   suggestions: { enabled: boolean; waitWindow: number };

--- a/src/interfaces/lightspeed.ts
+++ b/src/interfaces/lightspeed.ts
@@ -300,10 +300,12 @@ export interface ProviderFactory {
   createProvider(
     type: ProviderType,
     config: LightSpeedServiceSettings,
+    apiKey?: string,
   ): LLMProvider;
   getSupportedProviders(): ProviderInfo[];
   validateProviderConfig(
     type: ProviderType,
     config: LightSpeedServiceSettings,
+    apiKey?: string,
   ): boolean;
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -37,7 +37,6 @@ export class SettingsManager {
           provider: "wca",
           apiEndpoint: "https://c.ai.ansible.redhat.com",
           modelName: undefined,
-          apiKey: "",
           maxTokens: undefined,
         };
 
@@ -67,7 +66,6 @@ export class SettingsManager {
         provider: llmSettings.provider,
         apiEndpoint: llmSettings.apiEndpoint,
         modelName: llmSettings.modelName,
-        apiKey: llmSettings.apiKey,
         maxTokens: llmSettings.maxTokens
           ? Number.parseInt(llmSettings.maxTokens, 10)
           : undefined,

--- a/test/unit/lightspeed/llmProviderSettings.test.ts
+++ b/test/unit/lightspeed/llmProviderSettings.test.ts
@@ -256,12 +256,13 @@ describe("LlmProviderSettings", () => {
       const settings = await llmProviderSettings.getAllSettings();
 
       expect(settings.provider).toBe("google");
-      expect(settings.apiKey).toBe(TEST_API_KEYS.GOOGLE);
       expect(settings.apiEndpoint).toBe(
         "https://generativelanguage.googleapis.com/v1beta",
       );
       expect(settings.modelName).toBe("gemini-2.5-flash");
       expect(settings.connectionStatuses.google).toBe(true);
+      // apiKey must NOT be returned by getAllSettings (kept in secret store only)
+      expect((settings as Record<string, unknown>).apiKey).toBeUndefined();
     });
   });
 

--- a/test/unit/lightspeed/providerManager.test.ts
+++ b/test/unit/lightspeed/providerManager.test.ts
@@ -6,11 +6,13 @@ import type {
   LLMProvider,
   ProviderStatus,
 } from "@src/features/lightspeed/providers/base";
+import type { LlmProviderSettings } from "@src/features/lightspeed/llmProviderSettings";
 import {
   PROVIDER_TYPES,
   MODEL_NAMES,
   GOOGLE_PROVIDER,
   TEST_LIGHTSPEED_SETTINGS,
+  TEST_API_KEYS,
   TEST_PROMPTS,
   TEST_CONTENT,
   TEST_RESPONSES,
@@ -73,6 +75,7 @@ describe("ProviderManager", () => {
   let providerManager: ProviderManager;
   let mockSettingsManager: SettingsManager;
   let mockWcaApi: LightSpeedAPI;
+  let mockLlmProviderSettings: LlmProviderSettings;
   let mockLlmProvider: LLMProvider;
 
   beforeEach(async () => {
@@ -95,6 +98,14 @@ describe("ProviderManager", () => {
       getStatus: vi.fn(),
     } as unknown as LightSpeedAPI;
 
+    // Setup mock LlmProviderSettings that returns apiKey from secret store
+    mockLlmProviderSettings = {
+      get: vi.fn(async (_provider: string, key: string) => {
+        if (key === "apiKey") return TEST_API_KEYS.GOOGLE;
+        return "";
+      }),
+    } as unknown as LlmProviderSettings;
+
     // Get the mock provider from the factory
     const factoryModule =
       await import("@src/features/lightspeed/providers/factory.js");
@@ -116,7 +127,11 @@ describe("ProviderManager", () => {
 
   describe("constructor and initialization", () => {
     it("should initialize with Google provider when configured", async () => {
-      providerManager = new ProviderManager(mockSettingsManager, mockWcaApi);
+      providerManager = new ProviderManager(
+        mockSettingsManager,
+        mockWcaApi,
+        mockLlmProviderSettings,
+      );
 
       // Wait for async initialization
       await new Promise((resolve) => setTimeout(resolve, 0));
@@ -126,6 +141,7 @@ describe("ProviderManager", () => {
       expect(createProvider).toHaveBeenCalledWith(
         PROVIDER_TYPES.GOOGLE,
         mockSettingsManager.settings.lightSpeedService,
+        TEST_API_KEYS.GOOGLE,
       );
       expect(getStatus).toHaveBeenCalled();
     });
@@ -133,7 +149,11 @@ describe("ProviderManager", () => {
     it("should not initialize provider when lightspeed is disabled", async () => {
       mockSettingsManager.settings.lightSpeedService.enabled = false;
 
-      providerManager = new ProviderManager(mockSettingsManager, mockWcaApi);
+      providerManager = new ProviderManager(
+        mockSettingsManager,
+        mockWcaApi,
+        mockLlmProviderSettings,
+      );
       await new Promise((resolve) => setTimeout(resolve, 0));
 
       const createProvider = vi.mocked(providerFactory.createProvider);
@@ -145,7 +165,11 @@ describe("ProviderManager", () => {
         ...TEST_LIGHTSPEED_SETTINGS.WCA,
       };
 
-      providerManager = new ProviderManager(mockSettingsManager, mockWcaApi);
+      providerManager = new ProviderManager(
+        mockSettingsManager,
+        mockWcaApi,
+        mockLlmProviderSettings,
+      );
       await new Promise((resolve) => setTimeout(resolve, 0));
 
       const createProvider = vi.mocked(providerFactory.createProvider);
@@ -163,7 +187,11 @@ describe("ProviderManager", () => {
         throw new Error("Invalid API key");
       });
 
-      providerManager = new ProviderManager(mockSettingsManager, mockWcaApi);
+      providerManager = new ProviderManager(
+        mockSettingsManager,
+        mockWcaApi,
+        mockLlmProviderSettings,
+      );
       await new Promise((resolve) => setTimeout(resolve, 0));
 
       expect(consoleErrorSpy).toHaveBeenCalledWith(
@@ -186,7 +214,11 @@ describe("ProviderManager", () => {
         error: "API key invalid",
       });
 
-      providerManager = new ProviderManager(mockSettingsManager, mockWcaApi);
+      providerManager = new ProviderManager(
+        mockSettingsManager,
+        mockWcaApi,
+        mockLlmProviderSettings,
+      );
       await new Promise((resolve) => setTimeout(resolve, 0));
 
       expect(consoleWarnSpy).toHaveBeenCalledWith(
@@ -200,7 +232,11 @@ describe("ProviderManager", () => {
 
   describe("refreshProviders", () => {
     it("should reinitialize provider on refresh", async () => {
-      providerManager = new ProviderManager(mockSettingsManager, mockWcaApi);
+      providerManager = new ProviderManager(
+        mockSettingsManager,
+        mockWcaApi,
+        mockLlmProviderSettings,
+      );
       await new Promise((resolve) => setTimeout(resolve, 0));
 
       vi.clearAllMocks();
@@ -216,7 +252,11 @@ describe("ProviderManager", () => {
 
   describe("getActiveProvider", () => {
     it("should return llmprovider when Google provider is configured", async () => {
-      providerManager = new ProviderManager(mockSettingsManager, mockWcaApi);
+      providerManager = new ProviderManager(
+        mockSettingsManager,
+        mockWcaApi,
+        mockLlmProviderSettings,
+      );
       await new Promise((resolve) => setTimeout(resolve, 0));
 
       const activeProvider = providerManager.getActiveProvider();
@@ -229,7 +269,11 @@ describe("ProviderManager", () => {
         ...TEST_LIGHTSPEED_SETTINGS.WCA,
       };
 
-      providerManager = new ProviderManager(mockSettingsManager, mockWcaApi);
+      providerManager = new ProviderManager(
+        mockSettingsManager,
+        mockWcaApi,
+        mockLlmProviderSettings,
+      );
       await new Promise((resolve) => setTimeout(resolve, 0));
 
       const activeProvider = providerManager.getActiveProvider();
@@ -240,7 +284,11 @@ describe("ProviderManager", () => {
     it("should return null when lightspeed is disabled", async () => {
       mockSettingsManager.settings.lightSpeedService.enabled = false;
 
-      providerManager = new ProviderManager(mockSettingsManager, mockWcaApi);
+      providerManager = new ProviderManager(
+        mockSettingsManager,
+        mockWcaApi,
+        mockLlmProviderSettings,
+      );
       await new Promise((resolve) => setTimeout(resolve, 0));
 
       const activeProvider = providerManager.getActiveProvider();
@@ -254,7 +302,11 @@ describe("ProviderManager", () => {
         throw new Error("Invalid API key");
       });
 
-      providerManager = new ProviderManager(mockSettingsManager, mockWcaApi);
+      providerManager = new ProviderManager(
+        mockSettingsManager,
+        mockWcaApi,
+        mockLlmProviderSettings,
+      );
       await new Promise((resolve) => setTimeout(resolve, 0));
 
       const activeProvider = providerManager.getActiveProvider();
@@ -266,7 +318,11 @@ describe("ProviderManager", () => {
   describe("getProviderStatus", () => {
     it("should return WCA status when requested", async () => {
       mockSettingsManager.settings.lightSpeedService.enabled = true;
-      providerManager = new ProviderManager(mockSettingsManager, mockWcaApi);
+      providerManager = new ProviderManager(
+        mockSettingsManager,
+        mockWcaApi,
+        mockLlmProviderSettings,
+      );
       await new Promise((resolve) => setTimeout(resolve, 0));
 
       const status = providerManager.getProviderStatus("wca");
@@ -292,7 +348,11 @@ describe("ProviderManager", () => {
       const getStatus = vi.mocked(mockLlmProvider.getStatus);
       getStatus.mockResolvedValue(mockStatus);
 
-      providerManager = new ProviderManager(mockSettingsManager, mockWcaApi);
+      providerManager = new ProviderManager(
+        mockSettingsManager,
+        mockWcaApi,
+        mockLlmProviderSettings,
+      );
       await new Promise((resolve) => setTimeout(resolve, 0));
 
       const status = providerManager.getProviderStatus("llmprovider");
@@ -303,7 +363,11 @@ describe("ProviderManager", () => {
     it("should return null when provider status not available", async () => {
       mockSettingsManager.settings.lightSpeedService.enabled = false;
 
-      providerManager = new ProviderManager(mockSettingsManager, mockWcaApi);
+      providerManager = new ProviderManager(
+        mockSettingsManager,
+        mockWcaApi,
+        mockLlmProviderSettings,
+      );
       await new Promise((resolve) => setTimeout(resolve, 0));
 
       mockSettingsManager.settings.lightSpeedService.provider =
@@ -327,7 +391,11 @@ describe("ProviderManager", () => {
       const completionRequest = vi.mocked(mockLlmProvider.completionRequest);
       completionRequest.mockResolvedValue(mockCompletion);
 
-      providerManager = new ProviderManager(mockSettingsManager, mockWcaApi);
+      providerManager = new ProviderManager(
+        mockSettingsManager,
+        mockWcaApi,
+        mockLlmProviderSettings,
+      );
       await new Promise((resolve) => setTimeout(resolve, 0));
 
       const params = {
@@ -355,7 +423,11 @@ describe("ProviderManager", () => {
       const completionRequest = vi.mocked(mockWcaApi.completionRequest);
       completionRequest.mockResolvedValue(mockCompletion);
 
-      providerManager = new ProviderManager(mockSettingsManager, mockWcaApi);
+      providerManager = new ProviderManager(
+        mockSettingsManager,
+        mockWcaApi,
+        mockLlmProviderSettings,
+      );
       await new Promise((resolve) => setTimeout(resolve, 0));
 
       const params = {
@@ -372,7 +444,11 @@ describe("ProviderManager", () => {
     it("should throw error when no active provider", async () => {
       mockSettingsManager.settings.lightSpeedService.enabled = false;
 
-      providerManager = new ProviderManager(mockSettingsManager, mockWcaApi);
+      providerManager = new ProviderManager(
+        mockSettingsManager,
+        mockWcaApi,
+        mockLlmProviderSettings,
+      );
       await new Promise((resolve) => setTimeout(resolve, 0));
 
       const params = {
@@ -397,7 +473,11 @@ describe("ProviderManager", () => {
       const chatRequest = vi.mocked(mockLlmProvider.chatRequest);
       chatRequest.mockResolvedValue(mockChatResponse);
 
-      providerManager = new ProviderManager(mockSettingsManager, mockWcaApi);
+      providerManager = new ProviderManager(
+        mockSettingsManager,
+        mockWcaApi,
+        mockLlmProviderSettings,
+      );
       await new Promise((resolve) => setTimeout(resolve, 0));
 
       const params = {
@@ -416,7 +496,11 @@ describe("ProviderManager", () => {
         ...TEST_LIGHTSPEED_SETTINGS.WCA,
       };
 
-      providerManager = new ProviderManager(mockSettingsManager, mockWcaApi);
+      providerManager = new ProviderManager(
+        mockSettingsManager,
+        mockWcaApi,
+        mockLlmProviderSettings,
+      );
       await new Promise((resolve) => setTimeout(resolve, 0));
 
       const params = {
@@ -431,7 +515,11 @@ describe("ProviderManager", () => {
     it("should throw error when no active provider", async () => {
       mockSettingsManager.settings.lightSpeedService.enabled = false;
 
-      providerManager = new ProviderManager(mockSettingsManager, mockWcaApi);
+      providerManager = new ProviderManager(
+        mockSettingsManager,
+        mockWcaApi,
+        mockLlmProviderSettings,
+      );
       await new Promise((resolve) => setTimeout(resolve, 0));
 
       const params = {
@@ -455,7 +543,11 @@ describe("ProviderManager", () => {
       const generatePlaybook = vi.mocked(mockLlmProvider.generatePlaybook);
       generatePlaybook.mockResolvedValue(mockPlaybook);
 
-      providerManager = new ProviderManager(mockSettingsManager, mockWcaApi);
+      providerManager = new ProviderManager(
+        mockSettingsManager,
+        mockWcaApi,
+        mockLlmProviderSettings,
+      );
       await new Promise((resolve) => setTimeout(resolve, 0));
 
       const params = {
@@ -488,7 +580,11 @@ describe("ProviderManager", () => {
       const mockedIsError = vi.mocked(isError);
       mockedIsError.mockReturnValue(false);
 
-      providerManager = new ProviderManager(mockSettingsManager, mockWcaApi);
+      providerManager = new ProviderManager(
+        mockSettingsManager,
+        mockWcaApi,
+        mockLlmProviderSettings,
+      );
       await new Promise((resolve) => setTimeout(resolve, 0));
 
       const params = {
@@ -516,7 +612,11 @@ describe("ProviderManager", () => {
         throw new Error("Invalid API key");
       });
 
-      providerManager = new ProviderManager(mockSettingsManager, mockWcaApi);
+      providerManager = new ProviderManager(
+        mockSettingsManager,
+        mockWcaApi,
+        mockLlmProviderSettings,
+      );
       await new Promise((resolve) => setTimeout(resolve, 0));
 
       const params = {
@@ -545,7 +645,11 @@ describe("ProviderManager", () => {
       playbookGenerationRequest.mockResolvedValue(mockErrorResponse);
       vi.mocked(isError).mockReturnValue(true);
 
-      providerManager = new ProviderManager(mockSettingsManager, mockWcaApi);
+      providerManager = new ProviderManager(
+        mockSettingsManager,
+        mockWcaApi,
+        mockLlmProviderSettings,
+      );
       await new Promise((resolve) => setTimeout(resolve, 0));
 
       const params = {
@@ -561,7 +665,11 @@ describe("ProviderManager", () => {
     it("should throw error when no active provider", async () => {
       mockSettingsManager.settings.lightSpeedService.enabled = false;
 
-      providerManager = new ProviderManager(mockSettingsManager, mockWcaApi);
+      providerManager = new ProviderManager(
+        mockSettingsManager,
+        mockWcaApi,
+        mockLlmProviderSettings,
+      );
       await new Promise((resolve) => setTimeout(resolve, 0));
 
       const params = {
@@ -586,7 +694,11 @@ describe("ProviderManager", () => {
       const generateRole = vi.mocked(mockLlmProvider.generateRole);
       generateRole.mockResolvedValue(mockRole);
 
-      providerManager = new ProviderManager(mockSettingsManager, mockWcaApi);
+      providerManager = new ProviderManager(
+        mockSettingsManager,
+        mockWcaApi,
+        mockLlmProviderSettings,
+      );
       await new Promise((resolve) => setTimeout(resolve, 0));
 
       const params = {
@@ -626,7 +738,11 @@ describe("ProviderManager", () => {
       const mockedIsError = vi.mocked(isError);
       mockedIsError.mockReturnValue(false);
 
-      providerManager = new ProviderManager(mockSettingsManager, mockWcaApi);
+      providerManager = new ProviderManager(
+        mockSettingsManager,
+        mockWcaApi,
+        mockLlmProviderSettings,
+      );
       await new Promise((resolve) => setTimeout(resolve, 0));
 
       const params = {
@@ -654,7 +770,11 @@ describe("ProviderManager", () => {
         throw new Error("Invalid API key");
       });
 
-      providerManager = new ProviderManager(mockSettingsManager, mockWcaApi);
+      providerManager = new ProviderManager(
+        mockSettingsManager,
+        mockWcaApi,
+        mockLlmProviderSettings,
+      );
       await new Promise((resolve) => setTimeout(resolve, 0));
 
       const params = {
@@ -682,7 +802,11 @@ describe("ProviderManager", () => {
       const mockedIsError = vi.mocked(isError);
       mockedIsError.mockReturnValue(true);
 
-      providerManager = new ProviderManager(mockSettingsManager, mockWcaApi);
+      providerManager = new ProviderManager(
+        mockSettingsManager,
+        mockWcaApi,
+        mockLlmProviderSettings,
+      );
       await new Promise((resolve) => setTimeout(resolve, 0));
 
       const params = {
@@ -698,7 +822,11 @@ describe("ProviderManager", () => {
     it("should throw error when no active provider", async () => {
       mockSettingsManager.settings.lightSpeedService.enabled = false;
 
-      providerManager = new ProviderManager(mockSettingsManager, mockWcaApi);
+      providerManager = new ProviderManager(
+        mockSettingsManager,
+        mockWcaApi,
+        mockLlmProviderSettings,
+      );
       await new Promise((resolve) => setTimeout(resolve, 0));
 
       const params = {
@@ -723,7 +851,11 @@ describe("ProviderManager", () => {
         },
       });
 
-      providerManager = new ProviderManager(mockSettingsManager, mockWcaApi);
+      providerManager = new ProviderManager(
+        mockSettingsManager,
+        mockWcaApi,
+        mockLlmProviderSettings,
+      );
       await new Promise((resolve) => setTimeout(resolve, 0));
 
       const status = await providerManager.testProviderConnection("wca");
@@ -745,7 +877,11 @@ describe("ProviderManager", () => {
         error: "Connection failed",
       });
 
-      providerManager = new ProviderManager(mockSettingsManager, mockWcaApi);
+      providerManager = new ProviderManager(
+        mockSettingsManager,
+        mockWcaApi,
+        mockLlmProviderSettings,
+      );
       await new Promise((resolve) => setTimeout(resolve, 0));
 
       const status = await providerManager.testProviderConnection("wca");
@@ -769,7 +905,11 @@ describe("ProviderManager", () => {
       const getStatus = vi.mocked(mockLlmProvider.getStatus);
       getStatus.mockResolvedValue(mockStatus);
 
-      providerManager = new ProviderManager(mockSettingsManager, mockWcaApi);
+      providerManager = new ProviderManager(
+        mockSettingsManager,
+        mockWcaApi,
+        mockLlmProviderSettings,
+      );
       await new Promise((resolve) => setTimeout(resolve, 0));
 
       const status =
@@ -782,7 +922,11 @@ describe("ProviderManager", () => {
     it("should return error when provider not configured", async () => {
       mockSettingsManager.settings.lightSpeedService.enabled = false;
 
-      providerManager = new ProviderManager(mockSettingsManager, mockWcaApi);
+      providerManager = new ProviderManager(
+        mockSettingsManager,
+        mockWcaApi,
+        mockLlmProviderSettings,
+      );
       await new Promise((resolve) => setTimeout(resolve, 0));
 
       const status =
@@ -797,7 +941,11 @@ describe("ProviderManager", () => {
 
   describe("getAvailableProviders", () => {
     it("should return available providers with Google active", async () => {
-      providerManager = new ProviderManager(mockSettingsManager, mockWcaApi);
+      providerManager = new ProviderManager(
+        mockSettingsManager,
+        mockWcaApi,
+        mockLlmProviderSettings,
+      );
       await new Promise((resolve) => setTimeout(resolve, 0));
 
       const providers = providerManager.getAvailableProviders();
@@ -822,7 +970,11 @@ describe("ProviderManager", () => {
         ...TEST_LIGHTSPEED_SETTINGS.WCA,
       };
 
-      providerManager = new ProviderManager(mockSettingsManager, mockWcaApi);
+      providerManager = new ProviderManager(
+        mockSettingsManager,
+        mockWcaApi,
+        mockLlmProviderSettings,
+      );
       await new Promise((resolve) => setTimeout(resolve, 0));
 
       const providers = providerManager.getAvailableProviders();
@@ -845,7 +997,11 @@ describe("ProviderManager", () => {
     it("should return all providers as inactive when lightspeed is disabled", async () => {
       mockSettingsManager.settings.lightSpeedService.enabled = false;
 
-      providerManager = new ProviderManager(mockSettingsManager, mockWcaApi);
+      providerManager = new ProviderManager(
+        mockSettingsManager,
+        mockWcaApi,
+        mockLlmProviderSettings,
+      );
       await new Promise((resolve) => setTimeout(resolve, 0));
 
       const providers = providerManager.getAvailableProviders();

--- a/test/unit/lightspeed/providers/factory.test.ts
+++ b/test/unit/lightspeed/providers/factory.test.ts
@@ -4,6 +4,7 @@ import type { ProviderType } from "@src/definitions/lightspeed";
 import {
   PROVIDER_TYPES,
   TEST_LIGHTSPEED_SETTINGS,
+  TEST_API_KEYS,
   API_ENDPOINTS,
 } from "@test/unit/lightspeed/testConstants.js";
 
@@ -65,7 +66,11 @@ describe("LLMProviderFactory", () => {
         const factory = LLMProviderFactory.getInstance();
         const config = TEST_LIGHTSPEED_SETTINGS.GOOGLE_FULL;
 
-        const provider = factory.createProvider(PROVIDER_TYPES.GOOGLE, config);
+        const provider = factory.createProvider(
+          PROVIDER_TYPES.GOOGLE,
+          config,
+          TEST_API_KEYS.GOOGLE,
+        );
 
         expect(provider).toBeDefined();
         expect(provider.name).toBe("google");
@@ -84,7 +89,11 @@ describe("LLMProviderFactory", () => {
         const factory = LLMProviderFactory.getInstance();
         const config = TEST_LIGHTSPEED_SETTINGS.GOOGLE_WITH_CUSTOM_ENDPOINT;
 
-        const provider = factory.createProvider(PROVIDER_TYPES.GOOGLE, config);
+        const provider = factory.createProvider(
+          PROVIDER_TYPES.GOOGLE,
+          config,
+          TEST_API_KEYS.GOOGLE,
+        );
 
         expect(provider).toBeDefined();
         expect(provider.name).toBe("google");
@@ -110,6 +119,7 @@ describe("LLMProviderFactory", () => {
         const provider = factory.createProvider(
           PROVIDER_TYPES.RHCUSTOM,
           config,
+          TEST_API_KEYS.RHCUSTOM,
         );
 
         expect(provider).toBeDefined();
@@ -123,6 +133,7 @@ describe("LLMProviderFactory", () => {
         const provider = factory.createProvider(
           PROVIDER_TYPES.RHCUSTOM,
           config,
+          TEST_API_KEYS.RHCUSTOM,
         );
 
         expect(provider).toBeDefined();
@@ -131,10 +142,7 @@ describe("LLMProviderFactory", () => {
 
       it("should throw error when API key is missing", () => {
         const factory = LLMProviderFactory.getInstance();
-        const config = {
-          ...TEST_LIGHTSPEED_SETTINGS.RHCUSTOM_MINIMAL,
-          apiKey: "",
-        };
+        const config = TEST_LIGHTSPEED_SETTINGS.RHCUSTOM_MINIMAL;
 
         expect(() => {
           factory.createProvider(PROVIDER_TYPES.RHCUSTOM, config);
@@ -149,7 +157,11 @@ describe("LLMProviderFactory", () => {
         };
 
         expect(() => {
-          factory.createProvider(PROVIDER_TYPES.RHCUSTOM, config);
+          factory.createProvider(
+            PROVIDER_TYPES.RHCUSTOM,
+            config,
+            TEST_API_KEYS.RHCUSTOM,
+          );
         }).toThrow("Model name is required for Red Hat AI");
       });
 
@@ -161,19 +173,20 @@ describe("LLMProviderFactory", () => {
         };
 
         expect(() => {
-          factory.createProvider(PROVIDER_TYPES.RHCUSTOM, config);
+          factory.createProvider(
+            PROVIDER_TYPES.RHCUSTOM,
+            config,
+            TEST_API_KEYS.RHCUSTOM,
+          );
         }).toThrow("API endpoint is required for Red Hat AI");
       });
 
       it("should throw error when API key is only whitespace", () => {
         const factory = LLMProviderFactory.getInstance();
-        const config = {
-          ...TEST_LIGHTSPEED_SETTINGS.RHCUSTOM_MINIMAL,
-          apiKey: "   ",
-        };
+        const config = TEST_LIGHTSPEED_SETTINGS.RHCUSTOM_MINIMAL;
 
         expect(() => {
-          factory.createProvider(PROVIDER_TYPES.RHCUSTOM, config);
+          factory.createProvider(PROVIDER_TYPES.RHCUSTOM, config, "   ");
         }).toThrow("API Key is required for Red Hat AI");
       });
 
@@ -187,6 +200,7 @@ describe("LLMProviderFactory", () => {
         const provider = factory.createProvider(
           PROVIDER_TYPES.RHCUSTOM,
           config,
+          TEST_API_KEYS.RHCUSTOM,
         );
         expect(provider).toBeDefined();
       });
@@ -201,6 +215,7 @@ describe("LLMProviderFactory", () => {
         const provider = factory.createProvider(
           PROVIDER_TYPES.RHCUSTOM,
           config,
+          TEST_API_KEYS.RHCUSTOM,
         );
         expect(provider).toBeDefined();
       });
@@ -215,6 +230,7 @@ describe("LLMProviderFactory", () => {
         const provider = factory.createProvider(
           PROVIDER_TYPES.RHCUSTOM,
           config,
+          TEST_API_KEYS.RHCUSTOM,
         );
         expect(provider).toBeDefined();
         expect(provider.name).toBe("rhcustom");
@@ -229,6 +245,7 @@ describe("LLMProviderFactory", () => {
         const provider = factory.createProvider(
           PROVIDER_TYPES.RHCUSTOM,
           config,
+          TEST_API_KEYS.RHCUSTOM,
         );
 
         expect(provider).toBeDefined();
@@ -245,6 +262,7 @@ describe("LLMProviderFactory", () => {
         const provider = factory.createProvider(
           PROVIDER_TYPES.RHCUSTOM,
           config,
+          TEST_API_KEYS.RHCUSTOM,
         );
 
         expect(provider).toBeDefined();
@@ -261,6 +279,7 @@ describe("LLMProviderFactory", () => {
         const provider = factory.createProvider(
           PROVIDER_TYPES.RHCUSTOM,
           config,
+          TEST_API_KEYS.RHCUSTOM,
         );
 
         expect(provider).toBeDefined();
@@ -277,6 +296,7 @@ describe("LLMProviderFactory", () => {
         const provider = factory.createProvider(
           PROVIDER_TYPES.RHCUSTOM,
           config,
+          TEST_API_KEYS.RHCUSTOM,
         );
 
         expect(provider).toBeDefined();
@@ -293,6 +313,7 @@ describe("LLMProviderFactory", () => {
         const provider = factory.createProvider(
           PROVIDER_TYPES.RHCUSTOM,
           config,
+          TEST_API_KEYS.RHCUSTOM,
         );
 
         expect(provider).toBeDefined();
@@ -309,6 +330,7 @@ describe("LLMProviderFactory", () => {
         const provider = factory.createProvider(
           PROVIDER_TYPES.RHCUSTOM,
           config,
+          TEST_API_KEYS.RHCUSTOM,
         );
 
         expect(provider).toBeDefined();
@@ -447,6 +469,7 @@ describe("LLMProviderFactory", () => {
         const isValid = factory.validateProviderConfig(
           PROVIDER_TYPES.GOOGLE,
           config,
+          TEST_API_KEYS.GOOGLE,
         );
 
         expect(isValid).toBe(true);
@@ -487,6 +510,7 @@ describe("LLMProviderFactory", () => {
         const isValid = factory.validateProviderConfig(
           PROVIDER_TYPES.RHCUSTOM,
           config,
+          TEST_API_KEYS.RHCUSTOM,
         );
 
         expect(isValid).toBe(true);
@@ -494,10 +518,7 @@ describe("LLMProviderFactory", () => {
 
       it("should return false when required apiKey is missing", () => {
         const factory = LLMProviderFactory.getInstance();
-        const config = {
-          ...TEST_LIGHTSPEED_SETTINGS.RHCUSTOM_MINIMAL,
-          apiKey: "",
-        };
+        const config = TEST_LIGHTSPEED_SETTINGS.RHCUSTOM_MINIMAL;
 
         const isValid = factory.validateProviderConfig(
           PROVIDER_TYPES.RHCUSTOM,
@@ -517,6 +538,7 @@ describe("LLMProviderFactory", () => {
         const isValid = factory.validateProviderConfig(
           PROVIDER_TYPES.RHCUSTOM,
           config,
+          TEST_API_KEYS.RHCUSTOM,
         );
 
         expect(isValid).toBe(false);
@@ -532,6 +554,7 @@ describe("LLMProviderFactory", () => {
         const isValid = factory.validateProviderConfig(
           PROVIDER_TYPES.RHCUSTOM,
           config,
+          TEST_API_KEYS.RHCUSTOM,
         );
 
         expect(isValid).toBe(false);

--- a/test/unit/lightspeed/testConstants.ts
+++ b/test/unit/lightspeed/testConstants.ts
@@ -126,7 +126,7 @@ export const TEST_CONFIGS = {
 // Base LightSpeedServiceSettings with all required common properties
 const BASE_LIGHTSPEED_SETTINGS: Omit<
   LightSpeedServiceSettings,
-  "provider" | "apiKey" | "apiEndpoint"
+  "provider" | "apiEndpoint"
 > = {
   enabled: true,
   modelName: undefined,
@@ -139,13 +139,11 @@ export const TEST_LIGHTSPEED_SETTINGS = {
   GOOGLE_MINIMAL: {
     ...BASE_LIGHTSPEED_SETTINGS,
     provider: PROVIDER_TYPES.GOOGLE,
-    apiKey: TEST_API_KEYS.GOOGLE,
     apiEndpoint: "",
   } as LightSpeedServiceSettings,
   GOOGLE_FULL: {
     ...BASE_LIGHTSPEED_SETTINGS,
     provider: PROVIDER_TYPES.GOOGLE,
-    apiKey: TEST_API_KEYS.GOOGLE,
     modelName: MODEL_NAMES.GEMINI_PRO,
     timeout: 45000,
     apiEndpoint: "",
@@ -153,39 +151,33 @@ export const TEST_LIGHTSPEED_SETTINGS = {
   GOOGLE_WITH_EMPTY_API_KEY: {
     ...BASE_LIGHTSPEED_SETTINGS,
     provider: PROVIDER_TYPES.GOOGLE,
-    apiKey: "",
     apiEndpoint: "",
   } as LightSpeedServiceSettings,
   GOOGLE_WITH_CUSTOM_ENDPOINT: {
     ...BASE_LIGHTSPEED_SETTINGS,
     provider: PROVIDER_TYPES.GOOGLE,
-    apiKey: TEST_API_KEYS.GOOGLE,
     modelName: MODEL_NAMES.GEMINI_PRO,
     apiEndpoint: "https://custom-gemini-proxy.example.com/v1beta",
   } as LightSpeedServiceSettings,
   WCA: {
     ...BASE_LIGHTSPEED_SETTINGS,
     provider: PROVIDER_TYPES.WCA,
-    apiKey: "",
     apiEndpoint: API_ENDPOINTS.WCA_DEFAULT,
   } as LightSpeedServiceSettings,
   UNSUPPORTED: {
     ...BASE_LIGHTSPEED_SETTINGS,
     provider: "unsupported" as string,
-    apiKey: "",
     apiEndpoint: "",
   } as LightSpeedServiceSettings,
   RHCUSTOM_MINIMAL: {
     ...BASE_LIGHTSPEED_SETTINGS,
     provider: PROVIDER_TYPES.RHCUSTOM,
-    apiKey: TEST_API_KEYS.RHCUSTOM,
     modelName: MODEL_NAMES.RHCUSTOM_DEEPSEEK,
     apiEndpoint: API_ENDPOINTS.RHCUSTOM,
   } as LightSpeedServiceSettings,
   RHCUSTOM_FULL: {
     ...BASE_LIGHTSPEED_SETTINGS,
     provider: PROVIDER_TYPES.RHCUSTOM,
-    apiKey: TEST_API_KEYS.RHCUSTOM,
     modelName: MODEL_NAMES.RHCUSTOM_GRANITE,
     apiEndpoint: API_ENDPOINTS.RHCUSTOM,
     timeout: DEFAULT_TIMEOUTS.CUSTOM,

--- a/test/unit/settings.test.ts
+++ b/test/unit/settings.test.ts
@@ -54,7 +54,14 @@ describe("SettingsManager", () => {
       expect(settingsManager.settings.lightSpeedService.apiEndpoint).toBe(
         "https://c.ai.ansible.redhat.com",
       );
-      expect(settingsManager.settings.lightSpeedService.apiKey).toBe("");
+      expect(
+        (
+          settingsManager.settings.lightSpeedService as unknown as Record<
+            string,
+            unknown
+          >
+        ).apiKey,
+      ).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
## Summary
- Close multiple API key information disclosure vectors by removing
  the key from in-memory settings, scrubbing legacy plain-text values,
  masking secrets in webviews, and sanitizing error logs.

## Changes
- **package.json**: Neuter the deprecated `ansible.lightspeed.apiKey`
  setting description to clarify it is no longer read.
- **llmProviderSettings.ts**: Add `scrubLegacySecrets()` that removes
  the plain-text `apiKey` from `settings.json` (global, workspace, and
  folder scopes) after migration to the secret store. Include
  `workspaceFolderValue` in migration scope precedence so folder-scoped
  keys are migrated before scrubbing. Use `!== undefined` checks for
  scrub conditions.  Remove `apiKey` from `getAllSettings()` return type.
- **llmProviderMessageHandlers.ts**: Mask password fields with
  `"••••••••"` in `sendProviderSettings()` so the real secret is never
  sent to the webview. Skip saving when the mask is returned unchanged.
- **extensionSettings.d.ts / settings.ts**: Remove `apiKey` from the
  `LightSpeedServiceSettings` interface and from `SettingsManager`,
  so the key is never held in memory.
- **factory.ts / lightspeed.ts**: Accept `apiKey` as a separate
  parameter to `createProvider()` and `validateProviderConfig()` so
  callers can pass it from the secret store at point-of-use. Trim
  and validate the API key before provider construction for both
  Google and RHCustom providers so whitespace-only values are
  correctly rejected.
- **providerManager.ts**: Read `apiKey` from `LlmProviderSettings`
  (secret store) only at provider-creation time.
- **base.ts (providers)**: Add `sanitizeErrorForLogging()` that redacts
  `Authorization: Bearer`, `apiKey`, `key`, and `x-goog-api-key`
  patterns from error output. Regexes handle both header-style and
  JSON-serialized formats, plus query-string parameters.
- **google.ts / rhcustom.ts**: Replace all raw `${error}`,
  `error.message`, `error.stack`, and `JSON.stringify(error)` logging
  with `sanitizeErrorForLogging()` consistently across every error
  path in both providers.
- **Tests**: Update all affected unit tests (factory, providerManager,
  llmProviderSettings, settings) to match the new API signatures.

## Test plan
- [x] ESLint passes on all changed files (0 errors)
- [x] TypeScript compiles (only pre-existing wdio/lsp errors remain)
- [x] All 119 tests in the 4 directly-affected test files pass
- [x] All CodeRabbit review threads resolved

Related: AAP-46674

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Remove API keys from in-memory settings, scrub legacy plaintext, mask secrets in webviews, and sanitize error logs so keys are stored only in VS Code secret storage and accessed at provider-creation to prevent accidental disclosure.

- Mark deprecated ansible.lightspeed.apiKey as no longer read (package.json)
- Scrub legacy apiKey values from settings.json across scopes
- Remove apiKey from LlmProviderSettings.getAllSettings() and LightSpeedServiceSettings
- Mask password fields with "••••••••" in webviews and skip saving unchanged masks
- Pass apiKey separately into createProvider()/validateProviderConfig()
- Read apiKey from secret store only at provider-creation time (ProviderManager)
- Add sanitizeErrorForLogging() and use it in Google/RHCustom providers
- Update unit tests for new signatures and behavior

Fixes - 

- https://redhat.atlassian.net/browse/AAP-74205
- https://redhat.atlassian.net/browse/AAP-74206
- https://redhat.atlassian.net/browse/AAP-74207
- https://redhat.atlassian.net/browse/AAP-74208
- https://redhat.atlassian.net/browse/AAP-74209


related: AAP-46674
<!-- end of auto-generated comment: release notes by coderabbit.ai -->