### PR TITLE
fix(mcp): prevent path traversal in MCP server tools (CVE-2026-44192)

### DIFF
--- a/knip.ts
+++ b/knip.ts
@@ -145,6 +145,7 @@ const config: KnipConfig = {
     "packages/ansible-mcp-server/src/server.ts": ["exports"],
     "packages/ansible-mcp-server/src/tools/adeTools.ts": ["types", "exports"],
     "packages/ansible-mcp-server/src/tools/executionEnv.ts": ["types"],
+    "packages/ansible-mcp-server/src/utils/pathValidation.ts": ["exports"],
   },
 };
 

--- a/packages/ansible-mcp-server/src/handlers.ts
+++ b/packages/ansible-mcp-server/src/handlers.ts
@@ -59,7 +59,7 @@ export function createAgentsGuidelinesHandler() {
   };
 }
 
-export function createAnsibleLintHandler() {
+export function createAnsibleLintHandler(workspaceRoot: string) {
   return async (args: { filePath: string; fix?: boolean }) => {
     try {
       // Check if fix parameter is explicitly provided
@@ -98,6 +98,7 @@ export function createAnsibleLintHandler() {
       const { result: lintingResult, fixedContent } = await runAnsibleLint(
         args.filePath,
         fix,
+        workspaceRoot,
       );
 
       // Ensure the result is an array before formatting

--- a/packages/ansible-mcp-server/src/server.ts
+++ b/packages/ansible-mcp-server/src/server.ts
@@ -380,7 +380,7 @@ export function createAnsibleMcpServer(workspaceRoot: string) {
         ],
       },
     },
-    createAnsibleLintHandler(),
+    createAnsibleLintHandler(workspaceRoot),
     [],
   );
 

--- a/packages/ansible-mcp-server/src/tools/ansibleLint.ts
+++ b/packages/ansible-mcp-server/src/tools/ansibleLint.ts
@@ -2,6 +2,7 @@ import { spawn } from "node:child_process";
 import { readFile, access } from "node:fs/promises";
 import { resolve } from "node:path";
 import { quote } from "shell-quote";
+import { validatePathWithinWorkspace } from "@src/utils/pathValidation.js";
 
 /**
  * Lints Ansible playbook file using the ansible-lint CLI.
@@ -14,6 +15,7 @@ import { quote } from "shell-quote";
 export async function runAnsibleLint(
   filePath: string,
   fix: boolean = false,
+  workspaceRoot?: string,
 ): Promise<{ result: unknown; fixedContent?: string }> {
   if (!filePath) {
     throw new Error("No file path was provided for linting.");
@@ -21,6 +23,10 @@ export async function runAnsibleLint(
 
   // Resolve the file path to absolute path
   const absolutePath = resolve(filePath);
+
+  if (workspaceRoot) {
+    validatePathWithinWorkspace(absolutePath, workspaceRoot);
+  }
 
   // Check if file exists
   try {

--- a/packages/ansible-mcp-server/src/tools/creator.ts
+++ b/packages/ansible-mcp-server/src/tools/creator.ts
@@ -1,6 +1,7 @@
 import { spawnSync } from "node:child_process";
 import { mkdirSync } from "node:fs";
 import { join } from "node:path";
+import { validatePathWithinWorkspace } from "@src/utils/pathValidation.js";
 
 /**
  * Runs ansible-creator with the specified command and arguments.
@@ -243,12 +244,38 @@ export function createProjectsHandler(workspaceRoot: string) {
       let projectPath: string;
 
       if (args.path) {
-        // If full path is provided, use it directly
-        projectPath = args.path;
+        try {
+          projectPath = validatePathWithinWorkspace(args.path, workspaceRoot);
+        } catch (error) {
+          const errorMessage =
+            error instanceof Error ? error.message : String(error);
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: `Error: ${errorMessage}\n`,
+              },
+            ],
+            isError: true,
+          };
+        }
       } else if (args.projectDirectory) {
-        // Create project directory in the workspace
-        // We know projectDirectory is defined here because we checked earlier
-        projectPath = join(workspaceRoot, args.projectDirectory);
+        const rawPath = join(workspaceRoot, args.projectDirectory);
+        try {
+          projectPath = validatePathWithinWorkspace(rawPath, workspaceRoot);
+        } catch (error) {
+          const errorMessage =
+            error instanceof Error ? error.message : String(error);
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: `Error: ${errorMessage}\n`,
+              },
+            ],
+            isError: true,
+          };
+        }
         try {
           mkdirSync(projectPath, { recursive: true });
         } catch (error) {

--- a/packages/ansible-mcp-server/src/tools/executionEnv.ts
+++ b/packages/ansible-mcp-server/src/tools/executionEnv.ts
@@ -8,6 +8,7 @@ import {
   getEERules,
   getSampleExecutionEnvironment,
 } from "@src/resources/eeSchema.js";
+import { validatePathWithinWorkspace } from "@src/utils/pathValidation.js";
 
 interface ExecutionEnvInputs {
   baseImage: string;
@@ -144,8 +145,13 @@ export async function generateExecutionEnvironment(
   workspaceRoot: string,
   generatedYaml: string, // LLM-generated YAML content from the client
 ): Promise<ExecutionEnvResult> {
-  const destinationPath =
+  const rawDestination =
     inputs.destinationPath || workspaceRoot || process.cwd();
+
+  const destinationPath = validatePathWithinWorkspace(
+    rawDestination,
+    workspaceRoot,
+  );
 
   // Ensure destination directory exists
   try {

--- a/packages/ansible-mcp-server/src/utils/pathValidation.ts
+++ b/packages/ansible-mcp-server/src/utils/pathValidation.ts
@@ -1,0 +1,66 @@
+import path from "node:path";
+import fs from "node:fs";
+
+export class PathTraversalError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PathTraversalError";
+  }
+}
+
+// Resolves symlinks for a path that may not exist yet by walking up
+// to the nearest existing ancestor, resolving it, then re-appending
+// the remaining segments. This handles macOS /var -> /private/var.
+function resolveWithSymlinks(targetPath: string): string {
+  try {
+    return fs.realpathSync(targetPath);
+  } catch {
+    const parent = path.dirname(targetPath);
+    if (parent === targetPath) {
+      return targetPath;
+    }
+    const resolvedParent = resolveWithSymlinks(parent);
+    return path.join(resolvedParent, path.basename(targetPath));
+  }
+}
+
+/**
+ * Resolves and validates that a path stays within the workspace root.
+ * Prevents path traversal attacks (CVE-2026-44192) by ensuring all
+ * file operations are constrained to the workspace directory.
+ *
+ * @returns The resolved absolute path guaranteed to be within workspaceRoot.
+ * @throws PathTraversalError if the path escapes the workspace.
+ */
+export function validatePathWithinWorkspace(
+  inputPath: string,
+  workspaceRoot: string,
+): string {
+  if (!inputPath || !inputPath.trim()) {
+    throw new PathTraversalError("Path must not be empty");
+  }
+
+  if (!workspaceRoot || !workspaceRoot.trim()) {
+    throw new PathTraversalError("Workspace root must not be empty");
+  }
+
+  const resolvedWorkspace = path.resolve(workspaceRoot);
+
+  const resolvedPath = path.isAbsolute(inputPath)
+    ? path.resolve(inputPath)
+    : path.resolve(resolvedWorkspace, inputPath);
+
+  const finalPath = resolveWithSymlinks(resolvedPath);
+  const realWorkspace = resolveWithSymlinks(resolvedWorkspace);
+
+  if (
+    finalPath !== realWorkspace &&
+    !finalPath.startsWith(realWorkspace + path.sep)
+  ) {
+    throw new PathTraversalError(
+      `Path '${inputPath}' resolves to '${finalPath}' which is outside the workspace '${realWorkspace}'`,
+    );
+  }
+
+  return finalPath;
+}

--- a/packages/ansible-mcp-server/test/tools/ansibleLint.test.ts
+++ b/packages/ansible-mcp-server/test/tools/ansibleLint.test.ts
@@ -42,7 +42,7 @@ describe("Ansible Lint Handler", () => {
 
   describe("Core linting functionality", () => {
     it("should detect and report linting issues in playbooks", async () => {
-      const handler = createAnsibleLintHandler();
+      const handler = createAnsibleLintHandler(testDir);
 
       const result = await handler({
         filePath: testPlaybookPath,
@@ -56,7 +56,7 @@ describe("Ansible Lint Handler", () => {
     });
 
     it("should report no issues for clean playbooks", async () => {
-      const handler = createAnsibleLintHandler();
+      const handler = createAnsibleLintHandler(testDir);
 
       const result = await handler({
         filePath: cleanPlaybookPath,
@@ -70,9 +70,9 @@ describe("Ansible Lint Handler", () => {
   });
 
   describe("Input validation", () => {
-    it("should handle non-existent file", async () => {
-      const handler = createAnsibleLintHandler();
-      const nonExistentFile = join(__dirname, "non-existent.yml");
+    it("should handle non-existent file within workspace", async () => {
+      const handler = createAnsibleLintHandler(testDir);
+      const nonExistentFile = join(testDir, "non-existent.yml");
 
       const result = await handler({
         filePath: nonExistentFile,
@@ -85,7 +85,7 @@ describe("Ansible Lint Handler", () => {
     });
 
     it("should handle empty file path", async () => {
-      const handler = createAnsibleLintHandler();
+      const handler = createAnsibleLintHandler(testDir);
 
       const result = await handler({
         filePath: "",
@@ -98,7 +98,7 @@ describe("Ansible Lint Handler", () => {
     });
 
     it("should handle ansible-lint process errors gracefully", async () => {
-      const handler = createAnsibleLintHandler();
+      const handler = createAnsibleLintHandler(testDir);
       // This test covers error handling paths in the ansible-lint execution
       const result = await handler({
         filePath: testPlaybookPath,
@@ -113,7 +113,7 @@ describe("Ansible Lint Handler", () => {
 
   describe("Fix parameter handling", () => {
     it("should prompt user for fix preference when fix parameter is undefined", async () => {
-      const handler = createAnsibleLintHandler();
+      const handler = createAnsibleLintHandler(testDir);
       const result = await handler({
         filePath: testPlaybookPath,
       });
@@ -128,7 +128,7 @@ describe("Ansible Lint Handler", () => {
     });
 
     it("should run linting without fixes when fix parameter is false", async () => {
-      const handler = createAnsibleLintHandler();
+      const handler = createAnsibleLintHandler(testDir);
       const result = await handler({
         filePath: testPlaybookPath,
         fix: false,
@@ -145,7 +145,7 @@ describe("Ansible Lint Handler", () => {
     });
 
     it("should run linting with automatic fixes when fix parameter is true", async () => {
-      const handler = createAnsibleLintHandler();
+      const handler = createAnsibleLintHandler(testDir);
       const result = await handler({
         filePath: testPlaybookPath,
         fix: true,
@@ -162,9 +162,39 @@ describe("Ansible Lint Handler", () => {
     });
   });
 
+  describe("Path traversal prevention", () => {
+    it("should reject file paths outside the workspace", async () => {
+      const handler = createAnsibleLintHandler(testDir);
+
+      const result = await handler({
+        filePath: "/etc/passwd",
+        fix: false,
+      });
+
+      expect(result.content).toBeDefined();
+      expect(result.content[0].text).toContain("Error");
+      expect(result.content[0].text).toContain("outside the workspace");
+      expect(result.isError).toBe(true);
+    });
+
+    it("should reject relative path traversal attempts", async () => {
+      const handler = createAnsibleLintHandler(testDir);
+
+      const result = await handler({
+        filePath: "../../../etc/passwd",
+        fix: false,
+      });
+
+      expect(result.content).toBeDefined();
+      expect(result.content[0].text).toContain("Error");
+      expect(result.content[0].text).toContain("outside the workspace");
+      expect(result.isError).toBe(true);
+    });
+  });
+
   describe("Fix functionality", () => {
     it("should apply fixes when fix: true is specified", async () => {
-      const handler = createAnsibleLintHandler();
+      const handler = createAnsibleLintHandler(testDir);
 
       const result = await handler({
         filePath: testPlaybookPath,
@@ -177,7 +207,7 @@ describe("Ansible Lint Handler", () => {
     });
 
     it("should not apply fixes when fix: false is specified", async () => {
-      const handler = createAnsibleLintHandler();
+      const handler = createAnsibleLintHandler(testDir);
 
       const result = await handler({
         filePath: testPlaybookPath,
@@ -190,7 +220,7 @@ describe("Ansible Lint Handler", () => {
     });
 
     it("should display fixed content when fix is applied and content is available", async () => {
-      const handler = createAnsibleLintHandler();
+      const handler = createAnsibleLintHandler(testDir);
 
       const result = await handler({
         filePath: testPlaybookPath,
@@ -205,7 +235,7 @@ describe("Ansible Lint Handler", () => {
     });
 
     it("should handle clean playbook with no issues", async () => {
-      const handler = createAnsibleLintHandler();
+      const handler = createAnsibleLintHandler(testDir);
 
       const result = await handler({
         filePath: cleanPlaybookPath,

--- a/packages/ansible-mcp-server/test/tools/creator.test.ts
+++ b/packages/ansible-mcp-server/test/tools/creator.test.ts
@@ -107,4 +107,40 @@ describe("creator", () => {
       expect(result.content).toBeDefined();
     });
   });
+
+  describe("Path traversal prevention", () => {
+    let traversalTestDir: string;
+
+    beforeAll(() => {
+      traversalTestDir = mkdtempSync(join(tmpdir(), "vitest-traversal-"));
+    });
+
+    afterAll(() => {
+      rmSync(traversalTestDir, { recursive: true, force: true });
+    });
+
+    it("should reject path parameter outside workspace", async () => {
+      const handler = createProjectsHandler(traversalTestDir);
+      const result = await handler({
+        projectType: "collection",
+        namespace: "foo",
+        collectionName: "bar",
+        path: "/tmp/evil-project",
+      });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("outside the workspace");
+    });
+
+    it("should reject projectDirectory with traversal", async () => {
+      const handler = createProjectsHandler(traversalTestDir);
+      const result = await handler({
+        projectType: "collection",
+        namespace: "foo",
+        collectionName: "bar",
+        projectDirectory: "../../etc",
+      });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("outside the workspace");
+    });
+  });
 });

--- a/packages/ansible-mcp-server/test/tools/executionEnv.test.ts
+++ b/packages/ansible-mcp-server/test/tools/executionEnv.test.ts
@@ -301,6 +301,40 @@ options:
         ),
       ).rejects.toThrow();
     });
+
+    it("should reject destinationPath outside workspace (path traversal)", async () => {
+      const validYaml =
+        "---\nversion: 3\nimages:\n  base_image:\n    name: test";
+
+      await expect(
+        generateExecutionEnvironment(
+          {
+            baseImage: "test",
+            tag: "test-ee:latest",
+            destinationPath: "/tmp/evil-dir",
+          },
+          tempDir,
+          validYaml,
+        ),
+      ).rejects.toThrow("outside the workspace");
+    });
+
+    it("should reject relative traversal in destinationPath", async () => {
+      const validYaml =
+        "---\nversion: 3\nimages:\n  base_image:\n    name: test";
+
+      await expect(
+        generateExecutionEnvironment(
+          {
+            baseImage: "test",
+            tag: "test-ee:latest",
+            destinationPath: "../../../etc/cron.d",
+          },
+          tempDir,
+          validYaml,
+        ),
+      ).rejects.toThrow("outside the workspace");
+    });
   });
 
   describe("formatExecutionEnvResult", () => {

--- a/packages/ansible-mcp-server/test/utils/pathValidation.test.ts
+++ b/packages/ansible-mcp-server/test/utils/pathValidation.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  symlinkSync,
+  rmSync,
+  realpathSync,
+} from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+  validatePathWithinWorkspace,
+  PathTraversalError,
+} from "@src/utils/pathValidation.js";
+
+describe("validatePathWithinWorkspace", () => {
+  let workspaceRoot: string;
+  let realWorkspaceRoot: string;
+  let outsideDir: string;
+
+  beforeAll(() => {
+    workspaceRoot = mkdtempSync(join(tmpdir(), "ws-test-"));
+    realWorkspaceRoot = realpathSync(workspaceRoot);
+    outsideDir = mkdtempSync(join(tmpdir(), "outside-test-"));
+
+    mkdirSync(join(workspaceRoot, "subdir"), { recursive: true });
+    writeFileSync(join(workspaceRoot, "file.yml"), "test");
+    writeFileSync(join(outsideDir, "secret.txt"), "secret");
+  });
+
+  afterAll(() => {
+    rmSync(workspaceRoot, { recursive: true, force: true });
+    rmSync(outsideDir, { recursive: true, force: true });
+  });
+
+  it("should accept a path within the workspace", () => {
+    const result = validatePathWithinWorkspace("subdir", workspaceRoot);
+    expect(result).toBe(join(realWorkspaceRoot, "subdir"));
+  });
+
+  it("should accept the workspace root itself", () => {
+    const result = validatePathWithinWorkspace(workspaceRoot, workspaceRoot);
+    expect(result).toBe(realWorkspaceRoot);
+  });
+
+  it("should accept an absolute path within the workspace", () => {
+    const absPath = join(workspaceRoot, "subdir");
+    const result = validatePathWithinWorkspace(absPath, workspaceRoot);
+    expect(result).toBe(join(realWorkspaceRoot, "subdir"));
+  });
+
+  it("should accept a non-existent path within the workspace", () => {
+    const result = validatePathWithinWorkspace("new-dir/nested", workspaceRoot);
+    expect(result).toBe(join(realWorkspaceRoot, "new-dir", "nested"));
+  });
+
+  it("should reject relative path traversal with ../", () => {
+    expect(() =>
+      validatePathWithinWorkspace("../../../etc/cron.d", workspaceRoot),
+    ).toThrow(PathTraversalError);
+  });
+
+  it("should reject traversal via subdir/../../..", () => {
+    expect(() =>
+      validatePathWithinWorkspace("subdir/../../../etc", workspaceRoot),
+    ).toThrow(PathTraversalError);
+  });
+
+  it("should reject absolute path outside workspace", () => {
+    expect(() =>
+      validatePathWithinWorkspace("/etc/cron.d", workspaceRoot),
+    ).toThrow(PathTraversalError);
+  });
+
+  it("should reject absolute path to another tmp directory", () => {
+    expect(() =>
+      validatePathWithinWorkspace(outsideDir, workspaceRoot),
+    ).toThrow(PathTraversalError);
+  });
+
+  it("should reject symlink that points outside workspace", () => {
+    const symlinkPath = join(workspaceRoot, "evil-link");
+    try {
+      symlinkSync(outsideDir, symlinkPath);
+      expect(() =>
+        validatePathWithinWorkspace("evil-link", workspaceRoot),
+      ).toThrow(PathTraversalError);
+    } finally {
+      rmSync(symlinkPath, { force: true });
+    }
+  });
+
+  it("should reject empty path", () => {
+    expect(() => validatePathWithinWorkspace("", workspaceRoot)).toThrow(
+      PathTraversalError,
+    );
+  });
+
+  it("should reject whitespace-only path", () => {
+    expect(() => validatePathWithinWorkspace("   ", workspaceRoot)).toThrow(
+      PathTraversalError,
+    );
+  });
+
+  it("should reject empty workspace root", () => {
+    expect(() => validatePathWithinWorkspace("subdir", "")).toThrow(
+      PathTraversalError,
+    );
+  });
+
+  it("should reject path that is a prefix of workspace but not a child", () => {
+    const trickPath = workspaceRoot + "def";
+    mkdirSync(trickPath, { recursive: true });
+    try {
+      expect(() =>
+        validatePathWithinWorkspace(trickPath, workspaceRoot),
+      ).toThrow(PathTraversalError);
+    } finally {
+      rmSync(trickPath, { recursive: true, force: true });
+    }
+  });
+
+  it("should handle paths with trailing slashes", () => {
+    const result = validatePathWithinWorkspace("subdir/", workspaceRoot);
+    expect(result).toBe(join(realWorkspaceRoot, "subdir"));
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes CVE-2026-44192: Path traversal vulnerability in the MCP server that allowed an attacker to manipulate an AI agent (via indirect prompt injection) into writing files to unauthorized locations, potentially leading to data exfiltration and staged RCE.
- Adds a centralized `validatePathWithinWorkspace()` utility that resolves paths (including symlinks and `../` sequences) and ensures they remain within `workspaceRoot`.
- Applies workspace-scoped path validation to all three vulnerable MCP tools: execution environment file generation (`destinationPath`), project scaffolding (`path`/`projectDirectory`), and ansible-lint (`filePath`).

Resolves: AAP-74221

## Test plan

- [ ] Verify `validatePathWithinWorkspace` rejects `../` traversal, absolute paths outside workspace, and symlinks pointing outside workspace (14 unit tests added)
- [ ] Verify execution environment tool rejects `destinationPath` outside workspace (2 tests added)
- [ ] Verify creator tool rejects `path` and `projectDirectory` outside workspace (2 tests added)
- [ ] Verify ansible-lint tool rejects `filePath` outside workspace (2 tests added)
- [ ] Verify all existing MCP server tests still pass (290/290 passing)
- [ ] Verify legitimate use cases (paths within workspace) continue to work

Assisted-by: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Adds workspace-scoped path validation to prevent path traversal (CVE-2026-44192). A new validatePathWithinWorkspace() (with PathTraversalError) resolves paths and symlinks and enforces that inputs stay inside the workspace, and three MCP tools now use it to block writes/reads outside allowed directories.

- Add PathTraversalError and validatePathWithinWorkspace(inputPath, workspaceRoot)
- Validate destinationPath in execution-environment generation
- Validate path and projectDirectory in project creator
- Validate filePath in ansible-lint before access
- Add 14 unit tests for the validator + tool-specific tests (execution-env, creator, ansible-lint)
- Export PathTraversalError for tests and suppress knip false positive

Fixes - 

- https://redhat.atlassian.net/browse/AAP-74221
- https://redhat.atlassian.net/browse/AAP-74225
- https://redhat.atlassian.net/browse/AAP-74228
- https://redhat.atlassian.net/browse/AAP-74232
- https://redhat.atlassian.net/browse/AAP-74232

fixes: AAP-74221
<!-- end of auto-generated comment: release notes by coderabbit.ai -->