### PR TITLE
fix: block command injection in EE settings

### DIFF
--- a/packages/ansible-language-server/package.json
+++ b/packages/ansible-language-server/package.json
@@ -75,6 +75,11 @@
     "./utils/getAnsibleMetaData": {
       "types": "./dist/utils/getAnsibleMetaData.d.ts",
       "default": "./dist/utils/getAnsibleMetaData.js"
+    },
+    "./utils/containerCommandSafety": {
+      "types": "./dist/utils/containerCommandSafety.d.ts",
+      "source": "./src/utils/containerCommandSafety.ts",
+      "default": "./dist/utils/containerCommandSafety.js"
     }
   },
   "files": [

--- a/packages/ansible-language-server/src/services/executionEnvironment.ts
+++ b/packages/ansible-language-server/src/services/executionEnvironment.ts
@@ -7,7 +7,14 @@ import { Connection } from "vscode-languageserver";
 import { v4 as uuidv4 } from "uuid";
 import { AnsibleConfig } from "@src/services/ansibleConfig.js";
 import { ImagePuller } from "@src/utils/imagePuller.js";
-import { asyncExec } from "@src/utils/misc.js";
+import {
+  formatVolumeMountSpec,
+  parseContainerOptions,
+  splitCommandString,
+  UnsafeContainerSettingError,
+  validateExecutionEnvironmentSettings,
+} from "@src/utils/containerCommandSafety.js";
+import { asyncSpawn, spawnSyncWithResult } from "@src/utils/misc.js";
 import { WorkspaceFolderContext } from "@src/services/workspaceManager.js";
 import type {
   ExtensionSettings,
@@ -68,6 +75,11 @@ export class ExecutionEnvironment {
         return;
       }
 
+      validateExecutionEnvironmentSettings(
+        this.settings.executionEnvironment.containerOptions,
+        this._container_volume_mounts || [],
+      );
+
       /* v8 ignore next 3 */
       this.updateContainerVolumeMountFromSettings();
       this.settingsContainerOptions =
@@ -81,7 +93,9 @@ export class ExecutionEnvironment {
       }
     } catch (error) {
       /* v8 ignore next 3 */
-      if (error instanceof Error) {
+      if (error instanceof UnsafeContainerSettingError) {
+        this.connection.window.showErrorMessage(error.message);
+      } else if (error instanceof Error) {
         this.connection.window.showErrorMessage(error.message);
       } else {
         /* v8 ignore next 3 */
@@ -98,24 +112,32 @@ export class ExecutionEnvironment {
 
   public async fetchPluginDocs(ansibleConfig: AnsibleConfig): Promise<void> {
     /* v8 ignore next 6 */
-    if (!this.isServiceInitialized || !this._container_image) {
+    if (
+      !this.isServiceInitialized ||
+      !this._container_image ||
+      !this._container_engine
+    ) {
       this.connection.console.error(
         `ExecutionEnvironment service not correctly initialized. Failed to fetch plugin docs`,
       );
       return;
     }
+    const containerEngine = this._container_engine;
     const containerName = this._container_image.replace(/[^a-z0-9]/gi, "_");
     let progressTracker;
 
     try {
       /* v8 ignore next 11 */
-      const containerImageIdCommand = `${this._container_engine} images ${this._container_image} --format="{{.ID}}" | head -n 1`;
-      this.connection.console.log(containerImageIdCommand);
-      this._container_image_id = child_process
-        .execSync(containerImageIdCommand, {
-          encoding: "utf-8",
-        })
-        .trim();
+      const imageIdArgv = ["images", this._container_image, "--format={{.ID}}"];
+      this.connection.console.log(
+        `${containerEngine} ${imageIdArgv.join(" ")}`,
+      );
+      const imageIdResult = spawnSyncWithResult(containerEngine, imageIdArgv);
+      this._container_image_id =
+        imageIdResult.stdout
+          .split("\n")
+          .map((line) => line.trim())
+          .find((line) => line !== "") ?? "";
       const cacheBase =
         process.env.XDG_CACHE_HOME ||
         `${process.env.HOME || os.homedir()}/.cache`;
@@ -225,7 +247,7 @@ export class ExecutionEnvironment {
   public wrapContainerArgs(
     command: string,
     mountPaths?: Set<string>,
-  ): string | undefined {
+  ): string[] | undefined {
     /* v8 ignore next 10 */
     if (
       !this.isServiceInitialized ||
@@ -264,11 +286,11 @@ export class ExecutionEnvironment {
 
     // handle container volume mounts setting from client
     if (this.settingsVolumeMounts && this.settingsVolumeMounts.length > 0) {
-      this.settingsVolumeMounts.forEach((volumeMount) => {
-        if (containerCommand.includes(volumeMount)) {
+      this.settingsVolumeMounts.forEach((volumeMountSpec) => {
+        if (containerCommand.includes(volumeMountSpec)) {
           return;
         }
-        containerCommand.push("-v", volumeMount);
+        containerCommand.push("-v", volumeMountSpec);
       });
     }
 
@@ -296,25 +318,23 @@ export class ExecutionEnvironment {
 
     // handle container options setting from client
     if (this.settingsContainerOptions && this.settingsContainerOptions !== "") {
-      const containerOptions = this.settingsContainerOptions.split(" ");
+      const containerOptions = parseContainerOptions(
+        this.settingsContainerOptions,
+      );
       containerOptions.forEach((containerOption) => {
-        if (
-          containerOption === "" ||
-          containerCommand.includes(containerOption)
-        ) {
+        if (containerCommand.includes(containerOption)) {
           return;
         }
         containerCommand.push(containerOption);
       });
     }
-    containerCommand.push(`--name als_${uuidv4()}`);
+    containerCommand.push("--name", `als_${uuidv4()}`);
     containerCommand.push(this._container_image);
-    containerCommand.push(command);
-    const generatedCommand = containerCommand.join(" ");
+    containerCommand.push(...splitCommandString(command));
     this.connection.console.log(
-      `container engine invocation: ${generatedCommand}`,
+      `container engine invocation: ${containerCommand.join(" ")}`,
     );
-    return generatedCommand;
+    return containerCommand;
   }
 
   private async pullContainerImage(): Promise<boolean> {
@@ -489,19 +509,11 @@ export class ExecutionEnvironment {
   private updateContainerVolumeMountFromSettings(): void {
     /* v8 ignore next 16 */
     for (const volumeMounts of this._container_volume_mounts || []) {
-      const fsSrcPath = volumeMounts.src;
-      const fsDestPath = volumeMounts.dest;
-      const options = volumeMounts.options;
-
-      let mountPath = `${fsSrcPath}:${fsDestPath}`;
-      if (options && options !== "") {
-        mountPath += `:${options}`;
-      }
+      const mountPath = formatVolumeMountSpec(volumeMounts);
       if (this.settingsVolumeMounts.includes(mountPath)) {
         continue;
-      } else {
-        this.settingsVolumeMounts.push("-v", mountPath);
       }
+      this.settingsVolumeMounts.push(mountPath);
     }
   }
 
@@ -547,36 +559,44 @@ export class ExecutionEnvironment {
 
   private runContainer(containerName: string): boolean {
     /* v8 ignore next 38 */
+    if (!this._container_engine || !this._container_image) {
+      return false;
+    }
+    const containerEngine = this._container_engine;
+    const containerImage = this._container_image;
+
     // ensure container is not running
     this.cleanUpContainer(containerName);
 
     try {
       // Do not add '-t' option when running the containers as this causes stderr noise, such:
       // The input device is not a TTY. The --tty and--interactive flags might not work properly
-      let command = `${this._container_engine} run -i --rm -d `;
+      const runArgv: string[] = ["run", "-i", "--rm", "-d"];
       if (this.settingsVolumeMounts && this.settingsVolumeMounts.length > 0) {
-        command += this.settingsVolumeMounts.join(" ");
+        this.settingsVolumeMounts.forEach((volumeMountSpec) => {
+          runArgv.push("-v", volumeMountSpec);
+        });
       }
 
       // handle Ansible environment variables
       for (const [envVarKey, envVarValue] of Object.entries(process.env)) {
         if (envVarKey.startsWith("ANSIBLE_")) {
-          command += ` -e ${envVarKey}=${envVarValue} `;
+          runArgv.push("-e", `${envVarKey}=${envVarValue}`);
         }
       }
-      command += ` -e ANSIBLE_FORCE_COLOR=0 `; // ensure output is parsable (no ANSI)
+      runArgv.push("-e", "ANSIBLE_FORCE_COLOR=0"); // ensure output is parsable (no ANSI)
       if (
         this.settingsContainerOptions &&
         this.settingsContainerOptions !== ""
       ) {
-        command += ` ${this.settingsContainerOptions} `;
+        runArgv.push(...parseContainerOptions(this.settingsContainerOptions));
       }
-      command += ` --name ${containerName} ${this._container_image} bash`;
+      runArgv.push("--name", containerName, containerImage, "bash");
 
-      this.connection.console.log(`run container with command '${command}'`);
-      child_process.execSync(command, {
-        encoding: "utf-8",
-      });
+      this.connection.console.log(
+        `run container with command '${containerEngine} ${runArgv.join(" ")}'`,
+      );
+      spawnSyncWithResult(containerEngine, runArgv);
     } catch (error) {
       this.connection.window.showErrorMessage(
         `Failed to initialize execution environment '${this._container_image}': ${error}`,
@@ -594,6 +614,10 @@ export class ExecutionEnvironment {
   ): Promise<string[]> {
     /* v8 ignore next 33 */
     const updatedHostDocPath: string[] = [];
+    const containerEngine = this._container_engine;
+    if (!containerEngine) {
+      return updatedHostDocPath;
+    }
 
     for (const srcPath of containerPluginPaths) {
       const destPath = path.join(hostPluginDocCacheBasePath, srcPath);
@@ -611,13 +635,11 @@ export class ExecutionEnvironment {
           .slice(0, -1)
           .join(path.sep);
         fs.mkdirSync(destPath, { recursive: true });
-        const copyCommand = `${this._container_engine} cp ${containerName}:${srcPath} ${destPathFolder}`;
+        const copyArgv = ["cp", `${containerName}:${srcPath}`, destPathFolder];
         this.connection.console.log(
-          `Copying plugins from container to local cache path ${copyCommand}`,
+          `Copying plugins from container to local cache path ${containerEngine} ${copyArgv.join(" ")}`,
         );
-        await asyncExec(copyCommand, {
-          encoding: "utf-8",
-        });
+        await asyncSpawn(containerEngine, copyArgv);
 
         updatedHostDocPath.push(destPath);
       }

--- a/packages/ansible-language-server/src/services/executionEnvironment.ts
+++ b/packages/ansible-language-server/src/services/executionEnvironment.ts
@@ -12,6 +12,7 @@ import {
   parseContainerOptions,
   splitCommandString,
   UnsafeContainerSettingError,
+  validateContainerEngineSetting,
   validateExecutionEnvironmentSettings,
 } from "@src/utils/containerCommandSafety.js";
 import { asyncSpawn, spawnSyncWithResult } from "@src/utils/misc.js";
@@ -78,6 +79,7 @@ export class ExecutionEnvironment {
       validateExecutionEnvironmentSettings(
         this.settings.executionEnvironment.containerOptions,
         this._container_volume_mounts || [],
+        this._container_image,
       );
 
       /* v8 ignore next 3 */
@@ -364,6 +366,15 @@ export class ExecutionEnvironment {
     return true;
   }
 
+  private isExecutableAvailable(command: string): boolean {
+    const result = child_process.spawnSync("which", [command], {
+      encoding: "utf-8",
+      shell: false,
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    return result.status === 0;
+  }
+
   private setContainerEngine(): boolean {
     /* v8 ignore next 41 */
     if (!this._container_engine) {
@@ -375,11 +386,7 @@ export class ExecutionEnvironment {
 
     if (this._container_engine === "auto") {
       for (const ce of ["podman", "docker"]) {
-        try {
-          child_process.execSync(`command -v ${ce}`, {
-            encoding: "utf-8",
-          });
-        } catch {
+        if (!this.isExecutableAvailable(ce)) {
           this.connection.console.info(`Container engine '${ce}' not found`);
           continue;
         }
@@ -389,12 +396,16 @@ export class ExecutionEnvironment {
       }
     } else {
       try {
-        child_process.execSync(`command -v ${this._container_engine}`, {
-          encoding: "utf-8",
-        });
+        validateContainerEngineSetting(this._container_engine);
       } catch (error) {
+        if (error instanceof Error) {
+          this.connection.window.showErrorMessage(error.message);
+        }
+        return false;
+      }
+      if (!this.isExecutableAvailable(this._container_engine)) {
         this.connection.window.showErrorMessage(
-          `Container engine '${this._container_engine}' not found. Failed with error '${error}'`,
+          `Container engine '${this._container_engine}' not found.`,
         );
         return false;
       }

--- a/packages/ansible-language-server/src/utils/commandRunner.ts
+++ b/packages/ansible-language-server/src/utils/commandRunner.ts
@@ -1,6 +1,6 @@
 import { URI } from "vscode-uri";
 import { Connection } from "vscode-languageserver";
-import { withInterpreter, asyncExec } from "@src/utils/misc.js";
+import { withInterpreter, asyncExec, asyncSpawn } from "@src/utils/misc.js";
 import { getAnsibleCommandExecPath } from "@src/utils/execPath.js";
 import { WorkspaceFolderContext } from "@src/services/workspaceManager.js";
 import type { ExtensionSettings } from "@src/interfaces/extensionSettings.js";
@@ -30,7 +30,7 @@ export class CommandRunner {
     stderr: string;
   }> {
     let executablePath: string;
-    let command: string | undefined;
+    let command: string | string[] | undefined;
     let runEnv: NodeJS.ProcessEnv;
     const isEEEnabled = this.settings.executionEnvironment.enabled;
     let interpreterPathFromConfig = this.settings.python.interpreterPath;
@@ -77,12 +77,19 @@ export class CommandRunner {
     const currentWorkingDirectory = workingDirectory
       ? workingDirectory
       : URI.parse(this.context.workspaceFolder.uri).path;
-    const result = await asyncExec(command, {
-      encoding: "utf-8",
+    const spawnOptions = {
+      encoding: "utf-8" as const,
       cwd: currentWorkingDirectory,
       env: runEnv,
       maxBuffer: 10 * 1000 * 1000,
-    });
+    };
+
+    if (Array.isArray(command)) {
+      const [executable, ...args] = command;
+      return asyncSpawn(executable, args, spawnOptions);
+    }
+
+    const result = await asyncExec(command, spawnOptions);
 
     return result;
   }

--- a/packages/ansible-language-server/src/utils/containerCommandSafety.ts
+++ b/packages/ansible-language-server/src/utils/containerCommandSafety.ts
@@ -1,0 +1,137 @@
+/**
+ * Keep in sync with src/utils/containerCommandSafety.ts (vscode extension).
+ */
+import type { IVolumeMounts } from "@src/interfaces/extensionSettings.js";
+
+/** Characters and sequences that enable shell command injection (CWE-78). */
+const UNSAFE_SHELL_PATTERN = /[;&|$`<>\\\n\r]|(?:\$\()|(?:\$\{)|(?:\$\))/;
+
+export class UnsafeContainerSettingError extends Error {
+  constructor(settingLabel: string) {
+    super(
+      `Invalid ${settingLabel}: contains disallowed shell metacharacters. ` +
+        "Remove characters such as ; | & $ ` and command substitution.",
+    );
+    this.name = "UnsafeContainerSettingError";
+  }
+}
+
+export function assertNoShellMetacharacters(
+  value: string,
+  settingLabel: string,
+): void {
+  if (UNSAFE_SHELL_PATTERN.test(value)) {
+    throw new UnsafeContainerSettingError(settingLabel);
+  }
+}
+
+/**
+ * Split a container-options string into argv tokens (supports simple quoting).
+ */
+export function parseContainerOptions(options: string): string[] {
+  const trimmed = options.trim();
+  if (trimmed === "") {
+    return [];
+  }
+  assertNoShellMetacharacters(
+    trimmed,
+    "ansible.executionEnvironment.containerOptions",
+  );
+
+  const tokens: string[] = [];
+  let current = "";
+  let inSingle = false;
+  let inDouble = false;
+
+  for (let i = 0; i < trimmed.length; i++) {
+    const char = trimmed[i];
+    if (inSingle) {
+      if (char === "'") {
+        inSingle = false;
+      } else {
+        current += char;
+      }
+      continue;
+    }
+    if (inDouble) {
+      if (char === '"') {
+        inDouble = false;
+      } else {
+        current += char;
+      }
+      continue;
+    }
+    if (char === "'") {
+      inSingle = true;
+      continue;
+    }
+    if (char === '"') {
+      inDouble = true;
+      continue;
+    }
+    if (/\s/.test(char)) {
+      if (current !== "") {
+        tokens.push(current);
+        current = "";
+      }
+      continue;
+    }
+    current += char;
+  }
+
+  if (inSingle || inDouble) {
+    throw new UnsafeContainerSettingError(
+      "ansible.executionEnvironment.containerOptions",
+    );
+  }
+  if (current !== "") {
+    tokens.push(current);
+  }
+  return tokens;
+}
+
+export function formatVolumeMountSpec(mount: IVolumeMounts): string {
+  assertNoShellMetacharacters(
+    mount.src,
+    "ansible.executionEnvironment.volumeMounts src",
+  );
+  assertNoShellMetacharacters(
+    mount.dest,
+    "ansible.executionEnvironment.volumeMounts dest",
+  );
+  if (mount.options !== undefined && mount.options !== "") {
+    assertNoShellMetacharacters(
+      mount.options,
+      "ansible.executionEnvironment.volumeMounts options",
+    );
+  }
+
+  let spec = `${mount.src}:${mount.dest}`;
+  if (mount.options !== undefined && mount.options !== "") {
+    spec += `:${mount.options}`;
+  }
+  return spec;
+}
+
+export function validateExecutionEnvironmentSettings(
+  containerOptions: string,
+  volumeMounts: Array<IVolumeMounts>,
+): void {
+  if (containerOptions.trim() !== "") {
+    parseContainerOptions(containerOptions);
+  }
+  for (const mount of volumeMounts) {
+    formatVolumeMountSpec(mount);
+  }
+}
+
+/**
+ * Split a command string into argv for the process run inside the container.
+ */
+export function splitCommandString(command: string): string[] {
+  const trimmed = command.trim();
+  if (trimmed === "") {
+    return [];
+  }
+  return parseContainerOptions(trimmed);
+}

--- a/packages/ansible-language-server/src/utils/containerCommandSafety.ts
+++ b/packages/ansible-language-server/src/utils/containerCommandSafety.ts
@@ -16,7 +16,7 @@ export class UnsafeContainerSettingError extends Error {
   }
 }
 
-export function assertNoShellMetacharacters(
+function assertNoShellMetacharacters(
   value: string,
   settingLabel: string,
 ): void {

--- a/packages/ansible-language-server/src/utils/containerCommandSafety.ts
+++ b/packages/ansible-language-server/src/utils/containerCommandSafety.ts
@@ -113,10 +113,31 @@ export function formatVolumeMountSpec(mount: IVolumeMounts): string {
   return spec;
 }
 
+function validateExecutionEnvironmentImage(image: string): void {
+  if (image.trim() === "") {
+    return;
+  }
+  assertNoShellMetacharacters(image, "ansible.executionEnvironment.image");
+}
+
+export function validateContainerEngineSetting(engine: string): void {
+  assertNoShellMetacharacters(
+    engine,
+    "ansible.executionEnvironment.containerEngine",
+  );
+  if (engine !== "auto" && engine !== "podman" && engine !== "docker") {
+    throw new UnsafeContainerSettingError(
+      "ansible.executionEnvironment.containerEngine",
+    );
+  }
+}
+
 export function validateExecutionEnvironmentSettings(
   containerOptions: string,
   volumeMounts: Array<IVolumeMounts>,
+  image: string,
 ): void {
+  validateExecutionEnvironmentImage(image);
   if (containerOptions.trim() !== "") {
     parseContainerOptions(containerOptions);
   }

--- a/packages/ansible-language-server/src/utils/misc.ts
+++ b/packages/ansible-language-server/src/utils/misc.ts
@@ -44,7 +44,7 @@ function validateActivationScript(scriptPath: string): string | undefined {
   return undefined;
 }
 
-export type SpawnResult = { stdout: string; stderr: string };
+type SpawnResult = { stdout: string; stderr: string };
 
 export function spawnSyncWithResult(
   command: string,

--- a/packages/ansible-language-server/src/utils/misc.ts
+++ b/packages/ansible-language-server/src/utils/misc.ts
@@ -1,6 +1,7 @@
 import * as child_process from "child_process";
 import { existsSync, statSync, promises as fs } from "node:fs";
 import { promisify } from "util";
+import type { SpawnOptions } from "child_process";
 import { TextDocument } from "vscode-languageserver-textdocument";
 import { Range } from "vscode-languageserver-types";
 import * as path from "path";
@@ -42,6 +43,75 @@ function validateActivationScript(scriptPath: string): string | undefined {
   }
   return undefined;
 }
+
+export type SpawnResult = { stdout: string; stderr: string };
+
+export function spawnSyncWithResult(
+  command: string,
+  args: string[],
+  options: child_process.SpawnSyncOptions = {},
+): SpawnResult {
+  const result = child_process.spawnSync(command, args, {
+    encoding: "utf-8",
+    shell: false,
+    ...options,
+  });
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    const message =
+      (result.stderr?.toString() || result.stdout?.toString() || "").trim() ||
+      `Process '${command}' exited with code ${result.status}`;
+    throw new Error(message);
+  }
+  return {
+    stdout: (result.stdout ?? "").toString(),
+    stderr: (result.stderr ?? "").toString(),
+  };
+}
+
+export function asyncSpawn(
+  command: string,
+  args: string[],
+  options: SpawnOptions = {},
+): Promise<SpawnResult> {
+  return new Promise((resolve, reject) => {
+    const proc = child_process.spawn(command, args, {
+      ...options,
+      shell: false,
+    });
+    let stdout = "";
+    let stderr = "";
+    proc.stdout?.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+    proc.stderr?.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+    proc.on("error", reject);
+    proc.on("close", (code) => {
+      if (code === 0) {
+        resolve({ stdout, stderr });
+        return;
+      }
+      const message =
+        stderr.trim() ||
+        stdout.trim() ||
+        `Process '${command}' exited with code ${code}`;
+      const error = new Error(message) as Error & {
+        code?: number;
+        stdout?: string;
+        stderr?: string;
+      };
+      error.code = code ?? undefined;
+      error.stdout = stdout;
+      error.stderr = stderr;
+      reject(error);
+    });
+  });
+}
+
 export function toLspRange(
   range: [number, number],
   textDocument: TextDocument,

--- a/packages/ansible-language-server/test/services/executionEnvironment.test.ts
+++ b/packages/ansible-language-server/test/services/executionEnvironment.test.ts
@@ -122,6 +122,24 @@ describe("@ee", () => {
       expect(ee.isServiceInitialized).toBe(false);
       expect(mockConnection.window.showErrorMessage.called).toBe(true);
     });
+
+    it("should reject unsafe containerOptions during initialize", async () => {
+      mockContext.documentSettings.get.resolves({
+        ...mockSettings,
+        executionEnvironment: {
+          ...mockSettings.executionEnvironment,
+          containerOptions: "; touch /tmp/cve-44191",
+        },
+      });
+      const ee = new ExecutionEnvironment(
+        mockConnection as any,
+        mockContext as any,
+      );
+      sandbox.stub(ee as any, "setContainerEngine").returns(true);
+      await ee.initialize();
+      expect(ee.isServiceInitialized).toBe(false);
+      expect(mockConnection.window.showErrorMessage.called).toBe(true);
+    });
   });
 
   describe("wrapContainerArgs", () => {
@@ -145,9 +163,11 @@ describe("@ee", () => {
       (ee as any).settingsVolumeMounts = [];
       (ee as any).settingsContainerOptions = "";
       const result = ee.wrapContainerArgs("echo hello", new Set(["/tmp"]));
-      expect(result).toContain("docker run --rm");
+      expect(result).toBeDefined();
+      expect(result?.join(" ")).toContain("docker run --rm");
       expect(result).toContain("test-image");
-      expect(result).toContain("echo hello");
+      expect(result).toContain("echo");
+      expect(result).toContain("hello");
     });
   });
 

--- a/packages/ansible-language-server/test/utils/containerCommandSafety.test.ts
+++ b/packages/ansible-language-server/test/utils/containerCommandSafety.test.ts
@@ -1,34 +1,29 @@
 import { describe, expect, it } from "vitest";
 import {
   UnsafeContainerSettingError,
-  assertNoShellMetacharacters,
   formatVolumeMountSpec,
   parseContainerOptions,
   validateExecutionEnvironmentSettings,
 } from "@src/utils/containerCommandSafety.js";
 
 describe("containerCommandSafety", () => {
-  describe("assertNoShellMetacharacters", () => {
+  describe("parseContainerOptions", () => {
     it("allows safe container flags", () => {
-      expect(() =>
-        assertNoShellMetacharacters("--net=host", "test"),
-      ).not.toThrow();
+      expect(parseContainerOptions("--net=host")).toEqual(["--net=host"]);
     });
 
     it("rejects command injection via semicolon", () => {
-      expect(() =>
-        assertNoShellMetacharacters("; touch /tmp/pwned", "test"),
-      ).toThrow(UnsafeContainerSettingError);
-    });
-
-    it("rejects command substitution", () => {
-      expect(() => assertNoShellMetacharacters("$(id)", "test")).toThrow(
+      expect(() => parseContainerOptions("; touch /tmp/pwned")).toThrow(
         UnsafeContainerSettingError,
       );
     });
-  });
 
-  describe("parseContainerOptions", () => {
+    it("rejects command substitution", () => {
+      expect(() => parseContainerOptions("$(id)")).toThrow(
+        UnsafeContainerSettingError,
+      );
+    });
+
     it("parses multiple flags", () => {
       expect(parseContainerOptions("--net=host --user=1000")).toEqual([
         "--net=host",

--- a/packages/ansible-language-server/test/utils/containerCommandSafety.test.ts
+++ b/packages/ansible-language-server/test/utils/containerCommandSafety.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import {
+  UnsafeContainerSettingError,
+  assertNoShellMetacharacters,
+  formatVolumeMountSpec,
+  parseContainerOptions,
+  validateExecutionEnvironmentSettings,
+} from "@src/utils/containerCommandSafety.js";
+
+describe("containerCommandSafety", () => {
+  describe("assertNoShellMetacharacters", () => {
+    it("allows safe container flags", () => {
+      expect(() =>
+        assertNoShellMetacharacters("--net=host", "test"),
+      ).not.toThrow();
+    });
+
+    it("rejects command injection via semicolon", () => {
+      expect(() =>
+        assertNoShellMetacharacters("; touch /tmp/pwned", "test"),
+      ).toThrow(UnsafeContainerSettingError);
+    });
+
+    it("rejects command substitution", () => {
+      expect(() => assertNoShellMetacharacters("$(id)", "test")).toThrow(
+        UnsafeContainerSettingError,
+      );
+    });
+  });
+
+  describe("parseContainerOptions", () => {
+    it("parses multiple flags", () => {
+      expect(parseContainerOptions("--net=host --user=1000")).toEqual([
+        "--net=host",
+        "--user=1000",
+      ]);
+    });
+
+    it("parses quoted values with spaces", () => {
+      expect(parseContainerOptions('--label "foo bar"')).toEqual([
+        "--label",
+        "foo bar",
+      ]);
+    });
+
+    it("rejects injection payloads", () => {
+      expect(() => parseContainerOptions("--net=host; touch /tmp/cve")).toThrow(
+        UnsafeContainerSettingError,
+      );
+    });
+
+    it("rejects reported containerOptions injection pattern (CVE-2026-44191)", () => {
+      const injectionPayload = "--net=host; touch /tmp/cve-2026-44191-pwned";
+      expect(() => parseContainerOptions(injectionPayload)).toThrow(
+        /disallowed shell metacharacters/,
+      );
+    });
+  });
+
+  describe("formatVolumeMountSpec", () => {
+    it("formats a valid mount", () => {
+      expect(
+        formatVolumeMountSpec({
+          src: "/host",
+          dest: "/container",
+          options: "Z",
+        }),
+      ).toBe("/host:/container:Z");
+    });
+
+    it("rejects injection in mount source", () => {
+      expect(() =>
+        formatVolumeMountSpec({
+          src: "/tmp; touch /tmp/pwned",
+          dest: "/container",
+          options: undefined,
+        }),
+      ).toThrow(UnsafeContainerSettingError);
+    });
+  });
+
+  describe("validateExecutionEnvironmentSettings", () => {
+    it("validates all settings together", () => {
+      expect(() =>
+        validateExecutionEnvironmentSettings("", [
+          { src: "/a", dest: "/b", options: undefined },
+        ]),
+      ).not.toThrow();
+    });
+  });
+});

--- a/packages/ansible-language-server/test/utils/containerCommandSafety.test.ts
+++ b/packages/ansible-language-server/test/utils/containerCommandSafety.test.ts
@@ -74,12 +74,32 @@ describe("containerCommandSafety", () => {
     });
   });
 
+  describe("validateExecutionEnvironmentImage", () => {
+    it("allows a normal image reference", () => {
+      expect(() =>
+        validateExecutionEnvironmentSettings(
+          "",
+          [],
+          "ghcr.io/ansible/community-ansible-dev-tools:latest",
+        ),
+      ).not.toThrow();
+    });
+
+    it("rejects injection in image name", () => {
+      expect(() =>
+        validateExecutionEnvironmentSettings("", [], "image; touch /tmp/pwned"),
+      ).toThrow(UnsafeContainerSettingError);
+    });
+  });
+
   describe("validateExecutionEnvironmentSettings", () => {
     it("validates all settings together", () => {
       expect(() =>
-        validateExecutionEnvironmentSettings("", [
-          { src: "/a", dest: "/b", options: undefined },
-        ]),
+        validateExecutionEnvironmentSettings(
+          "",
+          [{ src: "/a", dest: "/b", options: undefined }],
+          "ghcr.io/example:latest",
+        ),
       ).not.toThrow();
     });
   });

--- a/src/features/runner.ts
+++ b/src/features/runner.ts
@@ -3,6 +3,7 @@ import { existsSync } from "fs";
 import * as vscode from "vscode";
 
 /* local */
+import { validateExecutionEnvironmentSettings } from "@src/utils/containerCommandSafety";
 import { getContainerEngine } from "@src/utils/executionEnvironment";
 import { AnsibleCommands } from "@src/definitions/constants";
 import { registerCommandWithTelemetry } from "@src/utils/registerCommands";
@@ -70,11 +71,24 @@ export class AnsiblePlaybookRunProvider {
     console.log('Added a "Run with Ansible Navigator" command...');
   }
 
-  private addEEArgs(commandLineArgs: string[]): void {
+  private addEEArgs(commandLineArgs: string[]): boolean {
     const eeSettings = this.extensionSettings.settings.executionEnvironment;
     if (!eeSettings.enabled) {
       commandLineArgs.push("--ee false");
-      return;
+      return true;
+    }
+    try {
+      validateExecutionEnvironmentSettings(
+        eeSettings.containerOptions,
+        eeSettings.volumeMounts,
+      );
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : "Invalid execution environment settings.";
+      vscode.window.showErrorMessage(message);
+      return false;
     }
     commandLineArgs.push("--ee true");
     commandLineArgs.push("--pae false");
@@ -92,6 +106,7 @@ export class AnsiblePlaybookRunProvider {
       }
       commandLineArgs.push(`--eev ${mountPath}`);
     });
+    return true;
   }
 
   /**
@@ -196,7 +211,9 @@ export class AnsiblePlaybookRunProvider {
 
     commandLineArgs.push(shellQuote(playbookFsPath));
 
-    this.addEEArgs(commandLineArgs);
+    if (!this.addEEArgs(commandLineArgs)) {
+      return;
+    }
 
     const cmdArgs = commandLineArgs.map((arg) => arg).join(" ");
     const command = `${runExecutable} run ${cmdArgs}`;

--- a/src/features/runner.ts
+++ b/src/features/runner.ts
@@ -81,6 +81,7 @@ export class AnsiblePlaybookRunProvider {
       validateExecutionEnvironmentSettings(
         eeSettings.containerOptions,
         eeSettings.volumeMounts,
+        eeSettings.image,
       );
     } catch (error) {
       const message =
@@ -95,16 +96,16 @@ export class AnsiblePlaybookRunProvider {
     commandLineArgs.push(
       `--ce ${getContainerEngine(eeSettings.containerEngine)}`,
     );
-    commandLineArgs.push(`--eei ${eeSettings.image}`);
+    commandLineArgs.push(`--eei ${shellQuote(eeSettings.image)}`);
     if (eeSettings.containerOptions !== "") {
-      commandLineArgs.push(`--co ${eeSettings.containerOptions}`);
+      commandLineArgs.push(`--co ${shellQuote(eeSettings.containerOptions)}`);
     }
     eeSettings.volumeMounts.forEach((volumeMount) => {
       let mountPath = `${volumeMount.src}:${volumeMount.dest}`;
       if (volumeMount.options !== undefined) {
         mountPath += `:${volumeMount.options}`;
       }
-      commandLineArgs.push(`--eev ${mountPath}`);
+      commandLineArgs.push(`--eev ${shellQuote(mountPath)}`);
     });
     return true;
   }

--- a/src/utils/containerCommandSafety.ts
+++ b/src/utils/containerCommandSafety.ts
@@ -117,7 +117,11 @@ function formatVolumeMountSpec(mount: IVolumeMounts): string {
 export function validateExecutionEnvironmentSettings(
   containerOptions: string,
   volumeMounts: Array<IVolumeMounts>,
+  image: string,
 ): void {
+  if (image.trim() !== "") {
+    assertNoShellMetacharacters(image, "ansible.executionEnvironment.image");
+  }
   if (containerOptions.trim() !== "") {
     parseContainerOptions(containerOptions);
   }

--- a/src/utils/containerCommandSafety.ts
+++ b/src/utils/containerCommandSafety.ts
@@ -10,7 +10,7 @@ interface IVolumeMounts {
 /** Characters and sequences that enable shell command injection (CWE-78). */
 const UNSAFE_SHELL_PATTERN = /[;&|$`<>\\\n\r]|(?:\$\()|(?:\$\{)|(?:\$\))/;
 
-export class UnsafeContainerSettingError extends Error {
+class UnsafeContainerSettingError extends Error {
   constructor(settingLabel: string) {
     super(
       `Invalid ${settingLabel}: contains disallowed shell metacharacters. ` +
@@ -20,7 +20,7 @@ export class UnsafeContainerSettingError extends Error {
   }
 }
 
-export function assertNoShellMetacharacters(
+function assertNoShellMetacharacters(
   value: string,
   settingLabel: string,
 ): void {
@@ -29,7 +29,7 @@ export function assertNoShellMetacharacters(
   }
 }
 
-export function parseContainerOptions(options: string): string[] {
+function parseContainerOptions(options: string): string[] {
   const trimmed = options.trim();
   if (trimmed === "") {
     return [];
@@ -91,7 +91,7 @@ export function parseContainerOptions(options: string): string[] {
   return tokens;
 }
 
-export function formatVolumeMountSpec(mount: IVolumeMounts): string {
+function formatVolumeMountSpec(mount: IVolumeMounts): string {
   assertNoShellMetacharacters(
     mount.src,
     "ansible.executionEnvironment.volumeMounts src",

--- a/src/utils/containerCommandSafety.ts
+++ b/src/utils/containerCommandSafety.ts
@@ -1,0 +1,127 @@
+/**
+ * Keep in sync with packages/ansible-language-server/src/utils/containerCommandSafety.ts
+ */
+interface IVolumeMounts {
+  src: string;
+  dest: string;
+  options: string | undefined;
+}
+
+/** Characters and sequences that enable shell command injection (CWE-78). */
+const UNSAFE_SHELL_PATTERN = /[;&|$`<>\\\n\r]|(?:\$\()|(?:\$\{)|(?:\$\))/;
+
+export class UnsafeContainerSettingError extends Error {
+  constructor(settingLabel: string) {
+    super(
+      `Invalid ${settingLabel}: contains disallowed shell metacharacters. ` +
+        "Remove characters such as ; | & $ ` and command substitution.",
+    );
+    this.name = "UnsafeContainerSettingError";
+  }
+}
+
+export function assertNoShellMetacharacters(
+  value: string,
+  settingLabel: string,
+): void {
+  if (UNSAFE_SHELL_PATTERN.test(value)) {
+    throw new UnsafeContainerSettingError(settingLabel);
+  }
+}
+
+export function parseContainerOptions(options: string): string[] {
+  const trimmed = options.trim();
+  if (trimmed === "") {
+    return [];
+  }
+  assertNoShellMetacharacters(
+    trimmed,
+    "ansible.executionEnvironment.containerOptions",
+  );
+
+  const tokens: string[] = [];
+  let current = "";
+  let inSingle = false;
+  let inDouble = false;
+
+  for (let i = 0; i < trimmed.length; i++) {
+    const char = trimmed[i];
+    if (inSingle) {
+      if (char === "'") {
+        inSingle = false;
+      } else {
+        current += char;
+      }
+      continue;
+    }
+    if (inDouble) {
+      if (char === '"') {
+        inDouble = false;
+      } else {
+        current += char;
+      }
+      continue;
+    }
+    if (char === "'") {
+      inSingle = true;
+      continue;
+    }
+    if (char === '"') {
+      inDouble = true;
+      continue;
+    }
+    if (/\s/.test(char)) {
+      if (current !== "") {
+        tokens.push(current);
+        current = "";
+      }
+      continue;
+    }
+    current += char;
+  }
+
+  if (inSingle || inDouble) {
+    throw new UnsafeContainerSettingError(
+      "ansible.executionEnvironment.containerOptions",
+    );
+  }
+  if (current !== "") {
+    tokens.push(current);
+  }
+  return tokens;
+}
+
+export function formatVolumeMountSpec(mount: IVolumeMounts): string {
+  assertNoShellMetacharacters(
+    mount.src,
+    "ansible.executionEnvironment.volumeMounts src",
+  );
+  assertNoShellMetacharacters(
+    mount.dest,
+    "ansible.executionEnvironment.volumeMounts dest",
+  );
+  if (mount.options !== undefined && mount.options !== "") {
+    assertNoShellMetacharacters(
+      mount.options,
+      "ansible.executionEnvironment.volumeMounts options",
+    );
+  }
+
+  let spec = `${mount.src}:${mount.dest}`;
+  if (mount.options !== undefined && mount.options !== "") {
+    spec += `:${mount.options}`;
+  }
+  return spec;
+}
+
+export function validateExecutionEnvironmentSettings(
+  containerOptions: string,
+  volumeMounts: Array<IVolumeMounts>,
+): void {
+  if (containerOptions.trim() !== "") {
+    parseContainerOptions(containerOptions);
+  }
+  for (const mount of volumeMounts) {
+    formatVolumeMountSpec(mount);
+  }
+}

--- a/src/utils/executionEnvironment.ts
+++ b/src/utils/executionEnvironment.ts
@@ -8,11 +8,12 @@ export function getContainerEngine(containerEngine: string): string {
 
   let isCEFound = false;
   for (const ce of ["podman", "docker"]) {
-    try {
-      child_process.execSync(`which ${ce}`, {
-        encoding: "utf-8",
-      });
-    } catch {
+    const result = child_process.spawnSync("which", [ce], {
+      encoding: "utf-8",
+      shell: false,
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    if (result.status !== 0) {
       continue;
     }
     engine = ce;


### PR DESCRIPTION
## Summary

- Fix CWE-78 command injection via `ansible.executionEnvironment.containerOptions` and `ansible.executionEnvironment.volumeMounts` when values were concatenated into shell commands (`exec` / `execSync`).
- Add validation to reject shell metacharacters (`;`, `|`, `&`, `$`, command substitution, etc.) before use.
- Run container engine commands with `spawn` / `spawnSync` and `shell: false`, passing argv arrays instead of interpolated shell strings.
- Validate EE settings in the extension before “Run with Ansible Navigator” so malicious workspace settings cannot reach the terminal path.
- Add unit tests in `containerCommandSafety.test.ts` (including CVE-2026-44191 injection pattern).

related: CVE-2026-44191

## Test plan

- [ ] `task lint` (or `prek run --all-files`)
- [ ] `pnpm --filter @ansible/ansible-language-server run compile`
- [ ] `pnpm run compile`
- [ ] `cd packages/ansible-language-server && SKIP_PODMAN=1 SKIP_DOCKER=1 pnpm run test-without-ee`
- [ ] `npx vitest run --project=als test/utils/containerCommandSafety.test.ts`
- [ ] Manual: set `ansible.executionEnvironment.containerOptions` to `--net=host; touch /tmp/test` in workspace settings → extension/LS should error, no file created
- [ ] Manual: legitimate `--net=host` still works with EE enabled
- [ ] Manual: “Run with Ansible Navigator” with invalid EE settings shows error and does not run

Related: CVE-2026-44191

_Assisted-by: Claude Code_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Validate and sanitize execution-environment container settings to block shell metacharacters and prevent command injection (CVE-2026-44191) by replacing shell-interpolated exec calls with argv-based spawn/spawnSync (shell: false).

- Add containerCommandSafety utilities: tokenization, validation, UnsafeContainerSettingError
- Validate EE settings before “Run with Ansible Navigator”
- Replace exec/execSync with spawnSyncWithResult/asyncSpawn (shell: false)
- Pass container commands as argv arrays; update CommandRunner to accept string[]
- Add spawn helpers and normalize spawn error handling
- Add unit tests covering CVE injection patterns
- Export new utils via package.json

related: CVE-2026-44191
<!-- end of auto-generated comment: release notes by coderabbit.ai -->