### PR TITLE
fix: @typescript-eslint/restrict-template-expressions

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -89,7 +89,7 @@ export default defineConfig(
       "@typescript-eslint/unbound-method": "error",
       // "@typescript-eslint/no-unsafe-member-access": "error", // ~550 errors
       // "@typescript-eslint/no-floating-promises": "error", // ~100 errors
-      // "@typescript-eslint/restrict-template-expressions": "error",
+      "@typescript-eslint/restrict-template-expressions": "error",
       "@typescript-eslint/no-unsafe-argument": "error",
       "@typescript-eslint/no-unsafe-return": "error",
     },

--- a/packages/ansible-language-server/src/providers/completionProviderUtils.ts
+++ b/packages/ansible-language-server/src/providers/completionProviderUtils.ts
@@ -7,6 +7,11 @@ import { existsSync, readFileSync } from "fs";
 
 type varType = { variable: string; priority: number };
 
+const getEnumerableKeys = (value: unknown): string[] =>
+  value !== null && typeof value === "object" && !Array.isArray(value)
+    ? Object.keys(value)
+    : [];
+
 type varsPromptType = {
   name: string;
   prompt: string;
@@ -49,12 +54,12 @@ export function getVarsCompletion(
 
           if (Array.isArray(varsObject)) {
             varsObject.forEach((element) => {
-              Object.keys(element as object).forEach((key) => {
+              getEnumerableKeys(element).forEach((key) => {
                 varsCompletion.push({ variable: key, priority: varPriority });
               });
             });
           } else {
-            Object.keys(varsObject as object).forEach((key) => {
+            getEnumerableKeys(varsObject).forEach((key) => {
               varsCompletion.push({ variable: key, priority: varPriority });
             });
           }
@@ -83,12 +88,12 @@ export function getVarsCompletion(
 
           if (Array.isArray(varsObject)) {
             varsObject.forEach((element) => {
-              Object.keys(element as object).forEach((key) => {
+              getEnumerableKeys(element).forEach((key) => {
                 varsCompletion.push({ variable: key, priority: varPriority });
               });
             });
           } else {
-            Object.keys(varsObject as object).forEach((key) => {
+            getEnumerableKeys(varsObject).forEach((key) => {
               varsCompletion.push({ variable: key, priority: varPriority });
             });
           }
@@ -145,7 +150,7 @@ export function getVarsCompletion(
           if (Array.isArray(yamlDocContent)) {
             yamlDocContent.forEach((element) => {
               if (typeof element === "object") {
-                Object.keys(element as object).forEach((key) => {
+                getEnumerableKeys(element).forEach((key) => {
                   varsCompletion.push({ variable: key, priority: varPriority });
                 });
               }

--- a/packages/ansible-language-server/src/providers/validationProvider.ts
+++ b/packages/ansible-language-server/src/providers/validationProvider.ts
@@ -190,7 +190,9 @@ async function getSchemaValidation(
   try {
     return schemaValidator.validate(textDocument, schema);
   } catch (err) {
-    connection?.console.error(`Schema validation error: ${err}`);
+    connection?.console.error(
+      `Schema validation error: ${err instanceof Error ? err.message : String(err)}`,
+    );
     return [];
   }
 }

--- a/packages/ansible-language-server/src/services/executionEnvironment.ts
+++ b/packages/ansible-language-server/src/services/executionEnvironment.ts
@@ -165,7 +165,7 @@ export class ExecutionEnvironment {
         );
 
         this.connection.console.log(
-          `Cached plugin paths: \n collections_paths: ${ansibleConfig.collections_paths} \n module_locations: ${ansibleConfig.module_locations}`,
+          `Cached plugin paths: \n collections_paths: ${ansibleConfig.collections_paths.join(", ")} \n module_locations: ${ansibleConfig.module_locations.join(", ")}`,
         );
       } else {
         /* v8 ignore next 4 */
@@ -184,7 +184,7 @@ export class ExecutionEnvironment {
         }
         /* v8 ignore next 38 */
         this.connection.console.log(
-          `Identified plugin paths by AnsibleConfig service: \n collections_paths: ${ansibleConfig.collections_paths} \n module_locations: ${ansibleConfig.module_locations}`,
+          `Identified plugin paths by AnsibleConfig service: \n collections_paths: ${ansibleConfig.collections_paths.join(", ")} \n module_locations: ${ansibleConfig.module_locations.join(", ")}`,
         );
         ansibleConfig.collections_paths = await this.copyPluginDocFiles(
           hostCacheBasePath,
@@ -223,7 +223,7 @@ export class ExecutionEnvironment {
       }
       /* v8 ignore next 6 */
       this.connection.console.log(
-        `Copied plugin paths by ExecutionEnvironment service: \n collections_paths: ${ansibleConfig.collections_paths} \n module_locations: ${ansibleConfig.module_locations}`,
+        `Copied plugin paths by ExecutionEnvironment service: \n collections_paths: ${ansibleConfig.collections_paths.join(", ")} \n module_locations: ${ansibleConfig.module_locations.join(", ")}`,
       );
       // plugin cache successfully created
       fs.closeSync(
@@ -458,7 +458,7 @@ export class ExecutionEnvironment {
         }
       } catch (error) {
         console.error(
-          `Error detected while trying to stop the container ${containerName}: ${error}`,
+          `Error detected while trying to stop the container ${containerName}: ${error instanceof Error ? error.message : String(error)}`,
         );
       }
     }
@@ -491,7 +491,7 @@ export class ExecutionEnvironment {
         }
       } catch (error) {
         console.error(
-          `Error detected while trying to remove the container ${containerName}: ${error}`,
+          `Error detected while trying to remove the container ${containerName}: ${error instanceof Error ? error.message : String(error)}`,
         );
       }
     }
@@ -610,7 +610,7 @@ export class ExecutionEnvironment {
       spawnSyncWithResult(containerEngine, runArgv);
     } catch (error) {
       this.connection.window.showErrorMessage(
-        `Failed to initialize execution environment '${this._container_image}': ${error}`,
+        `Failed to initialize execution environment '${this._container_image}': ${error instanceof Error ? error.message : String(error)}`,
       );
       return false;
     }

--- a/packages/ansible-language-server/src/services/metadataLibrary.ts
+++ b/packages/ansible-language-server/src/services/metadataLibrary.ts
@@ -88,7 +88,7 @@ export class MetadataLibrary {
         if (error instanceof Error) {
           msg = error.message;
         } else {
-          msg = `${error}`;
+          msg = error instanceof Error ? error.message : String(error);
         }
         this.connection.window.showErrorMessage(msg);
       }

--- a/packages/ansible-language-server/src/services/schemaCache.ts
+++ b/packages/ansible-language-server/src/services/schemaCache.ts
@@ -43,7 +43,9 @@ export class SchemaCache {
       this.connection.console.info(`Fetched schema: ${url}`);
       return schema;
     } catch (err) {
-      this.connection.console.warn(`Failed to fetch schema ${url}: ${err}`);
+      this.connection.console.warn(
+        `Failed to fetch schema ${url}: ${err instanceof Error ? err.message : String(err)}`,
+      );
       // Return stale cache if available
       return cached?.schema;
     }

--- a/packages/ansible-language-server/src/utils/docsFormatter.ts
+++ b/packages/ansible-language-server/src/utils/docsFormatter.ts
@@ -88,7 +88,7 @@ export function formatOption(
     );
   }
   if (option.choices) {
-    const formattedChoiceArray = option.choices.map((c) => `\`${c}\``);
+    const formattedChoiceArray = option.choices.map((c) => `\`${String(c)}\``);
     sections.push(`*Choices*: [${formattedChoiceArray.toString()}]`);
   }
   if (option.aliases) {

--- a/packages/ansible-language-server/src/utils/imagePuller.ts
+++ b/packages/ansible-language-server/src/utils/imagePuller.ts
@@ -69,7 +69,7 @@ export class ImagePuller {
         );
         setupComplete = true;
       } catch (error) {
-        let errorMsg = `Failed to pull container image ${this._containerEngine} with error '${error}'`;
+        let errorMsg = `Failed to pull container image ${this._containerEngine} with error '${error instanceof Error ? error.message : String(error)}'`;
         errorMsg +=
           "Check the execution environment image name, connectivity to and permissions for the registry, and try again";
         this.connection.console.error(errorMsg);

--- a/packages/ansible-language-server/test/providers/hoverProvider.test.ts
+++ b/packages/ansible-language-server/test/providers/hoverProvider.test.ts
@@ -268,7 +268,7 @@ function testNonPlaybookAdjacentCollection(
       } else {
         expect(
           get_hover_value(actualHover),
-          `actual hover -> ${actualHover}`,
+          `actual hover -> ${String(actualHover)}`,
         ).toContain(doc);
       }
     });

--- a/packages/ansible-language-server/test/utils/yaml.test.ts
+++ b/packages/ansible-language-server/test/utils/yaml.test.ts
@@ -32,9 +32,9 @@ describe("yaml", function () {
     ]);
     const reason = brokenTests.get(context.task?.name);
     if (isWindows() && reason && context.task) {
-      const msg = `Marked ${context.task.name} as pending due to ${reason}`;
+      const msg = `Marked ${context.task.name} as pending due to ${String(reason)}`;
       if (process.env.GITHUB_ACTIONS) {
-        console.log(`::warning file=${context.task.file}:: ${msg}`);
+        console.log(`::warning file=${String(context.task.file)}:: ${msg}`);
       } else {
         console.log(`🚩 ${msg}`);
       }

--- a/packages/ansible-mcp-server/src/tools/creator.ts
+++ b/packages/ansible-mcp-server/src/tools/creator.ts
@@ -115,7 +115,7 @@ export function createProjectsHandler(workspaceRoot: string) {
           content: [
             {
               type: "text" as const,
-              text: `Error: Invalid project type '${args.projectType}'. Must be either 'collection' or 'playbook'.\n`,
+              text: `Error: Invalid project type '${String(args.projectType)}'. Must be either 'collection' or 'playbook'.\n`,
             },
           ],
           isError: true,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -188,7 +188,9 @@ export async function activate(context: ExtensionContext): Promise<void> {
   try {
     await pythonInterpreterManager.updatePythonInfoInStatusbar();
   } catch (error) {
-    console.error(`Error updating python status bar: ${error}`);
+    console.error(
+      `Error updating python status bar: ${error instanceof Error ? error.message : String(error)}`,
+    );
   }
 
   // Subscribe to Python environment changes to update the status bar and LS
@@ -209,7 +211,9 @@ export async function activate(context: ExtensionContext): Promise<void> {
         await pythonInterpreterManager.updatePythonInfoInStatusbar();
         await metaData.updateAnsibleInfoInStatusbar();
       } catch (error) {
-        console.error(`Error updating after environment change: ${error}`);
+        console.error(
+          `Error updating after environment change: ${error instanceof Error ? error.message : String(error)}`,
+        );
       }
     }),
   );
@@ -912,7 +916,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
             );
           } catch (error) {
             console.error(
-              `[Lightspeed Playbook Feedback] Telemetry failed: ${error}`,
+              `[Lightspeed Playbook Feedback] Telemetry failed: ${error instanceof Error ? error.message : String(error)}`,
               error,
             );
           }
@@ -962,7 +966,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
             );
           } catch (error) {
             console.error(
-              `[Lightspeed Role Feedback] Telemetry failed: ${error}`,
+              `[Lightspeed Role Feedback] Telemetry failed: ${error instanceof Error ? error.message : String(error)}`,
               error,
             );
           }
@@ -1452,7 +1456,7 @@ export function makeConfigurationMiddleware(
         originalResult = await next(params, token);
       } catch (error) {
         outputChannel.appendLine(
-          `[Ansible] Configuration middleware error: ${error}`,
+          `[Ansible] Configuration middleware error: ${error instanceof Error ? error.message : String(error)}`,
         );
         return [] as unknown as LSPAny[];
       }
@@ -1513,7 +1517,7 @@ export function makeConfigurationMiddleware(
           // Treat resolution failure as "no path" - log once and leave config unchanged
           if (lastLoggedResolvedByScope.get(scopeUri) !== "") {
             outputChannel.appendLine(
-              `[Ansible] Failed to resolve Python environment: ${error}`,
+              `[Ansible] Failed to resolve Python environment: ${error instanceof Error ? error.message : String(error)}`,
             );
             lastLoggedResolvedByScope.set(scopeUri, "");
           }

--- a/src/features/ansibleTox/controller.ts
+++ b/src/features/ansibleTox/controller.ts
@@ -86,7 +86,9 @@ export class AnsibleToxController {
 
     const fileName = splittedPath.pop();
     if (fileName === undefined) {
-      throw new TypeError(`Expected filename as string from ${splittedPath}`);
+      throw new TypeError(
+        `Expected filename as string from ${splittedPath.join("/")}`,
+      );
     }
 
     const parentFolderName = splittedPath.pop();
@@ -211,7 +213,7 @@ export class AnsibleToxController {
         if (e instanceof Error) {
           msg = e.message;
         } else {
-          msg = `${e}`;
+          msg = e instanceof Error ? e.message : String(e);
         }
         run.failed(test, new vscode.TestMessage(msg), Date.now() - start);
       }

--- a/src/features/ansibleTox/provider.ts
+++ b/src/features/ansibleTox/provider.ts
@@ -32,17 +32,16 @@ export class AnsibleToxProvider implements vscode.TaskProvider {
   }
 
   public resolveTask(_task: vscode.Task): vscode.Task | undefined {
-    const testenv = _task.definition.ansible;
+    const definition = _task.definition as ToxTaskDefinition;
+    const testenv = definition.testenv;
     if (testenv) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const definition: ToxTaskDefinition = <any>_task.definition;
       return new vscode.Task(
         definition,
         _task.scope ?? vscode.TaskScope.Workspace,
-        definition.ansible as string,
+        testenv,
         AnsibleToxProvider.toxType,
         new vscode.ShellExecution(
-          `${ANSIBLE_TOX_RUN_COMMAND} ${definition.ansible} --ansible --conf tox-ansible.ini`,
+          `${ANSIBLE_TOX_RUN_COMMAND} ${testenv} --ansible --conf tox-ansible.ini`,
         ),
       );
     }

--- a/src/features/contentCreator/webviewUtils.ts
+++ b/src/features/contentCreator/webviewUtils.ts
@@ -40,10 +40,18 @@ interface MessageHandlerConfig {
 interface Message {
   type?: string;
   command?: string;
-  data?: any;
+  data?: unknown;
   homedir?: string;
   tempdir?: string;
-  arguments?: any;
+  arguments?: unknown;
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object";
 }
 
 class MessageRouter {
@@ -55,22 +63,50 @@ class MessageRouter {
     private commonState?: Partial<CommonWebviewState>,
   ) {
     this.typeHandlers = {
-      homeDirectory: (message) => this.onHomeDirectory(message.data as string),
-      folderSelected: (message) =>
-        this.onFolderSelected(message.data as string),
-      fileSelected: (message) => this.onFileSelected(message.data as string),
-      logs: (message) => this.onLogs(message.data as string),
+      homeDirectory: (message) => {
+        const data = asString(message.data);
+        if (data !== undefined) {
+          this.onHomeDirectory(data);
+        }
+      },
+      folderSelected: (message) => {
+        const data = asString(message.data);
+        if (data !== undefined) {
+          this.onFolderSelected(data);
+        }
+      },
+      fileSelected: (message) => {
+        const data = asString(message.data);
+        if (data !== undefined) {
+          this.onFileSelected(data);
+        }
+      },
+      logs: (message) => {
+        const data = asString(message.data);
+        if (data !== undefined) {
+          this.onLogs(data);
+        }
+      },
     };
 
     this.commandHandlers = {
       homedirAndTempdir: (message) => {
-        if (message.homedir && message.tempdir) {
-          this.onHomedirAndTempdir(message.homedir, message.tempdir);
+        const homedir = asString(message.homedir);
+        const tempdir = asString(message.tempdir);
+        if (homedir && tempdir) {
+          this.onHomedirAndTempdir(homedir, tempdir);
         }
       },
-      "execution-log": (message) => this.onExecutionLog(message.arguments),
-      ADEPresence: (message) =>
-        this.onADEPresence(message.arguments as boolean),
+      "execution-log": (message) => {
+        if (isRecord(message.arguments)) {
+          this.onExecutionLog(message.arguments);
+        }
+      },
+      ADEPresence: (message) => {
+        if (typeof message.arguments === "boolean") {
+          this.onADEPresence(message.arguments);
+        }
+      },
     };
   }
 
@@ -149,7 +185,18 @@ export function setupMessageHandler(
   const router = new MessageRouter(config, commonState);
 
   const messageHandler = (event: MessageEvent) => {
-    router.handle(event.data as Message);
+    const payload = event.data;
+    if (!isRecord(payload)) {
+      return;
+    }
+    const msg = payload as Message;
+    if (msg.type !== undefined && typeof msg.type !== "string") {
+      return;
+    }
+    if (msg.command !== undefined && typeof msg.command !== "string") {
+      return;
+    }
+    router.handle(msg);
   };
 
   window.addEventListener("message", messageHandler);

--- a/src/features/lightspeed/ansibleContext.ts
+++ b/src/features/lightspeed/ansibleContext.ts
@@ -267,15 +267,16 @@ Generate Ansible inventory content with:
       if (Array.isArray(parsed)) {
         // Task list or playbook
         for (const item of parsed) {
-          if (typeof item !== "object") {
+          if (!item || typeof item !== "object") {
             errors.push("Invalid task or play structure");
             continue;
           }
+          const taskOrPlay = item as Record<string, unknown>;
 
           // Check for required fields in tasks
           if (
-            "name" in item ||
-            Object.keys(item as object).some(
+            "name" in taskOrPlay ||
+            Object.keys(taskOrPlay).some(
               (key) => key !== "name" && !key.startsWith("_"),
             )
           ) {
@@ -292,7 +293,9 @@ Generate Ansible inventory content with:
         }
       }
     } catch (yamlError) {
-      errors.push(`YAML syntax error: ${yamlError}`);
+      errors.push(
+        `YAML syntax error: ${yamlError instanceof Error ? yamlError.message : String(yamlError)}`,
+      );
     }
 
     return { valid: errors.length === 0, errors };

--- a/src/features/lightspeed/contentMatchesWebview.ts
+++ b/src/features/lightspeed/contentMatchesWebview.ts
@@ -17,6 +17,15 @@ import {
   IError,
 } from "@src/features/lightspeed/utils/errors";
 
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
 export class ContentMatchesWebview implements vscode.WebviewViewProvider {
   public static readonly viewType = "ansible.lightspeed.trainingMatchPanel";
   private _view?: vscode.WebviewView;
@@ -229,7 +238,9 @@ export class ContentMatchesWebview implements vscode.WebviewViewProvider {
 
       const contentMatchValue = contentMatchResponses.contentmatches[taskIndex];
       const taskDescription =
-        typeof taskNameDescription === "string" ? taskNameDescription : "";
+        typeof taskNameDescription === "string"
+          ? escapeHtml(taskNameDescription)
+          : "";
       contentMatchesHtml += this.renderContentMatchWithTasKDescription(
         contentMatchValue.contentmatch,
         taskDescription,

--- a/src/features/lightspeed/errors.ts
+++ b/src/features/lightspeed/errors.ts
@@ -118,7 +118,7 @@ class Errors {
       keys.forEach((key, index) => {
         pretty =
           pretty +
-          `${key}: ${items[key]}` +
+          `${key}: ${String(items[key])}` +
           (index < keys.length - 1 ? " " : "");
       });
     }

--- a/src/features/lightspeed/inlineSuggestions.ts
+++ b/src/features/lightspeed/inlineSuggestions.ts
@@ -332,8 +332,11 @@ async function requestSuggestion(
       suggestionId,
     );
   } catch (error) {
-    inlineSuggestionData["error"] = `${error}`;
-    vscode.window.showErrorMessage(`Error in inline suggestions: ${error}`);
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    inlineSuggestionData["error"] = errorMessage;
+    vscode.window.showErrorMessage(
+      `Error in inline suggestions: ${errorMessage}`,
+    );
     return { predictions: [], suggestionId: suggestionId };
   } finally {
     lightSpeedManager.statusBarProvider.statusBar.text =
@@ -578,7 +581,7 @@ function loadFile(inlinePosition: InlinePosition): DocumentInfo {
     });
   } catch (err) {
     vscode.window.showErrorMessage(
-      `Ansible Lightspeed expects valid YAML syntax to provide inline suggestions. Error: ${err}`,
+      `Ansible Lightspeed expects valid YAML syntax to provide inline suggestions. Error: ${err instanceof Error ? err.message : String(err)}`,
     );
     throw err;
   }

--- a/src/features/lightspeed/lightSpeedOAuthProvider.ts
+++ b/src/features/lightspeed/lightSpeedOAuthProvider.ts
@@ -261,7 +261,7 @@ export class LightSpeedAuthenticationProvider
       return session;
     } catch (e) {
       console.error(
-        `[ansible-lightspeed-oauth] Ansible Lightspeed sign in failed: ${e}`,
+        `[ansible-lightspeed-oauth] Ansible Lightspeed sign in failed: ${e instanceof Error ? e.message : String(e)}`,
       );
       throw e;
     }

--- a/src/features/lightspeed/lightspeedUser.ts
+++ b/src/features/lightspeed/lightspeedUser.ts
@@ -284,7 +284,7 @@ export class LightspeedUser {
         );
       const isSupportedClient = isSupportedCallback(redirectUri);
       this._logger.info(
-        `[ansible-lightspeed-user] Redirect URI ${redirectUri} is${isSupportedClient ? "" : " not"} supported by Lightspeed auth provider.`,
+        `[ansible-lightspeed-user] Redirect URI ${redirectUri.toString()} is${isSupportedClient ? "" : " not"} supported by Lightspeed auth provider.`,
       );
       if (!isSupportedClient) {
         return [AuthProviderType.rhsso, AuthProviderType.lightspeed];
@@ -393,7 +393,7 @@ export class LightspeedUser {
       return true;
     } catch (error) {
       this._logger.info(
-        `[ansible-lightspeed-user] Request for logged-in user info failed: ${error}`,
+        `[ansible-lightspeed-user] Request for logged-in user info failed: ${error instanceof Error ? error.message : String(error)}`,
       );
       if (error instanceof LightspeedAccessDenied) {
         // Auth provider has a dead session stored. We need to force it out.
@@ -539,7 +539,7 @@ export class LightspeedUser {
       return;
     }
     this._logger.debug(
-      `[ansible-lightspeed-user] Session found for auth provider "${this._userType}" with scopes "${this._session.scopes}"`,
+      `[ansible-lightspeed-user] Session found for auth provider "${this._userType}" with scopes "${this._session.scopes.join(", ")}"`,
     );
 
     if (this._userType === AuthProviderType.lightspeed) {

--- a/src/features/lightspeed/providers/factory.ts
+++ b/src/features/lightspeed/providers/factory.ts
@@ -61,7 +61,7 @@ export class LLMProviderFactory implements ProviderFactory {
         return this.createRHCustomProvider(config, apiKey);
 
       default:
-        throw new Error(`Unsupported provider type: ${type}`);
+        throw new Error(`Unsupported provider type: ${String(type)}`);
     }
   }
 

--- a/src/features/lightspeed/statusBar.ts
+++ b/src/features/lightspeed/statusBar.ts
@@ -116,7 +116,7 @@ export class LightspeedStatusBar {
       });
     } catch (error) {
       console.log(
-        `an error occurred updating status bar and tooltip: ${error}`,
+        `an error occurred updating status bar and tooltip: ${error instanceof Error ? error.message : String(error)}`,
       );
     }
 

--- a/src/features/lightspeed/utils/outlineGenerator.ts
+++ b/src/features/lightspeed/utils/outlineGenerator.ts
@@ -81,8 +81,14 @@ export function generateOutlineFromRole(roleYaml: string): string {
 
     // Extract task names
     for (const task of parsed) {
-      if (task.name) {
-        tasks.push(task.name as string);
+      if (
+        task &&
+        typeof task === "object" &&
+        "name" in task &&
+        typeof (task as { name?: unknown }).name === "string" &&
+        (task as { name: string }).name.trim().length > 0
+      ) {
+        tasks.push((task as { name: string }).name);
       }
     }
 

--- a/src/features/lightspeed/utils/readVarFiles.ts
+++ b/src/features/lightspeed/utils/readVarFiles.ts
@@ -13,7 +13,9 @@ export function readVarFiles(varFile: string): string | undefined {
     const updatedFileContents = yaml.stringify(parsedAnsibleVars);
     return updatedFileContents;
   } catch (err) {
-    console.error(`Failed to read ${varFile} with error ${err}`);
+    console.error(
+      `Failed to read ${varFile} with error ${err instanceof Error ? err.message : String(err)}`,
+    );
     return undefined;
   }
 }

--- a/src/features/lightspeed/utils/updateRolesContext.ts
+++ b/src/features/lightspeed/utils/updateRolesContext.ts
@@ -20,7 +20,9 @@ function getVarsFromRoles(
   try {
     dirContent = fs.readdirSync(varsRootPath);
   } catch (err) {
-    console.error(`Failed to read a var directory with error ${err}`);
+    console.error(
+      `Failed to read a var directory with error ${err instanceof Error ? err.message : String(err)}`,
+    );
     return;
   }
 
@@ -43,7 +45,9 @@ function getVarsFromRoles(
         return varsContext;
       }
     } catch (err) {
-      console.error(`Failed to read ${varsFile} with error ${err}`);
+      console.error(
+        `Failed to read ${varsFile} with error ${err instanceof Error ? err.message : String(err)}`,
+      );
     }
   }
 
@@ -62,7 +66,9 @@ export function updateRolesContext(
   try {
     dirContent = fs.readdirSync(rolesRootPath);
   } catch (error) {
-    console.error(`Cannot read the directory: ${error}`);
+    console.error(
+      `Cannot read the directory: ${error instanceof Error ? error.message : String(error)}`,
+    );
     return;
   }
 
@@ -98,7 +104,9 @@ export function updateRoleContext(
         .map((name) => path.basename(name, path.extname(name)));
       rolesContext[rolePath]["tasks"] = taskNames;
     } catch (err) {
-      console.error(`Failed to read "tasks" directory with error ${err}`);
+      console.error(
+        `Failed to read "tasks" directory with error ${err instanceof Error ? err.message : String(err)}`,
+      );
     }
   }
 

--- a/src/features/lightspeed/vue/views/fileOperations.ts
+++ b/src/features/lightspeed/vue/views/fileOperations.ts
@@ -99,7 +99,9 @@ export class FileOperations {
     const mainFileUrl = `${folderUrl}/roles/${roleName}/meta/main.yml`;
     console.log(`[ansible-creator] main.yml file url: ${mainFileUrl}`);
     const parsedUrl = Uri.parse(`vscode://file${mainFileUrl}`);
-    console.log(`[ansible-creator] Parsed main.yml file url: ${parsedUrl}`);
+    console.log(
+      `[ansible-creator] Parsed main.yml file url: ${parsedUrl.toString()}`,
+    );
     this.openFileInEditor(parsedUrl.toString());
   }
 

--- a/src/features/lightspeed/vue/views/webviewMessageHandlers.ts
+++ b/src/features/lightspeed/vue/views/webviewMessageHandlers.ts
@@ -323,7 +323,10 @@ export class WebviewMessageHandlers {
       collectionUrl?: string;
       projectUrl?: string;
     };
-    const folderUrl = (payload.collectionUrl || payload.projectUrl) as string;
+    const folderUrl = payload.collectionUrl || payload.projectUrl;
+    if (typeof folderUrl !== "string" || folderUrl.trim().length === 0) {
+      return;
+    }
     await this.fileOps.openFolderInWorkspaceProjects(folderUrl);
   }
 

--- a/src/features/utils/ansible.ts
+++ b/src/features/utils/ansible.ts
@@ -35,10 +35,10 @@ export function getAnsibleFileType(
     return "other";
   }
   const lastObject = parsedAnsibleDocument[parsedAnsibleDocument.length - 1];
-  if (typeof lastObject !== "object") {
+  if (lastObject === null || typeof lastObject !== "object") {
     return "other";
   }
-  const objectKeys = Object.keys(lastObject as object);
+  const objectKeys = Object.keys(lastObject as Record<string, unknown>);
   for (const keyword of objectKeys) {
     if (PlaybookKeywords.includes(keyword)) {
       return "playbook";

--- a/src/features/utils/formatAnsibleMetaData.ts
+++ b/src/features/utils/formatAnsibleMetaData.ts
@@ -3,6 +3,11 @@ import { MarkdownString, workspace } from "vscode";
 import * as os from "os";
 import * as path from "path";
 
+const asRecord = (value: unknown): Record<string, unknown> =>
+  value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+
 export function formatAnsibleMetaData(ansibleMetaData: any) {
   let mdString = "";
   let ansiblePresent = true;
@@ -13,18 +18,16 @@ export function formatAnsibleMetaData(ansibleMetaData: any) {
   const WARNING_STYLE = `style="color:${WARNING_COLOR};"`;
 
   // check if ansible is missing
-  if (
-    Object.keys(ansibleMetaData["ansible information"] as object).length === 0
-  ) {
+  const ansibleInfo = asRecord(ansibleMetaData?.["ansible information"]);
+  if (Object.keys(ansibleInfo).length === 0) {
     ansiblePresent = false;
     mdString += "#### $(close) Ansible not found in the environment\n";
 
     // if python exists
-    if (
-      Object.keys(ansibleMetaData["python information"] as object).length !== 0
-    ) {
-      const obj = ansibleMetaData["python information"];
-      mdString += `Python version used: \`${obj["version"]}\` from \`${obj["location"]}\``;
+    const pythonInfo = asRecord(ansibleMetaData?.["python information"]);
+    if (Object.keys(pythonInfo).length !== 0) {
+      const obj = pythonInfo;
+      mdString += `Python version used: \`${String(obj["version"])}\` from \`${String(obj["location"])}\``;
     }
 
     const markdown = new MarkdownString(mdString, true);
@@ -46,7 +49,7 @@ export function formatAnsibleMetaData(ansibleMetaData: any) {
 
   // check is ansible-lint is missing
   if (
-    Object.keys(ansibleMetaData["ansible-lint information"] as object)
+    Object.keys(asRecord(ansibleMetaData?.["ansible-lint information"]))
       .length === 0
   ) {
     ansibleLintPresent = false;
@@ -64,8 +67,10 @@ export function formatAnsibleMetaData(ansibleMetaData: any) {
     .getConfiguration("ansible.validation.lint")
     .get("enabled");
 
-  Object.keys(ansibleMetaData as object).forEach((mainKey) => {
-    if (Object.keys(ansibleMetaData[mainKey] as object).length === 0) {
+  const root = asRecord(ansibleMetaData);
+  Object.keys(root).forEach((mainKey) => {
+    const section = asRecord(root[mainKey]);
+    if (Object.keys(section).length === 0) {
       return;
     }
     // put a marker stating ansible-lint setting is disabled
@@ -76,18 +81,18 @@ export function formatAnsibleMetaData(ansibleMetaData: any) {
       mdString += `\n**${mainKey}:** \n`;
     }
 
-    const valueObj = ansibleMetaData[mainKey];
-    Object.keys(valueObj as object).forEach((key) => {
+    const valueObj = section;
+    Object.keys(valueObj).forEach((key) => {
       if (key === "upgrade status") {
-        const value = valueObj[key];
+        const value = valueObj[key] as string | number | boolean | null;
         if (value != null && String(value).trim().toLowerCase() !== "nil") {
-          mdString += ` <span ${WARNING_STYLE}>${value}</span>`;
+          mdString += ` <span ${WARNING_STYLE}>${String(value)}</span>`;
         }
         return;
       }
       mdString += `\n   - ${key}: `;
-      const value = valueObj[key];
-      if (typeof value === "object") {
+      const value = valueObj[key] as any;
+      if (Array.isArray(value)) {
         value.forEach((val: any, index: any) => {
           if (val && val !== "None") {
             if (key.includes("path")) {

--- a/src/features/vault.ts
+++ b/src/features/vault.ts
@@ -120,7 +120,9 @@ export class Vault {
             tabSize,
           );
         } catch (e) {
-          vscode.window.showErrorMessage(`Inline encryption failed: ${e}`);
+          vscode.window.showErrorMessage(
+            `Inline encryption failed: ${e instanceof Error ? e.message : String(e)}`,
+          );
           return;
         }
         const leadingSpaces = " ".repeat((indentationLevel + 1) * tabSize);
@@ -141,7 +143,9 @@ export class Vault {
             tabSize, // tabSize is always defined
           );
         } catch (e) {
-          vscode.window.showErrorMessage(`Inline decryption failed: ${e}`);
+          vscode.window.showErrorMessage(
+            `Inline decryption failed: ${e instanceof Error ? e.message : String(e)}`,
+          );
           return;
         }
         editor.edit((editBuilder) => {
@@ -169,7 +173,7 @@ export class Vault {
           );
         } catch (e) {
           vscode.window.showErrorMessage(
-            `Encryption of ${doc.fileName} failed: ${e}`,
+            `Encryption of ${doc.fileName} failed: ${e instanceof Error ? e.message : String(e)}`,
           );
         }
       } else if (type === "encrypted") {
@@ -182,7 +186,7 @@ export class Vault {
           );
         } catch (e) {
           vscode.window.showErrorMessage(
-            `Decryption of ${doc.fileName} failed: ${e}`,
+            `Decryption of ${doc.fileName} failed: ${e instanceof Error ? e.message : String(e)}`,
           );
         }
       }

--- a/src/features/welcomePage/welcomePagePanel.ts
+++ b/src/features/welcomePage/welcomePagePanel.ts
@@ -6,7 +6,7 @@ import { getSystemDetails } from "@src/features/utils/getSystemDetails";
 
 interface WebviewMessage {
   type: string;
-  payload: {
+  payload?: {
     id?: string;
     command?: string;
     url?: string;
@@ -76,20 +76,25 @@ export class WelcomePagePanel {
   }
 
   private async handleMessage(message: WebviewMessage) {
+    const payload =
+      message.payload && typeof message.payload === "object"
+        ? message.payload
+        : undefined;
+
     switch (message.type) {
       case "walkthrough-click":
-        if (message.payload.id) {
-          await this.handleWalkthroughClick(message.payload.id);
+        if (typeof payload?.id === "string") {
+          await this.handleWalkthroughClick(payload.id);
         }
         break;
       case "command-click":
-        if (message.payload.command) {
-          await this.handleCommandClick(message.payload.command);
+        if (typeof payload?.command === "string") {
+          await this.handleCommandClick(payload.command);
         }
         break;
       case "external-link":
-        if (message.payload.url) {
-          await this.handleExternalLink(message.payload.url);
+        if (typeof payload?.url === "string") {
+          await this.handleExternalLink(payload.url);
         }
         break;
       case "check-system-status":

--- a/src/services/PythonEnvironmentService.ts
+++ b/src/services/PythonEnvironmentService.ts
@@ -148,7 +148,7 @@ export class PythonEnvironmentService implements vscode.Disposable {
       }
     } catch (error) {
       console.error(
-        `[Ansible] Failed to activate Python Environments extension: ${error}`,
+        `[Ansible] Failed to activate Python Environments extension: ${error instanceof Error ? error.message : String(error)}`,
       );
       await this._initFromPythonExtension();
     }
@@ -196,7 +196,7 @@ export class PythonEnvironmentService implements vscode.Disposable {
       );
     } catch (error) {
       console.error(
-        `[Ansible] Failed to initialize Python extension fallback: ${error}`,
+        `[Ansible] Failed to initialize Python extension fallback: ${error instanceof Error ? error.message : String(error)}`,
       );
     }
   }
@@ -323,7 +323,7 @@ export class PythonEnvironmentService implements vscode.Disposable {
         return env;
       } catch (error) {
         console.error(
-          `[Ansible] Error getting environment (envs API): ${error}`,
+          `[Ansible] Error getting environment (envs API): ${error instanceof Error ? error.message : String(error)}`,
         );
       }
     }
@@ -343,7 +343,7 @@ export class PythonEnvironmentService implements vscode.Disposable {
         }
       } catch (error) {
         console.error(
-          `[Ansible] Error getting environment (python ext): ${error}`,
+          `[Ansible] Error getting environment (python ext): ${error instanceof Error ? error.message : String(error)}`,
         );
       }
     }
@@ -362,7 +362,7 @@ export class PythonEnvironmentService implements vscode.Disposable {
         return await this._pythonEnvApi.getEnvironments(scope);
       } catch (error) {
         console.error(
-          `[Ansible] Error getting environments (envs API): ${error}`,
+          `[Ansible] Error getting environments (envs API): ${error instanceof Error ? error.message : String(error)}`,
         );
       }
     }
@@ -383,7 +383,7 @@ export class PythonEnvironmentService implements vscode.Disposable {
         return results;
       } catch (error) {
         console.error(
-          `[Ansible] Error getting environments (python ext): ${error}`,
+          `[Ansible] Error getting environments (python ext): ${error instanceof Error ? error.message : String(error)}`,
         );
       }
     }
@@ -521,7 +521,7 @@ export class PythonEnvironmentService implements vscode.Disposable {
         return;
       } catch (error) {
         console.error(
-          `[Ansible] Error opening Python environment picker: ${error}`,
+          `[Ansible] Error opening Python environment picker: ${error instanceof Error ? error.message : String(error)}`,
         );
       }
     }

--- a/src/services/TerminalService.ts
+++ b/src/services/TerminalService.ts
@@ -108,7 +108,7 @@ export class TerminalService implements vscode.Disposable {
           );
         } catch (error) {
           console.warn(
-            `[Ansible] Terminal Service: Failed to create Python-activated terminal: ${error}`,
+            `[Ansible] Terminal Service: Failed to create Python-activated terminal: ${error instanceof Error ? error.message : String(error)}`,
           );
           terminal = vscode.window.createTerminal({
             name: options.name,

--- a/src/utils/mcpProvider.ts
+++ b/src/utils/mcpProvider.ts
@@ -80,7 +80,9 @@ export class AnsibleMcpServerProvider {
         `Registered MCP server: ${AnsibleMcpServerProvider.MCP_SERVER_NAME}`,
       );
     } catch (error) {
-      console.error(`Failed to provide MCP server definitions: ${error}`);
+      console.error(
+        `Failed to provide MCP server definitions: ${error instanceof Error ? error.message : String(error)}`,
+      );
     }
 
     return servers;
@@ -113,7 +115,7 @@ export class AnsibleMcpServerProvider {
 
       return server;
     } catch (error) {
-      const errorMessage = `Failed to resolve MCP server definition: ${error}`;
+      const errorMessage = `Failed to resolve MCP server definition: ${error instanceof Error ? error.message : String(error)}`;
       console.error(errorMessage);
       vscode.window.showErrorMessage(errorMessage);
       return undefined;
@@ -131,7 +133,9 @@ export class AnsibleMcpServerProvider {
       }
       return true;
     } catch (error) {
-      console.error(`Failed to check MCP server availability: ${error}`);
+      console.error(
+        `Failed to check MCP server availability: ${error instanceof Error ? error.message : String(error)}`,
+      );
       return false;
     }
   }

--- a/src/webviewHtml.ts
+++ b/src/webviewHtml.ts
@@ -122,7 +122,10 @@ export function getWebviewHtml(options: WebviewHtmlOptions): string {
   html = html.replace(/<script /g, `<script nonce="${nonce}" `);
 
   // Rewrite absolute /assets/ paths to webview URIs
-  html = html.replace(/(href|src)="\/assets\//g, `$1="${baseUri}/assets/`);
+  html = html.replace(
+    /(href|src)="\/assets\//g,
+    `$1="${baseUri.toString()}/assets/`,
+  );
 
   return html;
 }

--- a/test/e2e/e2e.utils.ts
+++ b/test/e2e/e2e.utils.ts
@@ -294,7 +294,7 @@ export async function testDiagnostics(
       assert.deepEqual(
         actualDiagnostic.range,
         expectedDiagnostic.range,
-        `Expected range ${expectedDiagnostic.range} but got ${actualDiagnostic.range}`,
+        `Expected range ${String(expectedDiagnostic.range)} but got ${String(actualDiagnostic.range)}`,
       );
       assert.strictEqual(
         actualDiagnostic.severity,
@@ -362,7 +362,7 @@ async function waitForDiagnosisCompletion(
       // treat it as if no processes were found to avoid test failures.
       // This makes the function more resilient to transient errors.
       console.warn(
-        `[waitForDiagnosisCompletion] Error checking for processes: ${error}`,
+        `[waitForDiagnosisCompletion] Error checking for processes: ${error instanceof Error ? error.message : String(error)}`,
       );
       processes = [];
     }

--- a/test/e2e/mcp/mcpActivation.test.ts
+++ b/test/e2e/mcp/mcpActivation.test.ts
@@ -79,7 +79,7 @@ describe("MCP server activation and availability (AAP-64488)", function () {
           `MCP CLI should be resolvable via module resolution or exist at:\n` +
             `  - Packaged: ${packagedCliPath} (exists: ${hasPackagedCli})\n` +
             `  - Development: ${devCliPath} (exists: ${hasDevCli})\n` +
-            `  - Module resolution error: ${error}`,
+            `  - Module resolution error: ${error instanceof Error ? error.message : String(error)}`,
         );
       }
     });

--- a/test/e2e/rootMochaHooks.ts
+++ b/test/e2e/rootMochaHooks.ts
@@ -26,10 +26,10 @@ try {
   // do this are: mise, asdf, pyenv.
   const result = cp.spawnSync(command, { shell: true });
   if (result.status === 0) {
-    console.info(`Detected: ${result.stdout}`);
+    console.info(`Detected: ${result.stdout.toString()}`);
   } else {
     throw new Error(
-      `rc=${result.status} stderr=${result.stderr} stdout=${result.stdout}`,
+      `rc=${result.status} stderr=${result.stderr.toString()} stdout=${result.stdout.toString()}`,
     );
   }
 } catch (err) {
@@ -37,7 +37,7 @@ try {
     .map(([k, v]) => `${k}=${v}`)
     .join("\n");
   console.error(
-    `error: test requisites not met, '${command}' returned ${err}\n${env}`,
+    `error: test requisites not met, '${command}' returned ${err instanceof Error ? err.message : String(err)}\n${env}`,
   );
   process.exit(PRETEST_ERR_RC);
 }
@@ -49,7 +49,7 @@ const logger = createLogger({
   format: format.combine(
     format.timestamp(),
     format.printf(({ timestamp, level, message }) => {
-      return `${timestamp} ${level}: ${message}`;
+      return `${String(timestamp)} ${String(level)}: ${String(message)}`;
     }),
   ),
   transports: [
@@ -90,7 +90,9 @@ export const mochaHooks = {
         fs.unlinkSync(settingsPath);
       }
     } catch (err) {
-      console.warn(`Error deleting settings file: ${err}`);
+      console.warn(
+        `Error deleting settings file: ${err instanceof Error ? err.message : String(err)}`,
+      );
     }
   },
 };

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -28,7 +28,7 @@ function ensureSettings(settings: Record<string, string | boolean>): void {
       currentSettings = JSON.parse(content);
     } catch (err) {
       console.warn(
-        `Failed to parse existing settings file at ${userSettingsPath}: ${err}`,
+        `Failed to parse existing settings file at ${userSettingsPath}: ${err instanceof Error ? err.message : String(err)}`,
       );
     }
   }

--- a/tools/helper.mts
+++ b/tools/helper.mts
@@ -193,7 +193,7 @@ function main(): void {
     const [vsix] = vsixFiles;
     if (vsixFiles.length !== 1 || vsix === undefined) {
       console.error(
-        `Publish command requires presence of exactly one '.vsix' on disk, found: ${vsixFiles}`,
+        `Publish command requires presence of exactly one '.vsix' on disk, found: ${vsixFiles.join(", ")}`,
       );
       process.exit(2);
     }


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Enables the `@typescript-eslint/restrict-template-expressions` ESLint rule to enforce type-safe template string formatting. Updates throughout the codebase to comply by explicitly converting values to strings, safely extracting error messages with instanceof checks, and replacing unsafe type casts with proper string coercion.

- Enable `@typescript-eslint/restrict-template-expressions` rule at error level in eslint.config.mjs
- Convert error values to strings using `error instanceof Error ? error.message : String(error)` pattern across error handling paths
- Add explicit String() conversions in template expressions where values may not be strings
- Replace `Object.keys(...as object)` with safer `getEnumerableKeys()` helper in completionProviderUtils.ts
- Update array logging to use `.join(", ")` instead of relying on default array-to-string conversion
- Improve type safety in webviewUtils.ts by treating message data as unknown and adding helpers to coerce to strings
- Add escapeHtml() helper in contentMatchesWebview.ts to prevent HTML injection
- Strengthen validation in ansibleContext.ts and outlineGenerator.ts to explicitly check objects before accessing properties
- Update formatAnsibleMetaData.ts to defensively normalize nested objects using optional chaining
- Make WebviewMessage.payload optional and add payload validation in message handlers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Related: AAP-66052