### PR TITLE
chore: upgrade node to 24.15

### DIFF
--- a/.config/mise.toml
+++ b/.config/mise.toml
@@ -28,7 +28,7 @@ http_retries = 5
 
 [tools]
 github-cli = "latest"
-node = "24.14.1"
+node = "24.15"
 python = "3.13"
 task = "latest"  # >=3.45 but mise does not support minimal condition
 uv = "latest"

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -12,7 +12,7 @@ runs:
       with:
         experimental: true
         # without specific version here will not upgrade old existing versions
-        version: 2026.3.13
+        version: 2026.5.15
         reshim: true
 
     - name: Runner image version

--- a/Taskfile.base.yml
+++ b/Taskfile.base.yml
@@ -19,6 +19,7 @@ tasks:
       - package.json
       - packages/*/package.json
       - pnpm-lock.yaml
+      - .config/mise.toml
     run: once
     interactive: true
   uv:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -67,6 +67,7 @@ tasks:
       - pnpm run vite-build
       - pnpm run build:extension
     sources:
+      - .config/mise.toml
       - package.json
       - "{src,test}/**/*"
       - tsconfig*.json
@@ -121,6 +122,7 @@ tasks:
     desc: Update node dependencies
     interactive: true # needed for ncu prompts
     cmds:
+      - mise upgrade --local
       - pnpm up -i -r
       - task: knip
   "deps:python":
@@ -262,6 +264,7 @@ tasks:
       - build
     sources:
       - "{src,media,webviews}/**/*" # do not include 'test' as they do not get into the package
+      - .config/mise.toml
       - .vscodeignore
       - CHANGELOG.md
       - README.md

--- a/packages/ansible-language-server/Taskfile.yml
+++ b/packages/ansible-language-server/Taskfile.yml
@@ -35,6 +35,7 @@ tasks:
     generates:
       - lib/**/*.*
     sources:
+      - ../../.config/mise.toml
       - ../../pnpm-lock.yaml
       - package.json
       - src/**/*.*
@@ -52,6 +53,7 @@ tasks:
     deps:
       - build
     sources:
+      - ../../.config/mise.toml
       - ../../pyproject.toml
       - ../../uv.lock
       - ../../vitest.config.ts

--- a/packages/ansible-mcp-server/Taskfile.yml
+++ b/packages/ansible-mcp-server/Taskfile.yml
@@ -32,6 +32,7 @@ tasks:
     generates:
       - lib/**/*.*
     sources:
+      - ../../.config/mise.toml
       - ../../pnpm-lock.yaml
       - package.json
       - src/**/*.*

--- a/tools/test-setup.sh
+++ b/tools/test-setup.sh
@@ -358,7 +358,7 @@ if [[ "${SKIP_PODMAN:-}" != '1' ]]; then
     PODMAN_VERSION="$(get_version podman 2>/dev/null || echo null)"
     podman container prune -f
     log notice "Pull our test container image with podman."
-    retry 3 60 podman pull --quiet "${IMAGE}" || {
+    retry 3 60 podman pull "${IMAGE}" || {
         log error "Failed to pull image after 3 attempts."
         exit 1
     }


### PR DESCRIPTION
Fixes: #2787


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Upgrade Node.js to version 24.15 and update build system to recognize tool version changes. The changes ensure that modifications to the `.config/mise.toml` file invalidate build caches by adding it as a source dependency across task definitions, and add `mise upgrade --local` to the dependency update workflow to synchronize local tool versions.

- Updated Node.js from 24.14.1 to 24.15 in `.config/mise.toml`
- Pinned jdx/mise-action from 2026.3.13 to 2026.5.15 in GitHub Actions setup
- Added `.config/mise.toml` to task sources in `Taskfile.base.yml`, `Taskfile.yml`, and package-level Taskfiles
- Added `mise upgrade --local` to `deps:node` task for syncing local tool versions during dependency updates
- Removed `--quiet` flag from podman image pull in `tools/test-setup.sh`

fixes: `#2787`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->