### PR TITLE
chore: sync agent skills from team-devtools

### DIFF
--- a/.agents/skills/diagnose-ci/SKILL.md
+++ b/.agents/skills/diagnose-ci/SKILL.md
@@ -210,7 +210,7 @@ gh pr diff PR_NUMBER --repo OWNER/REPO
 ```
 
 Understand what the bot changed. This constrains what files should be
-touched by a fix — best practice: avoid modifying anything
+touched by a fix — per Shatakshi's guidance: avoid modifying anything
 beyond the files already touched by the bot unless absolutely necessary.
 
 Note in the diagnosis which files the bot changed.
@@ -258,7 +258,6 @@ gh pr view PR_NUMBER --repo OWNER/REPO \
 - The fix is one of these safe categories ONLY: lockfile regeneration, formatter/linter auto-fix, removing unused imports, or adding a type annotation on a single line
 
 **NEEDS HUMAN REVIEW** — ANY of these:
-
 1. Multiple major version bumps in one PR
 2. Any major version bump that requires source code changes (not just
    lockfile/config)

--- a/.agents/skills/fix-bot-prs/SKILL.md
+++ b/.agents/skills/fix-bot-prs/SKILL.md
@@ -154,21 +154,17 @@ on the PR by `diagnose-ci`. There is nothing left to do.
 ### 4b. Apply by category
 
 **Lockfile regeneration:**
-
 ```bash
 pnpm install          # TypeScript
 uv lock               # Python
 ```
-
 Commit the regenerated lockfile.
 
 **Formatter/linter auto-fix:**
-
 ```bash
 npx prek run --all-files    # TypeScript
 tox -e lint                 # Python (some linters auto-fix)
 ```
-
 Commit any auto-formatted files.
 
 **Removing unused imports:**

--- a/.agents/skills/verify-local/SKILL.md
+++ b/.agents/skills/verify-local/SKILL.md
@@ -87,13 +87,11 @@ Use frozen/locked install to match CI:
 **TypeScript:**
 
 If `pnpm-lock.yaml` was modified (e.g., lockfile regen fix), use:
-
 ```bash
 pnpm install
 ```
 
 Otherwise:
-
 ```bash
 pnpm install --frozen-lockfile
 ```
@@ -102,13 +100,11 @@ The frozen check is CI's job. Verify-local's job is "will build/lint/pkg
 pass," not "is the lockfile in sync."
 
 **Python/tox:**
-
 ```bash
 uv sync --no-progress -q
 ```
 
 **Python/uv:**
-
 ```bash
 uv sync --no-progress -q
 ```

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -167,7 +167,7 @@ jobs:
           task ${{ steps.extract_context.outputs.context }}
 
       - name: task docs
-        timeout-minutes: 1
+        timeout-minutes: 2
         run: |
           task docs && task docs --status
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,8 @@
 ---
 exclude: >
   (?x)^(
-    .*.svg
+    .*.svg|
+    .agents/.*
   )$
 fail_fast: true
 minimum_prek_version: "0.3.4"
@@ -28,6 +29,7 @@ repos:
         priority: 1
       - id: md
         priority: 1
+        entry: markdownlint-cli2 --fix "**/*.md" "#node_modules" "#.agents"
       # - id: codecov
       #   priority: 1
       - id: shellcheck

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -59,6 +59,7 @@
   "files.watcherExclude": {
     "**/out": true
   },
+  "git.ignoreLimitWarning": true,
   "python.terminal.useEnvFile": true,
   "redhat.telemetry.enabled": false,
   "search.useParentIgnoreFiles": true,

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -17,6 +17,7 @@ enabled: true
 enableGlobDot: true
 useGitignore: true
 ignorePaths:
+  - ".agents/**"
   - "**/*-artifact-*.json"
   - "**/lib/"
   - "*.svg"


### PR DESCRIPTION
Automated sync of `.agents/skills/` from `ansible/team-devtools`.

Source: ansible/team-devtools@bf35cbbfbc38a08b5fb244d6fa28fdb140a78cc4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Automated sync of .agents/skills from team-devtools: added new skill docs, updated diagnose-ci wording, and excluded .agents from repository hooks to avoid linting synced files.

- Added skill docs: ade, ansible-creator, ansible-lint, plus multiple existing skills and README updates
- Edited .agents/skills/diagnose-ci/SKILL.md wording in Step 6
- Configured pre-commit, cspell, markdownlint-cli2 to ignore .agents

related: `#2803`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->