### PR TITLE
fix: address @typescript-eslint/no-unsafe-argument

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -156,7 +156,7 @@ jobs:
           task build && task build --status
 
       - name: task package
-        timeout-minutes: 3 # expected under 1 minutes
+        timeout-minutes: 4 # expected under 1 minutes
         run: |
           task als:package && task als:package --status
 
@@ -173,7 +173,7 @@ jobs:
           task docs && task docs --status
 
       - name: task package
-        timeout-minutes: 3
+        timeout-minutes: 4
         run: |
           task package -v && task package --status
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -90,7 +90,7 @@ export default defineConfig(
       // "@typescript-eslint/no-unsafe-member-access": "error", // ~550 errors
       // "@typescript-eslint/no-floating-promises": "error", // ~100 errors
       // "@typescript-eslint/restrict-template-expressions": "error",
-      // "@typescript-eslint/no-unsafe-argument": "error",
+      "@typescript-eslint/no-unsafe-argument": "error",
       "@typescript-eslint/no-unsafe-return": "error",
     },
     settings: {

--- a/packages/ansible-language-server/src/ansibleLanguageService.ts
+++ b/packages/ansible-language-server/src/ansibleLanguageService.ts
@@ -325,7 +325,7 @@ export class AnsibleLanguageService {
       try {
         if (completionItem.data?.documentUri) {
           const context = this.workspaceManager.getContext(
-            completionItem.data?.documentUri,
+            completionItem.data?.documentUri as string,
           );
           if (context) {
             return await doCompletionResolve(completionItem, context);
@@ -380,7 +380,7 @@ export class AnsibleLanguageService {
     // Send ansible info to client on receive of notification
     this.connection.onNotification(
       "update/ansible-metadata",
-      async (activeFileUri) => {
+      async (activeFileUri: string) => {
         const ctx = this.workspaceManager.getContext(activeFileUri);
         if (ctx !== undefined) {
           const ansibleMetaData = await getAnsibleMetaData(

--- a/packages/ansible-language-server/src/providers/completionProvider.ts
+++ b/packages/ansible-language-server/src/providers/completionProvider.ts
@@ -548,15 +548,18 @@ export async function doCompletionResolve(
 
     const docsLibrary = await context.docsLibrary;
     const [module] = await docsLibrary.findModule(
-      completionItem.data.moduleFqcn,
+      completionItem.data.moduleFqcn as string,
     );
 
     if (module && module.documentation) {
-      const [namespace, collection, name] =
-        completionItem.data.moduleFqcn.split(".");
+      const [namespace, collection, name] = (
+        completionItem.data.moduleFqcn as string
+      ).split(".");
 
       let useFqcn = (
-        await context.documentSettings.get(completionItem.data.documentUri)
+        await context.documentSettings.get(
+          completionItem.data.documentUri as string,
+        )
       ).ansible.useFullyQualifiedCollectionNames;
 
       if (!useFqcn) {
@@ -567,7 +570,7 @@ export async function doCompletionResolve(
         declaredCollections.push("ansible.builtin");
 
         const metadata = await context.documentMetadata.get(
-          completionItem.data.documentUri,
+          completionItem.data.documentUri as string,
         );
         if (metadata) {
           declaredCollections.push(...metadata.collections);
@@ -587,7 +590,7 @@ export async function doCompletionResolve(
       const insertText = completionItem.data.atEndOfLine
         ? `${insertName}:${resolveSuffix(
             "dict", // since a module is always a dictionary
-            completionItem.data.firstElementOfList,
+            completionItem.data.firstElementOfList as boolean,
             isAnsiblePlaybook,
           )}`
         : insertName;
@@ -602,7 +605,7 @@ export async function doCompletionResolve(
 
       completionItem.documentation = formatModule(
         module.documentation,
-        docsLibrary.getModuleRoute(completionItem.data.moduleFqcn),
+        docsLibrary.getModuleRoute(completionItem.data.moduleFqcn as string),
       );
     }
   }
@@ -612,8 +615,8 @@ export async function doCompletionResolve(
 
     const insertText = completionItem.data.atEndOfLine
       ? `${completionItem.label}:${resolveSuffix(
-          completionItem.data.type,
-          completionItem.data.firstElementOfList,
+          completionItem.data.type as string,
+          completionItem.data.firstElementOfList as boolean,
           isAnsiblePlaybook,
         )}`
       : completionItem.label;

--- a/packages/ansible-language-server/src/providers/completionProviderUtils.ts
+++ b/packages/ansible-language-server/src/providers/completionProviderUtils.ts
@@ -49,12 +49,12 @@ export function getVarsCompletion(
 
           if (Array.isArray(varsObject)) {
             varsObject.forEach((element) => {
-              Object.keys(element).forEach((key) => {
+              Object.keys(element as object).forEach((key) => {
                 varsCompletion.push({ variable: key, priority: varPriority });
               });
             });
           } else {
-            Object.keys(varsObject).forEach((key) => {
+            Object.keys(varsObject as object).forEach((key) => {
               varsCompletion.push({ variable: key, priority: varPriority });
             });
           }
@@ -83,12 +83,12 @@ export function getVarsCompletion(
 
           if (Array.isArray(varsObject)) {
             varsObject.forEach((element) => {
-              Object.keys(element).forEach((key) => {
+              Object.keys(element as object).forEach((key) => {
                 varsCompletion.push({ variable: key, priority: varPriority });
               });
             });
           } else {
-            Object.keys(varsObject).forEach((key) => {
+            Object.keys(varsObject as object).forEach((key) => {
               varsCompletion.push({ variable: key, priority: varPriority });
             });
           }
@@ -145,7 +145,7 @@ export function getVarsCompletion(
           if (Array.isArray(yamlDocContent)) {
             yamlDocContent.forEach((element) => {
               if (typeof element === "object") {
-                Object.keys(element).forEach((key) => {
+                Object.keys(element as object).forEach((key) => {
                   varsCompletion.push({ variable: key, priority: varPriority });
                 });
               }

--- a/packages/ansible-language-server/src/services/ansibleConfig.ts
+++ b/packages/ansible-language-server/src/services/ansibleConfig.ts
@@ -76,13 +76,18 @@ export class AnsibleConfig {
       const versionInfo = ini.parse(ansibleVersionResult.stdout);
       this._ansible_meta_data = versionInfo;
       this._module_locations = parsePythonStringArray(
-        versionInfo["configured module search path"],
+        versionInfo["configured module search path"] as string,
       );
       this._module_locations.push(
-        path.resolve(versionInfo["ansible python module location"], "modules"),
+        path.resolve(
+          versionInfo["ansible python module location"] as string,
+          "modules",
+        ),
       );
 
-      this._ansible_location = versionInfo["ansible python module location"];
+      this._ansible_location = versionInfo[
+        "ansible python module location"
+      ] as string;
 
       // get Python sys.path
       // this is needed to get the pre-installed collections to work

--- a/packages/ansible-language-server/src/settings-doc-generator.ts
+++ b/packages/ansible-language-server/src/settings-doc-generator.ts
@@ -100,7 +100,11 @@ function toDotNotation(
     const newKey = current ? `${current}.${key}` : key; // joined key with dot
     if (value && typeof value === "object") {
       if (_.isArray(value) && value[0]) {
-        toDotNotation(value[0], res, `${newKey}._array`); // it's an array object, so do it again (to identify array '._array' is added)
+        toDotNotation(
+          value[0] as ExtensionSettingsWithDescriptionBase,
+          res,
+          `${newKey}._array`,
+        ); // it's an array object, so do it again (to identify array '._array' is added)
       } else if (_.isArray(value) && !value[0]) {
         res[newKey] = value; // empty array
       } else {

--- a/packages/ansible-language-server/src/utils/docsParser.ts
+++ b/packages/ansible-language-server/src/utils/docsParser.ts
@@ -268,7 +268,10 @@ export class LazyModuleDocumentation implements IModuleMetadata {
           const document = parseDocument(m.groups.doc);
           // There's about 20 modules (out of ~3200) in Ansible 2.9 libs that contain YAML syntax errors
           // Still, document.toJSON() works on them
-          this._contents.set(m.groups.name, document.toJSON());
+          this._contents.set(
+            m.groups.name,
+            document.toJSON() as Record<string, unknown>,
+          );
           this.errors = document.errors;
         }
       }

--- a/packages/ansible-language-server/src/utils/yaml.ts
+++ b/packages/ansible-language-server/src/utils/yaml.ts
@@ -539,10 +539,10 @@ export function parseAllDocuments(str: string, options?: Options): Document[] {
   if (!str) {
     return [];
   }
-  const doc = parseDocument(
-    str,
-    Object.assign({ keepSourceTokens: true, options }),
-  );
+  const doc = parseDocument(str, {
+    keepSourceTokens: true,
+    ...options,
+  });
   return [doc];
 }
 

--- a/packages/ansible-language-server/test/globalSetup.ts
+++ b/packages/ansible-language-server/test/globalSetup.ts
@@ -15,10 +15,10 @@ const pkg = require(
 const SKIP_PODMAN = (process.env.SKIP_PODMAN ?? "0") === "1";
 const SKIP_DOCKER = (process.env.SKIP_DOCKER ?? "0") === "1";
 let EE_VERSION = "N/A";
-const DEFAULT_CONTAINER =
-  pkg.contributes.configuration[6]?.properties[
+const DEFAULT_CONTAINER: string =
+  (pkg.contributes.configuration[6]?.properties[
     "ansible.executionEnvironment.image"
-  ]?.default ?? "";
+  ]?.default as string | undefined) ?? "";
 
 function exec(cmd: string[], options: SpawnSyncOptions = {}) {
   options.stdio = "inherit";

--- a/packages/ansible-language-server/test/services/executionEnvironment.test.ts
+++ b/packages/ansible-language-server/test/services/executionEnvironment.test.ts
@@ -1,7 +1,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { expect } from "vitest";
 import sinon from "sinon";
+import { Connection } from "vscode-languageserver";
 import { ExecutionEnvironment } from "@src/services/executionEnvironment.js";
+import { WorkspaceFolderContext } from "@src/services/workspaceManager.js";
 
 const mockConnection = {
   window: {
@@ -57,8 +59,8 @@ describe("@ee", () => {
   describe("constructor", () => {
     it("should initialize properties", () => {
       const ee = new ExecutionEnvironment(
-        mockConnection as any,
-        mockContext as any,
+        mockConnection as unknown as Connection,
+        mockContext as unknown as WorkspaceFolderContext,
       );
       expect(ee.isServiceInitialized).toBe(false);
     });
@@ -70,8 +72,8 @@ describe("@ee", () => {
         executionEnvironment: { enabled: false },
       });
       const ee = new ExecutionEnvironment(
-        mockConnection as any,
-        mockContext as any,
+        mockConnection as unknown as Connection,
+        mockContext as unknown as WorkspaceFolderContext,
       );
       await ee.initialize();
       expect(ee.isServiceInitialized).toBe(true);
@@ -80,8 +82,8 @@ describe("@ee", () => {
     it("should set isServiceInitialized false if setContainerEngine fails", async () => {
       mockContext.documentSettings.get.resolves(mockSettings);
       const ee = new ExecutionEnvironment(
-        mockConnection as any,
-        mockContext as any,
+        mockConnection as unknown as Connection,
+        mockContext as unknown as WorkspaceFolderContext,
       );
       sandbox.stub(ee as any, "setContainerEngine").returns(false);
       await ee.initialize();
@@ -91,8 +93,8 @@ describe("@ee", () => {
     it("should set isServiceInitialized false if pullContainerImage fails", async () => {
       mockContext.documentSettings.get.resolves(mockSettings);
       const ee = new ExecutionEnvironment(
-        mockConnection as any,
-        mockContext as any,
+        mockConnection as unknown as Connection,
+        mockContext as unknown as WorkspaceFolderContext,
       );
       sandbox.stub(ee as any, "setContainerEngine").returns(true);
       sandbox.stub(ee as any, "pullContainerImage").resolves(false);
@@ -103,8 +105,8 @@ describe("@ee", () => {
     it("should set isServiceInitialized true if all steps succeed", async () => {
       mockContext.documentSettings.get.resolves(mockSettings);
       const ee = new ExecutionEnvironment(
-        mockConnection as any,
-        mockContext as any,
+        mockConnection as unknown as Connection,
+        mockContext as unknown as WorkspaceFolderContext,
       );
       sandbox.stub(ee as any, "setContainerEngine").returns(true);
       sandbox.stub(ee as any, "pullContainerImage").resolves(true);
@@ -115,8 +117,8 @@ describe("@ee", () => {
     it("should handle errors and set isServiceInitialized false", async () => {
       mockContext.documentSettings.get.rejects(new Error("fail"));
       const ee = new ExecutionEnvironment(
-        mockConnection as any,
-        mockContext as any,
+        mockConnection as unknown as Connection,
+        mockContext as unknown as WorkspaceFolderContext,
       );
       await ee.initialize();
       expect(ee.isServiceInitialized).toBe(false);
@@ -132,8 +134,8 @@ describe("@ee", () => {
         },
       });
       const ee = new ExecutionEnvironment(
-        mockConnection as any,
-        mockContext as any,
+        mockConnection as unknown as Connection,
+        mockContext as unknown as WorkspaceFolderContext,
       );
       sandbox.stub(ee as any, "setContainerEngine").returns(true);
       await ee.initialize();
@@ -145,8 +147,8 @@ describe("@ee", () => {
   describe("wrapContainerArgs", () => {
     it("should return undefined if not initialized", () => {
       const ee = new ExecutionEnvironment(
-        mockConnection as any,
-        mockContext as any,
+        mockConnection as unknown as Connection,
+        mockContext as unknown as WorkspaceFolderContext,
       );
       const result = ee.wrapContainerArgs("echo hello");
       expect(result).toBeUndefined();
@@ -154,8 +156,8 @@ describe("@ee", () => {
 
     it("should generate a container command string", () => {
       const ee = new ExecutionEnvironment(
-        mockConnection as any,
-        mockContext as any,
+        mockConnection as unknown as Connection,
+        mockContext as unknown as WorkspaceFolderContext,
       );
       ee.isServiceInitialized = true;
       (ee as any)._container_engine = "docker";
@@ -174,8 +176,8 @@ describe("@ee", () => {
   describe("getBasicContainerAndImageDetails", () => {
     it("should return basic details", () => {
       const ee = new ExecutionEnvironment(
-        mockConnection as any,
-        mockContext as any,
+        mockConnection as unknown as Connection,
+        mockContext as unknown as WorkspaceFolderContext,
       );
       (ee as any)._container_engine = "docker";
       (ee as any)._container_image = "test-image";

--- a/packages/ansible-mcp-server/src/server.ts
+++ b/packages/ansible-mcp-server/src/server.ts
@@ -1,11 +1,20 @@
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  McpServer,
+  type ToolCallback,
+} from "@modelcontextprotocol/sdk/server/mcp.js";
+import type {
+  AnySchema,
+  ZodRawShapeCompat,
+} from "@modelcontextprotocol/sdk/server/zod-compat.js";
 import { z } from "zod";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import {
   CallToolRequestSchema,
+  type CallToolRequest,
   type CallToolResult,
   ErrorCode,
   McpError,
+  type ToolAnnotations,
 } from "@modelcontextprotocol/sdk/types.js";
 import {
   createZenOfAnsibleHandler,
@@ -209,18 +218,36 @@ export function createAnsibleMcpServer(workspaceRoot: string) {
   // Store original registerTool method
   const originalRegisterTool = server.registerTool.bind(server);
 
+  type RegisterToolConfig = {
+    title?: string;
+    description?: string;
+    inputSchema?: ZodRawShapeCompat | AnySchema;
+    outputSchema?: ZodRawShapeCompat | AnySchema;
+    annotations?: ToolAnnotations & {
+      keywords?: string[];
+      useCases?: string[];
+    };
+    _meta?: Record<string, unknown>;
+  };
+
+  type RegisterToolHandler = (
+    ...args: any[] // eslint-disable-line @typescript-eslint/no-explicit-any
+  ) => CallToolResult | Promise<CallToolResult>;
+
   // Helper function to register a tool with dependencies
   const registerToolWithDeps = (
     name: string,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    config: any,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    handler: any,
+    config: RegisterToolConfig,
+    handler: RegisterToolHandler,
     dependencies: Dependency[] = [],
   ) => {
     registeredTools.add(name);
     toolDependencies.set(name, dependencies);
-    return originalRegisterTool(name, config, handler);
+    return originalRegisterTool(
+      name,
+      config as Parameters<McpServer["registerTool"]>[1],
+      handler as ToolCallback,
+    );
   };
 
   // Register core tools
@@ -892,8 +919,7 @@ export function createAnsibleMcpServer(workspaceRoot: string) {
   // Add custom error handling for tool calls using the underlying server
   server.server.setRequestHandler(
     CallToolRequestSchema,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    async (request: any) => {
+    async (request: CallToolRequest) => {
       const toolName = request.params.name;
 
       if (!registeredTools.has(toolName)) {
@@ -945,7 +971,7 @@ export function createAnsibleMcpServer(workspaceRoot: string) {
 
       // Log available tools for debugging
       const availableToolNames = handlers
-        ? Object.keys(handlers).join(", ")
+        ? Object.keys(handlers as object).join(", ")
         : "no handlers object";
       console.error(
         `[MCP] Tool '${toolName}' handler not found. Available handlers: ${availableToolNames}`,

--- a/packages/ansible-mcp-server/src/tools/ansibleNavigator.ts
+++ b/packages/ansible-mcp-server/src/tools/ansibleNavigator.ts
@@ -409,7 +409,7 @@ export async function runAnsibleNavigator(
     );
 
     // Capture standard output with size limit
-    navProcess.stdout.on("data", (data) => {
+    navProcess.stdout.on("data", (data: Buffer | string) => {
       const dataStr = data.toString();
       outputSize += Buffer.byteLength(dataStr);
       if (outputSize > MAX_OUTPUT_SIZE) {
@@ -428,7 +428,7 @@ export async function runAnsibleNavigator(
     });
 
     // Capture standard error (for debug output) with size limit
-    navProcess.stderr.on("data", (data) => {
+    navProcess.stderr.on("data", (data: Buffer | string) => {
       const dataStr = data.toString();
       outputSize += Buffer.byteLength(dataStr);
       if (outputSize > MAX_OUTPUT_SIZE) {

--- a/packages/ansible-mcp-server/test/cli.test.ts
+++ b/packages/ansible-mcp-server/test/cli.test.ts
@@ -8,7 +8,7 @@ const pkgRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const pkg = JSON.parse(readFileSync(resolve(pkgRoot, "package.json"), "utf8"));
 
 describe("CLI entry point", () => {
-  const binPath = resolve(pkgRoot, pkg.bin);
+  const binPath = resolve(pkgRoot, pkg.bin as string);
 
   it("bin field points to a file that exists after build", () => {
     expect(

--- a/packages/ansible-mcp-server/test/inputSchemaValidation.test.ts
+++ b/packages/ansible-mcp-server/test/inputSchemaValidation.test.ts
@@ -42,7 +42,7 @@ describe("MCP Tool InputSchema Validation", () => {
     }
 
     const toolsWithSchema: string[] = [];
-    for (const toolName of Object.keys(registeredTools)) {
+    for (const toolName of Object.keys(registeredTools as object)) {
       const tool = registeredTools[toolName];
       if (tool && tool.inputSchema) {
         toolsWithSchema.push(toolName);

--- a/packages/ansible-mcp-server/test/testWrapper.ts
+++ b/packages/ansible-mcp-server/test/testWrapper.ts
@@ -35,7 +35,7 @@ export function createTestServer(workspaceRoot: string) {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const registeredTools = (server as any)._registeredTools;
       return registeredTools
-        ? Object.keys(registeredTools).map((name) => ({ name }))
+        ? Object.keys(registeredTools as object).map((name) => ({ name }))
         : [];
     },
     listResources: () => {
@@ -48,7 +48,9 @@ export function createTestServer(workspaceRoot: string) {
       // Resources are stored by URI, each resource has a 'name' property
       const resources: Array<{ name: string; uri: string }> = [];
 
-      for (const [uri, resource] of Object.entries(registeredResources)) {
+      for (const [uri, resource] of Object.entries(
+        registeredResources as Record<string, unknown>,
+      )) {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const name = (resource as any)?.name || uri;
         resources.push({ name, uri });
@@ -68,7 +70,9 @@ export function createTestServer(workspaceRoot: string) {
 
       // If not found by URI, try to find by name
       if (!resourceHandler) {
-        for (const [, resource] of Object.entries(registeredResources)) {
+        for (const [, resource] of Object.entries(
+          registeredResources as Record<string, unknown>,
+        )) {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           if ((resource as any)?.name === nameOrUri) {
             resourceHandler = resource;

--- a/packages/ansible-mcp-server/test/tools/adeTools.test.ts
+++ b/packages/ansible-mcp-server/test/tools/adeTools.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { spawn } from "node:child_process";
+import { spawn, type ChildProcess } from "node:child_process";
 
 // Mock child_process before importing the module
 vi.mock("node:child_process", () => ({
@@ -52,7 +52,7 @@ describe("ADE Tools", () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } as any;
 
-      vi.mocked(spawn).mockReturnValue(mockChild);
+      vi.mocked(spawn).mockReturnValue(mockChild as unknown as ChildProcess);
 
       const result = await executeCommand("command");
       expect(result.exitCode).toBe(0);
@@ -70,7 +70,7 @@ describe("ADE Tools", () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } as any;
 
-      vi.mocked(spawn).mockReturnValue(mockChild);
+      vi.mocked(spawn).mockReturnValue(mockChild as unknown as ChildProcess);
 
       const result = await executeCommand("command");
       expect(result.exitCode).toBe(0);
@@ -88,7 +88,7 @@ describe("ADE Tools", () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } as any;
 
-      vi.mocked(spawn).mockReturnValue(mockChild);
+      vi.mocked(spawn).mockReturnValue(mockChild as unknown as ChildProcess);
 
       const result = await executeCommand("command");
       expect(result.success).toBe(true);
@@ -114,8 +114,7 @@ describe("ADE Tools", () => {
         }),
       };
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      vi.mocked(spawn).mockReturnValue(mockChild as any);
+      vi.mocked(spawn).mockReturnValue(mockChild as unknown as ChildProcess);
 
       const result = await executeCommand("python", ["--version"]);
       expect(result.success).toBe(true);
@@ -139,8 +138,7 @@ describe("ADE Tools", () => {
         }),
       };
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      vi.mocked(spawn).mockReturnValue(mockChild as any);
+      vi.mocked(spawn).mockReturnValue(mockChild as unknown as ChildProcess);
 
       const result = await executeCommand("invalid-command");
       expect(result.success).toBe(false);
@@ -159,8 +157,7 @@ describe("ADE Tools", () => {
         }),
       };
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      vi.mocked(spawn).mockReturnValue(mockChild as any);
+      vi.mocked(spawn).mockReturnValue(mockChild as unknown as ChildProcess);
 
       const result = await executeCommand("bad-command");
       expect(result.success).toBe(false);
@@ -199,7 +196,7 @@ describe("ADE Tools", () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } as any;
 
-      vi.mocked(spawn).mockReturnValue(mockChild);
+      vi.mocked(spawn).mockReturnValue(mockChild as unknown as ChildProcess);
 
       const result = await checkPythonVersionAvailable("3.11");
       expect(result).toBe(true);
@@ -221,7 +218,7 @@ describe("ADE Tools", () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } as any;
 
-      vi.mocked(spawn).mockReturnValue(mockChild);
+      vi.mocked(spawn).mockReturnValue(mockChild as unknown as ChildProcess);
 
       const result = await checkPythonVersionAvailable("3.15");
       expect(result).toBe(false);
@@ -239,7 +236,7 @@ describe("ADE Tools", () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } as any;
 
-      vi.mocked(spawn).mockReturnValue(mockChild);
+      vi.mocked(spawn).mockReturnValue(mockChild as unknown as ChildProcess);
 
       const result = await checkPythonVersionAvailable();
       expect(result).toBe(true);
@@ -284,8 +281,7 @@ describe("ADE Tools", () => {
         }),
       };
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      vi.mocked(spawn).mockReturnValue(mockChild as any);
+      vi.mocked(spawn).mockReturnValue(mockChild as unknown as ChildProcess);
 
       const result = await checkADEInstalled();
       expect(result).toBe(true);
@@ -302,8 +298,7 @@ describe("ADE Tools", () => {
         }),
       };
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      vi.mocked(spawn).mockReturnValue(mockChild as any);
+      vi.mocked(spawn).mockReturnValue(mockChild as unknown as ChildProcess);
 
       const result = await checkADEInstalled();
       expect(result).toBe(false);
@@ -334,8 +329,7 @@ describe("ADE Tools", () => {
         }),
       };
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      vi.mocked(spawn).mockReturnValue(mockChild as any);
+      vi.mocked(spawn).mockReturnValue(mockChild as unknown as ChildProcess);
 
       const result = await checkADTInstalled();
       expect(result).toBe(true);
@@ -352,8 +346,7 @@ describe("ADE Tools", () => {
         }),
       };
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      vi.mocked(spawn).mockReturnValue(mockChild as any);
+      vi.mocked(spawn).mockReturnValue(mockChild as unknown as ChildProcess);
 
       const result = await checkADTInstalled();
       expect(result).toBe(false);
@@ -376,8 +369,7 @@ describe("ADE Tools", () => {
         }),
       };
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      vi.mocked(spawn).mockReturnValue(mockChild as any);
+      vi.mocked(spawn).mockReturnValue(mockChild as unknown as ChildProcess);
 
       const result = await checkADTInstalled();
       expect(result).toBe(false);
@@ -408,8 +400,7 @@ describe("ADE Tools", () => {
         }),
       };
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      vi.mocked(spawn).mockReturnValue(mockChild as any);
+      vi.mocked(spawn).mockReturnValue(mockChild as unknown as ChildProcess);
 
       const result = await checkADTInstalled();
       expect(result).toBe(false);
@@ -437,8 +428,7 @@ describe("ADE Tools", () => {
         }),
       };
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      vi.mocked(spawn).mockReturnValue(mockChild as any);
+      vi.mocked(spawn).mockReturnValue(mockChild as unknown as ChildProcess);
 
       await checkADTInstalled(workspaceRoot);
 
@@ -1635,7 +1625,7 @@ describe("ADE Tools", () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } as any;
 
-      vi.mocked(spawn).mockReturnValue(mockChild);
+      vi.mocked(spawn).mockReturnValue(mockChild as unknown as ChildProcess);
 
       const result = await createVirtualEnvironment("/test/workspace");
       expect(result.success).toBe(true);
@@ -1658,7 +1648,7 @@ describe("ADE Tools", () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } as any;
 
-      vi.mocked(spawn).mockReturnValue(mockChild);
+      vi.mocked(spawn).mockReturnValue(mockChild as unknown as ChildProcess);
 
       const result = await createVirtualEnvironment(
         "/test/workspace",
@@ -1684,7 +1674,7 @@ describe("ADE Tools", () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } as any;
 
-      vi.mocked(spawn).mockReturnValue(mockChild);
+      vi.mocked(spawn).mockReturnValue(mockChild as unknown as ChildProcess);
 
       const result = await createVirtualEnvironment(
         "/test/workspace",
@@ -1712,7 +1702,7 @@ describe("ADE Tools", () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } as any;
 
-      vi.mocked(spawn).mockReturnValue(mockChild);
+      vi.mocked(spawn).mockReturnValue(mockChild as unknown as ChildProcess);
 
       const result = await executeInVirtualEnvironment("/test/venv", "pip", [
         "install",
@@ -1739,7 +1729,7 @@ describe("ADE Tools", () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } as any;
 
-      vi.mocked(spawn).mockReturnValue(mockChild);
+      vi.mocked(spawn).mockReturnValue(mockChild as unknown as ChildProcess);
 
       const result = await installCollections("/test/workspace", [
         "ansible.posix",
@@ -1766,7 +1756,7 @@ describe("ADE Tools", () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } as any;
 
-      vi.mocked(spawn).mockReturnValue(mockChild);
+      vi.mocked(spawn).mockReturnValue(mockChild as unknown as ChildProcess);
 
       const result = await installRequirements(
         "/test/workspace",
@@ -1966,7 +1956,7 @@ describe("ADE Tools", () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } as any;
 
-      vi.mocked(spawn).mockReturnValue(mockChild);
+      vi.mocked(spawn).mockReturnValue(mockChild as unknown as ChildProcess);
 
       const result = await checkAnsibleLint();
       expect(result.success).toBe(true);

--- a/src/features/ansibleTox/provider.ts
+++ b/src/features/ansibleTox/provider.ts
@@ -39,7 +39,7 @@ export class AnsibleToxProvider implements vscode.TaskProvider {
       return new vscode.Task(
         definition,
         _task.scope ?? vscode.TaskScope.Workspace,
-        definition.ansible,
+        definition.ansible as string,
         AnsibleToxProvider.toxType,
         new vscode.ShellExecution(
           `${ANSIBLE_TOX_RUN_COMMAND} ${definition.ansible} --ansible --conf tox-ansible.ini`,

--- a/src/features/ansibleTox/runner.ts
+++ b/src/features/ansibleTox/runner.ts
@@ -50,9 +50,13 @@ export async function getToxEnvs(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } catch (err: any) {
     const channel = getOutputChannel();
-    channel.appendLine(err.stderr || "");
-    channel.appendLine(err.stdout || "");
-    if (err.stderr.includes("unrecognized arguments: --ansible")) {
+    const stderr: string =
+      typeof err.stderr === "string" ? err.stderr : String(err.stderr ?? "");
+    const stdout: string =
+      typeof err.stdout === "string" ? err.stdout : String(err.stdout ?? "");
+    channel.appendLine(stderr);
+    channel.appendLine(stdout);
+    if (stderr.includes("unrecognized arguments: --ansible")) {
       channel.appendLine(
         "Ansible Tox plugin is not installed in Python environment. Install tox-ansible plugin by running command 'pip install tox-ansible'.",
       );

--- a/src/features/contentCreator/vue/views/helper.ts
+++ b/src/features/contentCreator/vue/views/helper.ts
@@ -1,6 +1,9 @@
 import type { Disposable, ExtensionContext, Webview } from "vscode";
 import { getWebviewHtml } from "@src/webviewHtml";
-import { WebviewMessageHandlers } from "@src/features/lightspeed/vue/views/webviewMessageHandlers";
+import {
+  WebviewMessageHandlers,
+  WebviewMessage,
+} from "@src/features/lightspeed/vue/views/webviewMessageHandlers";
 
 function setupHtml(webview: Webview, context: ExtensionContext, name: string) {
   return getWebviewHtml({ webview, context, inputName: name });
@@ -14,8 +17,7 @@ async function setupWebviewHooks(
   const messageHandlers = new WebviewMessageHandlers();
 
   webview.onDidReceiveMessage(
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    async (message: any) => {
+    async (message: WebviewMessage) => {
       await messageHandlers.handleMessage(message, webview, context);
     },
     undefined,

--- a/src/features/contentCreator/webviewUtils.ts
+++ b/src/features/contentCreator/webviewUtils.ts
@@ -55,10 +55,11 @@ class MessageRouter {
     private commonState?: Partial<CommonWebviewState>,
   ) {
     this.typeHandlers = {
-      homeDirectory: (message) => this.onHomeDirectory(message.data),
-      folderSelected: (message) => this.onFolderSelected(message.data),
-      fileSelected: (message) => this.onFileSelected(message.data),
-      logs: (message) => this.onLogs(message.data),
+      homeDirectory: (message) => this.onHomeDirectory(message.data as string),
+      folderSelected: (message) =>
+        this.onFolderSelected(message.data as string),
+      fileSelected: (message) => this.onFileSelected(message.data as string),
+      logs: (message) => this.onLogs(message.data as string),
     };
 
     this.commandHandlers = {
@@ -68,7 +69,8 @@ class MessageRouter {
         }
       },
       "execution-log": (message) => this.onExecutionLog(message.arguments),
-      ADEPresence: (message) => this.onADEPresence(message.arguments),
+      ADEPresence: (message) =>
+        this.onADEPresence(message.arguments as boolean),
     };
   }
 
@@ -147,7 +149,7 @@ export function setupMessageHandler(
   const router = new MessageRouter(config, commonState);
 
   const messageHandler = (event: MessageEvent) => {
-    router.handle(event.data);
+    router.handle(event.data as Message);
   };
 
   window.addEventListener("message", messageHandler);

--- a/src/features/lightspeed/ansibleContext.ts
+++ b/src/features/lightspeed/ansibleContext.ts
@@ -275,7 +275,7 @@ Generate Ansible inventory content with:
           // Check for required fields in tasks
           if (
             "name" in item ||
-            Object.keys(item).some(
+            Object.keys(item as object).some(
               (key) => key !== "name" && !key.startsWith("_"),
             )
           ) {

--- a/src/features/lightspeed/api.ts
+++ b/src/features/lightspeed/api.ts
@@ -141,7 +141,7 @@ export class LightSpeedAPI {
       const data = await response.json();
 
       if (!response.ok) {
-        throw new HTTPError(response, response.status, data);
+        throw new HTTPError(response, response.status, data as object);
       }
 
       if (
@@ -239,7 +239,7 @@ export class LightSpeedAPI {
       const data = await response.json();
 
       if (!response.ok) {
-        throw new HTTPError(response, response.status, data);
+        throw new HTTPError(response, response.status, data as object);
       }
 
       if (showInfoMessage) {
@@ -290,7 +290,7 @@ export class LightSpeedAPI {
       const data = await response.json();
 
       if (!response.ok) {
-        throw new HTTPError(response, response.status, data);
+        throw new HTTPError(response, response.status, data as object);
       }
 
       return data as ContentMatchesResponseParams;
@@ -323,7 +323,7 @@ export class LightSpeedAPI {
       const data = await response.json();
 
       if (!response.ok) {
-        throw new HTTPError(response, response.status, data);
+        throw new HTTPError(response, response.status, data as object);
       }
 
       return data as ExplanationResponseParams;
@@ -356,7 +356,7 @@ export class LightSpeedAPI {
       const data = await response.json();
 
       if (!response.ok) {
-        throw new HTTPError(response, response.status, data);
+        throw new HTTPError(response, response.status, data as object);
       }
 
       return data as PlaybookGenerationResponseParams;
@@ -392,7 +392,7 @@ export class LightSpeedAPI {
       }
 
       if (!response.ok) {
-        throw new HTTPError(response, response.status, data);
+        throw new HTTPError(response, response.status, data as object);
       }
 
       return data as RoleGenerationResponseParams;
@@ -425,7 +425,7 @@ export class LightSpeedAPI {
       const data = await response.json();
 
       if (!response.ok) {
-        throw new HTTPError(response, response.status, data);
+        throw new HTTPError(response, response.status, data as object);
       }
 
       return data as ExplanationResponseParams;

--- a/src/features/lightspeed/clients/openaiCompatibleClient.ts
+++ b/src/features/lightspeed/clients/openaiCompatibleClient.ts
@@ -112,7 +112,7 @@ export class OpenAICompatibleClient {
           body?.error?.message ||
           body?.message ||
           `HTTP ${response.status} error`;
-        throw new OpenAIClientError(errorMessage, response.status);
+        throw new OpenAIClientError(String(errorMessage), response.status);
       }
 
       return body as ChatCompletionResponse;

--- a/src/features/lightspeed/contentMatchesWebview.ts
+++ b/src/features/lightspeed/contentMatchesWebview.ts
@@ -228,9 +228,11 @@ export class ContentMatchesWebview implements vscode.WebviewViewProvider {
       }
 
       const contentMatchValue = contentMatchResponses.contentmatches[taskIndex];
+      const taskDescription =
+        typeof taskNameDescription === "string" ? taskNameDescription : "";
       contentMatchesHtml += this.renderContentMatchWithTasKDescription(
         contentMatchValue.contentmatch,
-        taskNameDescription || "",
+        taskDescription,
       );
     }
     const html = `

--- a/src/features/lightspeed/lightSpeedOAuthProvider.ts
+++ b/src/features/lightspeed/lightSpeedOAuthProvider.ts
@@ -24,6 +24,7 @@ import {
   UriEventHandler,
   OAuthAccount,
   calculateTokenExpiryTime,
+  coerceExpiresIn,
   SESSIONS_SECRET_KEY,
   ACCOUNT_SECRET_KEY,
   getBaseUri,
@@ -435,7 +436,7 @@ export class LightSpeedAuthenticationProvider
           accessToken: data?.access_token,
           refreshToken: data?.refresh_token,
           expiresAtTimestampInSeconds: calculateTokenExpiryTime(
-            data?.expires_in,
+            coerceExpiresIn(data?.expires_in),
           ),
           // scope: data.scope,
         };
@@ -507,7 +508,7 @@ export class LightSpeedAuthenticationProvider
               accessToken: data?.access_token,
               refreshToken: data?.refresh_token,
               expiresAtTimestampInSeconds: calculateTokenExpiryTime(
-                data?.expires_in,
+                coerceExpiresIn(data?.expires_in),
               ),
               // scope: data.scope,
             };

--- a/src/features/lightspeed/providers/google.ts
+++ b/src/features/lightspeed/providers/google.ts
@@ -66,7 +66,11 @@ export class GoogleProvider extends BaseLLMProvider<GoogleConfig> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private handleGeminiError(error: any, operation: string): Error {
     // Use the reusable HTTP error handler from base class
-    return this.handleHttpError(error, operation, "Google Gemini");
+    return this.handleHttpError(
+      error as { status?: number; message?: string },
+      operation,
+      "Google Gemini",
+    );
   }
 
   async validateConfig(): Promise<boolean> {

--- a/src/features/lightspeed/providers/rhcustom.ts
+++ b/src/features/lightspeed/providers/rhcustom.ts
@@ -518,7 +518,7 @@ export class RHCustomProvider extends BaseLLMProvider<RHCustomConfig> {
           if (parsed && typeof parsed === "object") {
             console.log(
               "[RHCustom Provider] Parsed YAML keys:",
-              Object.keys(parsed),
+              Object.keys(parsed as object),
             );
           }
         } catch (parseError) {

--- a/src/features/lightspeed/utils/explanationUtils.ts
+++ b/src/features/lightspeed/utils/explanationUtils.ts
@@ -20,7 +20,7 @@ export function getObjectKeys(content: string): string[] {
     const parsedAnsibleDocument = yaml.parse(content);
     const lastObject = parsedAnsibleDocument[parsedAnsibleDocument.length - 1];
     if (typeof lastObject === "object") {
-      return Object.keys(lastObject);
+      return Object.keys(lastObject as object);
     }
   } catch {
     return [];

--- a/src/features/lightspeed/utils/outlineGenerator.ts
+++ b/src/features/lightspeed/utils/outlineGenerator.ts
@@ -82,7 +82,7 @@ export function generateOutlineFromRole(roleYaml: string): string {
     // Extract task names
     for (const task of parsed) {
       if (task.name) {
-        tasks.push(task.name);
+        tasks.push(task.name as string);
       }
     }
 

--- a/src/features/lightspeed/utils/parsePlays.ts
+++ b/src/features/lightspeed/utils/parsePlays.ts
@@ -1,14 +1,18 @@
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function parsePlays(plays: any[]): any[] {
+export function parsePlays(plays: unknown[]): unknown[] {
   if (!plays || !Array.isArray(plays) || plays.length === 0) {
     return [];
   }
-  let tasks: string[] = [];
+  const tasks: unknown[] = [];
   for (let i = 0; i < plays.length; i++) {
     const play = plays[i];
-    const tasksInAPlay = play.tasks;
-    if (tasksInAPlay) {
-      tasks = tasks.concat(tasksInAPlay);
+    if (typeof play !== "object" || play === null) {
+      continue;
+    }
+    const tasksInAPlay = (play as Record<string, unknown>).tasks;
+    if (Array.isArray(tasksInAPlay)) {
+      for (const task of tasksInAPlay) {
+        tasks.push(task);
+      }
     } else {
       // If tasks are not found in the play,
       // add the play itself to the tasks list

--- a/src/features/lightspeed/utils/webUtils.ts
+++ b/src/features/lightspeed/utils/webUtils.ts
@@ -40,6 +40,17 @@ export const generateCodeVerifier = (): string => {
     : generateCodeVerifier();
 };
 
+const DEFAULT_TOKEN_EXPIRES_IN_SECONDS = 3600;
+
+/** Coerce OAuth `expires_in` to a positive number of seconds. */
+export function coerceExpiresIn(
+  expiresIn: unknown,
+  defaultSeconds = DEFAULT_TOKEN_EXPIRES_IN_SECONDS,
+): number {
+  const num = typeof expiresIn === "number" ? expiresIn : Number(expiresIn);
+  return Number.isFinite(num) && num > 0 ? num : defaultSeconds;
+}
+
 // A function to return the expiry date and time in epoch
 export function calculateTokenExpiryTime(expiresIn: number) {
   const now = Math.floor(new Date().getTime() / 1000);

--- a/src/features/lightspeed/vue/views/helper.ts
+++ b/src/features/lightspeed/vue/views/helper.ts
@@ -1,6 +1,9 @@
 import type { Disposable, ExtensionContext, Webview } from "vscode";
 import { getWebviewHtml } from "@src/webviewHtml";
-import { WebviewMessageHandlers } from "@src/features/lightspeed/vue/views/webviewMessageHandlers";
+import {
+  WebviewMessageHandlers,
+  WebviewMessage,
+} from "@src/features/lightspeed/vue/views/webviewMessageHandlers";
 
 function setupHtml(webview: Webview, context: ExtensionContext, name: string) {
   return getWebviewHtml({ webview, context, inputName: name });
@@ -14,8 +17,7 @@ async function setupWebviewHooks(
   const messageHandlers = new WebviewMessageHandlers();
 
   webview.onDidReceiveMessage(
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    async (message: any) => {
+    async (message: WebviewMessage) => {
       await messageHandlers.handleMessage(message, webview, context);
     },
     undefined,

--- a/src/features/lightspeed/vue/views/llmProviderMessageHandlers.ts
+++ b/src/features/lightspeed/vue/views/llmProviderMessageHandlers.ts
@@ -9,7 +9,7 @@ import { LightspeedUser } from "@src/features/lightspeed/lightspeedUser";
 import { QuickLinksWebviewViewProvider } from "@src/features/quickLinks/utils/quickLinksViewProvider";
 import { ProviderInfo } from "@src/interfaces/lightspeed";
 
-interface LlmProviderMessage {
+export interface LlmProviderMessage {
   command: string;
   provider?: string;
   config?: Record<string, string>;

--- a/src/features/lightspeed/vue/views/llmProviderPanel.ts
+++ b/src/features/lightspeed/vue/views/llmProviderPanel.ts
@@ -5,6 +5,7 @@ import { disposePanelResources } from "@src/features/lightspeed/vue/views/panelU
 import {
   LlmProviderMessageHandlers,
   LlmProviderDependencies,
+  LlmProviderMessage,
 } from "@src/features/lightspeed/vue/views/llmProviderMessageHandlers";
 import { providerFactory } from "@src/features/lightspeed/providers/factory";
 
@@ -55,7 +56,7 @@ export class LlmProviderPanel {
     // Set up message handler
     this.messageHandlers.setWebview(this._panel.webview);
     this._panel.webview.onDidReceiveMessage(
-      async (message) => {
+      async (message: LlmProviderMessage) => {
         await this.messageHandlers.handleMessage(message);
       },
       undefined,

--- a/src/features/lightspeed/vue/views/webviewMessageHandlers.ts
+++ b/src/features/lightspeed/vue/views/webviewMessageHandlers.ts
@@ -64,7 +64,7 @@ import {
   isDocumentInRole,
 } from "@src/features/lightspeed/utils/explanationUtils";
 
-interface WebviewMessage {
+export interface WebviewMessage {
   type: string;
   data?: any;
   payload?: any;
@@ -133,8 +133,8 @@ export class WebviewMessageHandlers {
       explorerExplainRole: this.handleExplorerExplainRole.bind(this),
 
       // Data handlers
-      setPlaybookData: this.handleSetPlaybookData.bind(this),
-      setRoleData: this.handleSetRoleData.bind(this),
+      setPlaybookData: this.handleSetData.bind(this),
+      setRoleData: this.handleSetData.bind(this),
       getRecentPrompts: this.handleGetRecentPrompts.bind(this),
       getCollectionList: this.handleGetCollectionList.bind(this),
       writeRoleInWorkspace: this.handleWriteRoleInWorkspace.bind(this),
@@ -183,7 +183,7 @@ export class WebviewMessageHandlers {
     });
   }
 
-  private handleUiMounted(message: any, webview: vscode.Webview) {
+  private handleUiMounted(message: WebviewMessage, webview: vscode.Webview) {
     // Get workspace directory instead of home directory
     let workspaceDir = os.homedir(); // fallback
     if (vscode.workspace.workspaceFolders) {
@@ -200,10 +200,10 @@ export class WebviewMessageHandlers {
   // File/Folder Handlers
 
   private async handleOpenFolderExplorer(
-    message: any,
+    message: WebviewMessage,
     webview: vscode.Webview,
   ) {
-    const defaultPath = message.payload?.defaultPath;
+    const defaultPath = message.payload?.defaultPath as string | undefined;
     const uri = await window.showOpenDialog({
       canSelectFolders: true,
       canSelectFiles: false,
@@ -218,8 +218,11 @@ export class WebviewMessageHandlers {
     }
   }
 
-  private async handleOpenFileExplorer(message: any, webview: vscode.Webview) {
-    const defaultPath = message.payload?.defaultPath;
+  private async handleOpenFileExplorer(
+    message: WebviewMessage,
+    webview: vscode.Webview,
+  ) {
+    const defaultPath = message.payload?.defaultPath as string | undefined;
     const uri = await window.showOpenDialog({
       canSelectFolders: false,
       canSelectFiles: true,
@@ -234,31 +237,40 @@ export class WebviewMessageHandlers {
     }
   }
 
-  private async handleOpenEditor(message: any) {
-    const content: string = message.data.content;
+  private async handleOpenEditor(message: WebviewMessage) {
+    const content = message.data.content as string;
     await openNewPlaybookEditor(content);
   }
 
   // Creator Handlers
-  private async handleInitCreate(message: any, webview: vscode.Webview) {
+  private async handleInitCreate(
+    message: WebviewMessage,
+    webview: vscode.Webview,
+  ) {
     const payload = message.payload as
       | AnsibleCollectionFormInterface
       | AnsibleProjectFormInterface;
     await this.creatorOps.runInitCommand(payload, webview);
   }
 
-  private async handleInitCreatePlugin(message: any, webview: vscode.Webview) {
+  private async handleInitCreatePlugin(
+    message: WebviewMessage,
+    webview: vscode.Webview,
+  ) {
     const payload = message.payload as PluginFormInterface;
     await this.creatorOps.runPluginAddCommand(payload, webview);
   }
 
-  private async handleInitCreateRole(message: any, webview: vscode.Webview) {
+  private async handleInitCreateRole(
+    message: WebviewMessage,
+    webview: vscode.Webview,
+  ) {
     const payload = message.payload as RoleFormInterface;
     await this.creatorOps.runRoleAddCommand(payload, webview);
   }
 
   private async handleInitCreateDevcontainer(
-    message: any,
+    message: WebviewMessage,
     webview: vscode.Webview,
     context: vscode.ExtensionContext,
   ) {
@@ -271,7 +283,7 @@ export class WebviewMessageHandlers {
   }
 
   private async handleInitCreateDevfile(
-    message: any,
+    message: WebviewMessage,
     webview: vscode.Webview,
     context: vscode.ExtensionContext,
   ) {
@@ -280,37 +292,47 @@ export class WebviewMessageHandlers {
   }
 
   private async handleInitCreateExecutionEnv(
-    message: any,
+    message: WebviewMessage,
     webview: vscode.Webview,
   ) {
     const payload = message.payload as AnsibleExecutionEnvInterface;
     await this.runExecutionEnvCreateProcess(payload, webview);
   }
 
-  private async handleCheckAdePresence(message: any, webview: vscode.Webview) {
+  private async handleCheckAdePresence(
+    message: WebviewMessage,
+    webview: vscode.Webview,
+  ) {
     await this.creatorOps.isADEPresent(webview);
   }
 
   // File Operation Handlers
-  private async handleInitCopyLogs(message: any) {
-    const payload = message.payload;
+  private async handleInitCopyLogs(message: WebviewMessage) {
+    const payload = message.payload as { initExecutionLogs: string };
     vscode.env.clipboard.writeText(payload.initExecutionLogs);
     await vscode.window.showInformationMessage("Logs copied to clipboard");
   }
 
-  private async handleInitOpenLogFile(message: any) {
-    const payload = message.payload;
+  private async handleInitOpenLogFile(message: WebviewMessage) {
+    const payload = message.payload as { logFileUrl: string };
     await this.fileOps.openLogFile(payload.logFileUrl);
   }
 
-  private async handleInitOpenScaffoldedFolder(message: any) {
-    const payload = message.payload;
-    const folderUrl = payload.collectionUrl || payload.projectUrl;
+  private async handleInitOpenScaffoldedFolder(message: WebviewMessage) {
+    const payload = message.payload as {
+      collectionUrl?: string;
+      projectUrl?: string;
+    };
+    const folderUrl = (payload.collectionUrl || payload.projectUrl) as string;
     await this.fileOps.openFolderInWorkspaceProjects(folderUrl);
   }
 
-  private async handleInitOpenScaffoldedFolderPlugin(message: any) {
-    const payload = message.payload;
+  private async handleInitOpenScaffoldedFolderPlugin(message: WebviewMessage) {
+    const payload = message.payload as {
+      projectUrl: string;
+      pluginName: string;
+      pluginType: string;
+    };
     await this.fileOps.openFolderInWorkspacePlugin(
       payload.projectUrl,
       payload.pluginName,
@@ -318,26 +340,29 @@ export class WebviewMessageHandlers {
     );
   }
 
-  private async handleInitOpenRoleFolder(message: any) {
-    const payload = message.payload;
+  private async handleInitOpenRoleFolder(message: WebviewMessage) {
+    const payload = message.payload as {
+      projectUrl: string;
+      roleName: string;
+    };
     await this.fileOps.openFolderInWorkspaceRole(
       payload.projectUrl,
       payload.roleName,
     );
   }
 
-  private async handleInitOpenDevcontainerFolder(message: any) {
-    const payload = message.payload;
+  private async handleInitOpenDevcontainerFolder(message: WebviewMessage) {
+    const payload = message.payload as { projectUrl: string };
     await this.fileOps.openFolderInWorkspaceDevcontainer(payload.projectUrl);
   }
 
-  private async handleInitOpenDevfile(message: any) {
-    const payload = message.payload;
+  private async handleInitOpenDevfile(message: WebviewMessage) {
+    const payload = message.payload as { projectUrl: string };
     await this.fileOps.openDevfile(payload.projectUrl);
   }
 
-  private async handleInitOpenScaffoldedFile(message: any) {
-    const payload = message.payload;
+  private async handleInitOpenScaffoldedFile(message: WebviewMessage) {
+    const payload = message.payload as { projectUrl?: string };
     const projectUrl = payload.projectUrl;
     if (projectUrl) {
       // For execution environment, open the specific YAML file
@@ -347,8 +372,14 @@ export class WebviewMessageHandlers {
   }
 
   // LightSpeed Handlers
-  private async handleExplainPlaybook(message: any, webview: vscode.Webview) {
-    const { data } = message;
+  private async handleExplainPlaybook(
+    message: WebviewMessage,
+    webview: vscode.Webview,
+  ) {
+    const data = message.data as {
+      content: string;
+      explanationId: string;
+    };
     const lightSpeedStatusbarText =
       await lightSpeedManager.statusBarProvider.getLightSpeedStatusBarText();
 
@@ -381,8 +412,15 @@ export class WebviewMessageHandlers {
       lightSpeedStatusbarText;
   }
 
-  private async handleExplainRole(message: any, webview: vscode.Webview) {
-    const { data } = message;
+  private async handleExplainRole(
+    message: WebviewMessage,
+    webview: vscode.Webview,
+  ) {
+    const data = message.data as {
+      files: GenerationListEntry[];
+      roleName: string;
+      explanationId: string;
+    };
     const lightSpeedStatusbarText =
       await lightSpeedManager.statusBarProvider.getLightSpeedStatusBarText();
 
@@ -417,11 +455,15 @@ export class WebviewMessageHandlers {
   }
 
   private async handleGenerateRole(
-    message: any,
+    message: WebviewMessage,
     webview: vscode.Webview,
     context: vscode.ExtensionContext,
   ) {
-    const { data } = message;
+    const data = message.data as {
+      name?: string;
+      text: string;
+      outline: string;
+    };
     const generationId = uuidv4();
 
     const response = await generateRole(
@@ -455,11 +497,14 @@ export class WebviewMessageHandlers {
   }
 
   private async handleGeneratePlaybook(
-    message: any,
+    message: WebviewMessage,
     webview: vscode.Webview,
     context: vscode.ExtensionContext,
   ) {
-    const { data } = message;
+    const data = message.data as {
+      text: string;
+      outline: string;
+    };
     const generationId = uuidv4();
     const response = await generatePlaybook(
       lightSpeedManager.apiInstance,
@@ -484,38 +529,44 @@ export class WebviewMessageHandlers {
     updatePromptHistory(context, data.text);
   }
 
-  private async handleExplanationThumbsUp(message: any) {
+  private async handleExplanationThumbsUp(message: WebviewMessage) {
+    const data = message.data as {
+      action?: ThumbsUpDownAction;
+      explanationId: string;
+      explanationType?: "playbook" | "role";
+    };
     await thumbsUpDown(
-      message.data.action ?? ThumbsUpDownAction.UP,
-      message.data.explanationId,
-      message.data.explanationType ?? "playbook",
+      data.action ?? ThumbsUpDownAction.UP,
+      data.explanationId,
+      data.explanationType ?? "playbook",
     );
   }
 
-  private async handleExplanationThumbsDown(message: any) {
+  private async handleExplanationThumbsDown(message: WebviewMessage) {
+    const data = message.data as {
+      action?: ThumbsUpDownAction;
+      explanationId: string;
+      explanationType?: "playbook" | "role";
+    };
     await thumbsUpDown(
-      message.data.action ?? ThumbsUpDownAction.DOWN,
-      message.data.explanationId,
-      message.data.explanationType ?? "playbook",
+      data.action ?? ThumbsUpDownAction.DOWN,
+      data.explanationId,
+      data.explanationType ?? "playbook",
     );
   }
 
   // Data Handlers
-  private handleSetPlaybookData(message: any, webview: vscode.Webview) {
+  private handleSetData(message: WebviewMessage, webview: vscode.Webview) {
     webview.postMessage({
       type: message.type,
       data: message.data,
     });
   }
 
-  private handleSetRoleData(message: any, webview: vscode.Webview) {
-    webview.postMessage({
-      type: message.type,
-      data: message.data,
-    });
-  }
-
-  private handleGetTelemetryStatus(message: any, webview: vscode.Webview) {
+  private handleGetTelemetryStatus(
+    message: WebviewMessage,
+    webview: vscode.Webview,
+  ) {
     const telemetryEnabled = vscode.workspace
       .getConfiguration("redhat")
       .get<boolean>("telemetry.enabled", true);
@@ -531,7 +582,7 @@ export class WebviewMessageHandlers {
   }
 
   private handleGetRecentPrompts(
-    message: any,
+    message: WebviewMessage,
     webview: vscode.Webview,
     context: vscode.ExtensionContext,
   ) {
@@ -545,7 +596,10 @@ export class WebviewMessageHandlers {
     });
   }
 
-  private async handleGetCollectionList(message: any, webview: vscode.Webview) {
+  private async handleGetCollectionList(
+    message: WebviewMessage,
+    webview: vscode.Webview,
+  ) {
     await new Promise((resolve) => setTimeout(resolve, 200));
     webview.postMessage({
       type: message.type,
@@ -553,7 +607,7 @@ export class WebviewMessageHandlers {
     });
   }
 
-  private async handleFeedback(message: any) {
+  private async handleFeedback(message: WebviewMessage) {
     const request = message.data.request as FeedbackRequestParams;
     const provider =
       lightSpeedManager.settingsManager.settings.lightSpeedService.provider;
@@ -598,10 +652,14 @@ export class WebviewMessageHandlers {
   }
 
   private async handleWriteRoleInWorkspace(
-    message: any,
+    message: WebviewMessage,
     webview: vscode.Webview,
   ) {
-    const { data } = message;
+    const data = message.data as {
+      roleName: string;
+      collectionName: string;
+      files: string[][];
+    };
     const roleName: string = data.roleName;
     const collectionName: string = data.collectionName;
     const files = data.files.map((i: string[]) => ({
@@ -1203,7 +1261,10 @@ export class WebviewMessageHandlers {
   }
 
   // Explorer Handlers
-  private async handleGetExplorerState(message: any, webview: vscode.Webview) {
+  private async handleGetExplorerState(
+    message: WebviewMessage,
+    webview: vscode.Webview,
+  ) {
     const hasPlaybookOpened = this.hasPlaybookOpened();
     const hasRoleOpened = await this.hasRoleOpened();
 

--- a/src/features/runner.ts
+++ b/src/features/runner.ts
@@ -55,7 +55,7 @@ export class AnsiblePlaybookRunProvider {
       this.vsCodeExtCtx,
       this.telemetry,
       AnsibleCommands.ANSIBLE_PLAYBOOK_RUN,
-      (fileObj) => this.invokeViaAnsiblePlaybook(fileObj),
+      (fileObj?: vscode.Uri) => this.invokeViaAnsiblePlaybook(fileObj),
       false,
     );
     console.log('Added a "Run Ansible Playbook" command...');
@@ -64,7 +64,7 @@ export class AnsiblePlaybookRunProvider {
       this.vsCodeExtCtx,
       this.telemetry,
       AnsibleCommands.ANSIBLE_NAVIGATOR_RUN,
-      (fileObj) => this.invokeViaAnsibleNavigator(fileObj),
+      (fileObj?: vscode.Uri) => this.invokeViaAnsibleNavigator(fileObj),
       false,
     );
 
@@ -94,7 +94,7 @@ export class AnsiblePlaybookRunProvider {
     commandLineArgs.push("--ee true");
     commandLineArgs.push("--pae false");
     commandLineArgs.push(
-      `--ce ${getContainerEngine(eeSettings.containerEngine)}`,
+      `--ce ${getContainerEngine(eeSettings.containerEngine as string)}`,
     );
     commandLineArgs.push(`--eei ${shellQuote(eeSettings.image)}`);
     if (eeSettings.containerOptions !== "") {
@@ -157,14 +157,12 @@ export class AnsiblePlaybookRunProvider {
    * A callback method for running `ansible-playbook` command.
    * @param fileObj - The file path to execute the command.
    */
-  private async invokeViaAnsiblePlaybook(
-    ...fileObj: vscode.Uri[] | undefined[]
-  ): Promise<void> {
+  private async invokeViaAnsiblePlaybook(fileObj?: vscode.Uri): Promise<void> {
     const runExecutable = this.ansiblePlaybookExecutablePath;
     const playbookArguments =
       this.extensionSettings.settings.playbook.arguments;
     const commandLineArgs: string[] = [];
-    const playbookFsPath = extractTargetFsPath(...fileObj);
+    const playbookFsPath = extractTargetFsPath(fileObj);
     if (typeof playbookFsPath === "undefined") {
       vscode.window.showErrorMessage(
         `No Ansible playbook file has been specified to be executed with ansible-playbook.`,
@@ -191,12 +189,10 @@ export class AnsiblePlaybookRunProvider {
    * A callback method for running `ansible-navigator run command`.
    * @param fileObj - The file path to execute the command.
    */
-  private async invokeViaAnsibleNavigator(
-    ...fileObj: vscode.Uri[] | undefined[]
-  ): Promise<void> {
+  private async invokeViaAnsibleNavigator(fileObj?: vscode.Uri): Promise<void> {
     const runExecutable = this.ansibleNavigatorExecutablePath;
     const commandLineArgs: string[] = [];
-    const playbookFsPath = extractTargetFsPath(...fileObj);
+    const playbookFsPath = extractTargetFsPath(fileObj);
     if (typeof playbookFsPath === "undefined") {
       vscode.window.showErrorMessage(
         `No Ansible playbook file has been specified to be executed with ansible-navigator run.`,
@@ -229,7 +225,7 @@ export class AnsiblePlaybookRunProvider {
  * @returns A path to the currently selected file.
  */
 function extractTargetFsPath(
-  ...priorityPathObjs: vscode.Uri[] | undefined[]
+  ...priorityPathObjs: (vscode.Uri | undefined)[]
 ): string | undefined {
   const pathCandidates: vscode.Uri[] = [
     ...priorityPathObjs,

--- a/src/features/utils/ansible.ts
+++ b/src/features/utils/ansible.ts
@@ -38,7 +38,7 @@ export function getAnsibleFileType(
   if (typeof lastObject !== "object") {
     return "other";
   }
-  const objectKeys = Object.keys(lastObject);
+  const objectKeys = Object.keys(lastObject as object);
   for (const keyword of objectKeys) {
     if (PlaybookKeywords.includes(keyword)) {
       return "playbook";

--- a/src/features/utils/applyFileInspectionForKeywords.ts
+++ b/src/features/utils/applyFileInspectionForKeywords.ts
@@ -20,7 +20,7 @@ export async function applyFileInspectionForKeywords(
 
     if (parsedYaml && Array.isArray(parsedYaml)) {
       // Check for all seq
-      const topLevelKeys = Object.keys(parsedYaml[0]);
+      const topLevelKeys = Object.keys(parsedYaml[0] as object);
       const ansibleTopLevelKeys = [
         "hosts",
         "import_playbook",

--- a/src/features/utils/applyModelines.ts
+++ b/src/features/utils/applyModelines.ts
@@ -68,7 +68,7 @@ async function applyModeLines(
 
     const language = modelineOptions.language;
 
-    if (language && language.length > 0) {
+    if (typeof language === "string" && language.length > 0) {
       if (language === "ansible" || language === "yaml") {
         console.log("[modelines] language set by modelines");
         await vscode.languages.setTextDocumentLanguage(

--- a/src/features/utils/data.ts
+++ b/src/features/utils/data.ts
@@ -4,8 +4,8 @@ export function compareObjects(baseObject: any, newObject: any): boolean {
     return false;
   }
   // compare the number of keys
-  const baseObjectKeys = Object.keys(baseObject);
-  const newObjectKeys = Object.keys(newObject);
+  const baseObjectKeys = Object.keys(baseObject as object);
+  const newObjectKeys = Object.keys(newObject as object);
 
   if (baseObjectKeys.length !== newObjectKeys.length) {
     return false;

--- a/src/features/utils/formatAnsibleMetaData.ts
+++ b/src/features/utils/formatAnsibleMetaData.ts
@@ -13,12 +13,16 @@ export function formatAnsibleMetaData(ansibleMetaData: any) {
   const WARNING_STYLE = `style="color:${WARNING_COLOR};"`;
 
   // check if ansible is missing
-  if (Object.keys(ansibleMetaData["ansible information"]).length === 0) {
+  if (
+    Object.keys(ansibleMetaData["ansible information"] as object).length === 0
+  ) {
     ansiblePresent = false;
     mdString += "#### $(close) Ansible not found in the environment\n";
 
     // if python exists
-    if (Object.keys(ansibleMetaData["python information"]).length !== 0) {
+    if (
+      Object.keys(ansibleMetaData["python information"] as object).length !== 0
+    ) {
       const obj = ansibleMetaData["python information"];
       mdString += `Python version used: \`${obj["version"]}\` from \`${obj["location"]}\``;
     }
@@ -41,7 +45,10 @@ export function formatAnsibleMetaData(ansibleMetaData: any) {
   }
 
   // check is ansible-lint is missing
-  if (Object.keys(ansibleMetaData["ansible-lint information"]).length === 0) {
+  if (
+    Object.keys(ansibleMetaData["ansible-lint information"] as object)
+      .length === 0
+  ) {
     ansibleLintPresent = false;
   }
 
@@ -57,8 +64,8 @@ export function formatAnsibleMetaData(ansibleMetaData: any) {
     .getConfiguration("ansible.validation.lint")
     .get("enabled");
 
-  Object.keys(ansibleMetaData).forEach((mainKey) => {
-    if (Object.keys(ansibleMetaData[mainKey]).length === 0) {
+  Object.keys(ansibleMetaData as object).forEach((mainKey) => {
+    if (Object.keys(ansibleMetaData[mainKey] as object).length === 0) {
       return;
     }
     // put a marker stating ansible-lint setting is disabled
@@ -70,7 +77,7 @@ export function formatAnsibleMetaData(ansibleMetaData: any) {
     }
 
     const valueObj = ansibleMetaData[mainKey];
-    Object.keys(valueObj).forEach((key) => {
+    Object.keys(valueObj as object).forEach((key) => {
       if (key === "upgrade status") {
         const value = valueObj[key];
         if (value != null && String(value).trim().toLowerCase() !== "nil") {
@@ -86,9 +93,9 @@ export function formatAnsibleMetaData(ansibleMetaData: any) {
             if (key.includes("path")) {
               mdString += `\n       ${
                 index + 1
-              }. <a href='${val}'>${getTildePath(val)}</a>`;
+              }. <a href='${val}'>${getTildePath(val as string)}</a>`;
             } else {
-              mdString += `\n       ${index + 1}. ${getTildePath(val)}`;
+              mdString += `\n       ${index + 1}. ${getTildePath(val as string)}`;
             }
           }
           if (index === value.length - 1) {
@@ -97,15 +104,15 @@ export function formatAnsibleMetaData(ansibleMetaData: any) {
         });
       } else {
         if (key.includes("path")) {
-          mdString += `<a href='${value}'>${getTildePath(value)}</a>`;
+          mdString += `<a href='${value}'>${getTildePath(value as string)}</a>`;
         } else if (key.includes("version")) {
-          const versionInfo = value.split(/\r?\n/); // first part of versionInfo has the version no., the second part has message (if any)
+          const versionInfo = (value as string).split(/\r?\n/); // first part of versionInfo has the version no., the second part has message (if any)
           mdString += `\`${versionInfo[0]}\`\n`;
           if (versionInfo[1]) {
             mdString += `*<span style="color:${WARNING_COLOR};">${versionInfo[1]}*\n`;
           }
         } else if (key.includes("location")) {
-          mdString += `${getTildePath(value)}\n`;
+          mdString += `${getTildePath(value as string)}\n`;
         } else {
           mdString += `${value}\n`;
         }

--- a/src/features/welcomePage/welcomePagePanel.ts
+++ b/src/features/welcomePage/welcomePagePanel.ts
@@ -35,7 +35,7 @@ export class WelcomePagePanel {
     this._panel.webview.html = this.getWebviewHtml(context);
 
     this._panel.webview.onDidReceiveMessage(
-      async (message) => {
+      async (message: WebviewMessage) => {
         await this.handleMessage(message);
       },
       undefined,

--- a/test/unit/configurationMiddleware.test.ts
+++ b/test/unit/configurationMiddleware.test.ts
@@ -1,7 +1,17 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { makeConfigurationMiddleware } from "@src/extension";
 import type { PythonEnvironmentService } from "@src/services/PythonEnvironmentService";
+import type {
+  CancellationToken,
+  ConfigurationParams,
+  LSPAny,
+} from "vscode-languageserver-protocol";
+import type { HandlerResult } from "vscode-jsonrpc";
+
+type ConfigurationNext = (
+  params: ConfigurationParams,
+  token: CancellationToken,
+) => HandlerResult<LSPAny[], void>;
 
 describe("makeConfigurationMiddleware", function () {
   let mockPythonEnvService: {
@@ -12,12 +22,16 @@ describe("makeConfigurationMiddleware", function () {
     appendLine: ReturnType<typeof vi.fn>;
   };
   let middleware: ReturnType<typeof makeConfigurationMiddleware>;
-  let mockNext: ReturnType<typeof vi.fn>;
+  let mockNext: ReturnType<typeof vi.fn<ConfigurationNext>>;
 
-  const mockToken = {
+  const mockToken: CancellationToken = {
     isCancellationRequested: false,
     onCancellationRequested: vi.fn(),
   };
+
+  async function invokeMiddleware(params: ConfigurationParams) {
+    return middleware(params, mockToken, mockNext);
+  }
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -36,37 +50,29 @@ describe("makeConfigurationMiddleware", function () {
       mockOutputChannel as unknown as import("vscode").OutputChannel,
     );
 
-    mockNext = vi.fn();
+    mockNext = vi.fn<ConfigurationNext>();
   });
 
   it("should pass through non-ansible config sections unchanged", async function () {
-    const params = { items: [{ section: "editor" }] };
+    const params: ConfigurationParams = { items: [{ section: "editor" }] };
     const originalResult = [{ fontSize: 14 }];
     mockNext.mockResolvedValue(originalResult);
 
-    const result = await middleware(
-      params as any,
-      mockToken as any,
-      mockNext as any,
-    );
+    const result = await invokeMiddleware(params);
 
     expect(result).toEqual(originalResult);
     expect(mockPythonEnvService.getExecutablePath).not.toHaveBeenCalled();
   });
 
   it("should inject resolved path when interpreterPath is not set", async function () {
-    const params = { items: [{ section: "ansible" }] };
+    const params: ConfigurationParams = { items: [{ section: "ansible" }] };
     const originalResult = [{ python: { activationScript: "" } }];
     mockNext.mockResolvedValue(originalResult);
     mockPythonEnvService.getExecutablePath.mockResolvedValue(
       "/home/user/.venv/bin/python",
     );
 
-    const result = await middleware(
-      params as any,
-      mockToken as any,
-      mockNext as any,
-    );
+    const result = await invokeMiddleware(params);
 
     const config = (result as Record<string, unknown>[])[0];
     const pythonConfig = config.python as Record<string, unknown>;
@@ -77,17 +83,13 @@ describe("makeConfigurationMiddleware", function () {
   });
 
   it("should respect user-configured interpreterPath and not override it", async function () {
-    const params = { items: [{ section: "ansible" }] };
+    const params: ConfigurationParams = { items: [{ section: "ansible" }] };
     const originalResult = [
       { python: { interpreterPath: "/usr/local/bin/python3" } },
     ];
     mockNext.mockResolvedValue(originalResult);
 
-    const result = await middleware(
-      params as any,
-      mockToken as any,
-      mockNext as any,
-    );
+    const result = await invokeMiddleware(params);
 
     const config = (result as Record<string, unknown>[])[0];
     const pythonConfig = config.python as Record<string, unknown>;
@@ -99,19 +101,19 @@ describe("makeConfigurationMiddleware", function () {
   });
 
   it("should log when transitioning from a path to no path", async function () {
-    const params = { items: [{ section: "ansible" }] };
+    const params: ConfigurationParams = { items: [{ section: "ansible" }] };
 
     // First call — env resolves a path; mockNext returns a fresh object
     mockNext.mockResolvedValue([{ python: {} }]);
     mockPythonEnvService.getExecutablePath.mockResolvedValue(
       "/home/user/.venv/bin/python",
     );
-    await middleware(params as any, mockToken as any, mockNext as any);
+    await invokeMiddleware(params);
 
     // Second call — env returns nothing; fresh object avoids mutation leak
     mockNext.mockResolvedValue([{ python: {} }]);
     mockPythonEnvService.getExecutablePath.mockResolvedValue(undefined);
-    await middleware(params as any, mockToken as any, mockNext as any);
+    await invokeMiddleware(params);
 
     expect(mockOutputChannel.appendLine).toHaveBeenCalledWith(
       expect.stringContaining("No Python environment available"),
@@ -119,18 +121,14 @@ describe("makeConfigurationMiddleware", function () {
   });
 
   it("should handle config with no python section", async function () {
-    const params = { items: [{ section: "ansible" }] };
+    const params: ConfigurationParams = { items: [{ section: "ansible" }] };
     const originalResult = [{ ansible: { path: "/usr/bin/ansible" } }];
     mockNext.mockResolvedValue(originalResult);
     mockPythonEnvService.getExecutablePath.mockResolvedValue(
       "/usr/bin/python3",
     );
 
-    const result = await middleware(
-      params as any,
-      mockToken as any,
-      mockNext as any,
-    );
+    const result = await invokeMiddleware(params);
 
     const config = (result as Record<string, unknown>[])[0];
     const pythonConfig = config.python as Record<string, unknown>;
@@ -138,22 +136,18 @@ describe("makeConfigurationMiddleware", function () {
   });
 
   it("should handle null/undefined config entries", async function () {
-    const params = { items: [{ section: "ansible" }] };
+    const params: ConfigurationParams = { items: [{ section: "ansible" }] };
     const originalResult = [undefined];
     mockNext.mockResolvedValue(originalResult);
 
-    const result = await middleware(
-      params as any,
-      mockToken as any,
-      mockNext as any,
-    );
+    const result = await invokeMiddleware(params);
 
     expect(result).toEqual([undefined]);
     expect(mockPythonEnvService.getExecutablePath).not.toHaveBeenCalled();
   });
 
   it("should call getExecutablePath when scopeUri is present", async function () {
-    const params = {
+    const params: ConfigurationParams = {
       items: [{ section: "ansible", scopeUri: "file:///workspace/project" }],
     };
     const originalResult = [{ python: {} }];
@@ -162,11 +156,7 @@ describe("makeConfigurationMiddleware", function () {
       "/workspace/.venv/bin/python",
     );
 
-    const result = await middleware(
-      params as any,
-      mockToken as any,
-      mockNext as any,
-    );
+    const result = await invokeMiddleware(params);
 
     expect(mockPythonEnvService.getExecutablePath).toHaveBeenCalledTimes(1);
     const config = (result as Record<string, unknown>[])[0];
@@ -175,7 +165,7 @@ describe("makeConfigurationMiddleware", function () {
   });
 
   it("should handle multiple config items in a single request", async function () {
-    const params = {
+    const params: ConfigurationParams = {
       items: [
         { section: "editor" },
         { section: "ansible" },
@@ -192,11 +182,7 @@ describe("makeConfigurationMiddleware", function () {
       "/resolved/python",
     );
 
-    const result = await middleware(
-      params as any,
-      mockToken as any,
-      mockNext as any,
-    );
+    const result = await invokeMiddleware(params);
 
     const editorConfig = (result as Record<string, unknown>[])[0];
     expect(editorConfig).toEqual({ fontSize: 14 });
@@ -213,22 +199,18 @@ describe("makeConfigurationMiddleware", function () {
   });
 
   it("should return non-array results from next() unchanged", async function () {
-    const params = { items: [{ section: "ansible" }] };
+    const params: ConfigurationParams = { items: [{ section: "ansible" }] };
     const nonArrayResult = "unexpected";
-    mockNext.mockResolvedValue(nonArrayResult);
+    mockNext.mockResolvedValue(nonArrayResult as unknown as LSPAny[]);
 
-    const result = await middleware(
-      params as any,
-      mockToken as any,
-      mockNext as any,
-    );
+    const result = await invokeMiddleware(params);
 
     expect(result).toBe(nonArrayResult);
     expect(mockPythonEnvService.getExecutablePath).not.toHaveBeenCalled();
   });
 
   it("should preserve existing python config properties when injecting", async function () {
-    const params = { items: [{ section: "ansible" }] };
+    const params: ConfigurationParams = { items: [{ section: "ansible" }] };
     const originalResult = [
       { python: { activationScript: "/path/to/activate" } },
     ];
@@ -237,11 +219,7 @@ describe("makeConfigurationMiddleware", function () {
       "/injected/python",
     );
 
-    const result = await middleware(
-      params as any,
-      mockToken as any,
-      mockNext as any,
-    );
+    const result = await invokeMiddleware(params);
 
     const config = (result as Record<string, unknown>[])[0];
     const pythonConfig = config.python as Record<string, unknown>;
@@ -250,7 +228,7 @@ describe("makeConfigurationMiddleware", function () {
   });
 
   it("should only log once when same path is injected multiple times", async function () {
-    const params = { items: [{ section: "ansible" }] };
+    const params: ConfigurationParams = { items: [{ section: "ansible" }] };
     mockPythonEnvService.getExecutablePath.mockResolvedValue(
       "/home/user/.venv/bin/python",
     );
@@ -258,7 +236,7 @@ describe("makeConfigurationMiddleware", function () {
     // Each call returns a fresh object to avoid mutation leakage
     for (let n = 0; n < 3; n++) {
       mockNext.mockResolvedValue([{ python: {} }]);
-      await middleware(params as any, mockToken as any, mockNext as any);
+      await invokeMiddleware(params);
     }
 
     expect(mockOutputChannel.appendLine).toHaveBeenCalledTimes(1);
@@ -268,13 +246,13 @@ describe("makeConfigurationMiddleware", function () {
   });
 
   it("should log when transitioning between user-configured and auto-resolved with same path", async function () {
-    const params = { items: [{ section: "ansible" }] };
+    const params: ConfigurationParams = { items: [{ section: "ansible" }] };
 
     // First call: user has configured path
     mockNext.mockResolvedValue([
       { python: { interpreterPath: "/usr/bin/python3" } },
     ]);
-    await middleware(params as any, mockToken as any, mockNext as any);
+    await invokeMiddleware(params);
 
     // Should log user-configured
     expect(mockOutputChannel.appendLine).toHaveBeenCalledWith(
@@ -286,7 +264,7 @@ describe("makeConfigurationMiddleware", function () {
     mockPythonEnvService.getExecutablePath.mockResolvedValue(
       "/usr/bin/python3",
     );
-    await middleware(params as any, mockToken as any, mockNext as any);
+    await invokeMiddleware(params);
 
     // Should STILL log because source changed (user → auto-resolved)
     expect(mockOutputChannel.appendLine).toHaveBeenCalledWith(
@@ -295,14 +273,10 @@ describe("makeConfigurationMiddleware", function () {
   });
 
   it("should handle errors from next() gracefully", async function () {
-    const params = { items: [{ section: "ansible" }] };
+    const params: ConfigurationParams = { items: [{ section: "ansible" }] };
     mockNext.mockRejectedValue(new Error("Configuration fetch failed"));
 
-    const result = await middleware(
-      params as any,
-      mockToken as any,
-      mockNext as any,
-    );
+    const result = await invokeMiddleware(params);
 
     // Should return empty array and log error
     expect(result).toEqual([]);
@@ -312,17 +286,13 @@ describe("makeConfigurationMiddleware", function () {
   });
 
   it("should handle errors from getExecutablePath gracefully", async function () {
-    const params = { items: [{ section: "ansible" }] };
+    const params: ConfigurationParams = { items: [{ section: "ansible" }] };
     mockNext.mockResolvedValue([{ python: {} }]);
     mockPythonEnvService.getExecutablePath.mockRejectedValue(
       new Error("Python env resolution failed"),
     );
 
-    const result = await middleware(
-      params as any,
-      mockToken as any,
-      mockNext as any,
-    );
+    const result = await invokeMiddleware(params);
 
     // Should return unmodified result and log error once
     expect(result).toEqual([{ python: {} }]);
@@ -337,14 +307,14 @@ describe("makeConfigurationMiddleware", function () {
       new Error("Python env resolution failed"),
     );
 
-    await middleware(params as any, mockToken as any, mockNext as any);
+    await invokeMiddleware(params);
 
     // Should NOT log again
     expect(mockOutputChannel.appendLine).not.toHaveBeenCalled();
   });
 
   it("should expand tilde in user-configured interpreterPath", async function () {
-    const params = { items: [{ section: "ansible" }] };
+    const params: ConfigurationParams = { items: [{ section: "ansible" }] };
     const originalResult = [
       {
         python: {
@@ -359,11 +329,7 @@ describe("makeConfigurationMiddleware", function () {
       "/home/user/.local/share/virtualenvs/vsa/bin/python",
     );
 
-    const result = await middleware(
-      params as any,
-      mockToken as any,
-      mockNext as any,
-    );
+    const result = await invokeMiddleware(params);
 
     const config = (result as Record<string, unknown>[])[0];
     const pythonConfig = config.python as Record<string, unknown>;

--- a/test/unit/lightspeed/parsePlays.test.ts
+++ b/test/unit/lightspeed/parsePlays.test.ts
@@ -2,10 +2,22 @@ import assert from "assert";
 import * as yaml from "yaml";
 import { parsePlays } from "@src/features/lightspeed/utils/parsePlays";
 
-function parseYaml(yamlString: string) {
-  return yaml.parse(yamlString, {
+function parseYaml(yamlString: string): unknown[] {
+  const parsed: unknown = yaml.parse(yamlString, {
     keepSourceTokens: true,
   });
+  if (!Array.isArray(parsed)) {
+    throw new Error("Expected YAML array");
+  }
+  return parsed;
+}
+
+function getName(item: unknown): string | undefined {
+  if (typeof item !== "object" || item === null || !("name" in item)) {
+    return undefined;
+  }
+  const name = (item as { name?: unknown }).name;
+  return typeof name === "string" ? name : undefined;
 }
 
 describe("parsePlays", function () {
@@ -24,8 +36,8 @@ describe("parsePlays", function () {
     const out = parsePlays(parseYaml(PLAYBOOK));
     assert.ok(out);
     assert.equal(out.length, 2);
-    assert.equal(out[0].name, "Task 1");
-    assert.equal(out[1].name, "Task 2");
+    assert.equal(getName(out[0]), "Task 1");
+    assert.equal(getName(out[1]), "Task 2");
   });
 
   it("Test a playbook without tasks", function () {
@@ -38,7 +50,7 @@ describe("parsePlays", function () {
     const out = parsePlays(parseYaml(PLAYBOOK));
     assert.ok(out);
     assert.equal(out.length, 1);
-    assert.equal(out[0].name, "Test 2");
+    assert.equal(getName(out[0]), "Test 2");
   });
 
   it("Test a playbook with multiple plays", function () {
@@ -62,9 +74,9 @@ describe("parsePlays", function () {
     const out = parsePlays(parseYaml(PLAYBOOK));
     assert.ok(out);
     assert.equal(out.length, 4);
-    assert.equal(out[0].name, "Test 3-1");
-    assert.equal(out[1].name, "Task 1");
-    assert.equal(out[2].name, undefined);
-    assert.equal(out[3].name, undefined);
+    assert.equal(getName(out[0]), "Test 3-1");
+    assert.equal(getName(out[1]), "Task 1");
+    assert.equal(getName(out[2]), undefined);
+    assert.equal(getName(out[3]), undefined);
   });
 });

--- a/test/unit/lightspeed/views/lightspeedUtils.test.ts
+++ b/test/unit/lightspeed/views/lightspeedUtils.test.ts
@@ -11,6 +11,8 @@ import type {
   ExplanationResponseParams,
   GenerationListEntry,
 } from "@src/interfaces/lightspeed";
+import { RoleFileType } from "@src/interfaces/lightspeed";
+import type { LightSpeedAPI } from "@src/features/lightspeed/api";
 import { IError, isError } from "@src/features/lightspeed/utils/errors";
 import {
   TEST_PROMPTS,
@@ -63,7 +65,7 @@ vi.mock("vscode", async () => {
 import { lightSpeedManager } from "@src/extension";
 
 describe("lightspeedUtils", () => {
-  let mockApiInstance: typeof lightSpeedManager.apiInstance;
+  let mockApiInstance: LightSpeedAPI;
   let mockProviderManager: typeof lightSpeedManager.providerManager;
 
   beforeEach(() => {
@@ -74,7 +76,7 @@ describe("lightspeedUtils", () => {
       PROVIDER_TYPES.GOOGLE;
 
     // Get references to mocks
-    mockApiInstance = lightSpeedManager.apiInstance;
+    mockApiInstance = lightSpeedManager.apiInstance as LightSpeedAPI;
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     mockProviderManager = lightSpeedManager.providerManager!;
   });
@@ -92,8 +94,7 @@ describe("lightspeedUtils", () => {
       generatePlaybookMock.mockResolvedValue(mockLLMResponse);
 
       const result = await generatePlaybook(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        mockApiInstance as any,
+        mockApiInstance,
         TEST_PROMPTS.INSTALL_NGINX,
         "",
         "test-generation-id",
@@ -124,8 +125,7 @@ describe("lightspeedUtils", () => {
       generatePlaybook2.mockResolvedValue(mockLLMResponse);
 
       const result = await generatePlaybook(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        mockApiInstance as any,
+        mockApiInstance,
         TEST_PROMPTS.INSTALL_NGINX,
         customOutline,
         "test-generation-id",
@@ -151,8 +151,7 @@ describe("lightspeedUtils", () => {
       generatePlaybook3.mockRejectedValue(new Error(errorMessage));
 
       const result = await generatePlaybook(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        mockApiInstance as any,
+        mockApiInstance,
         TEST_PROMPTS.INSTALL_NGINX,
         "",
         "test-generation-id",
@@ -180,8 +179,7 @@ describe("lightspeedUtils", () => {
       playbookGenerationRequest.mockResolvedValue(mockWCAResponse);
 
       const result = await generatePlaybook(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        mockApiInstance as any,
+        mockApiInstance,
         TEST_PROMPTS.INSTALL_NGINX,
         "",
         "test-generation-id",
@@ -211,8 +209,7 @@ describe("lightspeedUtils", () => {
       chatRequest.mockResolvedValue(mockChatResponse);
 
       const result = await explainPlaybook(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        mockApiInstance as any,
+        mockApiInstance,
         playbookContent,
         explanationId,
       );
@@ -237,8 +234,7 @@ describe("lightspeedUtils", () => {
       chatRequest2.mockRejectedValue(new Error(errorMessage));
 
       const result = await explainPlaybook(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        mockApiInstance as any,
+        mockApiInstance,
         playbookContent,
         "test-explanation-id",
       );
@@ -265,8 +261,7 @@ describe("lightspeedUtils", () => {
       explanationRequest.mockResolvedValue(mockWCAResponse);
 
       const result = await explainPlaybook(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        mockApiInstance as any,
+        mockApiInstance,
         playbookContent,
         explanationId,
       );
@@ -292,8 +287,7 @@ describe("lightspeedUtils", () => {
       generateRoleMock.mockResolvedValue(mockLLMResponse);
 
       const result = await generateRole(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        mockApiInstance as any,
+        mockApiInstance,
         roleName,
         TEST_PROMPTS.CREATE_ROLE,
         "",
@@ -313,8 +307,7 @@ describe("lightspeedUtils", () => {
           {
             path: "tasks/main.yml",
             content: mockLLMResponse.content,
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            file_type: "task" as any,
+            file_type: RoleFileType.Task,
           },
         ],
         name: roleName,
@@ -335,8 +328,7 @@ describe("lightspeedUtils", () => {
       generateRole2.mockResolvedValue(mockLLMResponse);
 
       const result = await generateRole(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        mockApiInstance as any,
+        mockApiInstance,
         roleName,
         TEST_PROMPTS.CREATE_ROLE,
         customOutline,
@@ -368,8 +360,7 @@ describe("lightspeedUtils", () => {
       generateRole3.mockResolvedValue(mockLLMResponse);
 
       const result = await generateRole(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        mockApiInstance as any,
+        mockApiInstance,
         undefined,
         TEST_PROMPTS.CREATE_ROLE,
         "",
@@ -388,8 +379,7 @@ describe("lightspeedUtils", () => {
       generateRole4.mockRejectedValue(new Error(errorMessage));
 
       const result = await generateRole(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        mockApiInstance as any,
+        mockApiInstance,
         "test-role",
         TEST_PROMPTS.CREATE_ROLE,
         "",
@@ -413,8 +403,7 @@ describe("lightspeedUtils", () => {
           {
             path: "tasks/main.yml",
             content: ANSIBLE_CONTENT.SINGLE_TASK,
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            file_type: "task" as any,
+            file_type: RoleFileType.Task,
           },
         ],
         name: roleName,
@@ -428,8 +417,7 @@ describe("lightspeedUtils", () => {
       roleGenerationRequest.mockResolvedValue(mockWCAResponse);
 
       const result = await generateRole(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        mockApiInstance as any,
+        mockApiInstance,
         roleName,
         TEST_PROMPTS.CREATE_ROLE,
         "",
@@ -454,8 +442,7 @@ describe("lightspeedUtils", () => {
         {
           path: "tasks/main.yml",
           content: ANSIBLE_CONTENT.SINGLE_TASK,
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          file_type: "task" as any,
+          file_type: RoleFileType.Task,
         },
       ];
       const roleName = "test-role";
@@ -469,8 +456,7 @@ describe("lightspeedUtils", () => {
       chatRequest3.mockResolvedValue(mockChatResponse);
 
       const result = await explainRole(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        mockApiInstance as any,
+        mockApiInstance,
         roleFiles,
         roleName,
         explanationId,
@@ -497,14 +483,12 @@ describe("lightspeedUtils", () => {
         {
           path: "tasks/main.yml",
           content: ANSIBLE_CONTENT.SINGLE_TASK,
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          file_type: "task" as any,
+          file_type: RoleFileType.Task,
         },
         {
           path: "handlers/main.yml",
           content: "- name: restart nginx",
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          file_type: "handler" as any,
+          file_type: RoleFileType.Handler,
         },
       ];
       const roleName = "test-role";
@@ -518,8 +502,7 @@ describe("lightspeedUtils", () => {
       chatRequest4.mockResolvedValue(mockChatResponse);
 
       const result = await explainRole(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        mockApiInstance as any,
+        mockApiInstance,
         roleFiles,
         roleName,
         explanationId,
@@ -547,8 +530,7 @@ describe("lightspeedUtils", () => {
         {
           path: "tasks/main.yml",
           content: ANSIBLE_CONTENT.SINGLE_TASK,
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          file_type: "task" as any,
+          file_type: RoleFileType.Task,
         },
       ];
       const errorMessage = "Role explanation failed";
@@ -556,8 +538,7 @@ describe("lightspeedUtils", () => {
       chatRequest5.mockRejectedValue(new Error(errorMessage));
 
       const result = await explainRole(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        mockApiInstance as any,
+        mockApiInstance,
         roleFiles,
         "test-role",
         "test-explanation-id",
@@ -577,8 +558,7 @@ describe("lightspeedUtils", () => {
         {
           path: "tasks/main.yml",
           content: ANSIBLE_CONTENT.SINGLE_TASK,
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          file_type: "task" as any,
+          file_type: RoleFileType.Task,
         },
       ];
       const roleName = "test-role";
@@ -595,8 +575,7 @@ describe("lightspeedUtils", () => {
       roleExplanationRequest.mockResolvedValue(mockWCAResponse);
 
       const result = await explainRole(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        mockApiInstance as any,
+        mockApiInstance,
         roleFiles,
         roleName,
         explanationId,

--- a/test/unit/lightspeed/views/webviewMessageHandlers.test.ts
+++ b/test/unit/lightspeed/views/webviewMessageHandlers.test.ts
@@ -301,16 +301,15 @@ describe("WebviewMessageHandlers", () => {
 
   describe("System handlers", () => {
     it("should handle getHomeDirectory with workspace folders", () => {
-      const mockWorkspaceFolders = [
+      const mockWorkspaceFolders: readonly vscode.WorkspaceFolder[] = [
         {
-          uri: { fsPath: "/workspace/path" },
+          uri: { fsPath: "/workspace/path" } as vscode.Uri,
           name: "workspace",
           index: 0,
         },
       ];
       vi.spyOn(vscode.workspace, "workspaceFolders", "get").mockReturnValue(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        mockWorkspaceFolders as any,
+        mockWorkspaceFolders,
       );
 
       const message = { type: "getHomeDirectory", data: {} };
@@ -323,16 +322,15 @@ describe("WebviewMessageHandlers", () => {
     });
 
     it("should handle ui-mounted with workspace folders", () => {
-      const mockWorkspaceFolders = [
+      const mockWorkspaceFolders: readonly vscode.WorkspaceFolder[] = [
         {
-          uri: { fsPath: "/workspace/path" },
+          uri: { fsPath: "/workspace/path" } as vscode.Uri,
           name: "workspace",
           index: 0,
         },
       ];
       vi.spyOn(vscode.workspace, "workspaceFolders", "get").mockReturnValue(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        mockWorkspaceFolders as any,
+        mockWorkspaceFolders,
       );
 
       const message = { type: "ui-mounted", data: {} };
@@ -370,7 +368,7 @@ describe("WebviewMessageHandlers", () => {
         data: { content: "test playbook" },
       };
 
-      messageHandlers["handleSetPlaybookData"](message, mockWebview);
+      messageHandlers["handleSetData"](message, mockWebview);
 
       expect(mockWebview.postMessage).toHaveBeenCalledWith({
         type: "setPlaybookData",
@@ -384,7 +382,7 @@ describe("WebviewMessageHandlers", () => {
         data: { content: "test role" },
       };
 
-      messageHandlers["handleSetRoleData"](message, mockWebview);
+      messageHandlers["handleSetData"](message, mockWebview);
 
       expect(mockWebview.postMessage).toHaveBeenCalledWith({
         type: "setRoleData",
@@ -965,16 +963,15 @@ describe("WebviewMessageHandlers", () => {
 
   describe("Helper methods", () => {
     it("should get workspace folder when it exists", () => {
-      const mockWorkspaceFolders = [
+      const mockWorkspaceFolders: readonly vscode.WorkspaceFolder[] = [
         {
-          uri: { path: "/workspace/path" },
+          uri: { path: "/workspace/path" } as vscode.Uri,
           name: "workspace",
           index: 0,
         },
       ];
       vi.spyOn(vscode.workspace, "workspaceFolders", "get").mockReturnValue(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        mockWorkspaceFolders as any,
+        mockWorkspaceFolders,
       );
 
       const result = messageHandlers["getWorkspaceFolder"]();

--- a/test/unit/mcp/mcpServerIntegration.test.ts
+++ b/test/unit/mcp/mcpServerIntegration.test.ts
@@ -138,12 +138,15 @@ describe("MCP server integration — packaged extension simulation", function ()
     // must fall back to the direct packaged path to find the CLI.
     const provider = new AnsibleMcpServerProvider(tempDir);
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const cliPath = (provider as any).findCliPath();
+    const cliPath = (
+      provider as unknown as { findCliPath: () => string | null }
+    ).findCliPath();
 
     expect(cliPath).not.toBeNull();
     expect(cliPath).toContain("cli.cjs");
-    expect(fs.existsSync(cliPath)).toBe(true);
+    if (cliPath !== null) {
+      expect(fs.existsSync(cliPath)).toBe(true);
+    }
   });
 
   it("MCP server should start and list tools via JSON-RPC stdio", async function () {

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -58,6 +58,8 @@ function ensureSettings(settings: Record<string, string | boolean>): void {
 }
 
 export function resetSettings(): void {
-  const settings = JSON.parse(fs.readFileSync(originalSettingsPath, "utf-8"));
+  const settings = JSON.parse(
+    fs.readFileSync(originalSettingsPath, "utf-8"),
+  ) as Record<string, string | boolean>;
   ensureSettings(settings);
 }

--- a/test/wdio/sidebar.spec.ts
+++ b/test/wdio/sidebar.spec.ts
@@ -18,7 +18,7 @@ describe("Sidebar and settings", () => {
     const title = await sideBar.getTitlePart().getTitle();
     assert.match(title, /Ansible Development Tools/i);
 
-    const workspaceFolder = await browser.executeWorkbench((vscode) => {
+    const workspaceFolder: string = await browser.executeWorkbench((vscode) => {
       return vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? "";
     });
     if (workspaceFolder) {

--- a/webviews/lightspeed/src/utils/vscode.ts
+++ b/webviews/lightspeed/src/utils/vscode.ts
@@ -44,9 +44,9 @@ class WebviewApi<StateType = unknown> {
 
     this.webviewApi = acquireVsCodeApi<StateType>();
     window.addEventListener("message", (event: MessageEvent) => {
-      const message = event.data || {};
+      const message = (event.data ?? {}) as Record<string, unknown>;
       this._runListener(
-        message[this._options.typeKey],
+        message[this._options.typeKey] as string | number | undefined,
         message[this._options.dataKey],
       );
     });


### PR DESCRIPTION
Related: AAP-66052

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Enabled the `@typescript-eslint/no-unsafe-argument` rule and fixed violations by adding explicit type assertions/casts and tightened typings across the codebase to satisfy the new lint constraint.

- Enabled rule in root eslint.config.mjs
- Added targeted type assertions/casts in language-server, completion providers, utilities, tests, webviews, Lightspeed, MCP server, and other features
- Minor refactors to function signatures and error handling to improve type safety

related: AAP-66052
<!-- end of auto-generated comment: release notes by coderabbit.ai -->