### PR TITLE
chore: avoid creating deployment for ci workflow run

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -227,7 +227,9 @@ jobs:
     needs:
       - lint
 
-    environment: ci
+    environment:
+      name: ci
+      deployment: false
     env:
       SKIP_DOCKER: ${{ matrix.env.SKIP_DOCKER || 0 }}
       SKIP_PODMAN: ${{ matrix.env.SKIP_PODMAN || 0 }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated the CI workflow's `build` job environment configuration to explicitly prevent deployment creation by setting `deployment: false` alongside the environment name. This ensures the CI job references the environment without triggering automatic deployment workflows.

- Modified `.github/workflows/ci.yaml` to change `build` job environment from simple string reference to object specifying `name: ci` and `deployment: false`

related: `#198`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->