### PR TITLE
chore: build logic fixes to avoid duplicate runs

### DIFF
--- a/.agents/skills/diagnose-ci/SKILL.md
+++ b/.agents/skills/diagnose-ci/SKILL.md
@@ -116,7 +116,7 @@ Check what exists in the repo root:
 
 ```text
 if Taskfile.yml exists AND package.json exists -> TypeScript project
-   lint command:  task lint / npx prek run --all-files
+   lint command:  task lint / prek run --all-files
    build command: task build
    test command:  task test
    package command: task package (runs knip, builds artifacts)
@@ -159,8 +159,8 @@ ordered by frequency within each toolchain.
 | 4 | **Knip dead code** | `Failed to run task "knip"`, `Extension in project not registered` | Update `knip.ts` config — remove unregistered extensions, suppress pre-existing unused types |
 | 5 | **Build artifact missing** | `ENOENT` referencing `dist/` or `.bin/` | Run build first, workspace dep may need rebuild |
 | 6 | **Test failure** | `AssertionError`, `expect(` failure | Read the failing test, update to match new dep API |
-| 7 | **prek/formatter** | `Files were modified by following hooks`, `prek exited with code 1` | Run `npx prek run --all-files` locally, commit the formatted files |
-| 8 | **Biome formatting** | `biome check` diff output | Run `npx biome check --write --unsafe`, commit changes |
+| 7 | **prek/formatter** | `Files were modified by following hooks`, `prek exited with code 1` | Run `prek run --all-files` locally, commit the formatted files |
+| 8 | **Biome formatting** | `biome check` diff output | Run `npm exec -- biome check --write --unsafe`, commit changes |
 
 ### Python/tox failures
 

--- a/.agents/skills/fix-bot-prs/SKILL.md
+++ b/.agents/skills/fix-bot-prs/SKILL.md
@@ -162,7 +162,7 @@ Commit the regenerated lockfile.
 
 **Formatter/linter auto-fix:**
 ```bash
-npx prek run --all-files    # TypeScript
+prek run --all-files    # TypeScript
 tox -e lint                 # Python (some linters auto-fix)
 ```
 Commit any auto-formatted files.

--- a/.agents/skills/verify-local/SKILL.md
+++ b/.agents/skills/verify-local/SKILL.md
@@ -134,7 +134,7 @@ Do NOT pipe the command through other commands when capturing exit codes
 |---|-------|---------|------|-----------------|
 | 1 | build | `task build` | ~30s | TypeScript errors, missing exports, tsup bundling |
 | 2 | package | `task package` | ~45s | Knip dead code, npm packaging, vitest list |
-| 3 | lint | `npx prek run --all-files` | ~30s | ESLint, biome, ruff, codespell, cspell, yamllint, shellcheck |
+| 3 | lint | `prek run --all-files` | ~30s | ESLint, biome, ruff, codespell, cspell, yamllint, shellcheck |
 
 `task package` is the critical one — it runs knip which catches most
 lockfile-related breakage.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -155,8 +155,8 @@ jobs:
         run: |
           task build && task build --status
 
-      - name: task package
-        timeout-minutes: 4 # expected under 1 minutes
+      - name: task als:package
+        timeout-minutes: 4
         run: |
           task als:package && task als:package --status
 
@@ -164,18 +164,12 @@ jobs:
         if: >-
           steps.extract_context.outputs.context != '' &&
           !contains(steps.extract_context.outputs.tasks, steps.extract_context.outputs.context)
-        run: |
-          task ${{ steps.extract_context.outputs.context }}
+        run: task ${{ steps.extract_context.outputs.context }}
 
       - name: task docs
         timeout-minutes: 2
         run: |
           task docs && task docs --status
-
-      - name: task package
-        timeout-minutes: 4
-        run: |
-          task package -v && task package --status
 
       - name: task dry (check that test frameworks are not misconfigured, but do not run tests)
         run: task dry
@@ -187,6 +181,12 @@ jobs:
         timeout-minutes: 3
         run: |
           task lint
+
+      - name: task package
+        timeout-minutes: 4
+        run: |
+          task als:package && task als:package --status
+          task package && task package --status
 
       - name: task finish
         run: task finish

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
         priority: 1
       - id: md
         priority: 1
-        entry: npx markdownlint-cli2 --fix "**/*.md" "#node_modules" "#.agents"
+        entry: npm exec -- markdownlint-cli2 --fix "**/*.md" "#node_modules" "#.agents"
       # - id: codecov
       #   priority: 1
       - id: shellcheck
@@ -53,7 +53,7 @@ repos:
         language: system
         pass_filenames: false
         always_run: true
-        entry: npx biome check --write --unsafe
+        entry: npm exec -- biome check --write --unsafe
       - id: eslint
         name: eslint
         entry: pnpm exec eslint --no-warn-ignored --color --format=gha --fix --max-warnings=0 --concurrency=2

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@ This document provides guidelines for AI agents working on this codebase.
 
 - **Always validate changes**: Run `task lint` and `task test` and resolve any reported build issues.
 - **Avoid `__dirname`**: Do not use `__dirname` in new code. It doesn't work well with transpiled code as relative paths differ when files are transpiled. Use `PROJECT_ROOT` from `test/setup.ts` instead.
+- Always use `npm exec --` instead of `npx` because it can cause accidental installation of unversioned packages from `npmjs.com` when this is not desired, also they can prevent unattended usage occasionally.
 
 ## Pull Request Checklist
 

--- a/Taskfile.base.yml
+++ b/Taskfile.base.yml
@@ -32,8 +32,8 @@ tasks:
     generates:
       - "{{ .VIRTUAL_ENV }}/pyvenv.cfg"
       - "{{ .VIRTUAL_ENV }}/CACHEDIR.TAG"
-      - resources/contentCreator/createDevfile/devfile-template.txt
-      - resources/contentCreator/createDevcontainer/.devcontainer
+      - "{{ .TASKFILE_DIR }}/resources/contentCreator/createDevfile/devfile-template.txt"
+      - "{{ .TASKFILE_DIR }}/resources/contentCreator/createDevcontainer/.devcontainer/**/*.*"
     dir: "{{ .TASKFILE_DIR }}"
     sources:
       - pyproject.toml

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -233,9 +233,9 @@ tasks:
       - "{src,test}/**/*"
       - wdio.conf.ts
     cmds:
-      - "npx pnpm pretest:wdio"
+      - "pnpm pretest:wdio"
       - "node tools/ensure-chromedriver.mts"
-      - "{{.XVFB}}npx pnpm test:wdio"
+      - "{{.XVFB}}pnpm test:wdio"
     interactive: true
   unit:
     desc: Run unit tests with coverage report
@@ -279,7 +279,7 @@ tasks:
       - cmd: task als:package
       - cmd: task mcp:package
       # we want to build both all the time:
-      - node ./tools/helper.mts --package
+      - npm run package
       - node packages/ansible-language-server/tools/can-release.mts
       - task: knip
       - defer: { task: finish }

--- a/docs/development/test_code.md
+++ b/docs/development/test_code.md
@@ -44,7 +44,7 @@ Each type of test has its own script and can be run by `task <command>`:
 
     To run a single UI test spec, use the `--spec` flag:
 
-    `npx pnpm test:wdio -- --spec test/wdio/smoke.spec.ts`
+    `pnpm test:wdio -- --spec test/wdio/smoke.spec.ts`
 
 ### Language server test scripts
 

--- a/docs/mcp/README.md
+++ b/docs/mcp/README.md
@@ -325,7 +325,7 @@ You can test that the server starts correctly by sending an MCP
 
 ```bash
 echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"0.1"}}}' \
-  | npx -y @ansible/ansible-mcp-server --stdio
+  | npm exec -- ansible-mcp-server --stdio
 ```
 
 Or with the container:

--- a/packages/ansible-mcp-server/Taskfile.yml
+++ b/packages/ansible-mcp-server/Taskfile.yml
@@ -83,7 +83,6 @@ tasks:
     cmds:
       - rm -f {{ .GIT_ROOT }}/out/ansible-{{ .PROJECT }}-*.tgz
       - npm pkg set version={{ .VERSION }}
-      - pnpm exec tsup --silent
       - npm pack --silent --ignore-scripts --pack-destination '{{ .GIT_ROOT }}/out'
       - defer: npm pkg set version=0.0.0
     silent: false

--- a/test/README.md
+++ b/test/README.md
@@ -74,5 +74,5 @@ Run against real VS Code Electron using WebDriverIO (no container needed):
 To run a single spec file:
 
 ```shell
-    npx pnpm test:wdio -- --spec test/wdio/smoke.spec.ts
+    pnpm test:wdio -- --spec test/wdio/smoke.spec.ts
 ```

--- a/tools/helper.mts
+++ b/tools/helper.mts
@@ -179,12 +179,13 @@ function main(): void {
   const resolved = resolveVersion();
 
   if (wantVersion) {
-    logVersionResolution(resolved);
+    if (process.env.DEBUG === "1") {
+      logVersionResolution(resolved);
+    }
     console.log(resolved.version);
     return;
   }
 
-  logVersionResolution(resolved);
   const preReleaseArg = resolved.preRelease ? "--pre-release" : "";
 
   if (wantPublish) {
@@ -197,7 +198,9 @@ function main(): void {
       process.exit(2);
     }
     run([
-      "npx",
+      "npm",
+      "exec",
+      "--",
       "vsce",
       "publish",
       preReleaseArg,
@@ -207,17 +210,28 @@ function main(): void {
       "--readme-path",
       "docs/README.md",
     ]);
-    run(["npx", "ovsx", "publish", preReleaseArg, "--skip-duplicate", vsix]);
+    run([
+      "npm",
+      "exec",
+      "--",
+      "ovsx",
+      "publish",
+      preReleaseArg,
+      "--skip-duplicate",
+      vsix,
+    ]);
     return;
   }
 
   if (wantPackage) {
-    run(["npx", "rimraf", "-g", "./out/*.vsix"]);
+    run(["npm", "exec", "--", "rimraf", "-g", "./out/*.vsix"]);
     // --no-dependencies needed due to https://github.com/microsoft/vscode-vsce/issues/439
     // most options are supposed to be loaded from package.json but --no-update-package-json apparently is still needed
     const vsixFile = `out/ansible-${resolved.version}.vsix`;
     run([
-      "npx",
+      "npm",
+      "exec",
+      "--",
       "vsce",
       "package",
       "--no-update-package-json",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Replace ad-hoc npx usage with direct command execution or npm exec to avoid duplicate package-manager runs, prevent accidental unversioned installs, and standardize CI/build tooling invocations across the repo.

- Taskfile.yml: remove npx from wdio and package task commands
- .agents/skills/diagnose-ci/SKILL.md: invoke prek directly; update biome fix to npm exec form
- .agents/skills/fix-bot-prs/SKILL.md: run prek without npx
- .agents/skills/verify-local/SKILL.md: remove npx from TypeScript lint command
- .pre-commit-config.yaml: use npm exec for markdownlint-cli2 and biome hooks
- AGENTS.md: recommend npm exec -- instead of npx
- Taskfile.base.yml: use {{ .TASKFILE_DIR }}-prefixed dependency paths
- docs/development/test_code.md: update WDIO test example to remove npx pnpm
- docs/mcp/README.md: use npm exec for ansible-mcp-server invocation
- test/README.md: update WDIO spec command to remove npx
- tools/helper.mts: log version conditionally and switch release/package invocations to npm exec --
- packages/ansible-mcp-server/Taskfile.yml: adjust package flow to use build and npm pack

related: `#0000`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->