### PR TITLE
fix: validate activation script path to prevent command injection

### DIFF
--- a/packages/ansible-language-server/src/utils/misc.ts
+++ b/packages/ansible-language-server/src/utils/misc.ts
@@ -1,5 +1,5 @@
 import * as child_process from "child_process";
-import { existsSync, promises as fs } from "node:fs";
+import { existsSync, statSync, promises as fs } from "node:fs";
 import { promisify } from "util";
 import { TextDocument } from "vscode-languageserver-textdocument";
 import { Range } from "vscode-languageserver-types";
@@ -17,7 +17,7 @@ function isVenvDirectory(binDir: string): boolean {
 export const asyncExec = promisify(child_process.exec);
 
 // eslint-disable-next-line no-control-regex
-const SHELL_METACHARACTERS = /[\x00\n\r$`;&|(){}<>!]/;
+const SHELL_METACHARACTERS = /[\x00\n\r$`;&|(){}<>!']/;
 
 export function validatePlaybookPath(fsPath: string): string | undefined {
   if (SHELL_METACHARACTERS.test(fsPath)) {
@@ -29,6 +29,19 @@ export function validatePlaybookPath(fsPath: string): string | undefined {
   return undefined;
 }
 
+function validateActivationScript(scriptPath: string): string | undefined {
+  if (SHELL_METACHARACTERS.test(scriptPath)) {
+    return `Activation script path contains potentially unsafe characters: ${scriptPath}`;
+  }
+  try {
+    if (!statSync(scriptPath).isFile()) {
+      return `Activation script path is not a file: ${scriptPath}`;
+    }
+  } catch {
+    return `Activation script does not exist: ${scriptPath}`;
+  }
+  return undefined;
+}
 export function toLspRange(
   range: [number, number],
   textDocument: TextDocument,
@@ -77,8 +90,13 @@ export function withInterpreter(
   });
 
   if (activationScript) {
-    command = `sh -c '. ${activationScript} && ${executable} ${args}'`;
-    return { command: command, env: process.env };
+    const validationError = validateActivationScript(activationScript);
+    if (!validationError) {
+      command = `sh -c '. ${activationScript} && ${executable} ${args}'`;
+      return { command: command, env: process.env };
+    } else {
+      console.debug(validationError);
+    }
   }
 
   if (interpreterPath) {

--- a/packages/ansible-language-server/test/utils/withInterpreter.test.ts
+++ b/packages/ansible-language-server/test/utils/withInterpreter.test.ts
@@ -1,5 +1,8 @@
 import { expect, describe, it } from "vitest";
 import { withInterpreter } from "@src/utils/misc.js";
+import * as os from "os";
+import * as path from "path";
+import * as fs from "fs";
 
 interface testType {
   scenario: string;
@@ -16,16 +19,6 @@ describe("withInterpreter", function () {
   const alwaysFalse = () => false;
 
   const tests: testType[] = [
-    {
-      scenario: "when activation script is provided",
-      executable: "ansible-lint",
-      args: "playbook.yml",
-      interpreterPath: "",
-      activationScript: "/path/to/venv/bin/activate",
-      expectedCommand:
-        "sh -c '. /path/to/venv/bin/activate && ansible-lint playbook.yml'",
-      expectedEnv: {},
-    },
     {
       scenario: "when no activation script is provided",
       executable: "ansible-lint",
@@ -173,5 +166,100 @@ describe("withInterpreter", function () {
         "/home/user/.local/share/virtualenvs/myproject",
       );
     });
+  });
+
+  describe("activation script validation", function () {
+    it("should reject activation script with shell metacharacters", function () {
+      const result = withInterpreter(
+        "ansible-lint",
+        "playbook.yml",
+        "",
+        "/tmp/activate; rm -rf /",
+      );
+
+      expect(result.command).toBe("ansible-lint playbook.yml");
+    });
+
+    it("should reject activation script that does not exist", function () {
+      const result = withInterpreter(
+        "ansible-lint",
+        "playbook.yml",
+        "",
+        "/nonexistent/path/to/activate",
+      );
+
+      expect(result.command).toBe("ansible-lint playbook.yml");
+    });
+
+    it("should fall through to interpreter path when activation script is invalid", function () {
+      const result = withInterpreter(
+        "ansible-lint",
+        "playbook.yml",
+        "/home/user/.venv/bin/python3",
+        "/tmp/activate$(whoami)",
+        alwaysTrue,
+      );
+
+      expect(result.command).toBe("ansible-lint playbook.yml");
+      expect(result.env.VIRTUAL_ENV).toBe("/home/user/.venv");
+    });
+
+    it("should accept a valid activation script that exists", function () {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "als-test-"));
+      const scriptPath = path.join(tmpDir, "activate");
+      fs.writeFileSync(scriptPath, "# activation script");
+
+      try {
+        const result = withInterpreter(
+          "ansible-lint",
+          "playbook.yml",
+          "",
+          scriptPath,
+        );
+
+        expect(result.command).toBe(
+          `sh -c '. ${scriptPath} && ansible-lint playbook.yml'`,
+        );
+      } finally {
+        fs.unlinkSync(scriptPath);
+        fs.rmdirSync(tmpDir);
+      }
+    });
+  });
+});
+
+describe("activation script validation via withInterpreter", function () {
+  it("should reject all shell metacharacter injection attempts", function () {
+    const malicious = [
+      "/tmp/activate; rm -rf /",
+      "/tmp/activate$(whoami)",
+      "/tmp/activate`id`",
+      "/tmp/activate & echo pwned",
+      "/tmp/activate | cat /etc/passwd",
+      "/tmp/activate\nmalicious",
+      "/tmp/activate$HOME",
+      "/tmp/'; rm -rf / #",
+    ];
+
+    for (const p of malicious) {
+      const result = withInterpreter("ansible-lint", "playbook.yml", "", p);
+      expect(result.command).toBe("ansible-lint playbook.yml");
+    }
+  });
+
+  it("should reject a directory path as activation script", function () {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "als-test-"));
+
+    try {
+      const result = withInterpreter(
+        "ansible-lint",
+        "playbook.yml",
+        "",
+        tmpDir,
+      );
+      expect(result.command).toBe("ansible-lint playbook.yml");
+    } finally {
+      fs.rmdirSync(tmpDir);
+    }
   });
 });


### PR DESCRIPTION
## Summary
- The `ansible.python.activationScript` setting was directly interpolated into a shell command (`sh -c '. ${activationScript} && ...'`) without any validation, allowing command injection via crafted workspace settings.
- Added `validateActivationScript()` that rejects paths containing shell metacharacters or pointing to non-file/nonexistent paths using `statSync().isFile()`.
- `withInterpreter()` now validates the activation script before using it — invalid values fall through to interpreter path handling.

## Test plan
- [x] Unit tests for `validateActivationScript()` covering valid files, shell metacharacter injection, nonexistent paths, and directory paths
- [x] Unit tests for `withInterpreter()` confirming fallthrough behavior on invalid activation scripts
- [x] Existing `withInterpreter` and `commandRunner` tests continue to pass
- [x] eslint passes with zero warnings

Assisted-by: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Adds validation for ansible.python.activationScript to prevent command injection by rejecting shell metacharacters and non-file paths; withInterpreter() now validates before interpolating activation scripts and falls back to interpreter handling when invalid.

- Add internal validateActivationScript() to reject unsafe paths and verify files with statSync().isFile()
- Update withInterpreter() to use validator and fall through on invalid scripts
- Add unit tests for validator and fallback behavior

related: CVE-2026-44190
<!-- end of auto-generated comment: release notes by coderabbit.ai -->