### PR TITLE
fix(extension): correct hybrid mode env switching and add observability

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "ansible-environments-mcp": "./packages/mcp-server/out/server.js"
   },
   "extensionDependencies": [
+    "ms-python.python",
     "redhat.vscode-yaml"
   ],
   "contributes": {

--- a/packages/core/src/services/CommandService.ts
+++ b/packages/core/src/services/CommandService.ts
@@ -23,6 +23,7 @@ try {
 }
 
 import { getCachedBinDir, getCachedToolPath, findExecutableWithCache } from './EnvironmentCache';
+import { log } from '../utils/logging';
 
 const execAsync = promisify(cp.exec);
 
@@ -77,15 +78,20 @@ export class CommandService {
             try {
                 const binDir = await this._binDirResolver(workspaceUri);
                 if (binDir) {
+                    log(`CommandService: binDirResolver -> ${binDir}`);
                     return binDir;
                 }
+                log('CommandService: binDirResolver returned null');
             } catch (error) {
-                console.error('CommandService: bin dir resolver failed:', error);
+                log(`CommandService: binDirResolver failed: ${error}`);
             }
+        } else {
+            log('CommandService: no binDirResolver set');
         }
 
-        // Fall back to cached environment
-        return getCachedBinDir();
+        const cached = getCachedBinDir();
+        log(`CommandService: falling back to cached binDir -> ${cached ?? 'null'}`);
+        return cached;
     }
 
     /**
@@ -98,18 +104,23 @@ export class CommandService {
         if (binDir) {
             const toolPath = path.join(binDir, toolName);
             if (fs.existsSync(toolPath)) {
+                log(`CommandService: ${toolName} found in binDir -> ${toolPath}`);
                 return toolPath;
             }
+            log(`CommandService: ${toolName} not in binDir ${binDir}`);
         }
 
         // Try cached environment
         const cachedPath = getCachedToolPath(toolName);
         if (cachedPath) {
+            log(`CommandService: ${toolName} found in cache -> ${cachedPath}`);
             return cachedPath;
         }
 
         // Fall back to PATH search
-        return findExecutableWithCache(toolName);
+        const pathResult = await findExecutableWithCache(toolName);
+        log(`CommandService: ${toolName} PATH fallback -> ${pathResult ?? 'not found'}`);
+        return pathResult;
     }
 
     /**

--- a/packages/core/src/services/DevToolsService.ts
+++ b/packages/core/src/services/DevToolsService.ts
@@ -6,11 +6,14 @@ try {
     // Running standalone (not in VS Code)
 }
 
+import * as path from 'path';
 import { SimpleEventEmitter } from '../utils/SimpleEventEmitter';
+import { log } from '../utils/logging';
 
 export interface DevToolPackage {
     name: string;
     version: string;
+    location?: string;
 }
 
 /**
@@ -124,6 +127,7 @@ export class DevToolsService {
             );
         }
         await this._packageInstaller();
+        await this.refresh();
     }
 
     /**
@@ -145,7 +149,9 @@ export class DevToolsService {
             name: 'Upgrade ansible-dev-tools',
             show: true,
         });
-        managed.sendCommand('pip install --upgrade --upgrade-strategy eager ansible-dev-tools', { waitForCompletion: false });
+        await managed.sendCommand('pip install --upgrade --upgrade-strategy eager ansible-dev-tools', { waitForCompletion: true });
+        log('DevToolsService: upgrade complete, refreshing packages');
+        await this.refresh();
     }
 
     /**
@@ -156,25 +162,33 @@ export class DevToolsService {
             const { getCommandService } = await import('./CommandService');
             const commandService = getCommandService();
             
+            const adtPath = await commandService.getToolPath('adt');
+            log(`DevToolsService: adt resolved to ${adtPath ?? 'not found'}`);
             const result = await commandService.runTool('adt', ['--version']);
             
             if (result.exitCode !== 0) {
-                console.error('DevToolsService: adt not found or failed');
+                log('DevToolsService: adt not found or failed');
                 this._packages = [];
                 return;
             }
 
+            const binDir = adtPath ? path.dirname(adtPath) : undefined;
+            log(`DevToolsService: using binDir ${binDir ?? 'none'}`);
+
             // Parse the adt --version output
             const packages: DevToolPackage[] = [];
+            const exeSuffix = process.platform === 'win32' ? '.exe' : '';
             const lines = result.stdout.trim().split('\n');
             for (const line of lines) {
                 const match = line.match(/^(\S+)\s+(\S+)$/);
                 if (match) {
-                    packages.push({ name: match[1], version: match[2] });
+                    const toolPath = binDir ? path.join(binDir, match[1] + exeSuffix) : undefined;
+                    packages.push({ name: match[1], version: match[2], location: toolPath });
                 }
             }
 
             this._packages = packages;
+            log(`DevToolsService: loaded ${packages.length} packages from ${binDir ?? 'PATH'}`);
         } catch (error) {
             console.error('DevToolsService: Failed to load packages:', error);
             this._packages = [];

--- a/packages/core/test/services/DevToolsService.test.ts
+++ b/packages/core/test/services/DevToolsService.test.ts
@@ -10,10 +10,13 @@ ansible-navigator 24.2.0
 
 const mocks = vi.hoisted(() => {
   const mockRunTool = vi.fn();
+  const mockGetToolPath = vi.fn();
   return {
     mockRunTool,
+    mockGetToolPath,
     getCommandService: vi.fn(() => ({
       runTool: mockRunTool,
+      getToolPath: mockGetToolPath,
     })),
   };
 });
@@ -35,9 +38,12 @@ describe("DevToolsService", () => {
   beforeEach(() => {
     resetDevToolsSingleton();
     mocks.mockRunTool.mockReset();
+    mocks.mockGetToolPath.mockReset();
     mocks.getCommandService.mockClear();
+    mocks.mockGetToolPath.mockResolvedValue("/mock/bin/adt");
     mocks.getCommandService.mockImplementation(() => ({
       runTool: mocks.mockRunTool,
+      getToolPath: mocks.mockGetToolPath,
     }));
   });
 
@@ -115,7 +121,7 @@ describe("DevToolsService", () => {
     });
     const svc = DevToolsService.getInstance();
     await svc.refresh();
-    expect(svc.getPackages()[0]).toEqual({ name: "ansible-builder", version: "24.2.0" });
+    expect(svc.getPackages()[0]).toEqual({ name: "ansible-builder", version: "24.2.0", location: "/mock/bin/ansible-builder" });
   });
 
   it("hasPackages returns true or false correctly", async () => {
@@ -138,7 +144,7 @@ describe("DevToolsService", () => {
     });
     const svc = DevToolsService.getInstance();
     await svc.refresh();
-    expect(svc.getPackage("ansible-lint")).toEqual({ name: "ansible-lint", version: "24.2.0" });
+    expect(svc.getPackage("ansible-lint")).toEqual({ name: "ansible-lint", version: "24.2.0", location: "/mock/bin/ansible-lint" });
   });
 
   it("getPackage returns undefined for unknown name", async () => {
@@ -225,7 +231,7 @@ describe("DevToolsService", () => {
     });
     const svc = DevToolsService.getInstance();
     await svc.refresh();
-    expect(svc.getPackage("ansible-lint")).toEqual({ name: "ansible-lint", version: "6.0.0" });
+    expect(svc.getPackage("ansible-lint")).toEqual({ name: "ansible-lint", version: "6.0.0", location: "/mock/bin/ansible-lint" });
   });
 
   it("refresh handles adt failure with non-zero exit code", async () => {

--- a/scripts/install-test-extensions.mjs
+++ b/scripts/install-test-extensions.mjs
@@ -20,6 +20,7 @@ const testRoot = path.resolve(process.cwd(), ".wdio-vscode");
 const extensionsDir = path.join(testRoot, "extensions");
 
 const DEPENDENCY_EXTENSIONS = [
+  "ms-python.python",
   "ms-python.vscode-python-envs",
   "redhat.vscode-yaml",
 ];

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -229,23 +229,26 @@ export function activate(context: vscode.ExtensionContext) {
     // Wire terminal factory into DevToolsService so upgrade works in all editors
     DevToolsService.setTerminalServiceFactory(() => TerminalService);
 
+    // Inject bin dir resolver into CommandService BEFORE any providers are
+    // constructed so that early refresh() calls resolve the venv, not ~/.local/bin.
+    const commandService = getCommandService();
+    commandService.setBinDirResolver(async (workspaceUri) => {
+        await pythonEnvService.initialize();
+        const env = await pythonEnvService.getEnvironment(workspaceUri as vscode.Uri | undefined);
+        if (env?.execInfo?.run?.executable) {
+            const binDir = path.dirname(env.execInfo.run.executable);
+            log(`binDirResolver: env=${env.displayName}, binDir=${binDir}`);
+            return binDir;
+        }
+        log('binDirResolver: no environment or executable found');
+        return null;
+    });
+
     pythonEnvService.initialize().then((available) => {
-        log(`Python Environment Service initialized: available=${available}, fullApi=${pythonEnvService.hasFullApi()}`);
+        log(`Python Environment Service initialized: available=${available}, fullApi=${pythonEnvService.hasFullApi()}, envsExt=${pythonEnvService.hasEnvsExtension()}`);
 
-        // Inject bin dir resolver into CommandService so @ansible/core
-        // can locate tools without depending on vscode directly
-        const commandService = getCommandService();
-        commandService.setBinDirResolver(async (workspaceUri) => {
-            const env = await pythonEnvService.getEnvironment(workspaceUri as vscode.Uri | undefined);
-            if (env?.execInfo?.run?.executable) {
-                const p = await import('path');
-                return p.dirname(env.execInfo.run.executable);
-            }
-            return null;
-        });
-
-        // Wire package installer into DevToolsService when full API is available
-        if (pythonEnvService.hasFullApi()) {
+        // Wire package installer into DevToolsService when envs extension is available
+        if (pythonEnvService.hasEnvsExtension()) {
             const devToolsService = DevToolsService.getInstance();
             devToolsService.setPackageInstaller(async () => {
                 const workspaceFolder = vscode.workspace.workspaceFolders?.[0]?.uri;
@@ -276,8 +279,15 @@ export function activate(context: vscode.ExtensionContext) {
             }
         };
 
+        let cacheDebounce: ReturnType<typeof setTimeout> | undefined;
         const envCacheListener = pythonEnvService.onDidChangeEnvironment(() => {
-            setTimeout(refreshCache, 500);
+            if (cacheDebounce) {
+                clearTimeout(cacheDebounce);
+            }
+            cacheDebounce = setTimeout(() => {
+                cacheDebounce = undefined;
+                void refreshCache();
+            }, 1000);
         });
         context.subscriptions.push(envCacheListener);
         setTimeout(refreshCache, 2000);

--- a/src/services/PythonEnvironmentService.ts
+++ b/src/services/PythonEnvironmentService.ts
@@ -33,9 +33,10 @@ export class PythonEnvironmentService implements vscode.Disposable {
     private static _instance: PythonEnvironmentService | undefined;
     private _pythonEnvApi: PythonEnvironmentApi | undefined;
     private _pythonExtApi: PythonExtension | undefined;
-    private _initialized = false;
-    private _petWarningShown = false;
+    private _petAvailable = false;
+    private _initPromise: Promise<boolean> | undefined;
     private _disposables: vscode.Disposable[] = [];
+    private _changeDebounce: ReturnType<typeof setTimeout> | undefined;
 
     private _onDidChangeEnvironment = new vscode.EventEmitter<DidChangeEnvironmentEventArgs>();
     public readonly onDidChangeEnvironment = this._onDidChangeEnvironment.event;
@@ -50,26 +51,32 @@ export class PythonEnvironmentService implements vscode.Disposable {
     }
 
     /**
-     * Initialize the service. Tries the Environments extension first; if PET
-     * is missing or the extension is absent, falls back to ms-python.python.
+     * Initialize the service.
+     *
+     * When the Environments extension is present it is always activated so
+     * createEnvironment / managePackages work regardless of PET. If PET is
+     * missing, ms-python.python is also initialized for environment discovery
+     * (hybrid mode).
      */
     public async initialize(): Promise<boolean> {
-        if (this._initialized) {
-            return this._pythonEnvApi !== undefined || this._pythonExtApi !== undefined;
+        if (this._initPromise) {
+            return this._initPromise;
         }
+        this._initPromise = this._doInitialize();
+        return this._initPromise;
+    }
 
+    private async _doInitialize(): Promise<boolean> {
         log(`Looking for Python Environments extension: ${PYTHON_ENVS_EXTENSION_ID}`);
 
         const envsExt = vscode.extensions.getExtension<PythonEnvironmentApi>(PYTHON_ENVS_EXTENSION_ID);
 
         if (envsExt) {
-            const petAvailable = this._isPetAvailable(envsExt.extensionPath);
+            this._petAvailable = this._isPetAvailable(envsExt.extensionPath);
+            await this._initFromEnvsExtension(envsExt);
 
-            if (petAvailable) {
-                await this._initFromEnvsExtension(envsExt);
-            } else {
-                log('PET binary not found — environment discovery will be degraded');
-                this._showPetWarning();
+            if (!this._petAvailable) {
+                log('PET binary not found — using ms-python.python for environment discovery');
                 await this._initFromPythonExtension();
             }
         } else {
@@ -77,7 +84,6 @@ export class PythonEnvironmentService implements vscode.Disposable {
             await this._initFromPythonExtension();
         }
 
-        this._initialized = true;
         return this._pythonEnvApi !== undefined || this._pythonExtApi !== undefined;
     }
 
@@ -109,8 +115,8 @@ export class PythonEnvironmentService implements vscode.Disposable {
                 this._pythonEnvApi = exports;
 
                 if (this._pythonEnvApi?.onDidChangeEnvironment) {
-                    const listener = this._pythonEnvApi.onDidChangeEnvironment((event) => {
-                        this._onDidChangeEnvironment.fire(event);
+                    const listener = this._pythonEnvApi.onDidChangeEnvironment(() => {
+                        this._fireChangeDebounced();
                     });
                     this._disposables.push(listener);
                 }
@@ -154,10 +160,10 @@ export class PythonEnvironmentService implements vscode.Disposable {
 
             this._disposables.push(
                 api.environments.onDidChangeActiveEnvironmentPath(() => {
-                    this._onDidChangeEnvironment.fire({});
+                    this._fireChangeDebounced();
                 }),
                 api.environments.onDidChangeEnvironments(() => {
-                    this._onDidChangeEnvironment.fire({});
+                    this._fireChangeDebounced();
                 }),
             );
 
@@ -226,27 +232,19 @@ export class PythonEnvironmentService implements vscode.Disposable {
     }
 
     // -------------------------------------------------------------------------
-    // Notification
+    // Debounced change notification
     // -------------------------------------------------------------------------
 
-    private _showPetWarning(): void {
-        if (this._petWarningShown) {
-            return;
-        }
-        this._petWarningShown = true;
+    private static readonly _CHANGE_DEBOUNCE_MS = 1500;
 
-        vscode.window.showWarningMessage(
-            'Python environment discovery is degraded (PET binary missing). ' +
-            'This commonly occurs in non-VS Code editors (Cursor, Dev Spaces, VSCodium). ' +
-            'Falling back to ms-python.python for environment resolution.',
-            'Learn More',
-        ).then((selection) => {
-            if (selection === 'Learn More') {
-                vscode.env.openExternal(
-                    vscode.Uri.parse('https://github.com/microsoft/vscode-python/issues/25820'),
-                );
-            }
-        });
+    private _fireChangeDebounced(): void {
+        if (this._changeDebounce) {
+            clearTimeout(this._changeDebounce);
+        }
+        this._changeDebounce = setTimeout(() => {
+            this._changeDebounce = undefined;
+            this._onDidChangeEnvironment.fire({});
+        }, PythonEnvironmentService._CHANGE_DEBOUNCE_MS);
     }
 
     // -------------------------------------------------------------------------
@@ -258,11 +256,18 @@ export class PythonEnvironmentService implements vscode.Disposable {
     }
 
     /**
-     * Whether the full Environments extension API is active (PET working).
-     * When false, createTerminal / managePackages / createEnvironment are
-     * not available.
+     * Whether the full Environments extension API is active with PET
+     * working. When true, environment discovery is fast and complete.
      */
     public hasFullApi(): boolean {
+        return this._pythonEnvApi !== undefined && this._petAvailable;
+    }
+
+    /**
+     * Whether environment creation and package management are available
+     * (envs extension active, PET not required for these operations).
+     */
+    public hasEnvsExtension(): boolean {
         return this._pythonEnvApi !== undefined;
     }
 
@@ -284,7 +289,8 @@ export class PythonEnvironmentService implements vscode.Disposable {
             resolvedScope = vscode.workspace.workspaceFolders?.[0]?.uri;
         }
 
-        if (this._pythonEnvApi) {
+        // When PET is available, the envs extension owns all state.
+        if (this._pythonEnvApi && this._petAvailable) {
             try {
                 return await this._pythonEnvApi.getEnvironment(resolvedScope);
             } catch (error) {
@@ -292,6 +298,8 @@ export class PythonEnvironmentService implements vscode.Disposable {
             }
         }
 
+        // Hybrid mode or python-ext-only: ms-python.python owns the
+        // active environment, so query it directly.
         if (this._pythonExtApi) {
             try {
                 const envPath = this._pythonExtApi.environments.getActiveEnvironmentPath(resolvedScope);
@@ -310,7 +318,7 @@ export class PythonEnvironmentService implements vscode.Disposable {
     public async getEnvironments(scope: vscode.Uri | 'all' | 'global' = 'all'): Promise<PythonEnvironment[]> {
         await this.initialize();
 
-        if (this._pythonEnvApi) {
+        if (this._pythonEnvApi && this._petAvailable) {
             try {
                 return await this._pythonEnvApi.getEnvironments(scope);
             } catch (error) {
@@ -372,28 +380,41 @@ export class PythonEnvironmentService implements vscode.Disposable {
     public async setEnvironment(scope: SetEnvironmentScope, environment?: PythonEnvironment): Promise<void> {
         await this.initialize();
 
-        if (this._pythonEnvApi) {
+        log(`setEnvironment: env=${environment?.displayName}, executable=${environment?.execInfo?.run?.executable}, petAvailable=${this._petAvailable}`);
+
+        // When PET is available, the envs extension owns discovery AND selection.
+        if (this._pythonEnvApi && this._petAvailable) {
+            log('setEnvironment: using envs extension API (PET available)');
             await this._pythonEnvApi.setEnvironment(scope, environment);
             return;
         }
 
+        // Hybrid mode or python-ext-only: environments were discovered by
+        // ms-python.python, so we must use its API to switch.
         if (this._pythonExtApi) {
             try {
                 if (environment?.execInfo?.run?.executable) {
                     const resource = scope instanceof vscode.Uri ? scope : undefined;
+                    log(`setEnvironment: calling updateActiveEnvironmentPath(${environment.execInfo.run.executable})`);
                     await this._pythonExtApi.environments.updateActiveEnvironmentPath(
                         environment.execInfo.run.executable,
                         resource,
                     );
+                    log('setEnvironment: updateActiveEnvironmentPath succeeded');
                 } else {
+                    log('setEnvironment: no executable, opening interpreter picker');
                     await vscode.commands.executeCommand('python.setInterpreter');
                 }
-            } catch {
+                return;
+            } catch (error) {
+                log(`setEnvironment: updateActiveEnvironmentPath failed: ${error}`);
                 vscode.window.showErrorMessage(
                     'Unable to set Python environment. Please use the Python extension\'s interpreter picker.',
                 );
             }
         }
+
+        log('setEnvironment: no API available to set environment');
     }
 
     public async createEnvironment(
@@ -440,6 +461,9 @@ export class PythonEnvironmentService implements vscode.Disposable {
     }
 
     public dispose(): void {
+        if (this._changeDebounce) {
+            clearTimeout(this._changeDebounce);
+        }
         this._disposables.forEach((d) => d.dispose());
         this._disposables = [];
         this._onDidChangeEnvironment.dispose();

--- a/src/services/TerminalService.ts
+++ b/src/services/TerminalService.ts
@@ -68,7 +68,7 @@ export class TerminalService {
         let terminal: vscode.Terminal;
         let expectActivation = false;
 
-        if (this._pythonEnvService?.hasFullApi() && workspaceFolder) {
+        if (this._pythonEnvService?.hasEnvsExtension() && workspaceFolder) {
             const environment = await this._pythonEnvService.getEnvironment(workspaceFolder);
             
             if (environment) {

--- a/src/views/AnsibleDevToolsProvider.ts
+++ b/src/views/AnsibleDevToolsProvider.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import { DevToolsService } from '@ansible/core';
 import type { DevToolPackage } from '@ansible/core';
 import type { PythonEnvironmentService } from '../services/PythonEnvironmentService';
+import { log } from '../extension';
 
 export class AnsibleDevToolsProvider implements vscode.TreeDataProvider<DevToolPackage> {
     private _onDidChangeTreeData: vscode.EventEmitter<DevToolPackage | undefined | null | void> = new vscode.EventEmitter<DevToolPackage | undefined | null | void>();
@@ -10,6 +11,7 @@ export class AnsibleDevToolsProvider implements vscode.TreeDataProvider<DevToolP
     private _service: DevToolsService;
     private _envListener: vscode.Disposable | undefined;
     private _serviceListener: vscode.Disposable | undefined;
+    private _refreshDebounce: ReturnType<typeof setTimeout> | undefined;
 
     constructor(pythonEnvService: PythonEnvironmentService) {
         this._service = DevToolsService.getInstance();
@@ -26,12 +28,23 @@ export class AnsibleDevToolsProvider implements vscode.TreeDataProvider<DevToolP
             await pythonEnvService.initialize();
 
             this._envListener = pythonEnvService.onDidChangeEnvironment(() => {
-                this.refresh();
+                log('AnsibleDevToolsProvider: environment changed, scheduling refresh');
+                if (this._refreshDebounce) {
+                    clearTimeout(this._refreshDebounce);
+                }
+                this._refreshDebounce = setTimeout(() => {
+                    this._refreshDebounce = undefined;
+                    void this.refresh();
+                }, 1000);
             });
 
-            await this.refresh();
+            // Don't refresh eagerly — wait for the environment change event
+            // which fires once the Python extension has discovered environments.
+            // An eager refresh here would resolve tools from ~/.local/bin
+            // because the venv hasn't been discovered yet.
+            log('AnsibleDevToolsProvider: initialized, waiting for environment discovery');
         } catch (error) {
-            console.error('Failed to initialize AnsibleDevToolsProvider:', error);
+            log(`AnsibleDevToolsProvider: init failed: ${error}`);
         }
     }
 
@@ -44,6 +57,9 @@ export class AnsibleDevToolsProvider implements vscode.TreeDataProvider<DevToolP
         item.description = element.version;
         item.iconPath = new vscode.ThemeIcon('package');
         item.contextValue = 'devToolPackage';
+        if (element.location) {
+            item.tooltip = element.location;
+        }
         return item;
     }
 
@@ -59,6 +75,9 @@ export class AnsibleDevToolsProvider implements vscode.TreeDataProvider<DevToolP
     }
 
     dispose() {
+        if (this._refreshDebounce) {
+            clearTimeout(this._refreshDebounce);
+        }
         this._envListener?.dispose();
         this._serviceListener?.dispose();
         this._onDidChangeTreeData.dispose();

--- a/src/views/CollectionsProvider.ts
+++ b/src/views/CollectionsProvider.ts
@@ -38,6 +38,7 @@ export class CollectionsProvider implements vscode.TreeDataProvider<TreeNode> {
     private _service: CollectionsService;
     private _envListener: vscode.Disposable | undefined;
     private _serviceListener: vscode.Disposable | undefined;
+    private _refreshDebounce: ReturnType<typeof setTimeout> | undefined;
 
     constructor(pythonEnvService: PythonEnvironmentService) {
         this._service = CollectionsService.getInstance();
@@ -59,7 +60,13 @@ export class CollectionsProvider implements vscode.TreeDataProvider<TreeNode> {
             await pythonEnvService.initialize();
 
             this._envListener = pythonEnvService.onDidChangeEnvironment(() => {
-                this.refresh();
+                if (this._refreshDebounce) {
+                    clearTimeout(this._refreshDebounce);
+                }
+                this._refreshDebounce = setTimeout(() => {
+                    this._refreshDebounce = undefined;
+                    this.refresh();
+                }, 1000);
             });
         } catch (error) {
             log(`CollectionsProvider: Failed to set up env change listener: ${error}`);
@@ -185,6 +192,9 @@ export class CollectionsProvider implements vscode.TreeDataProvider<TreeNode> {
     }
 
     dispose() {
+        if (this._refreshDebounce) {
+            clearTimeout(this._refreshDebounce);
+        }
         this._envListener?.dispose();
         this._serviceListener?.dispose();
         this._onDidChangeTreeData.dispose();


### PR DESCRIPTION
## Summary
- Fix environment switching in hybrid mode (PET missing): `setEnvironment`, `getEnvironment`, and `getEnvironments` now correctly delegate to `ms-python.python` when PET is unavailable, instead of silently failing through the envs extension API
- Add diagnostic logging throughout the tool resolution chain (CommandService, DevToolsService, binDirResolver, setEnvironment) for easier troubleshooting
- Auto-refresh devtools tree view after install/upgrade operations

## Changes
- **PythonEnvironmentService**: Gate `getEnvironment()`, `getEnvironments()`, and `setEnvironment()` on `_petAvailable` before using the envs extension API; fall through to ms-python.python in hybrid mode
- **PythonEnvironmentService**: Make `initialize()` idempotent with `_initPromise`; add service-level debounce (1.5s) for `onDidChangeEnvironment`
- **PythonEnvironmentService**: Remove PET-missing warning popup (hybrid mode works transparently)
- **DevToolsService**: Add `location` field to `DevToolPackage` with platform-aware exe suffix for Windows; auto-refresh after `install()` and `upgrade()`; switch upgrade to `waitForCompletion: true`
- **CommandService**: Add logging to `getBinDir()` and `getToolPath()` showing resolver result, cache fallback, and PATH fallback
- **AnsibleDevToolsProvider**: Show tool installation path as tooltip; defer initial refresh until environment discovery completes; add debounced env change listener
- **CollectionsProvider**: Add debounced env change listener to prevent refresh storms
- **extension.ts**: Move `setBinDirResolver` before provider construction; debounce `refreshCache`; declare `ms-python.python` as `extensionDependency` (envs extension kept as runtime check only — not a hard dependency since it's unavailable on some marketplaces)
- **TerminalService**: Use `hasEnvsExtension()` instead of `hasFullApi()` for terminal activation
- **Tests**: Update DevToolsService tests to mock `getToolPath` and assert `location` field
- **CI**: Add `ms-python.python` to UI test dependency extensions (required by new `extensionDependencies`)