### PR TITLE
fix: address @typescript-eslint/await-thenable

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -108,6 +108,7 @@ rollup
 sarif
 seealso
 sonarcloud
+sonarlint
 sonarqube
 summ
 sysninja

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -63,6 +63,10 @@
   "python.terminal.useEnvFile": true,
   "redhat.telemetry.enabled": false,
   "search.useParentIgnoreFiles": true,
+  "sonarlint.connectedMode.project": {
+    "connectionId": "ansible",
+    "projectKey": "ansible_vscode-ansible"
+  },
   "vitest.maximumConfigs": 10,
   "vitest.shellType": "terminal"
 }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -85,7 +85,7 @@ export default defineConfig(
       "no-empty-function": "error",
       "no-prototype-builtins": "error",
       // "@typescript-eslint/require-await": "error",  // electron import
-      // "@typescript-eslint/await-thenable": "error", // ~58 errors
+      "@typescript-eslint/await-thenable": "error",
       "@typescript-eslint/unbound-method": "error",
       // "@typescript-eslint/no-unsafe-member-access": "error", // ~550 errors
       "@typescript-eslint/no-floating-promises": "error",

--- a/packages/ansible-language-server/src/services/workspaceManager.ts
+++ b/packages/ansible-language-server/src/services/workspaceManager.ts
@@ -62,7 +62,7 @@ export class WorkspaceManager {
   ): Promise<void> {
     await Promise.all(
       _.map(Array.from(this.folderContexts.values()), (folder) =>
-        callbackfn(folder),
+        Promise.resolve(callbackfn(folder)),
       ),
     );
   }

--- a/packages/ansible-language-server/src/utils/docsFinder.ts
+++ b/packages/ansible-language-server/src/utils/docsFinder.ts
@@ -26,16 +26,16 @@ export async function findDocumentation(
   let files;
   switch (kind) {
     case "builtin":
-      files = await globArray([`${dir}/**/*.py`, "!/**/_*.py"]);
+      files = globArray([`${dir}/**/*.py`, "!/**/_*.py"]);
       break;
     case "builtin_doc_fragment":
-      files = await globArray([
+      files = globArray([
         `${path.resolve(dir, "../")}/plugins/doc_fragments/*.py`,
         "!/**/_*.py",
       ]);
       break;
     case "collection":
-      files = await globArray([
+      files = globArray([
         `${dir}/ansible_collections/*/*/plugins/modules/*.py`,
         `${dir}/ansible_collections/*/*/plugins/modules/**/*.py`,
         `!${dir}/ansible_collections/*/*/plugins/modules/_*.py`,
@@ -43,7 +43,7 @@ export async function findDocumentation(
       ]).filter((item) => !fs.lstatSync(item).isSymbolicLink());
       break;
     case "collection_doc_fragment":
-      files = await globArray([
+      files = globArray([
         `${dir}/ansible_collections/*/*/plugins/doc_fragments/*.py`,
         `!${dir}/ansible_collections/*/*/plugins/doc_fragments/_*.py`,
       ]);
@@ -97,12 +97,10 @@ export async function findPluginRouting(
   let files;
   switch (kind) {
     case "builtin":
-      files = await globArray([`${dir}/config/ansible_builtin_runtime.yml`]);
+      files = globArray([`${dir}/config/ansible_builtin_runtime.yml`]);
       break;
     case "collection":
-      files = await globArray([
-        `${dir}/ansible_collections/*/*/meta/runtime.yml`,
-      ]);
+      files = globArray([`${dir}/ansible_collections/*/*/meta/runtime.yml`]);
       break;
   }
   for (const file of files) {

--- a/packages/ansible-language-server/test/utils/yaml.test.ts
+++ b/packages/ansible-language-server/test/utils/yaml.test.ts
@@ -44,50 +44,50 @@ describe("yaml", function () {
 
   describe("ancestryBuilder", function () {
     it("canGetParent", async function () {
-      const path = await getPathInFile("ancestryBuilder.yml", 4, 7);
+      const path = getPathInFile("ancestryBuilder.yml", 4, 7);
       const node = new AncestryBuilder(path).parent().get();
       expect(node).toBeInstanceOf(YAMLMap);
     });
 
     it("canGetAssertedParent", async function () {
-      const path = await getPathInFile("ancestryBuilder.yml", 4, 7);
+      const path = getPathInFile("ancestryBuilder.yml", 4, 7);
       const node = new AncestryBuilder(path).parent(YAMLMap).get();
       expect(node).toBeInstanceOf(YAMLMap);
     });
 
     it("canAssertParent", async function () {
-      const path = await getPathInFile("ancestryBuilder.yml", 4, 7);
+      const path = getPathInFile("ancestryBuilder.yml", 4, 7);
       const node = new AncestryBuilder(path).parent(YAMLSeq).get();
       expect(node).toBeNull();
     });
 
     it("canGetAncestor", async function () {
-      const path = await getPathInFile("ancestryBuilder.yml", 4, 7);
+      const path = getPathInFile("ancestryBuilder.yml", 4, 7);
       const node = new AncestryBuilder(path).parent().parent().get();
       expect(node).toBeInstanceOf(YAMLSeq);
     });
 
     it("canGetParentPath", async function () {
-      const path = await getPathInFile("ancestryBuilder.yml", 4, 7);
+      const path = getPathInFile("ancestryBuilder.yml", 4, 7);
       const subPath = new AncestryBuilder(path).parent().getPath();
       expect(subPath).toBeInstanceOf(Array);
       expect(subPath).toHaveLength((path?.length || 0) - 2);
     });
 
     it("canGetKey", async function () {
-      const path = await getPathInFile("ancestryBuilder.yml", 4, 7);
+      const path = getPathInFile("ancestryBuilder.yml", 4, 7);
       const key = new AncestryBuilder(path).parent(YAMLMap).getStringKey();
       expect(key).toBe("name");
     });
 
     it("canGetKeyForValue", async function () {
-      const path = await getPathInFile("ancestryBuilder.yml", 4, 13);
+      const path = getPathInFile("ancestryBuilder.yml", 4, 13);
       const key = new AncestryBuilder(path).parent(YAMLMap).getStringKey();
       expect(key).toBe("name");
     });
 
     it("canGetKeyPath", async function () {
-      const path = await getPathInFile("ancestryBuilder.yml", 4, 7);
+      const path = getPathInFile("ancestryBuilder.yml", 4, 7);
       const subPath = new AncestryBuilder(path).parent(YAMLMap).getKeyPath();
       expect(subPath).toBeInstanceOf(Array);
       expect(subPath).toHaveLength(path?.length || 0);
@@ -98,7 +98,7 @@ describe("yaml", function () {
     });
 
     it("canGetAssertedParentOfKey", async function () {
-      const path = await getPathInFile("ancestryBuilder.yml", 4, 7);
+      const path = getPathInFile("ancestryBuilder.yml", 4, 7);
       const node = new AncestryBuilder(path).parentOfKey().get();
       expect(node).toBeInstanceOf(YAMLMap);
       if (node) {
@@ -113,13 +113,13 @@ describe("yaml", function () {
     });
 
     it("canAssertParentOfKey", async function () {
-      const path = await getPathInFile("ancestryBuilder.yml", 4, 13);
+      const path = getPathInFile("ancestryBuilder.yml", 4, 13);
       const node = new AncestryBuilder(path).parentOfKey().get();
       expect(node).toBeNull();
     });
 
     it("canGetIndentationParent", async function () {
-      const path = await getPathInFile("ancestryBuilder.yml", 7, 9);
+      const path = getPathInFile("ancestryBuilder.yml", 7, 9);
       const node = new AncestryBuilder(path)
         .parent(YAMLMap)
         .parent(YAMLMap)
@@ -131,7 +131,7 @@ describe("yaml", function () {
       // skipped -> the YAML parser doesn't correctly interpret indentation in
       // otherwise empty lines; a workaround is implemented for completion
       // provider
-      const path = await getPathInFile("ancestryBuilder.yml", 9, 9);
+      const path = getPathInFile("ancestryBuilder.yml", 9, 9);
       if (path) {
         const node = new AncestryBuilder(path)
           .parent(YAMLMap)
@@ -145,7 +145,7 @@ describe("yaml", function () {
       // skipped -> the YAML parser doesn't correctly interpret indentation in
       // otherwise empty lines; a workaround is implemented for completion
       // provider
-      const path = await getPathInFile("ancestryBuilder.yml", 15, 9);
+      const path = getPathInFile("ancestryBuilder.yml", 15, 9);
       const node = new AncestryBuilder(path)
         .parent(YAMLMap)
         .parent(YAMLMap)
@@ -156,7 +156,7 @@ describe("yaml", function () {
 
   describe("getDeclaredCollections", function () {
     it("canGetCollections", async function () {
-      const path = await getPathInFile("getDeclaredCollections.yml", 13, 7);
+      const path = getPathInFile("getDeclaredCollections.yml", 13, 7);
       const collections = getDeclaredCollections(path);
       expect(collections).toEqual(
         expect.arrayContaining([
@@ -167,7 +167,7 @@ describe("yaml", function () {
     });
 
     it("canGetCollectionsFromPreTasks", async function () {
-      const path = await getPathInFile("getDeclaredCollections.yml", 9, 7);
+      const path = getPathInFile("getDeclaredCollections.yml", 9, 7);
       const collections = getDeclaredCollections(path);
       expect(collections).toEqual(
         expect.arrayContaining([
@@ -178,7 +178,7 @@ describe("yaml", function () {
     });
 
     it("canGetCollectionsFromBlock", async function () {
-      const path = await getPathInFile("getDeclaredCollections.yml", 12, 11);
+      const path = getPathInFile("getDeclaredCollections.yml", 12, 11);
       const collections = getDeclaredCollections(path);
       expect(collections).toEqual(
         expect.arrayContaining([
@@ -189,7 +189,7 @@ describe("yaml", function () {
     });
 
     it("canGetCollectionsFromNestedBlock", async function () {
-      const path = await getPathInFile("getDeclaredCollections.yml", 23, 15);
+      const path = getPathInFile("getDeclaredCollections.yml", 23, 15);
       const collections = getDeclaredCollections(path);
       expect(collections).toEqual(
         expect.arrayContaining([
@@ -200,7 +200,7 @@ describe("yaml", function () {
     });
 
     it("canGetCollectionsFromRescue", async function () {
-      const path = await getPathInFile("getDeclaredCollections.yml", 27, 11);
+      const path = getPathInFile("getDeclaredCollections.yml", 27, 11);
       const collections = getDeclaredCollections(path);
       expect(collections).toEqual(
         expect.arrayContaining([
@@ -211,7 +211,7 @@ describe("yaml", function () {
     });
 
     it("canGetCollectionsFromAlways", async function () {
-      const path = await getPathInFile("getDeclaredCollections.yml", 31, 11);
+      const path = getPathInFile("getDeclaredCollections.yml", 31, 11);
       const collections = getDeclaredCollections(path);
       expect(collections).toEqual(
         expect.arrayContaining([
@@ -222,13 +222,13 @@ describe("yaml", function () {
     });
 
     it("canWorkWithoutCollections", async function () {
-      const path = await getPathInFile("getDeclaredCollections.yml", 38, 7);
+      const path = getPathInFile("getDeclaredCollections.yml", 38, 7);
       const collections = getDeclaredCollections(path);
       expect(collections).toEqual(expect.arrayContaining([]));
     });
 
     it("canWorkWithEmptyCollections", async function () {
-      const path = await getPathInFile("getDeclaredCollections.yml", 46, 7);
+      const path = getPathInFile("getDeclaredCollections.yml", 46, 7);
       const collections = getDeclaredCollections(path);
       expect(collections).toEqual(expect.arrayContaining([]));
     });
@@ -236,91 +236,55 @@ describe("yaml", function () {
 
   describe("isTaskParam", function () {
     it("canCorrectlyConfirmTaskParam", async function () {
-      const path = (await getPathInFile(
-        "isTaskParamInTaskFile.yml",
-        2,
-        3,
-      )) as Node[];
+      const path = getPathInFile("isTaskParamInTaskFile.yml", 2, 3) as Node[];
       const test = isTaskParam(path);
       expect(test).to.be.eq(true);
     });
 
     it("canCorrectlyNegateTaskParam", async function () {
-      const path = (await getPathInFile(
-        "isTaskParamInvalid.yml",
-        1,
-        1,
-      )) as Node[];
+      const path = getPathInFile("isTaskParamInvalid.yml", 1, 1) as Node[];
       const test = isTaskParam(path);
       expect(test).to.be.eq(false);
     });
 
     it("canCorrectlyNegateTaskParamForValue", async function () {
-      const path = (await getPathInFile(
-        "isTaskParamInTaskFile.yml",
-        2,
-        9,
-      )) as Node[];
+      const path = getPathInFile("isTaskParamInTaskFile.yml", 2, 9) as Node[];
       const test = isTaskParam(path);
       expect(test).to.be.eq(false);
     });
 
     it("canCorrectlyNegateTaskParamForPlay", async function () {
-      const path = (await getPathInFile(
-        "isTaskParamInPlaybook.yml",
-        4,
-        3,
-      )) as Node[];
+      const path = getPathInFile("isTaskParamInPlaybook.yml", 4, 3) as Node[];
       const test = isTaskParam(path);
       expect(test).to.be.eq(false);
     });
 
     it("canCorrectlyNegateTaskParamForBlock", async function () {
-      const path = (await getPathInFile(
-        "isTaskParamInPlaybook.yml",
-        14,
-        7,
-      )) as Node[];
+      const path = getPathInFile("isTaskParamInPlaybook.yml", 14, 7) as Node[];
       const test = isTaskParam(path);
       expect(test).to.be.eq(false);
     });
 
     it("canCorrectlyNegateTaskParamForRole", async function () {
-      const path = (await getPathInFile(
-        "isTaskParamInPlaybook.yml",
-        17,
-        7,
-      )) as Node[];
+      const path = getPathInFile("isTaskParamInPlaybook.yml", 17, 7) as Node[];
       const test = isTaskParam(path);
       expect(test).to.be.eq(false);
     });
 
     it("canCorrectlyConfirmTaskParamInPreTasks", async function () {
-      const path = (await getPathInFile(
-        "isTaskParamInPlaybook.yml",
-        6,
-        7,
-      )) as Node[];
+      const path = getPathInFile("isTaskParamInPlaybook.yml", 6, 7) as Node[];
       const test = isTaskParam(path);
       expect(test).to.be.eq(true);
     });
 
     it("canCorrectlyConfirmTaskParamInTasks", async function () {
-      const path = (await getPathInFile(
-        "isTaskParamInPlaybook.yml",
-        9,
-        7,
-      )) as Node[];
+      const path = getPathInFile("isTaskParamInPlaybook.yml", 9, 7) as Node[];
       const test = isTaskParam(path);
       expect(test).to.be.eq(true);
     });
 
     it("canCorrectlyConfirmTaskParamInBlock", async function () {
-      const path = (await getPathInFile(
-        "isTaskParamInPlaybook.yml",
-        13,
-        11,
-      )) as Node[];
+      const path = getPathInFile("isTaskParamInPlaybook.yml", 13, 11) as Node[];
       const test = isTaskParam(path);
       expect(test).to.be.eq(true);
     });
@@ -328,43 +292,43 @@ describe("yaml", function () {
 
   describe("isPlayParam", function () {
     it("canCorrectlyConfirmPlayParam", async function () {
-      const path = (await getPathInFile("isPlayParam.yml", 1, 3)) as Node[];
+      const path = getPathInFile("isPlayParam.yml", 1, 3) as Node[];
       const test = isPlayParam(path, "file://test/isPlay.yml");
       expect(test).to.be.eq(true);
     });
 
     it("canCorrectlyConfirmPlayParamWithoutPath", async function () {
-      const path = (await getPathInFile("isPlayParam.yml", 1, 3)) as Node[];
+      const path = getPathInFile("isPlayParam.yml", 1, 3) as Node[];
       const test = isPlayParam(path);
       expect(test).to.be.eq(true);
     });
 
     it("canCorrectlyConfirmPlayParamInStrangePath", async function () {
-      const path = (await getPathInFile("isPlayParam.yml", 1, 3)) as Node[];
+      const path = getPathInFile("isPlayParam.yml", 1, 3) as Node[];
       const test = isPlayParam(path, "file:///roles/test/tasks/isPlay.yml");
       expect(test).to.be.eq(true);
     });
 
     it("canCorrectlyNegatePlayParamInRolePathWithoutPlayKeywords", async function () {
-      const path = (await getPathInFile("isPlayParam.yml", 7, 3)) as Node[];
+      const path = getPathInFile("isPlayParam.yml", 7, 3) as Node[];
       const test = isPlayParam(path, "file:///roles/test/tasks/isPlay.yml");
       expect(test).to.be.eq(false);
     });
 
     it("canCorrectlyNegatePlayParamForNonRootSequence", async function () {
-      const path = (await getPathInFile("isPlayParam.yml", 14, 7)) as Node[];
+      const path = getPathInFile("isPlayParam.yml", 14, 7) as Node[];
       const test = isPlayParam(path, "file://test/isPlay.yml");
       expect(test).to.be.eq(false);
     });
 
     it("canCorrectlyNegatePlayParamForNonRootSequenceWithoutPath", async function () {
-      const path = (await getPathInFile("isPlayParam.yml", 14, 7)) as Node[];
+      const path = getPathInFile("isPlayParam.yml", 14, 7) as Node[];
       const test = isPlayParam(path);
       expect(test).to.be.eq(false);
     });
 
     it("canCorrectlyNegatePlayParamForValue", async function () {
-      const path = (await getPathInFile("isPlayParam.yml", 1, 9)) as Node[];
+      const path = getPathInFile("isPlayParam.yml", 1, 9) as Node[];
       const test = isPlayParam(path);
       expect(test).to.be.eq(false);
     });
@@ -372,19 +336,19 @@ describe("yaml", function () {
 
   describe("isBlockParam", function () {
     it("canCorrectlyConfirmBlockParam", async function () {
-      const path = (await getPathInFile("isBlockParam.yml", 2, 3)) as Node[];
+      const path = getPathInFile("isBlockParam.yml", 2, 3) as Node[];
       const test = isBlockParam(path);
       expect(test).to.be.eq(true);
     });
 
     it("canCorrectlyNegateBlockParam", async function () {
-      const path = (await getPathInFile("isBlockParam.yml", 5, 3)) as Node[];
+      const path = getPathInFile("isBlockParam.yml", 5, 3) as Node[];
       const test = isBlockParam(path);
       expect(test).to.be.eq(false);
     });
 
     it("canCorrectlyNegateBlockParamOnValue", async function () {
-      const path = (await getPathInFile("isBlockParam.yml", 2, 11)) as Node[];
+      const path = getPathInFile("isBlockParam.yml", 2, 11) as Node[];
       const test = isBlockParam(path);
       expect(test).to.be.eq(false);
     });
@@ -392,19 +356,19 @@ describe("yaml", function () {
 
   describe("isRoleParam", function () {
     it("canCorrectlyConfirmRoleParam", async function () {
-      const path = (await getPathInFile("isRoleParam.yml", 5, 7)) as Node[];
+      const path = getPathInFile("isRoleParam.yml", 5, 7) as Node[];
       const test = isRoleParam(path);
       expect(test).to.be.eq(true);
     });
 
     it("canCorrectlyNegateRoleParam", async function () {
-      const path = (await getPathInFile("isRoleParam.yml", 4, 3)) as Node[];
+      const path = getPathInFile("isRoleParam.yml", 4, 3) as Node[];
       const test = isRoleParam(path);
       expect(test).to.be.eq(false);
     });
 
     it("canCorrectlyNegateRoleParamOnValue", async function () {
-      const path = (await getPathInFile("isRoleParam.yml", 5, 13)) as Node[];
+      const path = getPathInFile("isRoleParam.yml", 5, 13) as Node[];
       const test = isRoleParam(path);
       expect(test).to.be.eq(false);
     });

--- a/packages/ansible-mcp-server/test/errorHandling.test.ts
+++ b/packages/ansible-mcp-server/test/errorHandling.test.ts
@@ -3,7 +3,7 @@ import { createAnsibleMcpServer } from "@src/server.js";
 
 describe("MCP Server Error Handling", () => {
   it("should provide helpful error message with available tools when requesting non-existent tool", async () => {
-    const server = await createAnsibleMcpServer("/test/workspace");
+    const server = createAnsibleMcpServer("/test/workspace");
 
     // Try to call the tools/call handler directly
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -34,7 +34,7 @@ describe("MCP Server Error Handling", () => {
   });
 
   it("should provide helpful error message listing all available tools", async () => {
-    const server = await createAnsibleMcpServer("/test/workspace");
+    const server = createAnsibleMcpServer("/test/workspace");
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const requestHandler = (server.server as any)._requestHandlers?.get(
@@ -63,7 +63,7 @@ describe("MCP Server Error Handling", () => {
   });
 
   it("should successfully call existing tools", async () => {
-    const server = await createAnsibleMcpServer("/test/workspace");
+    const server = createAnsibleMcpServer("/test/workspace");
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const requestHandler = (server.server as any)._requestHandlers?.get(
@@ -87,7 +87,7 @@ describe("MCP Server Error Handling", () => {
   });
 
   it("should handle empty tool name gracefully", async () => {
-    const server = await createAnsibleMcpServer("/test/workspace");
+    const server = createAnsibleMcpServer("/test/workspace");
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const requestHandler = (server.server as any)._requestHandlers?.get(
@@ -113,7 +113,7 @@ describe("MCP Server Error Handling", () => {
   });
 
   it("should handle missing tool handler gracefully", async () => {
-    const server = await createAnsibleMcpServer("/test/workspace");
+    const server = createAnsibleMcpServer("/test/workspace");
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const requestHandler = (server.server as any)._requestHandlers?.get(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -571,7 +571,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
    * Handle "Ansible Tox" in the extension
    */
   const ansibleToxController = new AnsibleToxController();
-  context.subscriptions.push(await ansibleToxController.create());
+  context.subscriptions.push(ansibleToxController.create());
 
   const workspaceTox = findProjectDir();
 

--- a/src/features/lightspeed/utils/data.ts
+++ b/src/features/lightspeed/utils/data.ts
@@ -281,13 +281,13 @@ export async function getRoleYamlFiles(
 ): Promise<GenerationListEntry[]> {
   const files = [] as GenerationListEntry[];
   const directories = ["defaults", "tasks"];
-  directories.forEach(async (dir) => {
+  for (const dir of directories) {
     const dirPath = `${rolePath}/${dir}`;
     if (fs.existsSync(dirPath)) {
-      const yamlFiles = await fs
-        .readdirSync(dirPath)
-        .filter((file) => /\.(yml|yaml)$/.test(file));
-      yamlFiles.forEach((file) => {
+      const yamlFiles = (await fs.promises.readdir(dirPath)).filter((file) =>
+        /\.(yml|yaml)$/.test(file),
+      );
+      for (const file of yamlFiles) {
         const fileContents = readVarFiles(`${dirPath}/${file}`);
         if (fileContents) {
           files.push({
@@ -296,9 +296,9 @@ export async function getRoleYamlFiles(
             content: fileContents,
           } as GenerationListEntry);
         }
-      });
+      }
     }
-  });
+  }
 
   return files;
 }

--- a/src/features/lightspeed/vue/views/webviewMessageHandlers.ts
+++ b/src/features/lightspeed/vue/views/webviewMessageHandlers.ts
@@ -370,7 +370,7 @@ export class WebviewMessageHandlers {
     if (projectUrl) {
       // For execution environment, open the specific YAML file
       const filePath = `${projectUrl}/execution-environment.yml`;
-      await this.fileOps.openFileInEditor(filePath);
+      this.fileOps.openFileInEditor(filePath);
     }
   }
 


### PR DESCRIPTION
Related: AAP-66052


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Enabled the `@typescript-eslint/await-thenable` ESLint rule and fixed violations across the codebase. The rule detects improper await usage, including awaiting non-promise values and missing awaits on actual promises. Changes involve removing unnecessary awaits, wrapping promises properly, and refactoring async patterns for correct handling.

- Added `sonarlint` to dictionary
- Configured SonarLint connected mode project in VSCode settings
- Enabled `@typescript-eslint/await-thenable` ESLint rule as error
- Modified `WorkspaceManager.forEachContext` to wrap callback with `Promise.resolve()`
- Fixed `docsFinder.ts` to not await non-promise `globArray()` calls
- Updated YAML tests to call `getPathInFile()` synchronously
- Updated MCP Server tests to construct server without await
- Modified `extension.ts` to not await `ansibleToxController.create()`
- Refactored `getRoleYamlFiles` to properly handle async file operations with `for...of` and `await`
- Removed await from `openFileInEditor()` call in webview message handler

related: AAP-66052

<!-- end of auto-generated comment: release notes by coderabbit.ai -->