### PR TITLE
ci: bump codecov-action to v7.0.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -523,7 +523,7 @@ jobs:
 
       - name: Upload test coverage data to codecov.io
         if: ${{ always() && hashFiles('out/coverage/**/*coverage.xml') != '' && github.event_name != 'schedule' }}
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+        uses: codecov/codecov-action@e53489f4d376d79066609109e7a95a29eb3740b1 # v7.0.0
         with:
           name: ${{ matrix.name }}
           files: ./out/coverage/**/*coverage.xml
@@ -533,7 +533,7 @@ jobs:
 
       - name: Upload junit test results to codecov.io
         if: ${{ !cancelled() && hashFiles('out/junit/**/*.xml') != '' && github.event_name != 'schedule' }}
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+        uses: codecov/codecov-action@e53489f4d376d79066609109e7a95a29eb3740b1 # v7.0.0
         with:
           directory: out/junit
           fail_ci_if_error: true


### PR DESCRIPTION
Fixes GPG signature verification failure caused by Codecov's Keybase account migration (codecov/codecov-action#1956).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Bumps the Codecov GitHub Action from v6.0.1 to v7.0.0 in the CI workflow to resolve GPG signature verification failures caused by Codecov's Keybase account migration.

- Updated codecov/codecov-action to v7.0.0 (pinned by commit SHA) in the build job's coverage upload step
- Updated codecov/codecov-action to v7.0.0 (pinned by commit SHA) in the build job's JUnit results upload step

related: `#1956`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->