### PR TITLE
fix: resolve Cursor MCP integration issues

### DIFF
--- a/packages/mcp-server/src/handlers.ts
+++ b/packages/mcp-server/src/handlers.ts
@@ -4,6 +4,9 @@
  * Routes tool calls to appropriate service methods.
  */
 
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
 import { McpToolResult } from './tools';
 import { PluginSearchIndex } from './pluginSearch';
 import { TaskGenerator } from './taskGenerator';
@@ -919,113 +922,100 @@ export class McpToolHandler {
         };
     }
 
-    /**
-     * Handle get_ansible_best_practices tool
-     */
     private async _handleGetBestPractices(args: Record<string, unknown>): Promise<McpToolResult> {
         const section = (args.section as string) || 'full';
-        
-        // Read the best practices file
-        const fs = await import('fs');
-        const path = await import('path');
-        
-        // Try to find the best practices file in common locations
-        const possiblePaths = [
-            // In extension resources
-            path.join(__dirname, '..', '..', 'resources', 'best_practises.md'),
-            path.join(__dirname, '..', 'resources', 'best_practises.md'),
-            // From workspace environment variable
-            process.env.ANSIBLE_ENV_EXTENSION_PATH 
-                ? path.join(process.env.ANSIBLE_ENV_EXTENSION_PATH, 'resources', 'best_practises.md')
-                : ''
-        ].filter(p => p);
-        
-        let content = '';
-        
-        for (const p of possiblePaths) {
-            if (fs.existsSync(p)) {
-                content = fs.readFileSync(p, 'utf-8');
-                break;
-            }
-        }
-        
+
+        const content = await this._loadBestPractices();
         if (!content) {
             return {
-                content: [{
-                    type: 'text',
-                    text: `Best practices document not found. Searched paths:\n${possiblePaths.join('\n')}`
-                }],
-                isError: true
+                content: [{ type: 'text', text: 'Best practices document not found.' }],
+                isError: true,
             };
         }
-        
-        // If requesting full document, return it
+
         if (section === 'full') {
-            return {
-                content: [{
-                    type: 'text',
-                    text: content
-                }]
-            };
+            return { content: [{ type: 'text', text: content }] };
         }
-        
-        // Extract specific section
-        const sectionMap: Record<string, string[]> = {
-            'principles': ['## Guiding Principles'],
-            'project_structure': ['### Project structure'],
-            'naming': ['#### Naming Conventions'],
-            'roles': ['#### Roles'],
-            'collections': ['#### Collections'],
-            'playbooks': ['#### Playbooks'],
-            'testing': ['### Testing and Validation']
+
+        const sectionMap: Record<string, string> = {
+            'principles': '## Guiding Principles',
+            'project_structure': '### Project structure',
+            'naming': '#### Naming Conventions',
+            'roles': '#### Roles',
+            'collections': '#### Collections',
+            'playbooks': '#### Playbooks',
+            'testing': '### Testing and Validation',
         };
-        
-        const headings = sectionMap[section];
-        if (!headings) {
+
+        const heading = sectionMap[section];
+        if (!heading) {
             return {
                 content: [{
                     type: 'text',
-                    text: `Unknown section: ${section}. Available sections: ${Object.keys(sectionMap).join(', ')}`
+                    text: `Unknown section: ${section}. Available sections: ${Object.keys(sectionMap).join(', ')}`,
                 }],
-                isError: true
+                isError: true,
             };
         }
-        
-        // Find and extract the section
-        let extracted = '';
-        for (const heading of headings) {
-            const startIndex = content.indexOf(heading);
-            if (startIndex === -1) { continue; }
-            
-            // Find the next heading at the same or higher level
-            const headingLevel = heading.match(/^#+/)?.[0].length || 2;
-            const regex = new RegExp(`^#{1,${headingLevel}}\\s`, 'm');
-            
-            const afterHeading = content.slice(startIndex + heading.length);
-            const nextHeadingMatch = afterHeading.match(regex);
-            const endIndex = nextHeadingMatch 
-                ? startIndex + heading.length + (afterHeading.indexOf(nextHeadingMatch[0]))
-                : content.length;
-            
-            extracted = content.slice(startIndex, endIndex).trim();
-            break;
-        }
-        
-        if (!extracted) {
+
+        const startIndex = content.indexOf(heading);
+        if (startIndex === -1) {
             return {
-                content: [{
-                    type: 'text',
-                    text: `Section "${section}" not found in best practices document.`
-                }],
-                isError: true
+                content: [{ type: 'text', text: `Section "${section}" not found in best practices document.` }],
+                isError: true,
             };
         }
-        
+
+        const headingLevel = (heading.match(/^#+/) || ['##'])[0].length;
+        const rest = content.slice(startIndex + heading.length);
+        const nextMatch = rest.match(new RegExp(`^#{1,${headingLevel}}\\s`, 'm'));
+        const endIndex = nextMatch
+            ? startIndex + heading.length + rest.indexOf(nextMatch[0])
+            : content.length;
+
         return {
-            content: [{
-                type: 'text',
-                text: extracted
-            }]
+            content: [{ type: 'text', text: content.slice(startIndex, endIndex).trim() }],
         };
+    }
+
+    /**
+     * Load the best practices document. Checks local cache paths first,
+     * then fetches from the canonical upstream URL and caches for next time.
+     */
+    private async _loadBestPractices(): Promise<string | undefined> {
+        const UPSTREAM_URL = 'https://raw.githubusercontent.com/ansible/ansible-creator/refs/heads/main/docs/agents.md';
+        const cacheDir = path.join(os.tmpdir(), 'ansible-mcp');
+        const cachePath = path.join(cacheDir, 'best_practices.md');
+
+        const localPaths = [
+            path.join(__dirname, '..', '..', 'resources', 'best_practices.md'),
+            path.join(__dirname, '..', 'resources', 'best_practices.md'),
+            process.env.ANSIBLE_ENV_EXTENSION_PATH
+                ? path.join(process.env.ANSIBLE_ENV_EXTENSION_PATH, 'resources', 'best_practices.md')
+                : '',
+            cachePath,
+        ].filter(Boolean);
+
+        for (const p of localPaths) {
+            if (fs.existsSync(p)) {
+                return fs.readFileSync(p, 'utf-8');
+            }
+        }
+
+        try {
+            const res = await fetch(UPSTREAM_URL);
+            if (res.ok) {
+                const text = await res.text();
+                try {
+                    if (!fs.existsSync(cacheDir)) {
+                        fs.mkdirSync(cacheDir, { recursive: true });
+                    }
+                    fs.writeFileSync(cachePath, text, 'utf-8');
+                } catch { /* cache write is best-effort */ }
+                return text;
+            }
+        } catch { /* network unavailable */ }
+
+        return undefined;
     }
 }

--- a/packages/mcp-server/test/handlers.test.ts
+++ b/packages/mcp-server/test/handlers.test.ts
@@ -774,6 +774,7 @@ describe('McpToolHandler', () => {
 
         it('returns error when file not found', async () => {
             fsMock.existsSync.mockReturnValue(false);
+            vi.spyOn(global, 'fetch').mockRejectedValue(new Error('network unavailable'));
 
             const result = await handler.handleTool('get_ansible_best_practices', {});
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -165,7 +165,7 @@ export function activate(context: vscode.ExtensionContext) {
         if (registerCursorMcpServer(context)) {
             log('MCP server registered via Cursor extension API');
         } else {
-            log('Cursor MCP API not available — user can configure manually via command');
+            log('Cursor MCP auto-registration failed (API unavailable or server binary missing) — user can configure manually via command');
         }
     } else if (isMcpAvailable()) {
         registerMcpServerProvider(context);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,7 +31,7 @@ import {
     getCommandService,
 } from '@ansible/core';
 import type { PythonEnvironment, SchemaNode } from '@ansible/core';
-import { registerMcpServerProvider, isMcpAvailable, configureCursorMcp, showCursorMcpStatus, getMcpStatus } from './mcp';
+import { registerMcpServerProvider, isMcpAvailable, registerCursorMcpServer, configureCursorMcp, showCursorMcpStatus, getMcpStatus, detectIde } from './mcp';
 import { getLlmService } from './services/LlmService';
 import { registerFileAssociation } from './features/fileAssociation';
 import { registerVaultCommand } from './features/vault';
@@ -159,8 +159,15 @@ export function activate(context: vscode.ExtensionContext) {
     // Set initial MCP status context
     updateMcpStatusContext();
 
-    // Register MCP server provider for VS Code Copilot integration
-    if (isMcpAvailable()) {
+    // Register MCP server with the appropriate IDE API
+    const ide = detectIde();
+    if (ide === 'cursor') {
+        if (registerCursorMcpServer(context)) {
+            log('MCP server registered via Cursor extension API');
+        } else {
+            log('Cursor MCP API not available — user can configure manually via command');
+        }
+    } else if (isMcpAvailable()) {
         registerMcpServerProvider(context);
         log('MCP server provider registered for VS Code');
     } else {

--- a/src/mcp/cursorConfig.ts
+++ b/src/mcp/cursorConfig.ts
@@ -2,7 +2,15 @@ import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import { log } from '../extension';
+
+let _outputChannel: vscode.OutputChannel | undefined;
+
+function log(message: string): void {
+    if (!_outputChannel) {
+        _outputChannel = vscode.window.createOutputChannel('Ansible Environments');
+    }
+    _outputChannel.appendLine(`[${new Date().toISOString()}] ${message}`);
+}
 
 /* eslint-disable @typescript-eslint/no-explicit-any -- Cursor extension API is not typed in @types/vscode */
 
@@ -264,6 +272,15 @@ async function openCursorMcpSettings(): Promise<void> {
 // Status
 // -------------------------------------------------------------------------
 
+function escapeHtml(text: string): string {
+    return text
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
+
 /**
  * Show the current Cursor MCP configuration status
  */
@@ -279,7 +296,7 @@ export async function showCursorMcpStatus(context: vscode.ExtensionContext): Pro
 
     const lines: string[] = [
         '## Ansible Environments MCP Server Status\n',
-        `**Server Path:** \`${serverPath}\``,
+        `**Server Path:** \`${escapeHtml(serverPath)}\``,
         `**Server Exists:** ${fs.existsSync(serverPath) ? 'Yes' : 'No'}`,
         `**Cursor Extension API:** ${cursorApi ? 'Available' : 'Not available'}\n`,
         '### Configuration Files\n',
@@ -301,8 +318,8 @@ export async function showCursorMcpStatus(context: vscode.ExtensionContext): Pro
                 const pathMatch = configured.args?.[0] === serverPath;
                 lines.push(`**${label}:** ${pathMatch ? 'Configured correctly' : 'Path mismatch'}`);
                 if (!pathMatch) {
-                    lines.push(`  - Configured: \`${configured.args?.[0]}\``);
-                    lines.push(`  - Expected: \`${serverPath}\``);
+                    lines.push(`  - Configured: \`${escapeHtml(String(configured.args?.[0] ?? ''))}\``);
+                    lines.push(`  - Expected: \`${escapeHtml(serverPath)}\``);
                 }
             } else {
                 lines.push(`**${label}:** Not configured`);
@@ -407,7 +424,7 @@ export function getMcpStatus(context: vscode.ExtensionContext): McpStatus {
         try {
             const content = JSON.parse(fs.readFileSync(globalConfigPath, 'utf8'));
             const configured = content.mcpServers?.[MCP_SERVER_NAME];
-            cursorGlobalConfigured = !!configured;
+            cursorGlobalConfigured = configured?.args?.[0] === serverPath;
         } catch { /* invalid JSON */ }
     }
 
@@ -416,7 +433,7 @@ export function getMcpStatus(context: vscode.ExtensionContext): McpStatus {
         try {
             const content = JSON.parse(fs.readFileSync(workspaceConfigPath, 'utf8'));
             const configured = content.mcpServers?.[MCP_SERVER_NAME];
-            cursorWorkspaceConfigured = !!configured;
+            cursorWorkspaceConfigured = configured?.args?.[0] === serverPath;
         } catch { /* invalid JSON */ }
     }
 

--- a/src/mcp/cursorConfig.ts
+++ b/src/mcp/cursorConfig.ts
@@ -2,6 +2,91 @@ import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
+import { log } from '../extension';
+
+/* eslint-disable @typescript-eslint/no-explicit-any -- Cursor extension API is not typed in @types/vscode */
+
+const MCP_SERVER_NAME = 'ansible-environments';
+
+// -------------------------------------------------------------------------
+// Cursor extension API types
+// -------------------------------------------------------------------------
+
+interface CursorMcpApi {
+    registerServer(config: { name: string; server: { command: string; args?: string[]; env?: Record<string, string> } }): void;
+    unregisterServer(name: string): void;
+}
+
+interface CursorNamespace {
+    mcp?: CursorMcpApi;
+}
+
+function getCursorMcpApi(): CursorMcpApi | undefined {
+    const cursor = (vscode as any).cursor as CursorNamespace | undefined;
+    if (cursor?.mcp && typeof cursor.mcp.registerServer === 'function') {
+        return cursor.mcp;
+    }
+    return undefined;
+}
+
+// -------------------------------------------------------------------------
+// Primary: Cursor extension API registration
+// -------------------------------------------------------------------------
+
+/**
+ * Register the MCP server via Cursor's extension API.
+ * The server is immediately available and enabled -- no config files,
+ * no manual toggle needed.
+ */
+function registerViaCursorApi(serverPath: string): boolean {
+    const api = getCursorMcpApi();
+    if (!api) {
+        return false;
+    }
+
+    const workspaceFolder = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+    try {
+        api.registerServer({
+            name: MCP_SERVER_NAME,
+            server: {
+                command: 'node',
+                args: [serverPath],
+                env: {
+                    ...(workspaceFolder ? { ANSIBLE_ENV_WORKSPACE: workspaceFolder } : {}),
+                },
+            },
+        });
+        log('MCP server registered via Cursor extension API');
+        return true;
+    } catch (error) {
+        log(`Cursor MCP API registration failed: ${error}`);
+        return false;
+    }
+}
+
+// -------------------------------------------------------------------------
+// Auto-registration at activation
+// -------------------------------------------------------------------------
+
+/**
+ * Automatically register the MCP server when running in Cursor.
+ * Called during extension activation, mirrors registerMcpServerProvider()
+ * for VS Code.
+ */
+export function registerCursorMcpServer(context: vscode.ExtensionContext): boolean {
+    const serverPath = context.asAbsolutePath(path.join('packages', 'mcp-server', 'out', 'server.js'));
+
+    if (!fs.existsSync(serverPath)) {
+        log(`MCP server binary not found at ${serverPath}`);
+        return false;
+    }
+
+    return registerViaCursorApi(serverPath);
+}
+
+// -------------------------------------------------------------------------
+// Fallback: mcp.json file-based configuration
+// -------------------------------------------------------------------------
 
 interface McpServerConfig {
     command: string;
@@ -14,49 +99,43 @@ interface McpConfig {
 }
 
 /**
- * Configure Cursor to use the Ansible Environments MCP server
+ * Write the MCP server entry to a Cursor mcp.json file.
+ * Used as a fallback when the Cursor extension API is unavailable.
  */
-export async function configureCursorMcp(context: vscode.ExtensionContext): Promise<void> {
-    const serverPath = context.asAbsolutePath(path.join('out', 'mcp', 'server.js'));
-    
-    // Check if server file exists
+async function configureViaMcpJson(context: vscode.ExtensionContext): Promise<void> {
+    const serverPath = context.asAbsolutePath(path.join('packages', 'mcp-server', 'out', 'server.js'));
+
     if (!fs.existsSync(serverPath)) {
         vscode.window.showErrorMessage(
-            'MCP server not found. Please ensure the extension is properly compiled.',
-            'Show Details'
-        ).then(selection => {
-            if (selection === 'Show Details') {
-                vscode.window.showInformationMessage(`Expected server at: ${serverPath}`);
-            }
-        });
+            `MCP server not found at: ${serverPath}`,
+        );
         return;
     }
 
-    // Determine config location - offer choice between global and workspace
     const configChoice = await vscode.window.showQuickPick([
         {
             label: '$(home) Global Configuration',
             description: 'Apply to all Cursor workspaces',
-            detail: `~/.cursor/mcp.json`,
-            value: 'global'
+            detail: '~/.cursor/mcp.json',
+            value: 'global',
         },
         {
             label: '$(folder) Workspace Configuration',
             description: 'Apply only to current workspace',
-            detail: `.cursor/mcp.json in workspace`,
-            value: 'workspace'
-        }
+            detail: '.cursor/mcp.json in workspace',
+            value: 'workspace',
+        },
     ], {
         title: 'Configure Cursor MCP',
-        placeHolder: 'Where should the MCP configuration be saved?'
+        placeHolder: 'Where should the MCP configuration be saved?',
     });
 
     if (!configChoice) {
-        return; // User cancelled
+        return;
     }
 
     let configPath: string;
-    
+
     if (configChoice.value === 'global') {
         configPath = path.join(os.homedir(), '.cursor', 'mcp.json');
     } else {
@@ -68,13 +147,11 @@ export async function configureCursorMcp(context: vscode.ExtensionContext): Prom
         configPath = path.join(workspaceFolder.uri.fsPath, '.cursor', 'mcp.json');
     }
 
-    // Ensure directory exists
     const configDir = path.dirname(configPath);
     if (!fs.existsSync(configDir)) {
         fs.mkdirSync(configDir, { recursive: true });
     }
 
-    // Load existing config or create new
     let config: McpConfig = { mcpServers: {} };
     if (fs.existsSync(configPath)) {
         try {
@@ -83,11 +160,11 @@ export async function configureCursorMcp(context: vscode.ExtensionContext): Prom
             if (!config.mcpServers) {
                 config.mcpServers = {};
             }
-        } catch (error) {
+        } catch {
             const overwrite = await vscode.window.showWarningMessage(
                 `Existing config at ${configPath} could not be parsed. Overwrite?`,
                 'Overwrite',
-                'Cancel'
+                'Cancel',
             );
             if (overwrite !== 'Overwrite') {
                 return;
@@ -96,44 +173,43 @@ export async function configureCursorMcp(context: vscode.ExtensionContext): Prom
         }
     }
 
-    // Check if already configured
-    if (config.mcpServers['ansible-environments']) {
-        const existingPath = config.mcpServers['ansible-environments'].args?.[0];
+    if (config.mcpServers[MCP_SERVER_NAME]) {
+        const existingPath = config.mcpServers[MCP_SERVER_NAME].args?.[0];
         if (existingPath === serverPath) {
             vscode.window.showInformationMessage(
-                'Cursor MCP is already configured for this extension.'
+                'Cursor MCP is already configured for this extension.',
             );
             return;
         }
 
         const update = await vscode.window.showWarningMessage(
-            `Ansible Environments MCP is already configured with a different path. Update it?`,
+            'Ansible Environments MCP is already configured with a different path. Update it?',
             'Update',
-            'Cancel'
+            'Cancel',
         );
         if (update !== 'Update') {
             return;
         }
     }
 
-    // Add/update our server config
-    config.mcpServers['ansible-environments'] = {
+    config.mcpServers[MCP_SERVER_NAME] = {
         command: 'node',
         args: [serverPath],
-        env: {}
+        env: {},
     };
 
-    // Write config
     try {
         fs.writeFileSync(configPath, JSON.stringify(config, null, 2), 'utf8');
-        
-        const restartAction = await vscode.window.showInformationMessage(
-            `Cursor MCP configured successfully!\n\nServer path: ${serverPath}\nConfig: ${configPath}\n\nPlease restart Cursor for changes to take effect.`,
-            'Open Config',
-            'OK'
+
+        const action = await vscode.window.showInformationMessage(
+            'Ansible MCP server added. Enable it in Cursor Settings (Ctrl+Shift+J) under Features > MCP.',
+            'Open MCP Settings',
+            'Open Config File',
         );
 
-        if (restartAction === 'Open Config') {
+        if (action === 'Open MCP Settings') {
+            await openCursorMcpSettings();
+        } else if (action === 'Open Config File') {
             const doc = await vscode.workspace.openTextDocument(configPath);
             await vscode.window.showTextDocument(doc);
         }
@@ -142,75 +218,108 @@ export async function configureCursorMcp(context: vscode.ExtensionContext): Prom
     }
 }
 
+// -------------------------------------------------------------------------
+// Public command handler
+// -------------------------------------------------------------------------
+
+/**
+ * Configure Cursor to use the Ansible Environments MCP server.
+ * Tries the Cursor extension API first; falls back to mcp.json.
+ */
+export async function configureCursorMcp(context: vscode.ExtensionContext): Promise<void> {
+    const serverPath = context.asAbsolutePath(path.join('packages', 'mcp-server', 'out', 'server.js'));
+
+    if (!fs.existsSync(serverPath)) {
+        vscode.window.showErrorMessage(
+            `MCP server not found at: ${serverPath}`,
+        );
+        return;
+    }
+
+    if (registerViaCursorApi(serverPath)) {
+        vscode.window.showInformationMessage(
+            'Ansible Environments MCP server registered and ready.',
+        );
+        return;
+    }
+
+    await configureViaMcpJson(context);
+}
+
+// -------------------------------------------------------------------------
+// Settings helper
+// -------------------------------------------------------------------------
+
+async function openCursorMcpSettings(): Promise<void> {
+    try {
+        await vscode.commands.executeCommand('workbench.action.openSettings', 'mcp');
+    } catch {
+        vscode.window.showInformationMessage(
+            'Open Cursor Settings (Ctrl+Shift+J) and navigate to Features > MCP.',
+        );
+    }
+}
+
+// -------------------------------------------------------------------------
+// Status
+// -------------------------------------------------------------------------
+
 /**
  * Show the current Cursor MCP configuration status
  */
 export async function showCursorMcpStatus(context: vscode.ExtensionContext): Promise<void> {
-    const serverPath = context.asAbsolutePath(path.join('out', 'mcp', 'server.js'));
+    const serverPath = context.asAbsolutePath(path.join('packages', 'mcp-server', 'out', 'server.js'));
     const globalConfigPath = path.join(os.homedir(), '.cursor', 'mcp.json');
     const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
-    const workspaceConfigPath = workspaceFolder 
+    const workspaceConfigPath = workspaceFolder
         ? path.join(workspaceFolder.uri.fsPath, '.cursor', 'mcp.json')
         : null;
+
+    const cursorApi = getCursorMcpApi();
 
     const lines: string[] = [
         '## Ansible Environments MCP Server Status\n',
         `**Server Path:** \`${serverPath}\``,
-        `**Server Exists:** ${fs.existsSync(serverPath) ? '✅ Yes' : '❌ No'}\n`,
-        '### Configuration Files\n'
+        `**Server Exists:** ${fs.existsSync(serverPath) ? 'Yes' : 'No'}`,
+        `**Cursor Extension API:** ${cursorApi ? 'Available' : 'Not available'}\n`,
+        '### Configuration Files\n',
     ];
 
-    // Check global config
-    if (fs.existsSync(globalConfigPath)) {
+    for (const [label, cfgPath] of [
+        ['Global (~/.cursor/mcp.json)', globalConfigPath],
+        ['Workspace (.cursor/mcp.json)', workspaceConfigPath],
+    ] as const) {
+        if (!cfgPath) { continue; }
+        if (!fs.existsSync(cfgPath)) {
+            lines.push(`**${label}:** File not found`);
+            continue;
+        }
         try {
-            const content = JSON.parse(fs.readFileSync(globalConfigPath, 'utf8'));
-            const configured = content.mcpServers?.['ansible-environments'];
+            const content = JSON.parse(fs.readFileSync(cfgPath, 'utf8'));
+            const configured = content.mcpServers?.[MCP_SERVER_NAME];
             if (configured) {
                 const pathMatch = configured.args?.[0] === serverPath;
-                lines.push(`**Global (~/.cursor/mcp.json):** ${pathMatch ? '✅ Configured correctly' : '⚠️ Path mismatch'}`);
+                lines.push(`**${label}:** ${pathMatch ? 'Configured correctly' : 'Path mismatch'}`);
                 if (!pathMatch) {
                     lines.push(`  - Configured: \`${configured.args?.[0]}\``);
                     lines.push(`  - Expected: \`${serverPath}\``);
                 }
             } else {
-                lines.push('**Global (~/.cursor/mcp.json):** ❌ Not configured');
+                lines.push(`**${label}:** Not configured`);
             }
         } catch {
-            lines.push('**Global (~/.cursor/mcp.json):** ⚠️ Invalid JSON');
-        }
-    } else {
-        lines.push('**Global (~/.cursor/mcp.json):** ❌ File not found');
-    }
-
-    // Check workspace config
-    if (workspaceConfigPath) {
-        if (fs.existsSync(workspaceConfigPath)) {
-            try {
-                const content = JSON.parse(fs.readFileSync(workspaceConfigPath, 'utf8'));
-                const configured = content.mcpServers?.['ansible-environments'];
-                if (configured) {
-                    const pathMatch = configured.args?.[0] === serverPath;
-                    lines.push(`**Workspace (.cursor/mcp.json):** ${pathMatch ? '✅ Configured correctly' : '⚠️ Path mismatch'}`);
-                } else {
-                    lines.push('**Workspace (.cursor/mcp.json):** ❌ Not configured');
-                }
-            } catch {
-                lines.push('**Workspace (.cursor/mcp.json):** ⚠️ Invalid JSON');
-            }
-        } else {
-            lines.push('**Workspace (.cursor/mcp.json):** ❌ File not found');
+            lines.push(`**${label}:** Invalid JSON`);
         }
     }
 
-    // Show in a webview or output
     const panel = vscode.window.createWebviewPanel(
         'mcpStatus',
         'MCP Server Status',
         vscode.ViewColumn.One,
-        {}
+        {},
     );
 
-    const htmlContent = `
+    panel.webview.html = `
 <!DOCTYPE html>
 <html>
 <head>
@@ -234,36 +343,30 @@ export async function showCursorMcpStatus(context: vscode.ExtensionContext): Pro
 </head>
 <body>
     ${lines.map(line => {
-        if (line.startsWith('##')) {
-            return `<h2>${line.replace('## ', '')}</h2>`;
-        } else if (line.startsWith('###')) {
+        if (line.startsWith('###')) {
             return `<h3>${line.replace('### ', '')}</h3>`;
-        } else {
-            // Convert markdown-style formatting
-            const html = line
-                .replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
-                .replace(/`([^`]+)`/g, '<code>$1</code>');
-            return `<div class="status-line">${html}</div>`;
+        } else if (line.startsWith('##')) {
+            return `<h2>${line.replace('## ', '')}</h2>`;
         }
+        const html = line
+            .replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
+            .replace(/`([^`]+)`/g, '<code>$1</code>');
+        return `<div class="status-line">${html}</div>`;
     }).join('\n')}
-    
+
     <div style="margin-top: 30px;">
         <p>To configure, run: <strong>Ansible Environments: Configure Cursor MCP</strong></p>
     </div>
 </body>
 </html>`;
-
-    panel.webview.html = htmlContent;
 }
 
-/**
- * Detected IDE type
- */
+// -------------------------------------------------------------------------
+// IDE detection & status types
+// -------------------------------------------------------------------------
+
 export type IdeType = 'cursor' | 'vscode' | 'unknown';
 
-/**
- * Detect which IDE we're running in
- */
 export function detectIde(): IdeType {
     const appName = vscode.env.appName.toLowerCase();
     if (appName.includes('cursor')) {
@@ -275,73 +378,64 @@ export function detectIde(): IdeType {
     return 'unknown';
 }
 
-/**
- * MCP configuration status
- */
 export interface McpStatus {
     ide: IdeType;
-    vscodeAvailable: boolean;  // VS Code MCP API is available (1.99+)
+    vscodeAvailable: boolean;
+    cursorApiAvailable: boolean;
     cursorGlobalConfigured: boolean;
     cursorWorkspaceConfigured: boolean;
     serverExists: boolean;
-    isConfigured: boolean;  // Overall: is MCP configured for the current IDE?
+    isConfigured: boolean;
 }
 
-/**
- * Get the current MCP configuration status
- */
 export function getMcpStatus(context: vscode.ExtensionContext): McpStatus {
-    const serverPath = context.asAbsolutePath(path.join('out', 'mcp', 'server.js'));
+    const serverPath = context.asAbsolutePath(path.join('packages', 'mcp-server', 'out', 'server.js'));
     const globalConfigPath = path.join(os.homedir(), '.cursor', 'mcp.json');
     const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
-    const workspaceConfigPath = workspaceFolder 
+    const workspaceConfigPath = workspaceFolder
         ? path.join(workspaceFolder.uri.fsPath, '.cursor', 'mcp.json')
         : null;
 
     const ide = detectIde();
     const serverExists = fs.existsSync(serverPath);
-    
-    // Check VS Code MCP API availability
+    const cursorApiAvailable = !!getCursorMcpApi();
+
     const vscodeAvailable = typeof (vscode as unknown as { lm?: { registerTool?: unknown } }).lm?.registerTool === 'function';
-    
-    // Check Cursor global config
+
     let cursorGlobalConfigured = false;
     if (fs.existsSync(globalConfigPath)) {
         try {
             const content = JSON.parse(fs.readFileSync(globalConfigPath, 'utf8'));
-            const configured = content.mcpServers?.['ansible-environments'];
-            cursorGlobalConfigured = configured && configured.args?.[0] === serverPath;
-        } catch {
-            // Invalid JSON
-        }
+            const configured = content.mcpServers?.[MCP_SERVER_NAME];
+            cursorGlobalConfigured = !!configured;
+        } catch { /* invalid JSON */ }
     }
-    
-    // Check Cursor workspace config
+
     let cursorWorkspaceConfigured = false;
     if (workspaceConfigPath && fs.existsSync(workspaceConfigPath)) {
         try {
             const content = JSON.parse(fs.readFileSync(workspaceConfigPath, 'utf8'));
-            const configured = content.mcpServers?.['ansible-environments'];
-            cursorWorkspaceConfigured = configured && configured.args?.[0] === serverPath;
-        } catch {
-            // Invalid JSON
-        }
+            const configured = content.mcpServers?.[MCP_SERVER_NAME];
+            cursorWorkspaceConfigured = !!configured;
+        } catch { /* invalid JSON */ }
     }
-    
-    // Determine if configured for current IDE
+
     let isConfigured = false;
     if (ide === 'vscode') {
         isConfigured = vscodeAvailable;
     } else if (ide === 'cursor') {
-        isConfigured = cursorGlobalConfigured || cursorWorkspaceConfigured;
+        isConfigured = cursorApiAvailable || cursorGlobalConfigured || cursorWorkspaceConfigured;
     }
-    
+
     return {
         ide,
         vscodeAvailable,
+        cursorApiAvailable,
         cursorGlobalConfigured,
         cursorWorkspaceConfigured,
         serverExists,
-        isConfigured
+        isConfigured,
     };
 }
+
+/* eslint-enable @typescript-eslint/no-explicit-any */

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -20,4 +20,4 @@ export {
     McpToolHandler,
 } from '@ansible/mcp-server';
 export { registerMcpServerProvider, isMcpAvailable } from './vscodeProvider';
-export { configureCursorMcp, showCursorMcpStatus, getMcpStatus, McpStatus, detectIde, IdeType } from './cursorConfig';
+export { registerCursorMcpServer, configureCursorMcp, showCursorMcpStatus, getMcpStatus, McpStatus, detectIde, IdeType } from './cursorConfig';


### PR DESCRIPTION
## Summary

- **MCP server path**: Fixed `cursorConfig.ts` pointing to `out/mcp/server.js` (does not exist) instead of `packages/mcp-server/out/server.js` (the actual standalone server entry point). This matches the path `vscodeProvider.ts` already uses.
- **Cursor extension API**: Register MCP server via `vscode.cursor.mcp.registerServer()` at activation time so the server is immediately available and enabled — no manual toggle or config file editing needed. Falls back to `mcp.json` for older Cursor versions without the API.
- **Removed misleading UX**: Dropped the "restart Cursor" message (Cursor picks up config changes dynamically). The fallback path now guides users to Cursor Settings > Features > MCP.
- **PET warning downgraded**: The `showWarningMessage` popup about PET binary missing is now a log message, since this is expected behavior in Cursor/VSCodium/Dev Spaces. (Upstream #2814 independently made the same change; the rebase kept their version.)
- **Best practices tool**: The `get_ansible_best_practices` MCP tool was trying to read a `resources/best_practises.md` file that was never created. Now fetches the canonical Ansible coding guidelines from `ansible-creator` upstream (`docs/agents.md`) with local cache fallback, keeping the same `fs.existsSync`/`readFileSync` interface the existing tests mock.

### Copilot review fixes (982d68b3)

- **Circular dependency**: `cursorConfig.ts` no longer imports `log` from `extension.ts`; uses its own lazy output channel reference to avoid the `extension -> mcp -> cursorConfig -> extension` cycle.
- **Misleading log message**: Failure log now covers both modes (API unavailable and server binary missing).
- **Config path validation**: `getMcpStatus()` now checks `args[0]` matches the expected server path rather than just checking entry existence, preventing false-positive "configured" state.
- **HTML injection**: Added `escapeHtml()` to sanitize `mcp.json` values before rendering in the status webview.
- **Test fix**: Mocked `global.fetch` in the "file not found" test so the network fallback doesn't mask the error path.

## Test plan

- [ ] Open extension in Cursor — MCP server should auto-register without prompts
- [ ] Verify `get_ansible_best_practices` MCP tool returns the upstream Zen of Ansible content
- [ ] Confirm PET warning no longer shows as a popup in Cursor
- [ ] Run `npm run compile && npm run lint` — no new errors
- [ ] Existing `handlers.test.ts` best-practices tests pass (they mock `fs`)

related: #2810