### PR TITLE
chore: make renovate rebase less aggressive

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -33,8 +33,8 @@
   "lockFileMaintenance": {
     "enabled": true,
     "rangeStrategy": "replace",
-    "rebaseWhen": "behind-base-branch",
-    "recreateWhen": "always"
+    "rebaseWhen": "conflicted",
+    "recreateWhen": "auto"
   },
   "minimumReleaseAge": "1 days",
   "osvVulnerabilityAlerts": true,
@@ -102,6 +102,7 @@
   },
   "prHourlyLimit": 5,
   "rangeStrategy": "replace",
+  "rebaseWhen": "conflicted",
   "recreateWhen": "always",
   "separateMajorMinor": false,
   "separateMinorPatch": false,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated `renovate.json` to reduce aggressive Renovate rebasing behavior. Changed `lockFileMaintenance` settings from `rebaseWhen: "behind-base-branch"` to `"conflicted"` and `recreateWhen: "always"` to `"auto"`. Added `pre-commit` configuration with `rebaseWhen: "conflicted"`. This ensures Renovate only rebases when there are actual conflicts, not whenever the branch falls behind the base branch, reducing unnecessary CI runs and branch churn.

Changes:
- Modified `lockFileMaintenance.rebaseWhen` to only trigger on conflicts
- Modified `lockFileMaintenance.recreateWhen` to auto-mode
- Added `pre-commit.rebaseWhen` configuration for consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->