### PR TITLE
chore: reduce noise on build console

### DIFF
--- a/packages/ansible-language-server/Taskfile.yml
+++ b/packages/ansible-language-server/Taskfile.yml
@@ -105,10 +105,10 @@ tasks:
       - '{{ .GIT_ROOT }}/out/ansible-{{ .PROJECT }}-{{ .VERSION }}.tgz'
     cmds:
       - rm -f {{ .GIT_ROOT }}/out/ansible-{{ .PROJECT }}-*.tgz
-      - npm version {{ .VERSION }} --allow-same-version --no-git-tag-version
+      - npm pkg set version={{ .VERSION }}
       - pnpm run compile
-      - npm pack --ignore-scripts --pack-destination '{{ .GIT_ROOT }}/out'
-      - defer: npm version 0.0.0 --allow-same-version --no-git-tag-version
+      - npm pack --silent --ignore-scripts --pack-destination '{{ .GIT_ROOT }}/out'
+      - defer: npm pkg set version=0.0.0
     silent: false
   release:
     desc: Create a new release (used by CI)

--- a/packages/ansible-language-server/package.json
+++ b/packages/ansible-language-server/package.json
@@ -29,12 +29,12 @@
     "handlebars": "^4.7.8",
     "ini": "^7.0.0",
     "lodash": "^4.17.23",
+    "shell-quote": "^1.8.3",
     "uuid": "^14.0.0",
     "vscode-languageserver": "^9.0.1",
     "vscode-languageserver-protocol": "^3.17.5",
     "vscode-languageserver-textdocument": "^1.0.12",
     "vscode-languageserver-types": "^3.17.5",
-    "shell-quote": "^1.8.3",
     "vscode-uri": "^3.1.0",
     "yaml": "^2.8.3"
   },

--- a/packages/ansible-mcp-server/Taskfile.yml
+++ b/packages/ansible-mcp-server/Taskfile.yml
@@ -82,10 +82,10 @@ tasks:
       - '{{ .GIT_ROOT }}/out/ansible-{{ .PROJECT }}-{{ .VERSION }}.tgz'
     cmds:
       - rm -f {{ .GIT_ROOT }}/out/ansible-{{ .PROJECT }}-*.tgz
-      - npm version {{ .VERSION }} --allow-same-version --no-git-tag-version
+      - npm pkg set version={{ .VERSION }}
       - pnpm exec tsup --silent
       - npm pack --silent --ignore-scripts --pack-destination '{{ .GIT_ROOT }}/out'
-      - defer: npm version 0.0.0 --allow-same-version --no-git-tag-version
+      - defer: npm pkg set version=0.0.0
     silent: false
   container:
     desc: Build the MCP server container image

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -1,7 +1,38 @@
 import fs from "node:fs";
 import path from "node:path";
 import vue from "@vitejs/plugin-vue";
-import { defineConfig, type Plugin } from "vite";
+import { createLogger, defineConfig, type Plugin } from "vite";
+
+// biome-ignore lint/suspicious/noControlCharactersInRegex: ANSI escape codes
+const ANSI_RE = /\x1b\[[0-9;]*m/g; // eslint-disable-line no-control-regex
+
+/** Rolldown reporter table lines: `dist/...  12.34 kB` (optional `│ gzip: ...`). */
+const BUILD_OUTPUT_LINE_RE = /dist\/\S+\s+[\d.]+\s+kB/;
+
+function stripAnsi(msg: string): string {
+  return msg.replace(ANSI_RE, "");
+}
+
+function isBuildOutputTable(msg: string): boolean {
+  const lines = stripAnsi(msg).trim().split("\n").filter(Boolean);
+  return (
+    lines.length > 0 &&
+    lines.every((line) => BUILD_OUTPUT_LINE_RE.test(line.trim()))
+  );
+}
+
+const baseLogger = createLogger("info");
+const logger = createLogger("info", {
+  customLogger: {
+    ...baseLogger,
+    info(msg, options) {
+      if (isBuildOutputTable(msg)) {
+        return;
+      }
+      baseLogger.info(msg, options);
+    },
+  },
+});
 
 /**
  * Writes the dev server URL to a marker file so the extension host can
@@ -51,6 +82,7 @@ export default defineConfig({
     emptyOutDir: true,
     minify: false,
     outDir: "dist", // keep default
+    reportCompressedSize: false,
     rollupOptions: {
       // https://cn.vitejs.dev/guide/build.html#multi-page-app
       input: {
@@ -99,6 +131,7 @@ export default defineConfig({
       },
     },
   },
+  customLogger: logger,
   experimental: {
     renderBuiltUrl(filename: string) {
       if (filename.startsWith("assets/codicon")) {


### PR DESCRIPTION
- avoid listing `vite build` artifacts and their size
- avoid repeated version detection log messages


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Reduce build console noise by suppressing Rollup/Vite artifact-size table lines and repeated version logs. Implemented a custom Vite logger that strips ANSI codes and filters build-output lines; disabled compressed-size reporting; also adjusted packaging and hooks to use `npm pkg set version` and wrapped pnpm install in `mise exec`.

- Add ANSI strip + BUILD_OUTPUT_LINE_RE and isBuildOutputTable()
- Create custom logger and wire via customLogger
- Set build.reportCompressedSize: false in vite.config.mts
- Update .pre-commit-config.yaml pnpm-install entry to `mise exec -- pnpm install ...`
- Replace `npm version` with `npm pkg set version` in Taskfile.yml (packages)
related: `#2816`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->