### PR TITLE
refactor: unify path validation into shared helper

### DIFF
--- a/packages/ansible-language-server/src/utils/misc.ts
+++ b/packages/ansible-language-server/src/utils/misc.ts
@@ -19,28 +19,26 @@ export const asyncExec = promisify(child_process.exec);
 // eslint-disable-next-line no-control-regex
 const SHELL_METACHARACTERS = /[\x00\n\r$`;&|(){}<>!']/;
 
-export function validatePlaybookPath(fsPath: string): string | undefined {
-  if (SHELL_METACHARACTERS.test(fsPath)) {
-    return `Playbook path contains potentially unsafe characters: ${fsPath}`;
+function validateSafePath(filePath: string, label: string): string | undefined {
+  if (SHELL_METACHARACTERS.test(filePath)) {
+    return `${label} contains potentially unsafe characters: ${filePath}`;
   }
-  if (!existsSync(fsPath)) {
-    return `Playbook file does not exist: ${fsPath}`;
+  try {
+    if (!statSync(filePath).isFile()) {
+      return `${label} is not a file: ${filePath}`;
+    }
+  } catch {
+    return `${label} does not exist: ${filePath}`;
   }
   return undefined;
 }
 
+export function validatePlaybookPath(fsPath: string): string | undefined {
+  return validateSafePath(fsPath, "Playbook path");
+}
+
 function validateActivationScript(scriptPath: string): string | undefined {
-  if (SHELL_METACHARACTERS.test(scriptPath)) {
-    return `Activation script path contains potentially unsafe characters: ${scriptPath}`;
-  }
-  try {
-    if (!statSync(scriptPath).isFile()) {
-      return `Activation script path is not a file: ${scriptPath}`;
-    }
-  } catch {
-    return `Activation script does not exist: ${scriptPath}`;
-  }
-  return undefined;
+  return validateSafePath(scriptPath, "Activation script path");
 }
 export function toLspRange(
   range: [number, number],

--- a/packages/ansible-language-server/test/utils/withInterpreter.test.ts
+++ b/packages/ansible-language-server/test/utils/withInterpreter.test.ts
@@ -1,5 +1,5 @@
 import { expect, describe, it } from "vitest";
-import { withInterpreter } from "@src/utils/misc.js";
+import { withInterpreter, validatePlaybookPath } from "@src/utils/misc.js";
 import * as os from "os";
 import * as path from "path";
 import * as fs from "fs";
@@ -225,6 +225,43 @@ describe("withInterpreter", function () {
         fs.rmdirSync(tmpDir);
       }
     });
+  });
+});
+
+describe("validatePlaybookPath", function () {
+  it("should accept a valid file path", function () {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "als-test-"));
+    const filePath = path.join(tmpDir, "playbook.yml");
+    fs.writeFileSync(filePath, "---\n- hosts: all\n");
+
+    try {
+      expect(validatePlaybookPath(filePath)).toBeUndefined();
+    } finally {
+      fs.unlinkSync(filePath);
+      fs.rmdirSync(tmpDir);
+    }
+  });
+
+  it("should reject paths with shell metacharacters", function () {
+    expect(validatePlaybookPath("/tmp/play; rm -rf /")).toContain(
+      "unsafe characters",
+    );
+  });
+
+  it("should reject a directory path", function () {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "als-test-"));
+
+    try {
+      expect(validatePlaybookPath(tmpDir)).toContain("is not a file");
+    } finally {
+      fs.rmdirSync(tmpDir);
+    }
+  });
+
+  it("should reject a nonexistent path", function () {
+    expect(validatePlaybookPath("/nonexistent/playbook.yml")).toContain(
+      "does not exist",
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- Extracts a shared `validateSafePath(filePath, label)` helper to eliminate duplication between `validatePlaybookPath` and `validateActivationScript`
- Both validators now use `statSync().isFile()` for consistent behavior — rejects shell metacharacters, nonexistent paths, and directory paths
- `validatePlaybookPath` is upgraded from `existsSync` to `statSync().isFile()`, which also rejects directory paths (a playbook should always be a file)
- Adds direct unit tests for `validatePlaybookPath` covering valid files, metacharacters, directories, and nonexistent paths

## Test plan
- [x] All 18 existing + new unit tests pass
- [x] eslint passes with zero warnings
- [x] No behavioral change for `validateActivationScript` callers
- [x] `validatePlaybookPath` gains stricter directory rejection (correct behavior)

Assisted-by: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Unifies path validation by adding validateSafePath(filePath, label); both validators now use statSync().isFile() to reject shell metacharacters, nonexistent paths, and directories, with added unit tests for playbook validation.

- Extracted validateSafePath(filePath, label) in misc.ts
- validatePlaybookPath now uses statSync().isFile() (stricter directory rejection)
- validateActivationScript delegates to the shared helper (standardized errors)
- Added unit tests for validatePlaybookPath (valid file, metacharacters, directory, missing)
- Tests and eslint pass
<!-- end of auto-generated comment: release notes by coderabbit.ai -->