### PR TITLE
fix: codecov test don't merge PR

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,7 @@
 name: ci
 
 # Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the main branch
+# events but only for the main branch.
 on:
   merge_group:
     branches: ["main", "devel/*"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Added a trailing period to the GitHub Actions workflow comment for clarity and consistency with documentation standards.

- Updated the workflow comment from "events but only for the main branch" to "events but only for the main branch." in `.github/workflows/ci.yaml`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->