### PR TITLE
fix: address @typescript-eslint/no-floating-promises

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -88,7 +88,7 @@ export default defineConfig(
       // "@typescript-eslint/await-thenable": "error", // ~58 errors
       "@typescript-eslint/unbound-method": "error",
       // "@typescript-eslint/no-unsafe-member-access": "error", // ~550 errors
-      // "@typescript-eslint/no-floating-promises": "error", // ~100 errors
+      "@typescript-eslint/no-floating-promises": "error",
       "@typescript-eslint/restrict-template-expressions": "error",
       "@typescript-eslint/no-unsafe-argument": "error",
       "@typescript-eslint/no-unsafe-return": "error",

--- a/packages/ansible-language-server/src/ansibleLanguageService.ts
+++ b/packages/ansible-language-server/src/ansibleLanguageService.ts
@@ -206,7 +206,7 @@ export class AnsibleLanguageService {
 
     this.connection.onDidChangeWatchedFiles((params) => {
       try {
-        this.workspaceManager.forEachContext((context) => {
+        void this.workspaceManager.forEachContext((context) => {
           context.handleWatchedDocumentChange(params);
         });
       } catch (error) {
@@ -361,7 +361,7 @@ export class AnsibleLanguageService {
     // Custom actions that are performed on receiving special notifications from the client
     // Resync ansible inventory service by clearing the cached items
     this.connection.onNotification("resync/ansible-inventory", async () => {
-      this.workspaceManager.forEachContext((e) => {
+      await this.workspaceManager.forEachContext((e) => {
         // Invalidate ansible inventory cache
         e.clearAnsibleInventory();
         this.connection.window.showInformationMessage(
@@ -387,7 +387,7 @@ export class AnsibleLanguageService {
             ctx,
             this.connection,
           );
-          this.connection.sendNotification("update/ansible-metadata", [
+          void this.connection.sendNotification("update/ansible-metadata", [
             ansibleMetaData,
           ]);
         }

--- a/packages/ansible-language-server/src/server.ts
+++ b/packages/ansible-language-server/src/server.ts
@@ -18,14 +18,14 @@ const connection: Connection = createConnection(ProposedFeatures.all);
 // error message to the client if so.
 const errorMessage = getUnsupportedError();
 if (errorMessage) {
-  connection.sendNotification("ansible/errorMessage", errorMessage);
+  void connection.sendNotification("ansible/errorMessage", errorMessage);
 }
 
 const docChangeHandlers: NotificationHandler<DidChangeTextDocumentParams>[] =
   [];
 connection.onDidChangeTextDocument((params) => {
   for (const handler of docChangeHandlers) {
-    handler(params);
+    void handler(params);
   }
 });
 

--- a/packages/ansible-language-server/src/services/docsLibrary.ts
+++ b/packages/ansible-language-server/src/services/docsLibrary.ts
@@ -62,7 +62,7 @@ export class DocsLibrary {
       for (const collectionsPath of ansibleConfig.collections_paths) {
         await this.findDocumentationInCollectionsPath(collectionsPath);
       }
-      this.connection.sendNotification("ansible/docsLibraryReady", {
+      void this.connection.sendNotification("ansible/docsLibraryReady", {
         modulesCount: this.modules.size,
       });
     } catch (error) {

--- a/packages/ansible-language-server/src/services/validationManager.ts
+++ b/packages/ansible-language-server/src/services/validationManager.ts
@@ -76,7 +76,7 @@ export class ValidationManager {
 
     // send the diagnostics to the client
     for (const [fileUri, fileDiagnostics] of diagnosticsByFile) {
-      this.connection.sendDiagnostics({
+      void this.connection.sendDiagnostics({
         uri: fileUri,
         diagnostics: fileDiagnostics,
       });
@@ -202,7 +202,7 @@ export class ValidationManager {
     if (counter <= 0) {
       // clear diagnostics of files that are no longer referenced
       this.validationCache.delete(fileUri);
-      this.connection.sendDiagnostics({
+      void this.connection.sendDiagnostics({
         uri: fileUri,
         diagnostics: [],
       });

--- a/packages/ansible-language-server/test/validate-ls.ts
+++ b/packages/ansible-language-server/test/validate-ls.ts
@@ -19,7 +19,7 @@ const exit = async (languageServer: rpc.MessageConnection) => {
   });
 
   const notification = new rpc.NotificationType<string>("exit");
-  languageServer.sendNotification(notification);
+  void languageServer.sendNotification(notification);
 
   return ret;
 };
@@ -35,7 +35,7 @@ const notification = new rpc.NotificationType<string>(
 );
 
 connection.listen();
-connection.sendNotification(notification);
+void connection.sendNotification(notification);
 
-exit(connection);
+void exit(connection);
 console.log("Apparently ALS initialized successfully.");

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,7 +7,10 @@ sonar.issue.ignore.multicriteria.e1.resourceKey=**/test/**/*
 sonar.issue.ignore.multicriteria.e1.ruleKey=typescript:S4721
 sonar.issue.ignore.multicriteria.e2.resourceKey=**/test/**/*
 sonar.issue.ignore.multicriteria.e2.ruleKey=typescript:S4036
-sonar.issue.ignore.multicriteria=e1,e2
+# "void" should not be used typescript:S3735 ignoring due to conflict with eslint
+sonar.issue.ignore.multicriteria.e3.resourceKey=**
+sonar.issue.ignore.multicriteria.e3.ruleKey=typescript:S3735
+sonar.issue.ignore.multicriteria=e1,e2,e3
 sonar.log.level.app=DEBUG
 sonar.javascript.lcov.reportPaths=**/coverage/**/lcov.info
 sonar.junit.reportPaths=**/junit/*test-results.xml

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -278,7 +278,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
     vscode.commands.registerCommand(
       LightSpeedCommands.LIGHTSPEED_FETCH_TRAINING_MATCHES,
       () => {
-        lightSpeedManager.contentMatchesProvider.showContentMatches();
+        void lightSpeedManager.contentMatchesProvider.showContentMatches();
       },
     ),
   );
@@ -287,7 +287,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
     vscode.commands.registerCommand(
       LightSpeedCommands.LIGHTSPEED_CLEAR_TRAINING_MATCHES,
       () => {
-        lightSpeedManager.contentMatchesProvider.clearContentMatches();
+        void lightSpeedManager.contentMatchesProvider.clearContentMatches();
       },
     ),
   );
@@ -368,7 +368,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
   // Listen for text selection changes
   context.subscriptions.push(
     vscode.window.onDidChangeTextEditorSelection(async () => {
-      rejectPendingSuggestion();
+      void rejectPendingSuggestion();
     }),
   );
 
@@ -376,7 +376,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
   context.subscriptions.push(
     vscode.window.onDidChangeWindowState(async (state: vscode.WindowState) => {
       if (!state.focused) {
-        ignorePendingSuggestion();
+        void ignorePendingSuggestion();
       }
     }),
   );
@@ -411,7 +411,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
       if (!extSettings.settings.lightSpeedService.enabled) {
         return;
       }
-      metaData.sendAnsibleMetadataTelemetry();
+      void metaData.sendAnsibleMetadataTelemetry();
     }),
   );
   context.subscriptions.push(
@@ -463,19 +463,19 @@ export async function activate(context: ExtensionContext): Promise<void> {
         lightSpeedManager,
         pythonInterpreterManager,
       );
-      metaData.sendAnsibleMetadataTelemetry();
+      void metaData.sendAnsibleMetadataTelemetry();
     }),
   );
 
   context.subscriptions.push(
     workspace.onDidChangeTextDocument((e: vscode.TextDocumentChangeEvent) => {
-      inlineSuggestionTextDocumentChangeHandler(e);
+      void inlineSuggestionTextDocumentChangeHandler(e);
     }),
   );
 
   context.subscriptions.push(
     workspace.onDidChangeTextDocument((e: vscode.TextDocumentChangeEvent) => {
-      inlineSuggestionTextDocumentChangeHandler(e);
+      void inlineSuggestionTextDocumentChangeHandler(e);
     }),
   );
 
@@ -513,8 +513,8 @@ export async function activate(context: ExtensionContext): Promise<void> {
       if (!extSettings.settings.lightSpeedService.enabled) {
         return;
       }
-      lightSpeedManager.lightspeedExplorerProvider?.refreshWebView();
-      lightSpeedManager.statusBarProvider.updateLightSpeedStatusbar();
+      void lightSpeedManager.lightspeedExplorerProvider?.refreshWebView();
+      void lightSpeedManager.statusBarProvider.updateLightSpeedStatusbar();
     }),
   );
 
@@ -553,7 +553,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
         );
         return;
       }
-      lightspeedLogin(AuthProviderType.rhsso);
+      void lightspeedLogin(AuthProviderType.rhsso);
     },
   );
   context.subscriptions.push(lightspeedSignInWithRedHatCommand);
@@ -562,7 +562,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
   const lightspeedSignInWithLightspeedCommand = vscode.commands.registerCommand(
     LightSpeedCommands.LIGHTSPEED_SIGN_IN_WITH_LIGHTSPEED,
     () => {
-      lightspeedLogin(AuthProviderType.lightspeed);
+      void lightspeedLogin(AuthProviderType.lightspeed);
     },
   );
   context.subscriptions.push(lightspeedSignInWithLightspeedCommand);
@@ -927,13 +927,13 @@ export async function activate(context: ExtensionContext): Promise<void> {
 
         // WCA provider - send to API
         if (param.explanationId) {
-          lightSpeedManager.apiInstance.feedbackRequest(
+          void lightSpeedManager.apiInstance.feedbackRequest(
             { playbookExplanationFeedback: param },
             true,
             true,
           );
         } else {
-          lightSpeedManager.apiInstance.feedbackRequest(
+          void lightSpeedManager.apiInstance.feedbackRequest(
             { playbookOutlineFeedback: param },
             true,
             true,
@@ -976,7 +976,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
         }
 
         // WCA provider - send to API
-        lightSpeedManager.apiInstance.feedbackRequest(
+        void lightSpeedManager.apiInstance.feedbackRequest(
           { roleExplanationFeedback: param },
           true,
           true,
@@ -1380,7 +1380,7 @@ async function updateAnsibleStatusBar(
 function notifyAboutConflicts(): void {
   const conflictingExtensions = getConflictingExtensions();
   if (conflictingExtensions.length > 0) {
-    showUninstallConflictsNotification(conflictingExtensions);
+    void showUninstallConflictsNotification(conflictingExtensions);
   }
 }
 
@@ -1397,7 +1397,9 @@ async function resyncAnsibleInventory(): Promise<void> {
         console.log("resync ansible inventory event ->", event);
       },
     );
-    client.sendNotification(new NotificationType(`resync/ansible-inventory`));
+    void client.sendNotification(
+      new NotificationType(`resync/ansible-inventory`),
+    );
   }
 }
 

--- a/src/features/ansibleMetaData.ts
+++ b/src/features/ansibleMetaData.ts
@@ -127,7 +127,7 @@ export class MetadataManager {
       },
     );
     const activeFileUri = window.activeTextEditor?.document.uri.toString();
-    this.client.sendNotification(
+    void this.client.sendNotification(
       new NotificationType(`update/ansible-metadata`),
       [activeFileUri],
     );

--- a/src/features/ansibleTox/controller.ts
+++ b/src/features/ansibleTox/controller.ts
@@ -32,7 +32,7 @@ export class AnsibleToxController {
       "Ansible Tox",
       vscode.TestRunProfileKind.Run,
       (request, token) => {
-        this.runHandler(request, token);
+        void this.runHandler(request, token);
       },
     );
     this.controller.refreshHandler = async () => {
@@ -40,7 +40,7 @@ export class AnsibleToxController {
     };
     // Check all existing documents
     for (const document of vscode.workspace.textDocuments) {
-      this.parseTestsInAnsibleToxFile(document);
+      void this.parseTestsInAnsibleToxFile(document);
     }
 
     // Check for tox.ini files when a new document is opened or saved.

--- a/src/features/contentCreator/vue/views/panelUtils.ts
+++ b/src/features/contentCreator/vue/views/panelUtils.ts
@@ -13,7 +13,7 @@ export function setupPanelLifecycle(
   disposeCallback: () => void,
 ): void {
   panel.onDidDispose(disposeCallback, null, disposables);
-  ContentCreatorWebviewHelper.setupWebviewHooks(
+  void ContentCreatorWebviewHelper.setupWebviewHooks(
     panel.webview,
     disposables,
     context,

--- a/src/features/lightspeed/base.ts
+++ b/src/features/lightspeed/base.ts
@@ -133,7 +133,7 @@ export class LightSpeedManager {
       return;
     } else {
       this.lightSpeedAuthenticationProvider.initialize();
-      this.statusBarProvider.setLightSpeedStatusBarTooltip();
+      void this.statusBarProvider.setLightSpeedStatusBarTooltip();
       this.setContext();
     }
 

--- a/src/features/lightspeed/inlineSuggestions.ts
+++ b/src/features/lightspeed/inlineSuggestions.ts
@@ -98,7 +98,7 @@ const onLightspeedIsDisabled: CallbackEntry = async function (
   suggestionDisplayed: SuggestionDisplayed,
 ) {
   console.debug("[ansible-lightspeed] Ansible Lightspeed is disabled.");
-  lightSpeedManager.statusBarProvider.updateLightSpeedStatusbar();
+  void lightSpeedManager.statusBarProvider.updateLightSpeedStatusbar();
   suggestionDisplayed.reset();
   return [];
 };
@@ -713,7 +713,7 @@ async function requestInlineSuggest(
     if (lightSpeedManager.currentModelValue !== outputData.model) {
       lightSpeedManager.currentModelValue = outputData.model;
       // update the Lightspeed status bar tooltip with the model name
-      lightSpeedManager.statusBarProvider.setLightSpeedStatusBarTooltip();
+      void lightSpeedManager.statusBarProvider.setLightSpeedStatusBarTooltip();
     }
   }
   return outputData;
@@ -854,7 +854,7 @@ async function inlineSuggestionUserActionHandler(
   const inlineSuggestionFeedbackPayload = {
     inlineSuggestion: data,
   };
-  lightSpeedManager.apiInstance.feedbackRequest(
+  void lightSpeedManager.apiInstance.feedbackRequest(
     inlineSuggestionFeedbackPayload,
   );
   if (suggestionId === inlineSuggestionData["suggestionId"]) {

--- a/src/features/lightspeed/lightSpeedOAuthProvider.ts
+++ b/src/features/lightspeed/lightSpeedOAuthProvider.ts
@@ -303,7 +303,7 @@ export class LightSpeedAuthenticationProvider
 
       if (account) {
         const sessionId = account.id;
-        this.removeSession(sessionId);
+        void this.removeSession(sessionId);
       }
 
       this._logger.debug("[ansible-lightspeed-oauth] Disposing auth provider");

--- a/src/features/lightspeed/lightspeedUser.ts
+++ b/src/features/lightspeed/lightspeedUser.ts
@@ -404,7 +404,7 @@ export class LightspeedUser {
             { forceNewSession: true },
           );
         } else if (this._userType === AuthProviderType.lightspeed) {
-          this._lightspeedAuthenticationProvider.removeSession(session.id);
+          void this._lightspeedAuthenticationProvider.removeSession(session.id);
         }
       }
     }

--- a/src/features/lightspeed/providerManager.ts
+++ b/src/features/lightspeed/providerManager.ts
@@ -32,7 +32,7 @@ export class ProviderManager {
     this.settingsManager = settingsManager;
     this.wcaApi = wcaApi;
     this.llmProviderSettings = llmProviderSettings;
-    this.initializeLlmProvider();
+    void this.initializeLlmProvider();
   }
 
   /**

--- a/src/features/lightspeed/statusBar.ts
+++ b/src/features/lightspeed/statusBar.ts
@@ -64,7 +64,7 @@ export class LightspeedStatusBar {
     this.settingsManager = settingsManager;
     // create a new project lightspeed status bar item that we can manage
     this.statusBar = this.initialiseStatusBar();
-    this.updateLightSpeedStatusbar();
+    void this.updateLightSpeedStatusbar();
   }
 
   private initialiseStatusBar(): vscode.StatusBarItem {
@@ -110,9 +110,9 @@ export class LightspeedStatusBar {
 
   private handleStatusBar() {
     try {
-      this.getLightSpeedStatusBarText().then((text) => {
+      void this.getLightSpeedStatusBarText().then((text) => {
         this.statusBar.text = text;
-        this.setLightSpeedStatusBarTooltip();
+        void this.setLightSpeedStatusBarTooltip();
       });
     } catch (error) {
       console.log(
@@ -132,7 +132,7 @@ export class LightspeedStatusBar {
         "statusBarItem.warningBackground",
       );
     }
-    this.setLightSpeedStatusBarTooltip();
+    void this.setLightSpeedStatusBarTooltip();
     this.statusBar.show();
   }
 

--- a/src/features/lightspeed/vue/views/llmProviderMessageHandlers.ts
+++ b/src/features/lightspeed/vue/views/llmProviderMessageHandlers.ts
@@ -136,7 +136,7 @@ export class LlmProviderMessageHandlers {
     this.quickLinksProvider?.refreshProviderInfo();
 
     // Run heavy operations in background (don't block UI)
-    this.settingsManager.reinitialize().then(() => {
+    void this.settingsManager.reinitialize().then(() => {
       this.providerManager.refreshProviders().catch((error) => {
         console.error("Failed to refresh providers:", error);
       });

--- a/src/features/lightspeed/vue/views/llmProviderPanel.ts
+++ b/src/features/lightspeed/vue/views/llmProviderPanel.ts
@@ -64,7 +64,7 @@ export class LlmProviderPanel {
     );
 
     // Send initial settings
-    this.messageHandlers.sendProviderSettings();
+    void this.messageHandlers.sendProviderSettings();
   }
 
   // Renders the LLM Provider panel or reveals it if already open.

--- a/src/features/lightspeed/vue/views/panelUtils.ts
+++ b/src/features/lightspeed/vue/views/panelUtils.ts
@@ -18,7 +18,7 @@ export function setupPanelLifecycle(
     context,
     htmlEntryPoint,
   );
-  WebviewHelper.setupWebviewHooks(panel.webview, disposables, context);
+  void WebviewHelper.setupWebviewHooks(panel.webview, disposables, context);
 }
 
 /**

--- a/src/features/lightspeed/vue/views/webviewMessageHandlers.ts
+++ b/src/features/lightspeed/vue/views/webviewMessageHandlers.ts
@@ -648,7 +648,7 @@ export class WebviewMessageHandlers {
     }
 
     // WCA provider - send to API
-    lightSpeedManager.apiInstance.feedbackRequest(
+    void lightSpeedManager.apiInstance.feedbackRequest(
       request,
       process.env.TEST_LIGHTSPEED_ACCESS_TOKEN !== undefined,
     );

--- a/src/features/runner.ts
+++ b/src/features/runner.ts
@@ -51,7 +51,7 @@ export class AnsiblePlaybookRunProvider {
    * within VS Code.
    */
   private configureCommands() {
-    registerCommandWithTelemetry(
+    void registerCommandWithTelemetry(
       this.vsCodeExtCtx,
       this.telemetry,
       AnsibleCommands.ANSIBLE_PLAYBOOK_RUN,
@@ -60,7 +60,7 @@ export class AnsiblePlaybookRunProvider {
     );
     console.log('Added a "Run Ansible Playbook" command...');
 
-    registerCommandWithTelemetry(
+    void registerCommandWithTelemetry(
       this.vsCodeExtCtx,
       this.telemetry,
       AnsibleCommands.ANSIBLE_NAVIGATOR_RUN,

--- a/src/services/TerminalService.ts
+++ b/src/services/TerminalService.ts
@@ -276,7 +276,7 @@ export class TerminalService implements vscode.Disposable {
       env: options?.env,
     });
 
-    managed.sendCommand(command, { waitForCompletion: false });
+    void managed.sendCommand(command, { waitForCompletion: false });
     return managed.terminal;
   }
 

--- a/src/utils/telemetryUtils.ts
+++ b/src/utils/telemetryUtils.ts
@@ -158,7 +158,7 @@ export class TelemetryErrorHandler implements ErrorHandler {
   }
 
   error(error: Error, message: Message, count: number): ErrorHandlerResult {
-    sendTelemetry(this.telemetry, true, "ansible.lsp.error", {
+    void sendTelemetry(this.telemetry, true, "ansible.lsp.error", {
       jsonrpc: message.jsonrpc,
       error: error.message,
     });
@@ -269,7 +269,7 @@ export class TelemetryOutputChannel implements vscode.LogOutputChannel {
       }
       this.errors.push(value);
       const timeoutHandle = setTimeout(() => {
-        sendTelemetry(this.telemetry, true, "ansible.server.error", {
+        void sendTelemetry(this.telemetry, true, "ansible.server.error", {
           error: this.createErrorMessage(),
         });
         this.errors = [];

--- a/test/unit/webviews/lightspeed/ExplanationApp.test.ts
+++ b/test/unit/webviews/lightspeed/ExplanationApp.test.ts
@@ -56,7 +56,7 @@ describe("ExplanationApp", () => {
         (call) => call[0] === "setPlaybookData",
       )?.[1];
 
-      setPlaybookDataHandler?.({
+      void setPlaybookDataHandler?.({
         content: "- hosts: all\n  tasks:\n    - debug: msg=hello",
         fileName: "/path/to/playbook.yml",
       });
@@ -74,7 +74,7 @@ describe("ExplanationApp", () => {
       const setPlaybookDataHandler = onCalls.find(
         (call) => call[0] === "setPlaybookData",
       )?.[1];
-      setPlaybookDataHandler?.({
+      void setPlaybookDataHandler?.({
         content: "- hosts: all\n  tasks:\n    - debug: msg=hello",
         fileName: "/path/to/playbook.yml",
       });
@@ -84,7 +84,7 @@ describe("ExplanationApp", () => {
       const explainPlaybookHandler = onCalls.find(
         (call) => call[0] === "explainPlaybook",
       )?.[1];
-      explainPlaybookHandler?.({
+      void explainPlaybookHandler?.({
         content: "# Playbook Explanation\n\nThis playbook does something.",
       });
       await flushPromises();
@@ -102,7 +102,7 @@ describe("ExplanationApp", () => {
       const setPlaybookDataHandler = onCalls.find(
         (call) => call[0] === "setPlaybookData",
       )?.[1];
-      setPlaybookDataHandler?.({
+      void setPlaybookDataHandler?.({
         content: "- hosts: all\n  tasks:\n    - debug: msg=hello",
         fileName: "/path/to/playbook.yml",
       });
@@ -112,7 +112,7 @@ describe("ExplanationApp", () => {
       const explainPlaybookHandler = onCalls.find(
         (call) => call[0] === "explainPlaybook",
       )?.[1];
-      explainPlaybookHandler?.({ content: "" });
+      void explainPlaybookHandler?.({ content: "" });
       await flushPromises();
 
       expect(wrapper.html()).toContain("No explanation provided");
@@ -127,7 +127,7 @@ describe("ExplanationApp", () => {
       const setPlaybookDataHandler = onCalls.find(
         (call) => call[0] === "setPlaybookData",
       )?.[1];
-      setPlaybookDataHandler?.({
+      void setPlaybookDataHandler?.({
         content: "- hosts: all\n  vars:\n    foo: bar",
         fileName: "/path/to/playbook.yml",
       });
@@ -148,7 +148,7 @@ describe("ExplanationApp", () => {
         (call) => call[0] === "setRoleData",
       )?.[1];
 
-      setRoleDataHandler?.({
+      void setRoleDataHandler?.({
         files: [{ path: "tasks/main.yml", content: "- debug: msg=hello" }],
         roleName: "my_role",
       });
@@ -166,7 +166,7 @@ describe("ExplanationApp", () => {
       const setRoleDataHandler = onCalls.find(
         (call) => call[0] === "setRoleData",
       )?.[1];
-      setRoleDataHandler?.({
+      void setRoleDataHandler?.({
         files: [{ path: "tasks/main.yml", content: "- debug: msg=hello" }],
         roleName: "my_role",
       });
@@ -176,7 +176,7 @@ describe("ExplanationApp", () => {
       const explainRoleHandler = onCalls.find(
         (call) => call[0] === "explainRole",
       )?.[1];
-      explainRoleHandler?.({
+      void explainRoleHandler?.({
         content: "# Role Explanation\n\nThis role configures something.",
       });
       await flushPromises();
@@ -195,7 +195,7 @@ describe("ExplanationApp", () => {
         (call) => call[0] === "errorMessage",
       )?.[1];
 
-      errorHandler?.("Something went wrong");
+      void errorHandler?.("Something went wrong");
       await flushPromises();
 
       expect(wrapper.find(".codicon-error").exists()).toBe(true);
@@ -213,7 +213,7 @@ describe("ExplanationApp", () => {
       const setPlaybookDataHandler = onCalls.find(
         (call) => call[0] === "setPlaybookData",
       )?.[1];
-      setPlaybookDataHandler?.({
+      void setPlaybookDataHandler?.({
         content: "- hosts: all\n  tasks:\n    - debug: msg=hello",
         fileName: "/path/to/playbook.yml",
       });
@@ -223,7 +223,7 @@ describe("ExplanationApp", () => {
       const explainPlaybookHandler = onCalls.find(
         (call) => call[0] === "explainPlaybook",
       )?.[1];
-      explainPlaybookHandler?.({
+      void explainPlaybookHandler?.({
         content: "# Playbook Explanation\n\nThis playbook does something.",
       });
       await flushPromises();
@@ -243,14 +243,14 @@ describe("ExplanationApp", () => {
         (call) => call[0] === "telemetryStatus",
       )?.[1];
 
-      telemetryHandler?.({ enabled: false });
+      void telemetryHandler?.({ enabled: false });
       await flushPromises();
 
       // Set up explanation to show feedback box
       const setPlaybookDataHandler = onCalls.find(
         (call) => call[0] === "setPlaybookData",
       )?.[1];
-      setPlaybookDataHandler?.({
+      void setPlaybookDataHandler?.({
         content: "- hosts: all\n  tasks:\n    - debug: msg=hello",
         fileName: "/path/to/playbook.yml",
       });
@@ -259,7 +259,7 @@ describe("ExplanationApp", () => {
       const explainPlaybookHandler = onCalls.find(
         (call) => call[0] === "explainPlaybook",
       )?.[1];
-      explainPlaybookHandler?.({
+      void explainPlaybookHandler?.({
         content: "# Explanation",
       });
       await flushPromises();

--- a/test/unit/webviews/lightspeed/ExplorerApp.test.ts
+++ b/test/unit/webviews/lightspeed/ExplorerApp.test.ts
@@ -62,7 +62,10 @@ describe("ExplorerApp", () => {
         (call) => call[0] === "explorerStateUpdate",
       )?.[1];
 
-      explorerStateUpdateHandler?.({ isAuthenticated: false, provider: "wca" });
+      void explorerStateUpdateHandler?.({
+        isAuthenticated: false,
+        provider: "wca",
+      });
       await flushPromises();
 
       expect(wrapper.text()).toContain("Experience smarter automation");
@@ -77,7 +80,10 @@ describe("ExplorerApp", () => {
         (call) => call[0] === "explorerStateUpdate",
       )?.[1];
 
-      explorerStateUpdateHandler?.({ isAuthenticated: false, provider: "wca" });
+      void explorerStateUpdateHandler?.({
+        isAuthenticated: false,
+        provider: "wca",
+      });
       await flushPromises();
 
       const connectButton = wrapper.find("#lightspeed-explorer-connect");
@@ -96,7 +102,7 @@ describe("ExplorerApp", () => {
         (call) => call[0] === "explorerStateUpdate",
       )?.[1];
 
-      explorerStateUpdateHandler?.({
+      void explorerStateUpdateHandler?.({
         isAuthenticated: true,
         userContent: "Logged in as: test@example.com",
         hasPlaybookOpened: false,
@@ -130,7 +136,7 @@ describe("ExplorerApp", () => {
         (call) => call[0] === "explorerStateUpdate",
       )?.[1];
 
-      explorerStateUpdateHandler?.({
+      void explorerStateUpdateHandler?.({
         isAuthenticated: true,
         provider: "wca",
         userContent: "Logged in as: test@example.com",
@@ -148,7 +154,7 @@ describe("ExplorerApp", () => {
         (call) => call[0] === "explorerStateUpdate",
       )?.[1];
 
-      explorerStateUpdateHandler?.({
+      void explorerStateUpdateHandler?.({
         isAuthenticated: true,
         provider: "ollama",
         userContent: "Logged in as: test@example.com",
@@ -166,7 +172,7 @@ describe("ExplorerApp", () => {
         (call) => call[0] === "explorerStateUpdate",
       )?.[1];
 
-      explorerStateUpdateHandler?.({ isAuthenticated: true });
+      void explorerStateUpdateHandler?.({ isAuthenticated: true });
       await flushPromises();
 
       const button = wrapper.find(
@@ -188,7 +194,7 @@ describe("ExplorerApp", () => {
         (call) => call[0] === "explorerStateUpdate",
       )?.[1];
 
-      explorerStateUpdateHandler?.({
+      void explorerStateUpdateHandler?.({
         isAuthenticated: true,
         hasPlaybookOpened: true,
       });
@@ -213,7 +219,7 @@ describe("ExplorerApp", () => {
         (call) => call[0] === "explorerStateUpdate",
       )?.[1];
 
-      explorerStateUpdateHandler?.({ isAuthenticated: true });
+      void explorerStateUpdateHandler?.({ isAuthenticated: true });
       await flushPromises();
 
       const button = wrapper.find(
@@ -232,7 +238,7 @@ describe("ExplorerApp", () => {
         (call) => call[0] === "explorerStateUpdate",
       )?.[1];
 
-      explorerStateUpdateHandler?.({
+      void explorerStateUpdateHandler?.({
         isAuthenticated: true,
         hasRoleOpened: true,
       });
@@ -257,7 +263,7 @@ describe("ExplorerApp", () => {
       const explorerStateUpdateHandler = onCalls.find(
         (call) => call[0] === "explorerStateUpdate",
       )?.[1];
-      explorerStateUpdateHandler?.({
+      void explorerStateUpdateHandler?.({
         isAuthenticated: true,
         hasPlaybookOpened: false,
       });
@@ -273,7 +279,7 @@ describe("ExplorerApp", () => {
       const playbookStateHandler = onCalls.find(
         (call) => call[0] === "playbookOpenedStateChanged",
       )?.[1];
-      playbookStateHandler?.({ hasPlaybookOpened: true });
+      void playbookStateHandler?.({ hasPlaybookOpened: true });
       await flushPromises();
 
       // Button should now be enabled
@@ -293,7 +299,7 @@ describe("ExplorerApp", () => {
       const explorerStateUpdateHandler = onCalls.find(
         (call) => call[0] === "explorerStateUpdate",
       )?.[1];
-      explorerStateUpdateHandler?.({
+      void explorerStateUpdateHandler?.({
         isAuthenticated: true,
         hasRoleOpened: false,
       });
@@ -307,7 +313,7 @@ describe("ExplorerApp", () => {
       const roleStateHandler = onCalls.find(
         (call) => call[0] === "roleOpenedStateChanged",
       )?.[1];
-      roleStateHandler?.({ hasRoleOpened: true });
+      void roleStateHandler?.({ hasRoleOpened: true });
       await flushPromises();
 
       // Button should now be enabled
@@ -327,7 +333,7 @@ describe("ExplorerApp", () => {
       )?.[1];
 
       vi.mocked(vscodeApi.post).mockClear();
-      refreshHandler?.({});
+      void refreshHandler?.({});
 
       expect(vscodeApi.post).toHaveBeenCalledWith("getExplorerState", {});
     });

--- a/test/unit/webviews/lightspeed/PlaybookGenApp.test.ts
+++ b/test/unit/webviews/lightspeed/PlaybookGenApp.test.ts
@@ -79,7 +79,7 @@ describe("PlaybookGenApp", () => {
         (call) => call[0] === "errorMessage",
       )?.[1];
 
-      errorHandler?.("Generation failed");
+      void errorHandler?.("Generation failed");
       await flushPromises();
 
       expect(wrapper.findComponent({ name: "ErrorBox" }).exists()).toBe(true);
@@ -95,7 +95,7 @@ describe("PlaybookGenApp", () => {
         (call) => call[0] === "generatePlaybook",
       )?.[1];
 
-      generateHandler?.({
+      void generateHandler?.({
         playbook: "- hosts: all\n  tasks:\n    - debug: msg=hello",
         outline: "1. Debug message",
       });
@@ -112,7 +112,7 @@ describe("PlaybookGenApp", () => {
         (call) => call[0] === "generatePlaybook",
       )?.[1];
 
-      generateHandler?.({
+      void generateHandler?.({
         playbook: "- hosts: all\n  tasks:\n    - debug: msg=hello",
         outline: "1. Debug message",
       });
@@ -134,7 +134,7 @@ describe("PlaybookGenApp", () => {
         (call) => call[0] === "generatePlaybook",
       )?.[1];
 
-      generateHandler?.({
+      void generateHandler?.({
         playbook: "- hosts: all\n  tasks:\n    - debug: msg=hello",
         outline: "1. Debug message",
       });
@@ -154,7 +154,7 @@ describe("PlaybookGenApp", () => {
       )?.[1];
 
       // Go to page 2
-      generateHandler?.({
+      void generateHandler?.({
         playbook: "- hosts: all\n  tasks:\n    - debug: msg=hello",
         outline: "1. Debug message",
       });
@@ -182,7 +182,7 @@ describe("PlaybookGenApp", () => {
       )?.[1];
 
       // Go to page 2
-      generateHandler?.({
+      void generateHandler?.({
         playbook: "- hosts: all\n  tasks:\n    - debug: msg=hello",
         outline: "1. Debug message",
       });
@@ -207,7 +207,7 @@ describe("PlaybookGenApp", () => {
         (call) => call[0] === "generatePlaybook",
       )?.[1];
 
-      generateHandler?.({
+      void generateHandler?.({
         playbook: "- hosts: all\n  tasks:\n    - debug: msg=hello",
         outline: "1. Debug message",
       });
@@ -233,7 +233,7 @@ describe("PlaybookGenApp", () => {
         (call) => call[0] === "generatePlaybook",
       )?.[1];
 
-      generateHandler?.({
+      void generateHandler?.({
         playbook: "- hosts: all\n  tasks:\n    - debug: msg=hello",
         outline: "1. Debug message",
         warnings: ["Warning 1", "Warning 2"],

--- a/test/unit/webviews/lightspeed/RoleGenApp.test.ts
+++ b/test/unit/webviews/lightspeed/RoleGenApp.test.ts
@@ -87,7 +87,7 @@ describe("RoleGenApp", () => {
         (call) => call[0] === "errorMessage",
       )?.[1];
 
-      errorHandler?.("Generation failed");
+      void errorHandler?.("Generation failed");
       await flushPromises();
 
       expect(wrapper.findComponent({ name: "ErrorBox" }).exists()).toBe(true);
@@ -103,7 +103,7 @@ describe("RoleGenApp", () => {
         (call) => call[0] === "generateRole",
       )?.[1];
 
-      generateHandler?.({
+      void generateHandler?.({
         name: "my_role",
         files: [{ path: "tasks/main.yml", content: "- debug: msg=hello" }],
         outline: "1. Debug message",
@@ -121,7 +121,7 @@ describe("RoleGenApp", () => {
         (call) => call[0] === "generateRole",
       )?.[1];
 
-      generateHandler?.({
+      void generateHandler?.({
         name: "my_role",
         files: [{ path: "tasks/main.yml", content: "- debug: msg=hello" }],
         outline: "1. Debug message",
@@ -145,7 +145,7 @@ describe("RoleGenApp", () => {
         (call) => call[0] === "generateRole",
       )?.[1];
 
-      generateHandler?.({
+      void generateHandler?.({
         name: "my_role",
         files: [{ path: "tasks/main.yml", content: "- debug: msg=hello" }],
         outline: "1. Debug message",
@@ -166,7 +166,7 @@ describe("RoleGenApp", () => {
       )?.[1];
 
       // Go to page 2
-      generateHandler?.({
+      void generateHandler?.({
         name: "my_role",
         files: [
           { path: "tasks/main.yml", content: "- debug: msg=hello" },
@@ -201,7 +201,7 @@ describe("RoleGenApp", () => {
       )?.[1];
 
       // Go to page 2
-      generateHandler?.({
+      void generateHandler?.({
         name: "my_role",
         files: [{ path: "tasks/main.yml", content: "- debug: msg=hello" }],
         outline: "1. Debug message",
@@ -227,7 +227,7 @@ describe("RoleGenApp", () => {
         (call) => call[0] === "generateRole",
       )?.[1];
 
-      generateHandler?.({
+      void generateHandler?.({
         name: "my_role",
         files: [{ path: "tasks/main.yml", content: "- debug: msg=hello" }],
         outline: "1. Debug message",
@@ -253,7 +253,7 @@ describe("RoleGenApp", () => {
       )?.[1];
 
       // Go to page 2
-      generateHandler?.({
+      void generateHandler?.({
         name: "my_role",
         files: [{ path: "tasks/main.yml", content: "- debug: msg=hello" }],
         outline: "1. Debug message",
@@ -287,7 +287,7 @@ describe("RoleGenApp", () => {
         (call) => call[0] === "generateRole",
       )?.[1];
 
-      generateHandler?.({
+      void generateHandler?.({
         name: "my_role",
         files: [{ path: "tasks/main.yml", content: "- debug: msg=hello" }],
         outline: "1. Debug message",

--- a/test/unit/webviews/lightspeed/components/CollectionSelector.test.ts
+++ b/test/unit/webviews/lightspeed/components/CollectionSelector.test.ts
@@ -73,7 +73,7 @@ describe("CollectionSelector", () => {
       (call) => call[0] === "getCollectionList",
     )?.[1];
 
-    collectionHandler?.([
+    void collectionHandler?.([
       { fqcn: "my_namespace.my_collection", path: "/path/to/collection" },
     ]);
     await flushPromises();
@@ -94,7 +94,7 @@ describe("CollectionSelector", () => {
       (call) => call[0] === "getCollectionList",
     )?.[1];
 
-    collectionHandler?.([
+    void collectionHandler?.([
       { fqcn: "my_namespace.my_collection", path: "/path/to/collection" },
     ]);
     await flushPromises();
@@ -116,7 +116,7 @@ describe("CollectionSelector", () => {
       (call) => call[0] === "getCollectionList",
     )?.[1];
 
-    collectionHandler?.([
+    void collectionHandler?.([
       { fqcn: "my_namespace.my_collection", path: "/path/to/collection" },
     ]);
     await flushPromises();
@@ -131,7 +131,7 @@ describe("CollectionSelector", () => {
       props: {
         collectionName: "",
         "onUpdate:collectionName": (value: string | undefined): void => {
-          wrapper.setProps({ collectionName: value ?? "" });
+          void wrapper.setProps({ collectionName: value ?? "" });
         },
       },
     }) as VueWrapper<InstanceType<typeof CollectionSelector>>;
@@ -141,7 +141,7 @@ describe("CollectionSelector", () => {
       (call) => call[0] === "getCollectionList",
     )?.[1];
 
-    collectionHandler?.([
+    void collectionHandler?.([
       { fqcn: "my_namespace.my_collection", path: "/path/to/collection" },
     ]);
     await flushPromises();

--- a/test/wdio/smoke.spec.ts
+++ b/test/wdio/smoke.spec.ts
@@ -44,7 +44,7 @@ describe("VS Code Ansible smoke test", () => {
   });
 
   it("should launch a VS Code session", async () => {
-    expect(browser.sessionId).toBeDefined();
+    await expect(browser.sessionId).toBeDefined();
   });
 
   it("should show the Ansible activity bar icon", async () => {
@@ -53,7 +53,7 @@ describe("VS Code Ansible smoke test", () => {
     const viewControls = await activityBar.getViewControls();
     const titles = await Promise.all(viewControls.map((vc) => vc.getTitle()));
 
-    expect(titles.some((t) => t.includes("Ansible"))).toBe(true);
+    await expect(titles.some((t) => t.includes("Ansible"))).toBe(true);
   });
 
   it("should activate the Ansible extension", async () => {
@@ -62,7 +62,7 @@ describe("VS Code Ansible smoke test", () => {
       return ext?.isActive === true;
     });
 
-    expect(isActive).toBe(true);
+    await expect(isActive).toBe(true);
   });
 
   it("should register ansible commands", async function () {
@@ -94,6 +94,6 @@ describe("VS Code Ansible smoke test", () => {
       return editor?.document.languageId;
     });
 
-    expect(languageId).toBe("ansible");
+    await expect(languageId).toBe("ansible");
   });
 });

--- a/test/wdio/wdio.utils.ts
+++ b/test/wdio/wdio.utils.ts
@@ -1,0 +1,88 @@
+/**
+ * @file Shared helpers for WDIO specs (extension activation, activity bar).
+ */
+import { browser } from "@wdio/globals";
+import type { ViewControl } from "wdio-vscode-service";
+
+/** Open a fixture from the WDIO workspace to trigger `onLanguage:ansible`. */
+export async function openPlaybookFixture(
+  fixture = "playbook.ansible.yml",
+): Promise<void> {
+  await browser.executeWorkbench(async (vscode, fixtureName: string) => {
+    const folder = vscode.workspace.workspaceFolders?.[0];
+    if (!folder) {
+      throw new Error("WDIO workspace folder is missing");
+    }
+    const uri = vscode.Uri.joinPath(folder.uri, fixtureName);
+    const doc = await vscode.workspace.openTextDocument(uri);
+    await vscode.window.showTextDocument(doc, { preview: false });
+  }, fixture);
+}
+
+/** Wait until redhat.ansible is active, calling activate() if needed. */
+export async function waitForExtensionActive(timeout = 60_000): Promise<void> {
+  await browser.waitUntil(
+    async () =>
+      browser.executeWorkbench(async (vscode) => {
+        const ext = vscode.extensions.getExtension("redhat.ansible");
+        if (!ext) {
+          return false;
+        }
+        if (!ext.isActive) {
+          await ext.activate();
+        }
+        return ext.isActive;
+      }),
+    { timeout, timeoutMsg: "Ansible extension did not activate in time" },
+  );
+}
+
+/**
+ * Resolve the Ansible activity-bar view control, polling until contributions
+ * are registered. Prefer matching by visible title because `getViewControl`
+ * can return undefined briefly after activation.
+ */
+export async function getAnsibleViewControl(
+  timeout = 30_000,
+): Promise<ViewControl> {
+  let control: ViewControl | undefined;
+
+  await browser.waitUntil(
+    async () => {
+      const workbench = await browser.getWorkbench();
+      const activityBar = workbench.getActivityBar();
+
+      control = await activityBar.getViewControl("Ansible");
+      if (control) {
+        return true;
+      }
+
+      const viewControls = await activityBar.getViewControls();
+      for (const viewControl of viewControls) {
+        const title = await viewControl.getTitle();
+        if (title.includes("Ansible")) {
+          control = viewControl;
+          return true;
+        }
+      }
+      return false;
+    },
+    {
+      timeout,
+      interval: 1000,
+      timeoutMsg: "Ansible activity bar view control did not appear in time",
+    },
+  );
+
+  if (!control) {
+    throw new Error("Ansible view control not found after wait");
+  }
+  return control;
+}
+
+/** Standard setup: open ansible fixture, activate extension, wait for sidebar. */
+export async function prepareAnsibleExtension(): Promise<void> {
+  await openPlaybookFixture();
+  await waitForExtensionActive();
+  await getAnsibleViewControl();
+}

--- a/webviews/lightspeed/src/utils/vscode.ts
+++ b/webviews/lightspeed/src/utils/vscode.ts
@@ -74,10 +74,10 @@ class WebviewApi<StateType = unknown> {
     const listeners = this.listeners.get(type);
     if (listeners) {
       if (result !== undefined && result !== null) {
-        listeners[0]?.(result);
+        void listeners[0]?.(result);
       }
       if (error !== undefined && error !== null) {
-        listeners[1]?.(error);
+        void listeners[1]?.(error);
       }
     }
   }


### PR DESCRIPTION
Related: AAP-66052


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Enabled `@typescript-eslint/no-floating-promises` and fixed violations by explicitly discarding unawaited Promise results with the void operator across the codebase, preserving fire-and-forget behavior without changing control flow or public APIs.

- eslint.config.mjs: Enabled `@typescript-eslint/no-floating-promises`
- packages/ansible-language-server/src/ansibleLanguageService.ts: Added `void` to unawaited promise calls in notification handlers
- packages/ansible-language-server/src/server.ts: Added `void` to `connection.sendNotification()` and handler invocations
- packages/ansible-language-server/src/services/docsLibrary.ts: Added `void` to `sendNotification()` call
- packages/ansible-language-server/src/services/validationManager.ts: Added `void` to `sendDiagnostics()` calls
- packages/ansible-language-server/test/validate-ls.ts: Added `void` to `sendNotification()` and `exit()` calls in tests
- src/extension.ts: Added `void` to multiple async command and event handler registrations
- src/features/ansibleMetaData.ts: Added `void` to `sendNotification()` call
- src/features/ansibleTox/controller.ts: Added `void` to async handler and file parsing calls
- src/features/contentCreator/vue/views/panelUtils.ts: Added `void` to `setupWebviewHooks()` call
- src/features/lightspeed/base.ts: Added `void` to status bar tooltip update
- src/features/lightspeed/inlineSuggestions.ts: Added `void` to status bar and feedback calls
- src/features/lightspeed/lightSpeedOAuthProvider.ts: Added `void` to session removal call
- src/features/lightspeed/lightspeedUser.ts: Added `void` to `removeSession()` call
- src/features/lightspeed/providerManager.ts: Added `void` to `initializeLlmProvider()` call
- src/features/lightspeed/statusBar.ts: Added `void` to multiple status bar update calls
- src/features/lightspeed/vue/views/llmProviderMessageHandlers.ts: Added `void` to settings reinitialization
- src/features/lightspeed/vue/views/llmProviderPanel.ts: Added `void` to `sendProviderSettings()` call
- src/features/lightspeed/vue/views/panelUtils.ts: Added `void` to `setupWebviewHooks()` call
- src/features/lightspeed/vue/views/webviewMessageHandlers.ts: Added `void` to feedback API call
- src/features/runner.ts: Added `void` to command registration calls
- src/services/TerminalService.ts: Added `void` to `sendCommand()` call
- src/utils/telemetryUtils.ts: Added `void` to `sendTelemetry()` calls
- Multiple tests and webview utils: Prefixed handler invocations with `void` (ExplanationApp.test.ts, ExplorerApp.test.ts, PlaybookGenApp.test.ts, RoleGenApp.test.ts, CollectionSelector.test.ts, webviews/vscode util)
- test/wdio/smoke.spec.ts: Updated assertions to use `await expect()` for async checks
- sonar-project.properties: Added Sonar ignore entry for TypeScript rule in tests
- test/wdio/wdio.utils.ts: Added shared WDIO helpers for VS Code integration tests

related: AAP-66052
<!-- end of auto-generated comment: release notes by coderabbit.ai -->