### PR TITLE
chore: add missing "Attach to Server (src)" launch config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,7 +1,10 @@
 {
   "compounds": [
     {
-      "configurations": ["Launch Extension", "Attach to Server"],
+      "configurations": [
+        "Launch Extension",
+        "Attach to Server"
+      ],
       "name": "Both",
       "presentation": {
         "hidden": true,
@@ -10,7 +13,10 @@
       "stopAll": true
     },
     {
-      "configurations": ["Launch Extension", "Attach to Server (src)"],
+      "configurations": [
+        "Launch Extension",
+        "Attach to Server (src)"
+      ],
       "name": "Both (src)",
       "presentation": {
         "order": 1
@@ -20,18 +26,26 @@
   ],
   "configurations": [
     {
-      "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
+      "args": [
+        "--extensionDevelopmentPath=${workspaceFolder}"
+      ],
       "name": "Debug Extension (Vite)",
-      "outFiles": ["${workspaceFolder}/dist/extension/*.js"],
+      "outFiles": [
+        "${workspaceFolder}/dist/extension/*.js"
+      ],
       "postDebugTask": "kill-vite-dev",
       "preLaunchTask": "build-then-vite-dev",
       "request": "launch",
       "type": "extensionHost"
     },
     {
-      "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
+      "args": [
+        "--extensionDevelopmentPath=${workspaceFolder}"
+      ],
       "name": "Preview Extension (Vite)",
-      "outFiles": ["${workspaceFolder}/dist/extension/*.js"],
+      "outFiles": [
+        "${workspaceFolder}/dist/extension/*.js"
+      ],
       "preLaunchTask": "npm: vite-build",
       "request": "launch",
       "type": "extensionHost"
@@ -42,7 +56,9 @@
         "${workspaceFolder}/examples"
       ],
       "name": "Launch Extension",
-      "outFiles": ["${workspaceFolder}/dist/extension/*.js"],
+      "outFiles": [
+        "${workspaceFolder}/dist/extension/*.js"
+      ],
       "preLaunchTask": "build:extension",
       "request": "launch",
       "runtimeExecutable": "${execPath}",
@@ -57,7 +73,9 @@
         "VSCODE_REDHAT_TELEMETRY_DEBUG": "false"
       },
       "name": "Launch Extension (packed)",
-      "outFiles": ["${workspaceFolder}/dist/extension/*.js"],
+      "outFiles": [
+        "${workspaceFolder}/dist/extension/*.js"
+      ],
       "preLaunchTask": "build:extension",
       "request": "launch",
       "runtimeExecutable": "${execPath}",
@@ -71,7 +89,27 @@
       "port": 6010,
       "request": "attach",
       "restart": true,
-      "runtimeArgs": ["--max-old-space-size=4096"],
+      "runtimeArgs": [
+        "--max-old-space-size=4096"
+      ],
+      "timeout": 30000,
+      "type": "node"
+    },
+    {
+      "name": "Attach to Server (src)",
+      "outFiles": [
+        "${workspaceRoot}/packages/ansible-language-server/src/**/*.ts"
+      ],
+      "port": 6010,
+      "request": "attach",
+      "restart": true,
+      "runtimeArgs": [
+        "--max-old-space-size=4096"
+      ],
+      "resolveSourceMapLocations": [
+        "${workspaceFolder}/**",
+        "!**/node_modules/**"
+      ],
       "timeout": 30000,
       "type": "node"
     },
@@ -81,7 +119,9 @@
         "--extensionTestsPath=${workspaceFolder}/lib/test/index"
       ],
       "name": "Extension Tests",
-      "outFiles": ["${workspaceFolder}/out/test/**/*.js"],
+      "outFiles": [
+        "${workspaceFolder}/out/test/**/*.js"
+      ],
       "request": "launch",
       "runtimeExecutable": "${execPath}",
       "type": "extensionHost"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,10 +1,7 @@
 {
   "compounds": [
     {
-      "configurations": [
-        "Launch Extension",
-        "Attach to Server"
-      ],
+      "configurations": ["Launch Extension", "Attach to Server"],
       "name": "Both",
       "presentation": {
         "hidden": true,
@@ -13,10 +10,7 @@
       "stopAll": true
     },
     {
-      "configurations": [
-        "Launch Extension",
-        "Attach to Server (src)"
-      ],
+      "configurations": ["Launch Extension", "Attach to Server (src)"],
       "name": "Both (src)",
       "presentation": {
         "order": 1
@@ -26,26 +20,18 @@
   ],
   "configurations": [
     {
-      "args": [
-        "--extensionDevelopmentPath=${workspaceFolder}"
-      ],
+      "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
       "name": "Debug Extension (Vite)",
-      "outFiles": [
-        "${workspaceFolder}/dist/extension/*.js"
-      ],
+      "outFiles": ["${workspaceFolder}/dist/extension/*.js"],
       "postDebugTask": "kill-vite-dev",
       "preLaunchTask": "build-then-vite-dev",
       "request": "launch",
       "type": "extensionHost"
     },
     {
-      "args": [
-        "--extensionDevelopmentPath=${workspaceFolder}"
-      ],
+      "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
       "name": "Preview Extension (Vite)",
-      "outFiles": [
-        "${workspaceFolder}/dist/extension/*.js"
-      ],
+      "outFiles": ["${workspaceFolder}/dist/extension/*.js"],
       "preLaunchTask": "npm: vite-build",
       "request": "launch",
       "type": "extensionHost"
@@ -56,9 +42,7 @@
         "${workspaceFolder}/examples"
       ],
       "name": "Launch Extension",
-      "outFiles": [
-        "${workspaceFolder}/dist/extension/*.js"
-      ],
+      "outFiles": ["${workspaceFolder}/dist/extension/*.js"],
       "preLaunchTask": "build:extension",
       "request": "launch",
       "runtimeExecutable": "${execPath}",
@@ -73,9 +57,7 @@
         "VSCODE_REDHAT_TELEMETRY_DEBUG": "false"
       },
       "name": "Launch Extension (packed)",
-      "outFiles": [
-        "${workspaceFolder}/dist/extension/*.js"
-      ],
+      "outFiles": ["${workspaceFolder}/dist/extension/*.js"],
       "preLaunchTask": "build:extension",
       "request": "launch",
       "runtimeExecutable": "${execPath}",
@@ -89,9 +71,7 @@
       "port": 6010,
       "request": "attach",
       "restart": true,
-      "runtimeArgs": [
-        "--max-old-space-size=4096"
-      ],
+      "runtimeArgs": ["--max-old-space-size=4096"],
       "timeout": 30000,
       "type": "node"
     },
@@ -102,14 +82,12 @@
       ],
       "port": 6010,
       "request": "attach",
-      "restart": true,
-      "runtimeArgs": [
-        "--max-old-space-size=4096"
-      ],
       "resolveSourceMapLocations": [
         "${workspaceFolder}/**",
         "!**/node_modules/**"
       ],
+      "restart": true,
+      "runtimeArgs": ["--max-old-space-size=4096"],
       "timeout": 30000,
       "type": "node"
     },
@@ -119,9 +97,7 @@
         "--extensionTestsPath=${workspaceFolder}/lib/test/index"
       ],
       "name": "Extension Tests",
-      "outFiles": [
-        "${workspaceFolder}/out/test/**/*.js"
-      ],
+      "outFiles": ["${workspaceFolder}/out/test/**/*.js"],
       "request": "launch",
       "runtimeExecutable": "${execPath}",
       "type": "extensionHost"


### PR DESCRIPTION
The "Both (src)" compound referenced a configuration that did not exist, causing VS Code to error on launch. Added the missing configuration with source map resolution for TypeScript debugging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Adds the missing "Attach to Server (src)" VS Code launch configuration to restore the "Both (src)" compound and enable proper TypeScript sourcemap-based debugging of the language server.

- Add "Attach to Server (src)" launch configuration
- Set outFiles to src/**/*.ts for TypeScript sources
- Add resolveSourceMapLocations with exclusion of node_modules
- Keep attach settings (port 6010) and runtimeArgs (--max-old-space-size=4096)
- Reformat existing debug configs to multi-line for readability

fixes: `#2840`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->