### PR TITLE
chore: add project todo tracking and gap analysis

### DIFF
--- a/.agents/skills/manage-todos/SKILL.md
+++ b/.agents/skills/manage-todos/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: manage-todos
+description: >
+  Create, list, and complete project todos tracked as files in
+  .sdlc/todos/. Use when the user says "add a todo", "create a task",
+  "what's pending", "mark X done", "list todos", or discusses work
+  items for the next branch. Do NOT use for in-conversation ephemeral
+  todos — this is for persistent project-level tracking.
+user-invocable: true
+---
+
+# Manage Project Todos
+
+## Structure
+
+```
+.sdlc/todos/
+  pending/      → work not yet started or in progress
+  complete/     → finished work
+```
+
+One markdown file per todo. The directory determines status.
+
+## Creating a todo
+
+1. Pick a kebab-case filename from the title (e.g.,
+   `add-definition-provider.md`).
+2. Copy `.sdlc/templates/todo.md` and fill in:
+   - `title` — concise description
+   - `created` — today's date
+   - `status` — `pending`
+   - `priority` — `low`, `medium`, or `high`
+   - `scope` — one of: `core`, `ls`, `mcp`, `extension`, `panels`,
+     `views`, `ci`, `docs`
+3. Write a brief Context section explaining why this is needed.
+4. List concrete Acceptance criteria as checkboxes.
+5. Save to `.sdlc/todos/pending/<slug>.md`.
+
+Keep the file short — aim for under 40 lines.
+
+## Listing todos
+
+Read the `pending/` directory. Show a table:
+
+```
+| File | Title | Priority | Scope |
+```
+
+Parse the YAML frontmatter for each file.
+
+## Completing a todo
+
+1. Move the file from `pending/` to `complete/`.
+2. Update frontmatter: set `status: done`, add `completed: YYYY-MM-DD`.
+3. Check off acceptance criteria that were met.
+
+## Rules
+
+- One todo per file. Don't combine unrelated work.
+- Don't delete completed todos — move them to `complete/` for history.
+- If a todo becomes irrelevant, set `status: cancelled` in frontmatter
+  and move to `complete/`.
+- Todos are checked into git and travel with the branch. They are not
+  GitHub issues.

--- a/.sdlc/adrs/ADR-003-ee-via-devcontainers.md
+++ b/.sdlc/adrs/ADR-003-ee-via-devcontainers.md
@@ -1,0 +1,128 @@
+# ADR-003: Execution Environment Support via Dev Containers
+
+## Status
+
+Proposed
+
+## Date
+
+2026-05-26
+
+## Context
+
+The `main` extension provides a "run inside EE" mode via seven
+`ansible.executionEnvironment.*` configuration properties. When enabled,
+all Ansible tooling (ansible-lint, ansible-playbook, ansible-doc, etc.)
+is executed inside a container using podman or docker. The extension
+manages container lifecycle, volume mounts, pull policies, and engine
+selection internally.
+
+This approach has several problems:
+
+- **Duplicated container orchestration**: The extension reimplements
+  container exec, volume mounting, and engine detection — capabilities
+  already handled by VS Code's Dev Containers extension and the
+  devcontainer spec.
+- **Fragile runtime**: Subprocess calls routed through `docker exec`
+  or `podman exec` are brittle. Argument escaping, TTY handling, and
+  signal propagation differ between engines and versions.
+- **Incomplete developer experience**: Running inside an EE provides
+  Ansible tooling but not a full development environment. The user
+  still edits files on the host, with no access to the EE's Python
+  environment for debugging, testing, or ad-hoc scripting.
+- **Maintenance burden**: Seven config properties, engine auto-detection
+  logic, volume mount wiring, and pull policy handling represent
+  significant surface area to maintain and test.
+
+Meanwhile, the devcontainer ecosystem solves this problem at a platform
+level. A user can add an `ansible-dev-tools` layer to any EE image and
+open the workspace in a dev container, getting the full development
+experience — editor, terminal, tooling, and extensions — all running
+inside the container.
+
+## Decision
+
+**We will not reimplement the "run inside EE" mode. Instead, we will
+provide documentation and tooling to help users add a dev-tools layer
+to their EE images and use VS Code Dev Containers (or GitHub Codespaces)
+for EE-based development.**
+
+Concretely:
+
+1. The `ansible.executionEnvironment.*` configuration block will not be
+   ported to the `next` branch.
+2. The EE tree view retains its inspection capability (listing images,
+   showing installed collections and packages).
+3. Documentation and/or a Creator form will guide users through adding
+   an `ansible-dev-tools` layer to an existing EE definition and
+   generating a `.devcontainer/devcontainer.json` that uses the image.
+
+## Alternatives Considered
+
+### Alternative 1: Port the EE mode from main
+
+**Description**: Reimplement the seven config properties and container
+exec routing in the `next` architecture.
+
+**Pros**:
+- Feature parity with `main`
+- No user workflow change
+
+**Cons**:
+- Reimplements what devcontainers already solve
+- Ongoing maintenance of container engine abstraction
+- Fragile subprocess-through-container execution
+
+**Why not chosen**: The devcontainer approach provides a superior
+developer experience with less custom code.
+
+### Alternative 2: Drop EE support entirely
+
+**Description**: Remove the EE tree view and provide no EE integration.
+
+**Pros**:
+- Simplest implementation
+
+**Cons**:
+- Loses the ability to inspect EE images
+- No migration path for existing EE users
+
+**Why not chosen**: The inspection tree view is valuable and
+low-maintenance. Users need to see what's inside their EEs.
+
+## Consequences
+
+### Positive
+
+- Eliminates ~7 config properties and associated container exec logic
+- Users get a full dev environment inside the EE, not just routed
+  tooling
+- Leverages the mature devcontainer ecosystem and its VS Code
+  integration
+- Simpler extension architecture with less surface area
+
+### Negative
+
+- Users currently relying on EE mode need to migrate to devcontainers
+- Requires documentation effort to guide the migration
+- Dev Containers extension becomes a soft dependency for EE workflows
+
+### Neutral
+
+- The EE tree view continues to list and inspect images regardless
+- `ansible-builder build` command (gap #3) remains relevant for
+  building EE images
+
+## Related Decisions
+
+- [ADR-001](ADR-001-service-based-architecture.md): Service-based
+  architecture — EE inspection uses `ExecutionEnvService` in
+  `@ansible/core`
+
+---
+
+## Revision History
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-05-26 | AI-assisted | Initial proposal |

--- a/.sdlc/adrs/ADR-004-intentional-exclusions-from-main.md
+++ b/.sdlc/adrs/ADR-004-intentional-exclusions-from-main.md
@@ -1,0 +1,143 @@
+# ADR-004: Intentional Feature Exclusions from main
+
+## Status
+
+Accepted
+
+## Date
+
+2026-05-26
+
+## Context
+
+A comprehensive gap analysis between `main` and `next` identified
+features present in `main` (excluding Lightspeed) that do not exist
+in `next`. Some of these gaps are intentional — the `next` architecture
+handles the same user need differently or the feature is no longer
+appropriate. This ADR records those decisions to prevent them from
+resurfacing in future gap analyses.
+
+## Decision
+
+**The following features from `main` will NOT be ported to `next`.
+Each has a rationale tied to an architectural difference or a
+deliberate design choice.**
+
+### 1. `ansible.playbook.arguments` config property
+
+**What it did**: A single string setting appended to every
+`ansible-playbook` invocation.
+
+**Why excluded**: `next` has `PlaybookConfigPanel`, a webview form
+with per-playbook and global default run configuration (inventory,
+limits, tags, extra vars, etc.). This is a richer, more discoverable
+approach. A raw string arg field encourages unstructured, error-prone
+input.
+
+### 2. Welcome / ADT hub panel (`WelcomePagePanel`, `ansible-home`)
+
+**What it did**: A sidebar webview showing system readiness checks,
+tool versions, and shortcut links.
+
+**Why excluded**: `next`'s sidebar is composed of purpose-built tree
+views (environments, packages, collections, EE, Creator, playbooks,
+MCP tools) that provide more granular, actionable information. A
+monolithic "hub" panel adds no value when the tree views already
+surface the same data in context.
+
+### 3. Content Creator hardcoded webview panels (7 panels)
+
+**What they did**: Seven separate Vue panels, one per scaffold type
+(collection, project, devfile, EE definition, plugin, role,
+devcontainer).
+
+**Why excluded**: `next`'s `CreatorFormPanel` dynamically generates
+forms from the ansible-creator CLI schema. New scaffold types are
+automatically supported when ansible-creator adds them — no extension
+code changes required. A separate todo covers validating that the
+dynamic form handles all field-level validation the hardcoded panels
+provided.
+
+### 4. `ansible.completion.provideRedirectModules` config property
+
+**What it did**: Toggle to include redirected/legacy module short names
+in completions (e.g., `copy` instead of `ansible.builtin.copy`).
+
+**Why excluded**: Redirected module names are flagged by ansible-lint's
+FQCN rule. `ansible-lint --fix` auto-corrects them. Including legacy
+names in completions encourages the pattern that lint then flags —
+contradictory guidance. The completion provider should only offer
+FQCNs.
+
+### 5. `ansible.ansibleNavigator.path` config property
+
+**What it did**: Manual path override for the ansible-navigator
+executable.
+
+**Why excluded**: `next`'s `DevToolsService` and `CommandService`
+discover tools from the active Python environment's bin directory
+automatically. If ansible-navigator is installed via
+`ansible-dev-tools`, it is found without manual configuration. A
+separate todo covers adding ansible-navigator run support; it will
+use the existing service discovery, not a manual path setting.
+
+### 6. MCP server enable/disable toggle commands
+
+**What they did**: `ansible.mcpServer.enabled` and
+`ansible.mcpServer.disable` toggled a setting and registered/
+unregistered the MCP server provider.
+
+**Why excluded**: `next` handles MCP configuration differently with
+`ansibleMcpTools.configure` (opens MCP config) and
+`ansible-environments.configureCursorMcp` (writes Cursor MCP config).
+The MCP server is also registered as a VS Code `mcpServerDefinition`
+provider, making it discoverable by Copilot without manual toggling.
+
+### 7. DocsLibrary (module source indexing)
+
+**What it did**: Indexed Ansible module documentation by parsing
+Python source files and `meta/runtime.yml`, providing source file
+paths and line ranges for go-to-definition.
+
+**Why excluded**: Replaced by the centralized plugin doc cache
+(ADR-002). The `--metadata-dump` output provides the same
+documentation without parsing Python source. Go-to-definition will
+open the `PluginDocPanel` webview instead of raw Python files (see
+pending todo). The source-file-based approach required filesystem
+access to collection installations and broke in container/remote
+scenarios.
+
+## Consequences
+
+### Positive
+
+- Future gap analyses can reference this ADR instead of re-evaluating
+  each exclusion
+- Contributors understand why these features don't exist in `next`
+- Prevents accidental reimplementation of superseded patterns
+
+### Negative
+
+- Users migrating from `main` may miss specific features; migration
+  documentation should reference this ADR to explain the differences
+
+### Neutral
+
+- Some excluded features have successor implementations in `next`
+  (PlaybookConfigPanel, CreatorFormPanel, service discovery). Users
+  get the same capability through a different interface.
+
+## Related Decisions
+
+- [ADR-002](ADR-002-centralized-plugin-doc-cache.md): Replaces
+  DocsLibrary
+- [ADR-003](ADR-003-ee-via-devcontainers.md): Replaces EE mode
+  settings
+
+---
+
+## Revision History
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-05-26 | AI-assisted | Initial record of gap analysis exclusions |

--- a/.sdlc/adrs/ADR-005-architectural-invariants.md
+++ b/.sdlc/adrs/ADR-005-architectural-invariants.md
@@ -1,0 +1,139 @@
+# ADR-005: Architectural Invariants
+
+## Status
+
+Accepted
+
+## Date
+
+2026-05-26
+
+## Context
+
+The `next` branch establishes a new architecture for the Ansible VS
+Code extension (ADR-001 through ADR-004). As multiple contributors
+and AI agents work on the codebase, there is a risk of architectural
+erosion — adding functionality in the wrong layer, coupling to
+specific providers, bypassing shared services, or reimplementing
+solved problems.
+
+This ADR codifies the non-negotiable invariants that protect the
+architecture. Violating any of them creates compounding debt across
+packages. If an invariant needs to change, write a new ADR first.
+
+## Decision
+
+**The following invariants are enforced for all code on the `next`
+branch. They are referenced from `AGENTS.md` and must be checked
+before every commit.**
+
+### 1. Domain logic lives in `@ansible/core`, not in the extension (ADR-001)
+
+Services that operate on Ansible concepts (collections, plugins,
+environments, creator schemas, execution environments) belong in
+`packages/core/`. The extension (`src/`) contains only VS Code-specific
+code: panels, views, tree providers, and editor integrations.
+
+**Test**: If a new service could be useful to the MCP server or
+language server, it belongs in `@ansible/core`.
+
+### 2. `@ansible/core` has zero hard dependencies on `vscode` (ADR-001)
+
+All VS Code API usage in `packages/core/` uses the conditional pattern:
+
+```typescript
+let vscode: typeof import('vscode') | undefined;
+try { vscode = require('vscode'); } catch {}
+```
+
+An unconditional `import * as vscode from 'vscode'` in any core file
+breaks the MCP server and language server. This is non-negotiable.
+
+### 3. The plugin doc cache is the single source of truth (ADR-002)
+
+Never spawn `ansible-doc --json` for a single plugin when the cache is
+populated. All documentation consumers — hover, PluginDocPanel, MCP
+tools, completion — go through
+`CollectionsService.getPluginDocumentation()`.
+
+### 4. No direct LLM/AI provider coupling
+
+AI features use VS Code's `vscode.lm` API or the `LlmService`
+abstraction. Never import a specific LLM SDK (OpenAI, Anthropic,
+Ollama, etc.) directly into the extension or its packages. The
+extension delegates model selection to the editor. This keeps the
+extension vendor-neutral and avoids bundling large SDK dependencies.
+
+### 5. ansible-creator is the source of truth for content scaffolding (ADR-004)
+
+The extension does not hardcode scaffold templates, starter playbooks,
+or project structures. All content creation flows through
+`CreatorService` and the schema-driven `CreatorFormPanel`. If a new
+scaffold type is needed, it is added to ansible-creator — the
+extension picks it up automatically via the schema.
+
+### 6. Execution environments use dev containers, not container exec (ADR-003)
+
+Do not add `docker exec` / `podman exec` routing to run tooling inside
+EE containers. EE-based development uses VS Code Dev Containers with
+an `ansible-dev-tools` layer. The extension inspects EE images (tree
+view) and builds them (`ansible-builder`) but does not run inside them.
+
+### 7. Tools are discovered from the active Python environment (ADR-004)
+
+Services use `CommandService` to find tools (`ansible-doc`,
+`ansible-lint`, `ansible-playbook`, `ansible-navigator`, `ade`, etc.)
+in the active venv's bin directory. Do not add per-tool path
+configuration properties (e.g., `ansible.ansibleNavigator.path`).
+Tool availability is a function of the environment, not user config.
+
+### 8. Collection operations use ADE, not ansible-galaxy directly
+
+All collection installation, discovery, and management goes through
+`ade` (Ansible Development Environment tool). Do not invoke
+`ansible-galaxy collection install` or `ansible-galaxy collection list`
+directly. ADE provides consistent venv-aware behavior, unified
+logging, and a stable interface that insulates the extension from
+ansible-galaxy CLI changes. `CollectionsService.installCollection()`
+already enforces this.
+
+## Consequences
+
+### Positive
+
+- Clear boundaries prevent architectural erosion as the contributor
+  base grows
+- AI agents can check invariants mechanically before committing
+- New contributors understand the "why" behind structural decisions
+- Reduces code review burden — invariant violations are objective,
+  not subjective
+
+### Negative
+
+- Invariants constrain implementation choices; some shortcuts are
+  off-limits even when they would be faster
+- Requires discipline to write an ADR before changing an invariant
+
+### Neutral
+
+- The invariant list will grow as new architectural decisions are made
+- Each invariant should reference the ADR that established it
+
+## Related Decisions
+
+- [ADR-001](ADR-001-service-based-architecture.md): Service-based
+  architecture (invariants 1, 2)
+- [ADR-002](ADR-002-centralized-plugin-doc-cache.md): Plugin doc
+  cache (invariant 3)
+- [ADR-003](ADR-003-ee-via-devcontainers.md): EE via dev containers
+  (invariant 6)
+- [ADR-004](ADR-004-intentional-exclusions-from-main.md): Intentional
+  exclusions (invariants 5, 7)
+
+---
+
+## Revision History
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-05-26 | AI-assisted | Initial invariants (8 rules) |

--- a/.sdlc/adrs/README.md
+++ b/.sdlc/adrs/README.md
@@ -12,10 +12,27 @@ Decisions that are fully reflected in the codebase.
 | [ADR-001](ADR-001-service-based-architecture.md) | Service-Based Architecture with VS Code-Independent Core | 2026-05-26 |
 | [ADR-002](ADR-002-centralized-plugin-doc-cache.md) | Centralized Plugin Documentation Cache | 2026-05-26 |
 
+## Accepted
+
+Decisions that have been accepted but are not yet fully implemented.
+
+| ADR | Title | Date |
+|-----|-------|------|
+| [ADR-004](ADR-004-intentional-exclusions-from-main.md) | Intentional Feature Exclusions from main | 2026-05-26 |
+| [ADR-005](ADR-005-architectural-invariants.md) | Architectural Invariants | 2026-05-26 |
+
+## Proposed
+
+Decisions under consideration — not yet accepted or implemented.
+
+| ADR | Title | Date |
+|-----|-------|------|
+| [ADR-003](ADR-003-ee-via-devcontainers.md) | Execution Environment Support via Dev Containers | 2026-05-26 |
+
 ## Creating New ADRs
 
 1. Copy the template from `../templates/adr.md`
-2. Use the next available number (currently ADR-003)
+2. Use the next available number (currently ADR-006)
 3. Include:
    - Status (Proposed → Accepted → Implemented)
    - Date

--- a/.sdlc/templates/todo.md
+++ b/.sdlc/templates/todo.md
@@ -1,0 +1,24 @@
+---
+title: Short descriptive title
+created: YYYY-MM-DD
+status: pending
+priority: medium
+scope: core
+# Allowed: core, ls, mcp, extension, panels, views, ci, docs
+---
+
+# Title
+
+## Context
+
+Why is this needed? Link to the gap, ADR, or user request that
+motivates it.
+
+## Acceptance criteria
+
+- [ ] Criterion 1
+- [ ] Criterion 2
+
+## Notes
+
+Any implementation hints, related files, or open questions.

--- a/.sdlc/todos/README.md
+++ b/.sdlc/todos/README.md
@@ -1,0 +1,25 @@
+# Project Todos
+
+Lightweight task tracking for the `next` branch. One file per todo,
+managed by moving files between directories.
+
+```
+.sdlc/todos/
+  pending/    → work not yet started or in progress
+  complete/   → finished work (kept for reference)
+```
+
+## File naming
+
+Use a short kebab-case slug: `add-definition-provider.md`,
+`port-content-creator-webviews.md`.
+
+## Creating a new todo
+
+Copy the template from `../templates/todo.md` or use the `manage-todos`
+agent skill.
+
+## Completing a todo
+
+Move the file from `pending/` to `complete/` and update the frontmatter
+`status` to `done` and set `completed` to today's date.

--- a/.sdlc/todos/pending/add-ansible-navigator-run.md
+++ b/.sdlc/todos/pending/add-ansible-navigator-run.md
@@ -1,0 +1,30 @@
+---
+title: Add ansible-navigator run support
+created: 2026-05-26
+status: pending
+priority: medium
+scope: extension
+---
+
+# Add ansible-navigator run support
+
+## Context
+
+`main` supports running playbooks via `ansible-navigator run` in
+addition to `ansible-playbook`. ansible-navigator provides TUI-based
+execution, execution environment integration, and artifact collection.
+
+`next` only supports `ansible-playbook` runs from the Playbooks tree.
+
+## Acceptance criteria
+
+- [ ] "Run via ansible-navigator" option in Playbooks tree context menu
+- [ ] ansible-navigator discovered via CommandService from active venv
+- [ ] Runs in integrated terminal with venv activation
+
+## Notes
+
+ansible-navigator should be discovered via `DevToolsService` /
+`CommandService` from the active Python environment — no separate
+path config property needed. Consider whether this should be a run
+option in PlaybookConfigPanel or a separate command.

--- a/.sdlc/todos/pending/add-ee-build-command.md
+++ b/.sdlc/todos/pending/add-ee-build-command.md
@@ -1,0 +1,28 @@
+---
+title: Add execution environment build command
+created: 2026-05-26
+status: pending
+priority: medium
+scope: extension
+---
+
+# Add execution environment build command
+
+## Context
+
+`main` provides a context-menu command on `execution-environment.yml`
+files to run `ansible-builder build`. `next` has an EE tree view that
+lists container images but no build capability.
+
+## Acceptance criteria
+
+- [ ] Right-click `execution-environment.yml` in editor or explorer
+      triggers `ansible-builder build`
+- [ ] Build runs in integrated terminal with progress output
+- [ ] EE tree refreshes after successful build
+
+## Notes
+
+Should integrate with `CommandService` for venv-aware execution.
+Consider whether to add to the EE tree view as well (build from
+selected EE definition).

--- a/.sdlc/todos/pending/add-ee-devcontainer-guidance.md
+++ b/.sdlc/todos/pending/add-ee-devcontainer-guidance.md
@@ -1,0 +1,28 @@
+---
+title: Add EE-to-devcontainer guidance and tooling
+created: 2026-05-26
+status: pending
+priority: medium
+scope: docs
+---
+
+# Add EE-to-devcontainer guidance and tooling
+
+## Context
+
+Per ADR-003, the "run inside EE" mode from `main` will not be ported.
+Instead, users should add an `ansible-dev-tools` layer to their EE
+images and use VS Code Dev Containers.
+
+## Acceptance criteria
+
+- [ ] Documentation explaining how to add a dev-tools layer to an EE
+- [ ] Creator form or template for generating `.devcontainer/devcontainer.json`
+      from an EE image
+- [ ] Migration guide for users coming from main's EE mode
+
+## Notes
+
+The Creator already supports devcontainer scaffolding. This todo is
+about connecting EE images to that workflow and documenting the
+migration path.

--- a/.sdlc/todos/pending/add-extension-conflict-detection.md
+++ b/.sdlc/todos/pending/add-extension-conflict-detection.md
@@ -1,0 +1,26 @@
+---
+title: Add extension conflict detection
+created: 2026-05-26
+status: pending
+priority: low
+scope: extension
+---
+
+# Add extension conflict detection
+
+## Context
+
+`main` warns users when conflicting YAML or Ansible extensions are
+installed that could interfere with syntax highlighting or language
+features. `next` has no such detection.
+
+## Acceptance criteria
+
+- [ ] On activation, check for known conflicting extensions
+- [ ] Show a warning notification with guidance to disable conflicts
+- [ ] Maintain a list of known conflicting extension IDs
+
+## Notes
+
+Common conflicts include other YAML language extensions that override
+the Ansible file association or provide competing completions.

--- a/.sdlc/todos/pending/add-goto-definition-provider.md
+++ b/.sdlc/todos/pending/add-goto-definition-provider.md
@@ -1,0 +1,31 @@
+---
+title: Add go-to-definition that opens PluginDocPanel
+created: 2026-05-26
+status: pending
+priority: medium
+scope: ls
+---
+
+# Add go-to-definition that opens PluginDocPanel
+
+## Context
+
+`main` has a definition provider that jumps to the Python source file
+of a module. `next` has no definition provider but has the centralized
+plugin doc cache (ADR-002) and a rich PluginDocPanel webview.
+
+Rather than resolving Python source paths (which requires DocsLibrary),
+go-to-definition should open the PluginDocPanel webview for the
+targeted FQCN.
+
+## Acceptance criteria
+
+- [ ] Ctrl+click / F12 on a module FQCN in a task opens PluginDocPanel
+- [ ] The language server registers a `definitionProvider` capability
+- [ ] Works for both short names and FQCNs
+
+## Notes
+
+The LS will need to send a custom notification or command link to the
+client since webview panels can only be opened from the extension host,
+not from the language server process directly.

--- a/.sdlc/todos/pending/add-playbook-run-context-menus.md
+++ b/.sdlc/todos/pending/add-playbook-run-context-menus.md
@@ -1,0 +1,27 @@
+---
+title: Add playbook run to editor and explorer context menus
+created: 2026-05-26
+status: pending
+priority: low
+scope: extension
+---
+
+# Add playbook run to editor and explorer context menus
+
+## Context
+
+`main` has a "Run Ansible Playbook via..." submenu in both the editor
+right-click menu and file explorer right-click menu. `next` only
+exposes run commands from the Playbooks tree view.
+
+## Acceptance criteria
+
+- [ ] Right-click in an open Ansible file shows "Run Playbook" option
+- [ ] Right-click on an Ansible file in explorer shows "Run Playbook"
+- [ ] Submenu groups available runners (ansible-playbook, navigator)
+- [ ] When clause limits to `editorLangId == ansible` / `resourceLangId == ansible`
+
+## Notes
+
+Depends on ansible-navigator support (gap #2) for the full submenu.
+Can ship with just ansible-playbook initially.

--- a/.sdlc/todos/pending/add-python-env-fallback.md
+++ b/.sdlc/todos/pending/add-python-env-fallback.md
@@ -1,0 +1,43 @@
+---
+title: Add Python environment API fallback for non-PET editors
+created: 2026-05-26
+status: pending
+priority: high
+scope: extension
+---
+
+# Add Python environment API fallback for non-PET editors
+
+## Context
+
+`main` iterated on the Python environment service (originally ported
+from `next`) to add a fallback chain:
+
+1. `ms-python.vscode-python-envs` with PET binary (primary)
+2. `ms-python.python` environments API (fallback when PET is missing)
+
+The PET binary is missing on OpenVSX-based editors (VSCodium, Dev
+Spaces, Kiro) because the universal VSIX doesn't include
+platform-specific binaries. Without the fallback, environment
+discovery fails entirely on these platforms.
+
+`next` only has the primary path — no fallback.
+
+## Acceptance criteria
+
+- [ ] Detect when PET binary is missing from the vscode-python-envs
+      extension path
+- [ ] Fall back to `ms-python.python` `PythonExtension` API for
+      environment resolution
+- [ ] Show a non-intrusive warning that environment discovery may be
+      degraded
+- [ ] Environment change events work through both paths
+- [ ] Works on VSCodium, Dev Spaces, and other OpenVSX editors
+
+## Notes
+
+Reference `main`'s `src/services/PythonEnvironmentService.ts` for the
+implementation pattern. Key methods: `_isPetAvailable()`,
+`_initFromPythonExtension()`, `resolveInterpreterPath()` with dual
+API support. Consider porting to `@ansible/core` with conditional
+vscode imports for standalone compatibility.

--- a/.sdlc/todos/pending/add-resync-inventory-command.md
+++ b/.sdlc/todos/pending/add-resync-inventory-command.md
@@ -1,0 +1,27 @@
+---
+title: Add resync Ansible inventory command
+created: 2026-05-26
+status: pending
+priority: low
+scope: extension
+---
+
+# Add resync Ansible inventory command
+
+## Context
+
+The language server already handles the `resync/ansible-inventory`
+notification to clear and rebuild its inventory cache. `main` exposes
+this as a user-facing command `extension.resync-ansible-inventory`.
+`next` has no command wired to this notification.
+
+## Acceptance criteria
+
+- [ ] Command palette entry "Ansible: Resync Inventory"
+- [ ] Sends `resync/ansible-inventory` notification to the LS
+- [ ] Status bar or notification confirms completion
+
+## Notes
+
+Useful when the user modifies inventory files outside the editor or
+changes the active Python environment.

--- a/.sdlc/todos/pending/add-settings-shortcut-commands.md
+++ b/.sdlc/todos/pending/add-settings-shortcut-commands.md
@@ -1,0 +1,25 @@
+---
+title: Add settings shortcut commands
+created: 2026-05-26
+status: pending
+priority: low
+scope: extension
+---
+
+# Add settings shortcut commands
+
+## Context
+
+`main` has convenience commands to open VS Code settings filtered to
+the extension's config: "Open Ansible Extension Settings" and "Open
+Python Settings". `next` has no such shortcuts.
+
+## Acceptance criteria
+
+- [ ] Command palette entry to open settings filtered to extension config
+- [ ] Uses `vscode.commands.executeCommand('workbench.action.openSettings', '@ext:...')`
+
+## Notes
+
+Trivial to implement. One or two commands opening the settings UI
+with the appropriate filter string.

--- a/.sdlc/todos/pending/add-status-bar-items.md
+++ b/.sdlc/todos/pending/add-status-bar-items.md
@@ -1,0 +1,31 @@
+---
+title: Add status bar items for environment info
+created: 2026-05-26
+status: pending
+priority: medium
+scope: extension
+---
+
+# Add status bar items for environment info
+
+## Context
+
+`main` shows Ansible metadata (version) and the active Python
+interpreter in the VS Code status bar. This gives at-a-glance
+visibility without opening the sidebar.
+
+`next` has no status bar items — environment info is only in the
+sidebar tree views.
+
+## Acceptance criteria
+
+- [ ] Status bar item showing active Python environment
+- [ ] Status bar item showing Ansible version (from LS metadata)
+- [ ] Clicking the items opens relevant commands (select environment,
+      resync, etc.)
+- [ ] Items update when the active environment changes
+
+## Notes
+
+Use `vscode.window.createStatusBarItem()`. The LS already supports
+the `update/ansible-metadata` notification for version info.

--- a/.sdlc/todos/pending/add-telemetry.md
+++ b/.sdlc/todos/pending/add-telemetry.md
@@ -1,0 +1,30 @@
+---
+title: Add telemetry support
+created: 2026-05-26
+status: pending
+priority: low
+scope: extension
+---
+
+# Add telemetry support
+
+## Context
+
+`main` integrates Red Hat Segment telemetry via
+`@redhat-developer/vscode-redhat-telemetry` with an opt-in
+`redhat.telemetry.enabled` config property.
+
+`next` has no telemetry.
+
+## Acceptance criteria
+
+- [ ] Telemetry events for key user actions (activation, command usage,
+      feature engagement)
+- [ ] Opt-in config property with clear disclosure
+- [ ] Uses VS Code's built-in telemetry consent model
+
+## Notes
+
+Evaluate whether to use the Red Hat telemetry library or VS Code's
+native `vscode.env.telemetryLevel` API. The native API respects the
+user's global telemetry setting automatically.

--- a/.sdlc/todos/pending/create-walkthroughs.md
+++ b/.sdlc/todos/pending/create-walkthroughs.md
@@ -1,0 +1,33 @@
+---
+title: Create walkthroughs for new user onboarding
+created: 2026-05-26
+status: pending
+priority: low
+scope: extension
+---
+
+# Create walkthroughs for new user onboarding
+
+## Context
+
+`main` has three walkthroughs for guided onboarding. `next` has no
+walkthroughs but has significantly different features (tree views,
+Creator forms, plugin doc panel, MCP tools, AI integration) that
+should be highlighted during onboarding.
+
+The walkthroughs should be designed for `next`'s feature set, not
+ported directly from `main`.
+
+## Acceptance criteria
+
+- [ ] At least one walkthrough guiding environment setup
+- [ ] Walkthrough highlights key next-branch features (sidebar views,
+      plugin docs, Creator, playbook runner)
+- [ ] Steps use `next`'s actual commands and views
+- [ ] Registered in `package.json` contributes.walkthroughs
+
+## Notes
+
+Design the walkthrough content after the core features stabilize.
+Consider: environment selection, collection browsing, plugin doc
+panel, Creator scaffolding, playbook execution, MCP/AI tools.

--- a/.sdlc/todos/pending/creator-form-validation-analysis.md
+++ b/.sdlc/todos/pending/creator-form-validation-analysis.md
@@ -1,0 +1,35 @@
+---
+title: Analyze Creator form validation opportunities
+created: 2026-05-26
+status: pending
+priority: medium
+scope: panels
+---
+
+# Analyze Creator form validation opportunities
+
+## Context
+
+`next`'s `CreatorFormPanel` dynamically generates forms from the
+ansible-creator CLI schema. `main` had 7 hardcoded Vue panels with
+custom per-field validation (e.g., FQCN format checks, path existence,
+version format).
+
+The dynamic approach is architecturally superior but may miss
+field-level validation that the hardcoded panels provided.
+
+## Acceptance criteria
+
+- [ ] Deep-dive comparison of `main`'s per-panel validation logic
+      against `next`'s dynamic form capabilities
+- [ ] Identify validation rules from `main` that are missing in `next`
+- [ ] Propose how to add field-level validation to the schema-driven
+      form (e.g., regex patterns, custom validators, schema annotations)
+- [ ] Implement identified validation gaps
+
+## Notes
+
+Check `main`'s Creator panels for: FQCN namespace.name format
+validation, path existence/writability checks, version semver
+validation, required field enforcement, and any prerequisite checks
+(e.g., ansible-creator minimum version).

--- a/.sdlc/todos/pending/creator-simple-playbook-template.md
+++ b/.sdlc/todos/pending/creator-simple-playbook-template.md
@@ -1,0 +1,32 @@
+---
+title: Support simple playbook creation via Creator
+created: 2026-05-26
+status: pending
+priority: low
+scope: extension
+---
+
+# Support simple playbook creation via Creator
+
+## Context
+
+`main` has a "Create empty playbook" command that inserts a starter
+template. Rather than hardcoding a template in the extension, the
+Creator should be the source of truth for content examples.
+
+ansible-creator should support generating a simple example playbook
+(not just a full project), and the extension should expose that via
+a command or Creator tree entry.
+
+## Acceptance criteria
+
+- [ ] ansible-creator supports a simple/example playbook scaffold
+- [ ] Extension exposes a command to create a playbook from Creator
+- [ ] Generated playbook uses best-practice structure from Creator
+
+## Notes
+
+This depends on ansible-creator adding support for single-file
+playbook generation. Coordinate with the ansible-creator project.
+The extension's role is to expose the Creator capability, not to
+own the template content.

--- a/.sdlc/todos/pending/port-ansible-tox-integration.md
+++ b/.sdlc/todos/pending/port-ansible-tox-integration.md
@@ -1,0 +1,33 @@
+---
+title: Port and improve Ansible Tox integration
+created: 2026-05-26
+status: pending
+priority: medium
+scope: extension
+---
+
+# Port and improve Ansible Tox integration
+
+## Context
+
+`main` has an Ansible Tox integration providing a VS Code Test
+Controller and Task Provider for `tox-ansible.ini` environments.
+However, the implementation had reliability issues and never worked
+correctly in `main`.
+
+Port the concept to `next` with a fresh implementation using the
+service-based architecture.
+
+## Acceptance criteria
+
+- [ ] Test Controller discovers tox-ansible scenarios from workspace
+- [ ] Users can run individual scenarios from the Testing sidebar
+- [ ] Test results are reported back to the Test Controller
+- [ ] Task Provider for `tox-ansible` task type
+- [ ] Uses `CommandService` for venv-aware tox execution
+
+## Notes
+
+Rewrite rather than direct port. The `main` implementation had issues
+that should be investigated and fixed. Consider using `tox --list`
+JSON output for scenario discovery instead of parsing config files.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,101 @@
+# Agent Configuration — vscode-ansible (`next` branch)
+
+Read this file before touching code. It defines the architectural
+invariants and operational rules for the `next` branch.
+
+## Architectural Invariants
+
+These are non-negotiable. Violating any of them will break the system
+or create debt that compounds across packages. Do **not** work around
+them — if you think one needs to change, write an ADR first (see the
+`write-adr` skill).
+
+Full rationale for each invariant is in
+[ADR-005](.sdlc/adrs/ADR-005-architectural-invariants.md).
+
+1. **Domain logic lives in `@ansible/core`, not in the extension**
+   (ADR-001). If a service could be used by the MCP server or language
+   server, it belongs in `packages/core/`, not `src/`.
+
+2. **`@ansible/core` has zero hard dependencies on `vscode`**
+   (ADR-001). Use the conditional `try { vscode = require('vscode') }
+   catch {}` pattern. An unconditional `import` breaks MCP and LS.
+
+3. **The plugin doc cache is the single source of truth** (ADR-002).
+   Never spawn `ansible-doc --json` for one plugin when the cache is
+   populated. Use `CollectionsService.getPluginDocumentation()`.
+
+4. **No direct LLM/AI provider coupling.** Use `vscode.lm` or
+   `LlmService`. Never import a specific LLM SDK (OpenAI, Anthropic,
+   etc.) into the extension or packages.
+
+5. **ansible-creator is the source of truth for content scaffolding**
+   (ADR-004). No hardcoded templates. Use `CreatorService` and the
+   schema-driven `CreatorFormPanel`.
+
+6. **Execution environments use dev containers, not container exec**
+   (ADR-003). No `docker exec` / `podman exec` routing. EE development
+   uses VS Code Dev Containers.
+
+7. **Tools are discovered from the active Python environment**
+   (ADR-004). Use `CommandService`. No per-tool path config properties.
+
+8. **Collection operations use ADE, not ansible-galaxy directly.**
+   All install, discovery, and management goes through `ade`. Do not
+   invoke `ansible-galaxy` directly.
+
+## Branching Strategy
+
+See the `branching-strategy` skill for full details.
+
+- **`next`** is the active development branch. All PRs target `next`.
+- **`main`** is frozen (legacy codebase). Never merge between them.
+- Feature branches are created from `upstream/next`.
+- PRs require label (`breaking`, `chore`, `feat`, `fix`) and target
+  `next` explicitly.
+
+## Quality Gates
+
+Before committing:
+
+1. `npx tsc -b` — type check all packages
+2. `npx vitest run` — unit tests pass
+3. `npx eslint .` — no lint violations (when eslint config is available)
+4. Verify no architectural invariants (above) were violated
+
+## Commit Format
+
+[Conventional Commits](https://www.conventionalcommits.org). Scopes:
+`core`, `ls`, `mcp`, `extension`, `views`, `panels`, `ci`, `docs`.
+
+## Project Structure
+
+```
+packages/
+  core/             → @ansible/core (VS Code-independent services)
+  language-server/  → @ansible/language-server (LSP server)
+  mcp-server/       → @ansible/mcp-server (standalone MCP server)
+src/
+  extension.ts      → VS Code extension entry point
+  panels/           → Webview panels
+  views/            → TreeView providers
+  services/         → VS Code-specific services
+  features/         → Editor features (vault, file association)
+.sdlc/
+  adrs/             → Architecture Decision Records
+  todos/            → Project work items (pending/complete)
+  templates/        → ADR and todo templates
+.agents/
+  skills/           → Agent skills for common workflows
+```
+
+## Key Skills
+
+| Skill | When to use |
+|-------|-------------|
+| `submit-pr` | Creating a pull request |
+| `pr-review` | Responding to review comments |
+| `write-adr` | Architectural decisions (not bug fixes) |
+| `manage-todos` | Project work item tracking |
+| `branching-strategy` | Understanding next vs main |
+| `review-contributor-pr` | Reviewing external contributions |


### PR DESCRIPTION
## Summary
- Establish file-based todo tracking, gap analysis, architectural invariants, and agent configuration for the `next` branch.

## Changes
- **AGENTS.md**: Root-level agent configuration with 8 architectural invariants, branching strategy reference, quality gates, commit format, project structure overview, and skill index.
- **Todo structure**: `.sdlc/todos/pending/` and `.sdlc/todos/complete/` directories with one markdown file per work item.
- **15 pending todos** from gap analysis of `main` vs `next` (see table below).
- **ADR-003**: EE support via dev containers instead of custom container exec routing.
- **ADR-004**: 7 features intentionally excluded from `next` with rationale.
- **ADR-005**: 8 architectural invariants protecting the service-based architecture.
- **`manage-todos` agent skill**: Persistent project-level task tracking via files.

## Architectural Invariants (ADR-005)

1. Domain logic in `@ansible/core`, not extension
2. `@ansible/core` has zero hard `vscode` dependencies
3. Plugin doc cache is single source of truth
4. No direct LLM/AI provider coupling
5. ansible-creator is source of truth for scaffolding
6. EE uses dev containers, not container exec
7. Tools discovered from active Python env, no manual paths
8. Collection operations use ADE, not ansible-galaxy directly

## Pending todos (15)

| Priority | Todo | Scope |
|----------|------|-------|
| high | Python env API fallback for non-PET editors | extension |
| medium | Go-to-definition via PluginDocPanel | ls |
| medium | ansible-navigator run support | extension |
| medium | EE build command | extension |
| medium | EE-to-devcontainer guidance (ADR-003) | docs |
| medium | Port/improve Ansible Tox integration | extension |
| medium | Creator form validation analysis | panels |
| medium | Status bar items for environment info | extension |
| low | Playbook run context menus | extension |
| low | Resync inventory command | extension |
| low | Walkthroughs for onboarding | extension |
| low | Telemetry support | extension |
| low | Extension conflict detection | extension |
| low | Settings shortcut commands | extension |
| low | Simple playbook via Creator | extension |

## Intentional exclusions (ADR-004)

| Feature from main | Why excluded |
|-------------------|-------------|
| `ansible.playbook.arguments` | PlaybookConfigPanel is richer |
| Welcome/ADT hub panel | Tree views provide better info |
| 7 hardcoded Creator panels | Schema-driven CreatorFormPanel is superior |
| Redirect module completions | ansible-lint flags and fixes these |
| `ansible.ansibleNavigator.path` | DevToolsService auto-discovery |
| MCP enable/disable commands | Different approach in next |
| DocsLibrary | Replaced by ADR-002 centralized cache |

## Quality of life
- **AGENTS.md**: Root-level agent configuration with invariants, structure, and skill index.
- **ADR-003** (`.sdlc/adrs/ADR-003-ee-via-devcontainers.md`): EE via dev containers.
- **ADR-004** (`.sdlc/adrs/ADR-004-intentional-exclusions-from-main.md`): 7 intentional exclusions.
- **ADR-005** (`.sdlc/adrs/ADR-005-architectural-invariants.md`): 8 architectural invariants.
- **`manage-todos` agent skill**: Project-level task tracking.
- **Todo template** (`.sdlc/templates/todo.md`): Standard format for work items.

## Test plan
- [x] No code changes — documentation and tracking files only
- [x] All new files are valid markdown with YAML frontmatter