### PR TITLE
chore: use arm64 macos runner

### DIFF
--- a/.config/mise.toml
+++ b/.config/mise.toml
@@ -32,4 +32,4 @@ node = "24.14.1"
 python = "3.13"
 task = "latest"  # >=3.45 but mise does not support minimal condition
 uv = "latest"
-pnpm = "latest"
+pnpm = "10.33.2"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-# cspell:ignore oidc mxschmitt userns cgroupfs dorny
+# cspell:ignore oidc mxschmitt userns cgroupfs dorny xlarge
 name: ci
 
 # Controls when the action will run. Triggers the workflow on push or pull request
@@ -265,7 +265,7 @@ jobs:
           - name: test (macos)
             id: test-macos
             task-name: test
-            os: macos-15-large
+            os: macos-26 # or macos-15-xlarge for arm64 https://docs.github.com/en/actions/reference/runners/larger-runners
             env:
               SKIP_PODMAN: 1
               SKIP_DOCKER: 1


### PR DESCRIPTION
See: https://github.com/jdx/mise/discussions/9453
See: https://github.com/pnpm/pnpm/issues/11423
Unblocks: #2809


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Switch the CI workflow to use an ARM64-based macOS runner (`macos-26`) instead of `macos-15-large`, and pin the `pnpm` package manager version to `10.33.2` to ensure compatibility with the new runner architecture.

- Updated CI workflow to use `macos-26` ARM64 runner for the build job matrix
- Pinned `pnpm` version to `10.33.2` in `.config/mise.toml`

related: `#2809`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->