### PR TITLE
fix: address @typescript-eslint/no-unsafe-member-access

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
         priority: 0
         name: pnpm-install
         alias: pnpm
-        entry: pnpm install --frozen-lockfile --silent
+        entry: npm exec -- pnpm install --frozen-lockfile --silent
         language: system
         pass_filenames: false
         always_run: true
@@ -56,7 +56,7 @@ repos:
         entry: npm exec -- biome check --write --unsafe
       - id: eslint
         name: eslint
-        entry: pnpm exec eslint --no-warn-ignored --color --format=gha --fix --max-warnings=0 --concurrency=2
+        entry: npm exec -- eslint --no-warn-ignored --color --format=gha --fix --max-warnings=0 --concurrency=2
         language: system
         pass_filenames: false
         priority: 1

--- a/Taskfile.base.yml
+++ b/Taskfile.base.yml
@@ -95,7 +95,7 @@ tasks:
     interactive: true # no prefix
     dir: "{{ .TASKFILE_DIR }}" # mandatory because running from subfolder will not enable knip to find its config
     deps:
-      - package # production needs package, development needs build
+      - build # now both production and development builds are done by build step, also package itself runs knip at the end
     cmds:
       - npm exec -- knip
       - npm exec -- knip --production

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -87,7 +87,7 @@ export default defineConfig(
       // "@typescript-eslint/require-await": "error",  // electron import
       "@typescript-eslint/await-thenable": "error",
       "@typescript-eslint/unbound-method": "error",
-      // "@typescript-eslint/no-unsafe-member-access": "error", // ~550 errors
+      "@typescript-eslint/no-unsafe-member-access": "error",
       "@typescript-eslint/no-floating-promises": "error",
       "@typescript-eslint/restrict-template-expressions": "error",
       "@typescript-eslint/no-unsafe-argument": "error",
@@ -110,12 +110,21 @@ export default defineConfig(
       "@typescript-eslint/no-base-to-string": "off",
       // Mocks and dynamic fixtures routinely return `any`
       "@typescript-eslint/no-unsafe-return": "off",
+      "@typescript-eslint/no-unsafe-member-access": "off",
     },
   },
   {
     // WDIO tests use their own tsconfig with relative imports; path aliases aren't practical
     files: ["test/wdio/**/*.ts", "wdio.conf.ts"],
-    rules: { "no-restricted-imports": "off" },
+    rules: {
+      "no-restricted-imports": "off",
+      "@typescript-eslint/no-unsafe-member-access": "off",
+    },
+  },
+  {
+    // Webview TypeScript uses dynamic message payloads; Vue SFCs are linted by biome
+    files: ["webviews/**/*.{js,ts,tsx}"],
+    rules: { "@typescript-eslint/no-unsafe-member-access": "off" },
   },
   {
     // Standalone scripts have no tsconfig; skip eslint entirely

--- a/knip.ts
+++ b/knip.ts
@@ -36,6 +36,7 @@ const config: KnipConfig = {
     "mocha-multi-reporters",
     "mocha-junit-reporter",
     "ovsx",
+    "pnpm",
     "ts-node", // used by wdio autoCompileOpts, not directly imported
     // The following genuine runtime deps are only added in --production mode
     // because knip cannot trace them there:

--- a/package.json
+++ b/package.json
@@ -1130,6 +1130,7 @@
     "mocha-junit-reporter": "^2.2.1",
     "mocha-multi-reporters": "^1.5.1",
     "ovsx": "^1.0.0",
+    "pnpm": "^11.5.2",
     "prettier": "^3.8.3",
     "rimraf": "^6.1.3",
     "sinon": "^22.0.0",

--- a/packages/ansible-language-server/src/ansibleLanguageService.ts
+++ b/packages/ansible-language-server/src/ansibleLanguageService.ts
@@ -11,6 +11,7 @@ import { TextDocument } from "vscode-languageserver-textdocument";
 import {
   doCompletion,
   doCompletionResolve,
+  hasCompletionDocumentUri,
 } from "@src/providers/completionProvider.js";
 import { getDefinition } from "@src/providers/definitionProvider.js";
 import { doHover } from "@src/providers/hoverProvider.js";
@@ -323,9 +324,9 @@ export class AnsibleLanguageService {
 
     this.connection.onCompletionResolve(async (completionItem) => {
       try {
-        if (completionItem.data?.documentUri) {
+        if (hasCompletionDocumentUri(completionItem.data)) {
           const context = this.workspaceManager.getContext(
-            completionItem.data?.documentUri as string,
+            completionItem.data.documentUri,
           );
           if (context) {
             return await doCompletionResolve(completionItem, context);

--- a/packages/ansible-language-server/src/providers/completionProvider.ts
+++ b/packages/ansible-language-server/src/providers/completionProvider.ts
@@ -45,6 +45,64 @@ import {
 import { getVarsCompletion } from "@src/providers/completionProviderUtils.js";
 import { HostType } from "@src/services/ansibleInventory.js";
 
+interface ModuleCompletionResolveData {
+  documentUri: string;
+  moduleFqcn: string;
+  inlineCollections: string[];
+  atEndOfLine: boolean;
+  firstElementOfList: boolean;
+}
+
+interface OptionCompletionResolveData {
+  documentUri: string;
+  type: string;
+  range?: Range;
+  atEndOfLine: boolean;
+  firstElementOfList?: boolean;
+}
+
+export function hasCompletionDocumentUri(
+  data: unknown,
+): data is { documentUri: string } {
+  return (
+    data !== null &&
+    typeof data === "object" &&
+    "documentUri" in data &&
+    typeof (data as { documentUri: unknown }).documentUri === "string"
+  );
+}
+
+function isModuleCompletionResolveData(
+  data: unknown,
+): data is ModuleCompletionResolveData {
+  if (!hasCompletionDocumentUri(data)) {
+    return false;
+  }
+  const record = data as Record<string, unknown>;
+  return (
+    typeof record.moduleFqcn === "string" &&
+    Array.isArray(record.inlineCollections) &&
+    record.inlineCollections.every((c) => typeof c === "string") &&
+    typeof record.atEndOfLine === "boolean" &&
+    typeof record.firstElementOfList === "boolean"
+  );
+}
+
+function isOptionCompletionResolveData(
+  data: unknown,
+): data is OptionCompletionResolveData {
+  if (!hasCompletionDocumentUri(data)) {
+    return false;
+  }
+  const record = data as Record<string, unknown>;
+  return (
+    typeof record.type === "string" &&
+    typeof record.atEndOfLine === "boolean" &&
+    (record.firstElementOfList === undefined ||
+      typeof record.firstElementOfList === "boolean")
+  );
+}
+
 const priorityMap = {
   nameKeyword: 1,
   moduleName: 2,
@@ -543,35 +601,26 @@ export async function doCompletionResolve(
   completionItem: CompletionItem,
   context: WorkspaceFolderContext,
 ): Promise<CompletionItem> {
-  if (completionItem.data?.moduleFqcn && completionItem.data?.documentUri) {
+  if (isModuleCompletionResolveData(completionItem.data)) {
+    const data = completionItem.data;
     // resolve completion for a module
 
     const docsLibrary = await context.docsLibrary;
-    const [module] = await docsLibrary.findModule(
-      completionItem.data.moduleFqcn as string,
-    );
+    const [module] = await docsLibrary.findModule(data.moduleFqcn);
 
     if (module && module.documentation) {
-      const [namespace, collection, name] = (
-        completionItem.data.moduleFqcn as string
-      ).split(".");
+      const [namespace, collection, name] = data.moduleFqcn.split(".");
 
-      let useFqcn = (
-        await context.documentSettings.get(
-          completionItem.data.documentUri as string,
-        )
-      ).ansible.useFullyQualifiedCollectionNames;
+      let useFqcn = (await context.documentSettings.get(data.documentUri))
+        .ansible.useFullyQualifiedCollectionNames;
 
       if (!useFqcn) {
         // determine if the short name can really be used
 
-        const declaredCollections: Array<string> =
-          completionItem.data?.inlineCollections || [];
+        const declaredCollections: Array<string> = [...data.inlineCollections];
         declaredCollections.push("ansible.builtin");
 
-        const metadata = await context.documentMetadata.get(
-          completionItem.data.documentUri as string,
-        );
+        const metadata = await context.documentMetadata.get(data.documentUri);
         if (metadata) {
           declaredCollections.push(...metadata.collections);
         }
@@ -586,11 +635,11 @@ export async function doCompletionResolve(
         }
       }
 
-      const insertName = useFqcn ? completionItem.data.moduleFqcn : name;
-      const insertText = completionItem.data.atEndOfLine
+      const insertName = useFqcn ? data.moduleFqcn : name;
+      const insertText = data.atEndOfLine
         ? `${insertName}:${resolveSuffix(
             "dict", // since a module is always a dictionary
-            completionItem.data.firstElementOfList as boolean,
+            data.firstElementOfList,
             isAnsiblePlaybook,
           )}`
         : insertName;
@@ -605,18 +654,19 @@ export async function doCompletionResolve(
 
       completionItem.documentation = formatModule(
         module.documentation,
-        docsLibrary.getModuleRoute(completionItem.data.moduleFqcn as string),
+        docsLibrary.getModuleRoute(data.moduleFqcn),
       );
     }
   }
 
-  if (completionItem.data?.type) {
+  if (isOptionCompletionResolveData(completionItem.data)) {
+    const data = completionItem.data;
     // resolve completion for a module option or sub-option
 
-    const insertText = completionItem.data.atEndOfLine
+    const insertText = data.atEndOfLine
       ? `${completionItem.label}:${resolveSuffix(
-          completionItem.data.type as string,
-          completionItem.data.firstElementOfList as boolean,
+          data.type,
+          data.firstElementOfList ?? false,
           isAnsiblePlaybook,
         )}`
       : completionItem.label;

--- a/packages/ansible-language-server/src/providers/completionProviderUtils.ts
+++ b/packages/ansible-language-server/src/providers/completionProviderUtils.ts
@@ -2,6 +2,7 @@ import { CompletionItem, CompletionItemKind } from "vscode-languageserver";
 import { URI } from "vscode-uri";
 import { isScalar, Node, YAMLMap, YAMLSeq, parseDocument } from "yaml";
 import { AncestryBuilder, isPlayParam } from "@src/utils/yaml.js";
+import { hasOwnProperty, isObject } from "@src/utils/misc.js";
 import * as pathUri from "path";
 import { existsSync, readFileSync } from "fs";
 
@@ -12,11 +13,47 @@ const getEnumerableKeys = (value: unknown): string[] =>
     ? Object.keys(value)
     : [];
 
-type varsPromptType = {
+type VarsPromptEntry = {
   name: string;
   prompt: string;
   private?: boolean;
 };
+
+function collectVarsKeys(
+  varsValue: unknown,
+  varPriority: number,
+  varsCompletion: varType[],
+): void {
+  if (Array.isArray(varsValue)) {
+    varsValue.forEach((element) => {
+      getEnumerableKeys(element).forEach((key) => {
+        varsCompletion.push({ variable: key, priority: varPriority });
+      });
+    });
+  } else {
+    getEnumerableKeys(varsValue).forEach((key) => {
+      varsCompletion.push({ variable: key, priority: varPriority });
+    });
+  }
+}
+
+function isVarsPromptEntry(value: unknown): value is VarsPromptEntry {
+  return (
+    isObject(value) &&
+    hasOwnProperty(value, "name") &&
+    typeof value.name === "string"
+  );
+}
+
+function isVarsPromptArray(value: unknown): value is VarsPromptEntry[] {
+  return Array.isArray(value) && value.every(isVarsPromptEntry);
+}
+
+function isVarsFilesArray(value: unknown): value is string[] {
+  return (
+    Array.isArray(value) && value.every((entry) => typeof entry === "string")
+  );
+}
 
 /**
  * A function that computes the possible variable auto-completions scope-wise for a given position
@@ -48,21 +85,11 @@ export function getVarsCompletion(
         typeof parentKeyNode["value"] === "string"
       ) {
         path = parentKeyPath;
-        const scopedNode = path[path.length - 3].toJSON();
-        if (Object.prototype.hasOwnProperty.call(scopedNode, "vars")) {
-          const varsObject = scopedNode["vars"];
-
-          if (Array.isArray(varsObject)) {
-            varsObject.forEach((element) => {
-              getEnumerableKeys(element).forEach((key) => {
-                varsCompletion.push({ variable: key, priority: varPriority });
-              });
-            });
-          } else {
-            getEnumerableKeys(varsObject).forEach((key) => {
-              varsCompletion.push({ variable: key, priority: varPriority });
-            });
-          }
+        const scopedNode: Record<string, unknown> = path[
+          path.length - 3
+        ].toJSON() as Record<string, unknown>;
+        if (hasOwnProperty(scopedNode, "vars")) {
+          collectVarsKeys(scopedNode.vars, varPriority, varsCompletion);
         }
 
         continue;
@@ -82,21 +109,11 @@ export function getVarsCompletion(
         typeof parentKeyNode["value"] === "string"
       ) {
         path = parentKeyPath;
-        const scopedNode = path[path.length - 3].toJSON();
-        if (Object.prototype.hasOwnProperty.call(scopedNode, "vars")) {
-          const varsObject = scopedNode["vars"];
-
-          if (Array.isArray(varsObject)) {
-            varsObject.forEach((element) => {
-              getEnumerableKeys(element).forEach((key) => {
-                varsCompletion.push({ variable: key, priority: varPriority });
-              });
-            });
-          } else {
-            getEnumerableKeys(varsObject).forEach((key) => {
-              varsCompletion.push({ variable: key, priority: varPriority });
-            });
-          }
+        const scopedNode: Record<string, unknown> = path[
+          path.length - 3
+        ].toJSON() as Record<string, unknown>;
+        if (hasOwnProperty(scopedNode, "vars")) {
+          collectVarsKeys(scopedNode.vars, varPriority, varsCompletion);
         }
 
         continue;
@@ -111,54 +128,61 @@ export function getVarsCompletion(
 
   // handling vars_prompt
   varPriority = varPriority + 1;
-  const playNode = path[path.length - 3].toJSON();
-  if (Object.prototype.hasOwnProperty.call(playNode, "vars_prompt")) {
-    const varsPromptObject: varsPromptType[] = playNode["vars_prompt"];
-
-    varsPromptObject.forEach((element) => {
-      varsCompletion.push({ variable: element["name"], priority: varPriority });
-    });
+  const playNode: Record<string, unknown> = path[
+    path.length - 3
+  ].toJSON() as Record<string, unknown>;
+  if (hasOwnProperty(playNode, "vars_prompt")) {
+    const varsPromptObject = playNode.vars_prompt;
+    if (isVarsPromptArray(varsPromptObject)) {
+      varsPromptObject.forEach((element) => {
+        varsCompletion.push({ variable: element.name, priority: varPriority });
+      });
+    }
   }
 
   // handling vars_files
   varPriority = varPriority + 1;
-  if (Object.prototype.hasOwnProperty.call(playNode, "vars_files")) {
-    const varsPromptObject: string[] = playNode["vars_files"];
+  if (hasOwnProperty(playNode, "vars_files")) {
+    const varsFiles = playNode.vars_files;
+    if (isVarsFilesArray(varsFiles)) {
+      const currentDirectory = pathUri.dirname(URI.parse(documentUri).path);
+      varsFiles.forEach((element) => {
+        let varFilePath;
+        if (pathUri.isAbsolute(element)) {
+          varFilePath = element;
+        } else {
+          varFilePath = URI.parse(
+            pathUri.resolve(currentDirectory, element),
+          ).path;
+        }
 
-    const currentDirectory = pathUri.dirname(URI.parse(documentUri).path);
-    varsPromptObject.forEach((element) => {
-      let varFilePath;
-      if (pathUri.isAbsolute(element)) {
-        varFilePath = element;
-      } else {
-        varFilePath = URI.parse(
-          pathUri.resolve(currentDirectory, element),
-        ).path;
-      }
+        // read the vars_file and get the variables declared inside it
+        if (existsSync(varFilePath)) {
+          const file = readFileSync(varFilePath, {
+            encoding: "utf8",
+          });
 
-      // read the vars_file and get the variables declared inside it
-      if (existsSync(varFilePath)) {
-        const file = readFileSync(varFilePath, {
-          encoding: "utf8",
-        });
+          const contents = parseDocument(file).contents;
+          if (contents !== null) {
+            const yamlDocContent = contents.toJSON();
 
-        const contents = parseDocument(file).contents;
-        if (contents !== null) {
-          const yamlDocContent = contents.toJSON();
-
-          // variables declared in the file should be in list format only
-          if (Array.isArray(yamlDocContent)) {
-            yamlDocContent.forEach((element) => {
-              if (typeof element === "object") {
-                getEnumerableKeys(element).forEach((key) => {
-                  varsCompletion.push({ variable: key, priority: varPriority });
-                });
-              }
-            });
+            // variables declared in the file should be in list format only
+            if (Array.isArray(yamlDocContent)) {
+              yamlDocContent.forEach((yamlElement) => {
+                if (typeof yamlElement === "object") {
+                  getEnumerableKeys(yamlElement).forEach((key) => {
+                    varsCompletion.push({
+                      variable: key,
+                      priority: varPriority,
+                    });
+                  });
+                }
+              });
+            }
           }
         }
-      }
-    });
+      });
+    }
   }
 
   // return the completions as completion items

--- a/packages/ansible-language-server/src/services/ansibleLint.ts
+++ b/packages/ansible-language-server/src/services/ansibleLint.ts
@@ -10,9 +10,96 @@ import {
   Range,
 } from "vscode-languageserver";
 import { TextDocument } from "vscode-languageserver-textdocument";
-import { fileExists } from "@src/utils/misc.js";
+import { fileExists, isObject } from "@src/utils/misc.js";
 import { WorkspaceFolderContext } from "@src/services/workspaceManager.js";
 import { CommandRunner } from "@src/utils/commandRunner.js";
+
+interface AnsibleLintPosition {
+  line: number;
+  column?: number;
+}
+
+interface AnsibleLintLinesLocation {
+  begin: AnsibleLintPosition | number;
+  column?: number;
+}
+
+interface AnsibleLintLocation {
+  path: string;
+  positions?: {
+    begin: AnsibleLintPosition;
+  };
+  lines?: AnsibleLintLinesLocation;
+}
+
+interface AnsibleLintReportItem {
+  check_name: string;
+  location: AnsibleLintLocation;
+  severity?: string;
+  url?: string;
+  description?: string;
+}
+
+function isAnsibleLintPosition(value: unknown): value is AnsibleLintPosition {
+  return (
+    isObject(value) &&
+    typeof value.line === "number" &&
+    (value.column === undefined || typeof value.column === "number")
+  );
+}
+
+function hasValidBeginLocation(location: AnsibleLintLocation): boolean {
+  if (location.positions?.begin) {
+    return isAnsibleLintPosition(location.positions.begin);
+  }
+  if (location.lines?.begin !== undefined) {
+    const begin = location.lines.begin;
+    return (
+      typeof begin === "number" ||
+      (isObject(begin) && typeof begin.line === "number")
+    );
+  }
+  return false;
+}
+
+function isAnsibleLintReportItem(item: unknown): item is AnsibleLintReportItem {
+  if (!isObject(item)) {
+    return false;
+  }
+  if (typeof item.check_name !== "string") {
+    return false;
+  }
+  if (!isObject(item.location) || typeof item.location.path !== "string") {
+    return false;
+  }
+  return hasValidBeginLocation(item.location as unknown as AnsibleLintLocation);
+}
+
+function getBeginLineAndColumn(location: AnsibleLintLocation): {
+  line: number;
+  column: number;
+} {
+  if (location.positions?.begin) {
+    return {
+      line: location.positions.begin.line,
+      column: location.positions.begin.column ?? 1,
+    };
+  }
+  const linesBegin = location.lines?.begin;
+  if (typeof linesBegin === "number") {
+    return {
+      line: linesBegin,
+      column: location.lines?.column ?? 1,
+    };
+  }
+  if (isObject(linesBegin)) {
+    return {
+      line: linesBegin.line,
+      column: linesBegin.column ?? location.lines?.column ?? 1,
+    };
+  }
+  return { line: 1, column: 1 };
+}
 
 /**
  * Acts as and interface to ansible-lint and a cache of its output.
@@ -164,72 +251,57 @@ export class AnsibleLint {
       return diagnostics;
     }
     try {
-      const report = JSON.parse(result);
-      if (report instanceof Array) {
+      const report: unknown = JSON.parse(result);
+      if (Array.isArray(report)) {
         for (const item of report) {
-          if (
-            typeof item.check_name === "string" &&
-            item.location &&
-            typeof item.location.path === "string" &&
-            ((item.location.positions && item.location.positions.begin) ||
-              (item.location.lines &&
-                (item.location.lines.begin ||
-                  typeof item.location.lines.begin === "number")))
-          ) {
-            const begin_line = item.location.positions
-              ? item.location.positions.begin.line
-              : item.location.lines.begin.line ||
-                item.location.lines.begin ||
-                1;
-            const begin_column = item.location.positions
-              ? item.location.positions.begin.column
-              : item.location.lines.begin.column || 1;
-            const start: Position = {
-              line: begin_line - 1,
-              character: begin_column - 1,
-            };
-            const end: Position = {
-              line: begin_line - 1,
-              character: integer.MAX_VALUE,
-            };
-            const range: Range = {
-              start: start,
-              end: end,
-            };
-
-            let severity: DiagnosticSeverity = DiagnosticSeverity.Error;
-            if (item.severity) {
-              if (item.severity === "major") {
-                severity = DiagnosticSeverity.Error;
-              } else if (item.severity === "minor") {
-                severity = DiagnosticSeverity.Warning;
-              }
-            }
-
-            const path = `${workingDirectory}/${item.location.path}`;
-            const locationUri = URI.file(path).toString();
-
-            const helpUri: string = item.url ? item.url : undefined;
-            const helpUrlName: string = helpUri ? item.check_name : undefined;
-
-            let fileDiagnostics = diagnostics.get(locationUri);
-            if (!fileDiagnostics) {
-              fileDiagnostics = [];
-              diagnostics.set(locationUri, fileDiagnostics);
-            }
-            let message: string = item.check_name;
-            if (item.description) {
-              message = item.description;
-            }
-            fileDiagnostics.push({
-              message: message,
-              range: range || Range.create(0, 0, 0, 0),
-              severity: severity,
-              source: "ansible-lint",
-              code: helpUrlName,
-              codeDescription: { href: helpUri },
-            });
+          if (!isAnsibleLintReportItem(item)) {
+            continue;
           }
+          const { line: begin_line, column: begin_column } =
+            getBeginLineAndColumn(item.location);
+          const start: Position = {
+            line: begin_line - 1,
+            character: begin_column - 1,
+          };
+          const end: Position = {
+            line: begin_line - 1,
+            character: integer.MAX_VALUE,
+          };
+          const range: Range = {
+            start: start,
+            end: end,
+          };
+
+          let severity: DiagnosticSeverity = DiagnosticSeverity.Error;
+          if (item.severity === "major") {
+            severity = DiagnosticSeverity.Error;
+          } else if (item.severity === "minor") {
+            severity = DiagnosticSeverity.Warning;
+          }
+
+          const path = `${workingDirectory}/${item.location.path}`;
+          const locationUri = URI.file(path).toString();
+
+          const helpUri = typeof item.url === "string" ? item.url : undefined;
+          const helpUrlName = helpUri ? item.check_name : undefined;
+
+          let fileDiagnostics = diagnostics.get(locationUri);
+          if (!fileDiagnostics) {
+            fileDiagnostics = [];
+            diagnostics.set(locationUri, fileDiagnostics);
+          }
+          const message =
+            typeof item.description === "string"
+              ? item.description
+              : item.check_name;
+          fileDiagnostics.push({
+            message: message,
+            range: range || Range.create(0, 0, 0, 0),
+            severity: severity,
+            source: "ansible-lint",
+            code: helpUrlName,
+            ...(helpUri ? { codeDescription: { href: helpUri } } : {}),
+          });
         }
       }
     } catch (error) {

--- a/packages/ansible-language-server/src/services/settingsManager.ts
+++ b/packages/ansible-language-server/src/services/settingsManager.ts
@@ -6,6 +6,17 @@ import type {
   ExtensionSettings,
   SettingsEntry,
 } from "@src/interfaces/extensionSettings";
+import { isObject } from "@src/utils/misc.js";
+
+interface LegacyConfigurationSettings {
+  ansible?: ExtensionSettings;
+}
+
+function hasLegacyAnsibleSettings(
+  settings: unknown,
+): settings is LegacyConfigurationSettings {
+  return isObject(settings) && "ansible" in settings;
+}
 
 export class SettingsManager {
   private connection: Connection | null;
@@ -215,12 +226,18 @@ export class SettingsManager {
         h();
       });
     } else {
-      if (params.settings.ansible) {
+      if (
+        hasLegacyAnsibleSettings(params.settings) &&
+        params.settings.ansible
+      ) {
         this.configurationChangeHandlers.forEach((h) => {
           h();
         });
       }
-      this.globalSettings = params.settings.ansible || this.defaultSettings;
+      this.globalSettings =
+        (hasLegacyAnsibleSettings(params.settings) &&
+          params.settings.ansible) ||
+        this.defaultSettings;
     }
   }
 

--- a/packages/ansible-language-server/src/settings-doc-generator.ts
+++ b/packages/ansible-language-server/src/settings-doc-generator.ts
@@ -76,10 +76,8 @@ export function generateSettingsDocs(outputPath: string) {
   // Register a special function for handlebars to deal with the checking of "list" as value type of settings
   Handlebars.registerHelper(
     "ifValueArray",
-    function (this: unknown, arg1, options: Handlebars.HelperOptions) {
-      return arg1.toString() === "list"
-        ? options.fn(this)
-        : options.inverse(this);
+    function (this: unknown, arg1: unknown, options: Handlebars.HelperOptions) {
+      return String(arg1) === "list" ? options.fn(this) : options.inverse(this);
     },
   );
 

--- a/packages/ansible-language-server/src/utils/misc.ts
+++ b/packages/ansible-language-server/src/utils/misc.ts
@@ -1,4 +1,5 @@
 import * as child_process from "child_process";
+import { Buffer } from "node:buffer";
 import { existsSync, statSync, promises as fs } from "node:fs";
 import { promisify } from "util";
 import type { SpawnOptions } from "child_process";
@@ -81,10 +82,10 @@ export function asyncSpawn(
     });
     let stdout = "";
     let stderr = "";
-    proc.stdout?.on("data", (chunk) => {
+    proc.stdout?.on("data", (chunk: Buffer) => {
       stdout += chunk.toString();
     });
-    proc.stderr?.on("data", (chunk) => {
+    proc.stderr?.on("data", (chunk: Buffer) => {
       stderr += chunk.toString();
     });
     proc.on("error", reject);

--- a/packages/ansible-mcp-server/src/dependencyChecker.ts
+++ b/packages/ansible-mcp-server/src/dependencyChecker.ts
@@ -50,8 +50,8 @@ async function getCommandVersion(
     });
     let output = "";
 
-    child.stdout?.on("data", (d) => (output += d.toString()));
-    child.stderr?.on("data", (d) => (output += d.toString()));
+    child.stdout?.on("data", (d: Buffer | string) => (output += d.toString()));
+    child.stderr?.on("data", (d: Buffer | string) => (output += d.toString()));
 
     child.on("close", (code) => {
       if (code !== 0) {

--- a/packages/ansible-mcp-server/src/server.ts
+++ b/packages/ansible-mcp-server/src/server.ts
@@ -40,6 +40,20 @@ import {
 } from "@src/resources/eeSchema.js";
 import { getFullAgentsGuidelines } from "@src/resources/agents.js";
 
+type RegisteredToolHandler = (
+  args: Record<string, unknown>,
+  workspaceRoot?: string,
+) => CallToolResult | Promise<CallToolResult>;
+
+interface RegisteredToolEntry {
+  handler?: RegisteredToolHandler;
+}
+
+/** McpServer extension exposing the SDK's internal tool registry. */
+interface McpServerWithRegisteredTools {
+  _registeredTools?: Record<string, RegisteredToolEntry>;
+}
+
 export function createAnsibleMcpServer(workspaceRoot: string) {
   const server = new McpServer({
     name: "ansible-mcp-server",
@@ -952,21 +966,20 @@ export function createAnsibleMcpServer(workspaceRoot: string) {
       }
 
       // Execute the tool handler
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const handlers = (server as any)._registeredTools;
-      if (handlers && handlers[toolName]?.handler) {
+      const handlers: Record<string, RegisteredToolEntry> | undefined = (
+        server as unknown as McpServerWithRegisteredTools
+      )._registeredTools;
+      const toolHandler: RegisteredToolHandler | undefined =
+        handlers?.[toolName]?.handler;
+      if (toolHandler) {
         // Pass workspaceRoot to handlers that need it (like ansible_navigator)
-        const handlerArgs = request.params.arguments || {};
+        const handlerArgs: Record<string, unknown> =
+          request.params.arguments ?? {};
 
         if (toolName === "ansible_navigator") {
-          return (await handlers[toolName].handler(
-            handlerArgs,
-            workspaceRoot,
-          )) as CallToolResult;
+          return await toolHandler(handlerArgs, workspaceRoot);
         }
-        return (await handlers[toolName].handler(
-          handlerArgs,
-        )) as CallToolResult;
+        return await toolHandler(handlerArgs);
       }
 
       // Log available tools for debugging

--- a/packages/ansible-mcp-server/src/tools/adeTools.ts
+++ b/packages/ansible-mcp-server/src/tools/adeTools.ts
@@ -186,11 +186,11 @@ export async function executeCommand(
     let stdout = "";
     let stderr = "";
 
-    child.stdout?.on("data", (data) => {
+    child.stdout?.on("data", (data: Buffer | string) => {
       stdout += data.toString();
     });
 
-    child.stderr?.on("data", (data) => {
+    child.stderr?.on("data", (data: Buffer | string) => {
       stderr += data.toString();
     });
 
@@ -547,10 +547,12 @@ export async function checkConflictingPackages(): Promise<ADECommandResult> {
   const checkResult = await executeCommand("pip", ["list", "--format=json"]);
   if (checkResult.success) {
     try {
-      const packages = JSON.parse(checkResult.output);
+      const packages = JSON.parse(checkResult.output) as Array<{
+        name: string;
+        version: string;
+      }>;
       const oldAnsible = packages.find(
-        (pkg: { name: string; version: string }) =>
-          pkg.name === "ansible" && pkg.version.startsWith("2."),
+        (pkg) => pkg.name === "ansible" && pkg.version.startsWith("2."),
       );
 
       if (oldAnsible) {

--- a/packages/ansible-mcp-server/src/tools/ansibleLint.ts
+++ b/packages/ansible-mcp-server/src/tools/ansibleLint.ts
@@ -56,12 +56,12 @@ async function runAnsibleLintWithoutFix(
     let stderrData = "";
 
     // Capture standard output
-    lintProcess.stdout.on("data", (data) => {
+    lintProcess.stdout.on("data", (data: Buffer | string) => {
       stdoutData += data.toString();
     });
 
     // Capture standard error
-    lintProcess.stderr.on("data", (data) => {
+    lintProcess.stderr.on("data", (data: Buffer | string) => {
       stderrData += data.toString();
     });
 
@@ -138,12 +138,12 @@ async function runAnsibleLintOnFile(
     let stderrData = "";
 
     // Capture standard output
-    lintProcess.stdout.on("data", (data) => {
+    lintProcess.stdout.on("data", (data: Buffer | string) => {
       stdoutData += data.toString();
     });
 
     // Capture standard error
-    lintProcess.stderr.on("data", (data) => {
+    lintProcess.stderr.on("data", (data: Buffer | string) => {
       stderrData += data.toString();
     });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -234,6 +234,9 @@ importers:
       ovsx:
         specifier: ^1.0.0
         version: 1.0.0
+      pnpm:
+        specifier: ^11.5.2
+        version: 11.5.2
       prettier:
         specifier: ^3.8.3
         version: 3.8.3
@@ -5736,6 +5739,11 @@ packages:
   pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
     engines: {node: '>=4'}
+
+  pnpm@11.5.2:
+    resolution: {integrity: sha512-ccYx44IGbvwlYl1c8CkHXeB7YbN/bic1D72Esb2lhkyMGWetwoB3a0XDCnFcA1mjvgj+9C1bsJ4rmQKZeWkpFg==}
+    engines: {node: '>=22.13'}
+    hasBin: true
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -13010,6 +13018,8 @@ snapshots:
   pluralize@2.0.0: {}
 
   pluralize@8.0.0: {}
+
+  pnpm@11.5.2: {}
 
   possible-typed-array-names@1.1.0: {}
 

--- a/src/extensionConflicts.ts
+++ b/src/extensionConflicts.ts
@@ -17,32 +17,44 @@ const conflictingIDs = [
 // A set of VSCode extension ID's that are currently uninstalling
 const uninstallingIDs = new Set();
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function isExtensionPresent(obj: any): obj is Extension<any> {
-  return typeof obj !== "undefined" && !uninstallingIDs.has(obj.id);
+interface ExtensionPackageJson {
+  displayName?: string;
+}
+
+function extensionDisplayName(ext: Extension<unknown>): string {
+  const packageJson = ext.packageJSON as ExtensionPackageJson;
+  return typeof packageJson.displayName === "string"
+    ? packageJson.displayName
+    : ext.id;
+}
+
+function isExtensionPresent(obj: unknown): obj is Extension<unknown> {
+  return (
+    typeof obj !== "undefined" &&
+    typeof obj === "object" &&
+    obj !== null &&
+    "id" in obj &&
+    typeof (obj as Extension<unknown>).id === "string" &&
+    !uninstallingIDs.has((obj as Extension<unknown>).id)
+  );
 }
 
 /**
  * Get all of the installed extensions that currently conflict with us
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function getConflictingExtensions(): Extension<any>[] {
-  return (
-    conflictingIDs
-      .map((x) => extensions.getExtension(x))
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      .filter<Extension<any>>((ext): ext is Extension<any> =>
-        isExtensionPresent(ext),
-      )
-  );
+export function getConflictingExtensions(): Extension<unknown>[] {
+  return conflictingIDs
+    .map((x) => extensions.getExtension(x))
+    .filter<
+      Extension<unknown>
+    >((ext): ext is Extension<unknown> => isExtensionPresent(ext));
 }
 
 /**
  * Display the uninstall conflicting extension notification if there are any conflicting extensions currently installed
  */
 export async function showUninstallConflictsNotification(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  conflictingExts: Extension<any>[],
+  conflictingExts: Extension<unknown>[],
 ): Promise<void> {
   // Add all available conflicting extensions to the uninstalling IDs map
   for (const ext of conflictingExts) {
@@ -57,10 +69,10 @@ export async function showUninstallConflictsNotification(
   // Gather all the conflicting display names
   let conflictMsg: string;
   if (conflictingExts.length === 1) {
-    conflictMsg = `${conflictingExts[0].packageJSON.displayName} (${conflictingExts[0].id}) extension is incompatible with redhat.ansible. Please uninstall it.`;
+    conflictMsg = `${extensionDisplayName(conflictingExts[0])} (${conflictingExts[0].id}) extension is incompatible with redhat.ansible. Please uninstall it.`;
   } else {
     const extNames: string = conflictingExts
-      .map((ext) => `${ext.packageJSON.displayName} (${ext.id})`)
+      .map((ext) => `${extensionDisplayName(ext)} (${ext.id})`)
       .join(", ");
     conflictMsg = `The ${extNames} extensions are incompatible with redhat.ansible. Please uninstall them.`;
   }

--- a/src/features/ansibleMetaData.ts
+++ b/src/features/ansibleMetaData.ts
@@ -1,4 +1,3 @@
-/* eslint-disable  @typescript-eslint/no-explicit-any */
 import {
   ExtensionContext,
   window,
@@ -10,9 +9,20 @@ import {
 import { NotificationType } from "vscode-languageclient";
 import { LanguageClient } from "vscode-languageclient/node";
 import { TelemetryManager, sendTelemetry } from "@src/utils/telemetryUtils";
-import { formatAnsibleMetaData } from "@src/features/utils/formatAnsibleMetaData";
+import {
+  formatAnsibleMetaData,
+  type FormattedAnsibleMetaData,
+} from "@src/features/utils/formatAnsibleMetaData";
 import { compareObjects, getValueFromObject } from "@src/features/utils/data";
 import { SettingsManager } from "@src/settings";
+
+const asRecord = (value: unknown): Record<string, unknown> =>
+  value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+
+const asMetadataString = (value: unknown): string =>
+  typeof value === "string" || typeof value === "number" ? String(value) : "";
 
 interface ansibleMetadataEvent {
   ansibleVersion: string;
@@ -34,7 +44,7 @@ export class MetadataManager {
   private extensionSettings: SettingsManager;
   private currentAnsibleMetaEventData: ansibleMetadataEvent | undefined;
   private previousAnsibleMetaEventData: ansibleMetadataEvent | undefined;
-  private ansibleMetaData: any;
+  private ansibleMetaData: FormattedAnsibleMetaData | undefined;
 
   constructor(
     context: ExtensionContext,
@@ -90,15 +100,18 @@ export class MetadataManager {
     );
     this.metadataStatusBarItem.show();
     this.client.onNotification(
-      new NotificationType(`update/ansible-metadata`),
-      (ansibleMetaDataList: any) => {
-        this.ansibleMetaData = formatAnsibleMetaData(ansibleMetaDataList[0]);
+      new NotificationType<unknown[]>(`update/ansible-metadata`),
+      (ansibleMetaDataList) => {
+        const firstEntry = ansibleMetaDataList[0];
+        this.ansibleMetaData = formatAnsibleMetaData(firstEntry);
         if (this.ansibleMetaData.ansiblePresent) {
           console.log("Ansible found in the workspace");
-          this.cachedAnsibleVersion =
-            this.ansibleMetaData.metaData["ansible information"][
-              "core version"
-            ];
+          const ansibleInfo = asRecord(
+            this.ansibleMetaData.metaData["ansible information"],
+          );
+          this.cachedAnsibleVersion = asMetadataString(
+            ansibleInfo["core version"],
+          );
           const tooltip = this.ansibleMetaData.markdown;
           this.metadataStatusBarItem.text = this.ansibleMetaData.eeEnabled
             ? `$(bracket-dot) [EE] ${this.cachedAnsibleVersion}`
@@ -128,7 +141,7 @@ export class MetadataManager {
     );
     const activeFileUri = window.activeTextEditor?.document.uri.toString();
     void this.client.sendNotification(
-      new NotificationType(`update/ansible-metadata`),
+      new NotificationType<unknown[]>(`update/ansible-metadata`),
       [activeFileUri],
     );
 
@@ -140,20 +153,26 @@ export class MetadataManager {
       return;
     }
     // Extract ansibleVersion and pythonVersion safely
-    const ansibleVersion = getValueFromObject(this.ansibleMetaData.metaData, [
-      "ansible information",
-      "core version",
-    ]);
-    const pythonVersion = getValueFromObject(this.ansibleMetaData.metaData, [
-      "python information",
-      "version",
-    ]);
+    const ansibleVersion = asMetadataString(
+      getValueFromObject(this.ansibleMetaData.metaData, [
+        "ansible information",
+        "core version",
+      ]),
+    );
+    const pythonVersion = asMetadataString(
+      getValueFromObject(this.ansibleMetaData.metaData, [
+        "python information",
+        "version",
+      ]),
+    );
     const ansibleLintVersion = this.ansibleMetaData.ansibleLintPresent
-      ? getValueFromObject(this.ansibleMetaData.metaData, [
-          "ansible-lint information",
-          "version",
-        ])
-      : null;
+      ? asMetadataString(
+          getValueFromObject(this.ansibleMetaData.metaData, [
+            "ansible-lint information",
+            "version",
+          ]),
+        )
+      : undefined;
     this.currentAnsibleMetaEventData = {
       ansibleVersion,
       pythonVersion,

--- a/src/features/ansibleTox/runner.ts
+++ b/src/features/ansibleTox/runner.ts
@@ -15,6 +15,15 @@ import { PythonEnvironmentService } from "@src/services/PythonEnvironmentService
 
 const exec = util.promisify(child_process.exec);
 
+interface ExecProcessError extends Error {
+  stderr?: string;
+  stdout?: string;
+}
+
+function isExecProcessError(err: unknown): err is ExecProcessError {
+  return err instanceof Error;
+}
+
 export async function getToxEnvs(
   projDir: string,
   command: string = ANSIBLE_TOX_LIST_ENV_COMMAND,
@@ -47,13 +56,20 @@ export async function getToxEnvs(
       channel.show(true);
     }
     return stdout.trim().split(os.EOL);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  } catch (err: any) {
+  } catch (err: unknown) {
     const channel = getOutputChannel();
     const stderr: string =
-      typeof err.stderr === "string" ? err.stderr : String(err.stderr ?? "");
+      isExecProcessError(err) && typeof err.stderr === "string"
+        ? err.stderr
+        : isExecProcessError(err) && err.stderr != null
+          ? String(err.stderr)
+          : "";
     const stdout: string =
-      typeof err.stdout === "string" ? err.stdout : String(err.stdout ?? "");
+      isExecProcessError(err) && typeof err.stdout === "string"
+        ? err.stdout
+        : isExecProcessError(err) && err.stdout != null
+          ? String(err.stdout)
+          : "";
     channel.appendLine(stderr);
     channel.appendLine(stdout);
     if (stderr.includes("unrecognized arguments: --ansible")) {

--- a/src/features/contentCreator/vue/views/addPluginPagePanel.ts
+++ b/src/features/contentCreator/vue/views/addPluginPagePanel.ts
@@ -16,8 +16,14 @@ export class MainPanel {
     this._panel = panel;
 
     this._panel.webview.onDidReceiveMessage(
-      async (msg) => {
-        if (msg && msg.type === "request-requirements-status") {
+      async (msg: unknown) => {
+        if (
+          typeof msg === "object" &&
+          msg !== null &&
+          "type" in msg &&
+          (msg as Record<string, unknown>).type ===
+            "request-requirements-status"
+        ) {
           const status = await checkContentCreatorRequirements();
           this._panel.webview.postMessage({
             type: "requirements-status",

--- a/src/features/contentCreator/vue/views/createAnsibleCollectionPanel.ts
+++ b/src/features/contentCreator/vue/views/createAnsibleCollectionPanel.ts
@@ -16,8 +16,14 @@ export class MainPanel {
     this._panel = panel;
 
     this._panel.webview.onDidReceiveMessage(
-      async (msg) => {
-        if (msg && msg.type === "request-requirements-status") {
+      async (msg: unknown) => {
+        if (
+          typeof msg === "object" &&
+          msg !== null &&
+          "type" in msg &&
+          (msg as Record<string, unknown>).type ===
+            "request-requirements-status"
+        ) {
           const status = await checkContentCreatorRequirements();
           this._panel.webview.postMessage({
             type: "requirements-status",

--- a/src/features/contentCreator/vue/views/createAnsibleProjectPanel.ts
+++ b/src/features/contentCreator/vue/views/createAnsibleProjectPanel.ts
@@ -16,8 +16,14 @@ export class MainPanel {
     this._panel = panel;
 
     this._panel.webview.onDidReceiveMessage(
-      async (msg) => {
-        if (msg && msg.type === "request-requirements-status") {
+      async (msg: unknown) => {
+        if (
+          typeof msg === "object" &&
+          msg !== null &&
+          "type" in msg &&
+          (msg as Record<string, unknown>).type ===
+            "request-requirements-status"
+        ) {
           const status = await checkContentCreatorRequirements();
           this._panel.webview.postMessage({
             type: "requirements-status",

--- a/src/features/contentCreator/vue/views/createExecutionEnvPanel.ts
+++ b/src/features/contentCreator/vue/views/createExecutionEnvPanel.ts
@@ -23,8 +23,14 @@ export class MainPanel {
     );
 
     this._panel.webview.onDidReceiveMessage(
-      async (msg) => {
-        if (msg && msg.type === "request-requirements-status") {
+      async (msg: unknown) => {
+        if (
+          typeof msg === "object" &&
+          msg !== null &&
+          "type" in msg &&
+          (msg as Record<string, unknown>).type ===
+            "request-requirements-status"
+        ) {
           const status = await checkContentCreatorRequirements();
           this._panel.webview.postMessage({
             type: "requirements-status",

--- a/src/features/contentCreator/vue/views/createRolePanel.ts
+++ b/src/features/contentCreator/vue/views/createRolePanel.ts
@@ -16,8 +16,14 @@ export class MainPanel {
     this._panel = panel;
 
     this._panel.webview.onDidReceiveMessage(
-      async (msg) => {
-        if (msg && msg.type === "request-requirements-status") {
+      async (msg: unknown) => {
+        if (
+          typeof msg === "object" &&
+          msg !== null &&
+          "type" in msg &&
+          (msg as Record<string, unknown>).type ===
+            "request-requirements-status"
+        ) {
           const status = await checkContentCreatorRequirements();
           this._panel.webview.postMessage({
             type: "requirements-status",

--- a/src/features/contentCreator/webviewUtils.ts
+++ b/src/features/contentCreator/webviewUtils.ts
@@ -152,24 +152,31 @@ class MessageRouter {
     }
   }
 
-  private onExecutionLog(args: any): void {
+  private onExecutionLog(args: unknown): void {
     this.config?.onExecutionLog?.(args);
 
     if (
-      this.commonState?.logs &&
-      this.commonState?.logFileUrl &&
-      this.commonState?.openLogFileButtonDisabled &&
-      this.commonState?.createButtonDisabled &&
-      this.commonState?.isCreating
+      !isRecord(args) ||
+      !this.commonState?.logs ||
+      !this.commonState?.logFileUrl ||
+      !this.commonState?.openLogFileButtonDisabled ||
+      !this.commonState?.createButtonDisabled ||
+      !this.commonState?.isCreating
     ) {
-      this.commonState.logs.value = args.commandOutput;
-      this.commonState.logFileUrl.value = args.logFileUrl;
-      this.commonState.openLogFileButtonDisabled.value = !args.logFileUrl;
-      this.commonState.createButtonDisabled.value = false;
+      return;
+    }
 
-      if (args.status === "passed" || args.status === "failed") {
-        this.commonState.isCreating.value = false;
-      }
+    const commandOutput = asString(args.commandOutput) ?? "";
+    const logFileUrl = asString(args.logFileUrl) ?? "";
+    const status = asString(args.status);
+
+    this.commonState.logs.value = commandOutput;
+    this.commonState.logFileUrl.value = logFileUrl;
+    this.commonState.openLogFileButtonDisabled.value = !logFileUrl;
+    this.commonState.createButtonDisabled.value = false;
+
+    if (status === "passed" || status === "failed") {
+      this.commonState.isCreating.value = false;
     }
   }
 

--- a/src/features/lightspeed/api.ts
+++ b/src/features/lightspeed/api.ts
@@ -77,7 +77,8 @@ export class LightSpeedAPI {
     this.settingsManager = settingsManager;
     this.lightspeedAuthenticatedUser = lightspeedAuthenticatedUser;
     this._suggestionFeedbacks = [];
-    this._extensionVersion = context.extension.packageJSON.version;
+    const packageJson = context.extension.packageJSON as { version?: string };
+    this._extensionVersion = packageJson.version ?? "";
     this._oneClickTrialProvider = getOneClickTrialProvider();
     this.logger = logger;
   }
@@ -138,7 +139,10 @@ export class LightSpeedAPI {
         JSON.stringify(requestData),
       );
 
-      const data = await response.json();
+      interface CompletionApiResponse {
+        predictions?: unknown[];
+      }
+      const data = (await response.json()) as CompletionApiResponse;
 
       if (!response.ok) {
         throw new HTTPError(response, response.status, data as object);
@@ -146,6 +150,7 @@ export class LightSpeedAPI {
 
       if (
         response.status === 204 ||
+        !data.predictions ||
         data.predictions.length === 0 ||
         // currently we only support one inline suggestion
         !data.predictions[0]
@@ -384,7 +389,7 @@ export class LightSpeedAPI {
         JSON.stringify(requestData),
       );
 
-      const data = await response.json();
+      const data = (await response.json()) as RoleGenerationResponseParams;
 
       // to remove after roleGen GA
       if (data.role && !data.name) {
@@ -395,7 +400,7 @@ export class LightSpeedAPI {
         throw new HTTPError(response, response.status, data as object);
       }
 
-      return data as RoleGenerationResponseParams;
+      return data;
     } catch (error) {
       const mappedError: IError = mapError(error as Error);
       return mappedError;

--- a/src/features/lightspeed/clients/openaiCompatibleClient.ts
+++ b/src/features/lightspeed/clients/openaiCompatibleClient.ts
@@ -105,12 +105,16 @@ export class OpenAICompatibleClient {
 
       clearTimeout(timeoutId);
 
-      const body = await response.json();
+      interface ErrorResponseBody {
+        error?: { message?: string };
+        message?: string;
+      }
+      const body = (await response.json()) as ErrorResponseBody;
 
       if (!response.ok) {
         const errorMessage =
-          body?.error?.message ||
-          body?.message ||
+          body.error?.message ||
+          body.message ||
           `HTTP ${response.status} error`;
         throw new OpenAIClientError(String(errorMessage), response.status);
       }

--- a/src/features/lightspeed/contentMatchesWebview.ts
+++ b/src/features/lightspeed/contentMatchesWebview.ts
@@ -208,19 +208,21 @@ export class ContentMatchesWebview implements vscode.WebviewViewProvider {
       return noContentMatchesFoundHtml;
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let suggestedTasks: any[];
+    interface SuggestedTask {
+      name?: string;
+    }
+    let suggestedTasks: SuggestedTask[];
     try {
       suggestedTasks = yaml.parse(suggestion, {
         keepSourceTokens: true,
-      });
+      }) as SuggestedTask[];
     } catch (err) {
       this.log(err);
       return noContentMatchesFoundHtml;
     }
     if (isPlaybook) {
       // Note: When isPlaybook is True, suggestedTasks contains plays in a playbook instead of tasks.
-      suggestedTasks = parsePlays(suggestedTasks);
+      suggestedTasks = parsePlays(suggestedTasks) as SuggestedTask[];
     }
     if (
       !suggestedTasks ||

--- a/src/features/lightspeed/lightSpeedOAuthProvider.ts
+++ b/src/features/lightspeed/lightSpeedOAuthProvider.ts
@@ -141,8 +141,12 @@ export class LightSpeedAuthenticationProvider
   }
 
   private static getRedirectUri(context: ExtensionContext) {
-    const publisher = context.extension.packageJSON.publisher;
-    const name = context.extension.packageJSON.name;
+    const manifest = context.extension.packageJSON as {
+      publisher?: string;
+      name?: string;
+    };
+    const publisher = manifest.publisher ?? "";
+    const name = manifest.name ?? "";
 
     return `${env.uriScheme}://${publisher}.${name}`;
   }
@@ -428,15 +432,20 @@ export class LightSpeedAuthenticationProvider
         },
       );
 
-      const data = await response.json();
+      interface OAuthTokenResponse {
+        access_token?: string;
+        refresh_token?: string;
+        expires_in?: unknown;
+      }
+      const data = (await response.json()) as OAuthTokenResponse;
 
       if (response.ok) {
         const account: OAuthAccount = {
           type: "oauth",
-          accessToken: data?.access_token,
-          refreshToken: data?.refresh_token,
+          accessToken: data.access_token ?? "",
+          refreshToken: data.refresh_token ?? "",
           expiresAtTimestampInSeconds: calculateTokenExpiryTime(
-            coerceExpiresIn(data?.expires_in),
+            coerceExpiresIn(data.expires_in),
           ),
           // scope: data.scope,
         };
@@ -500,15 +509,20 @@ export class LightSpeedAuthenticationProvider
             },
           );
 
-          const data = await response.json();
+          interface OAuthTokenResponse {
+            access_token?: string;
+            refresh_token?: string;
+            expires_in?: unknown;
+          }
+          const data = (await response.json()) as OAuthTokenResponse;
 
           if (response.ok) {
             const account: OAuthAccount = {
               ...currentAccount,
-              accessToken: data?.access_token,
-              refreshToken: data?.refresh_token,
+              accessToken: data.access_token ?? currentAccount.accessToken,
+              refreshToken: data.refresh_token ?? currentAccount.refreshToken,
               expiresAtTimestampInSeconds: calculateTokenExpiryTime(
-                coerceExpiresIn(data?.expires_in),
+                coerceExpiresIn(data.expires_in),
               ),
               // scope: data.scope,
             };

--- a/src/features/lightspeed/providers/base.ts
+++ b/src/features/lightspeed/providers/base.ts
@@ -2,6 +2,7 @@ import {
   CompletionRequestParams,
   CompletionResponseParams,
 } from "@src/interfaces/lightspeed";
+import { AnsibleContextProcessor } from "@src/features/lightspeed/ansibleContext";
 
 export interface ProviderMetadata {
   ansibleFileType?:
@@ -135,12 +136,9 @@ export abstract class BaseLLMProvider<
     prompt: string,
     metadata?: ProviderMetadata,
   ): string {
-    const { AnsibleContextProcessor } = require("../ansibleContext");
-
     const ansibleContext = {
       fileType: metadata?.ansibleFileType || "playbook",
       documentUri: metadata?.documentUri,
-      workspaceContext: metadata?.workspaceContext,
     };
 
     return AnsibleContextProcessor.enhancePromptForAnsible(
@@ -154,7 +152,6 @@ export abstract class BaseLLMProvider<
    * Clean and validate Ansible output
    */
   protected cleanAnsibleOutput(output: string): string {
-    const { AnsibleContextProcessor } = require("../ansibleContext");
     return AnsibleContextProcessor.cleanAnsibleOutput(output) as string;
   }
 

--- a/src/features/lightspeed/providers/rhcustom.ts
+++ b/src/features/lightspeed/providers/rhcustom.ts
@@ -28,6 +28,7 @@ import {
   ChatMessage,
   OpenAIClientError,
 } from "@src/features/lightspeed/clients/openaiCompatibleClient";
+import * as yaml from "js-yaml";
 
 export interface RHCustomConfig {
   apiKey: string;
@@ -179,12 +180,15 @@ export class RHCustomProvider extends BaseLLMProvider<RHCustomConfig> {
    */
   private fixWindowsPathEscapes(yamlContent: string): string {
     // Find all double-quoted strings and fix unescaped backslashes
-    return yamlContent.replace(/"([^"]*)"/g, (match, content) => {
-      // Escape backslashes that aren't already escaped or part of valid escape sequences
-      // Valid escape sequences: \\, \", \/, \b, \f, \n, \r, \t
-      const fixed = content.replace(/\\(?!["\\/bfnrt])/g, "\\\\");
-      return `"${fixed}"`;
-    });
+    return yamlContent.replace(
+      /"([^"]*)"/g,
+      (_match: string, content: string) => {
+        // Escape backslashes that aren't already escaped or part of valid escape sequences
+        // Valid escape sequences: \\, \", \/, \b, \f, \n, \r, \t
+        const fixed = content.replace(/\\(?!["\\/bfnrt])/g, "\\\\");
+        return `"${fixed}"`;
+      },
+    );
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -505,8 +509,7 @@ export class RHCustomProvider extends BaseLLMProvider<RHCustomConfig> {
 
         // Try to parse and validate the structure before generating outline
         try {
-          const yaml = require("js-yaml");
-          const parsed = yaml.load(cleanedContent);
+          const parsed: unknown = yaml.load(cleanedContent);
           console.log(
             "[RHCustom Provider] Parsed YAML type:",
             Array.isArray(parsed) ? "array" : typeof parsed,

--- a/src/features/lightspeed/utils/explanationUtils.ts
+++ b/src/features/lightspeed/utils/explanationUtils.ts
@@ -17,7 +17,13 @@ function directoryContainsSomeRoleDirectories(files: string[]): boolean {
 
 export function getObjectKeys(content: string): string[] {
   try {
-    const parsedAnsibleDocument = yaml.parse(content);
+    const parsedAnsibleDocument = yaml.parse(content) as unknown;
+    if (
+      !Array.isArray(parsedAnsibleDocument) ||
+      parsedAnsibleDocument.length === 0
+    ) {
+      return [];
+    }
     const lastObject = parsedAnsibleDocument[parsedAnsibleDocument.length - 1];
     if (typeof lastObject === "object") {
       return Object.keys(lastObject as object);

--- a/src/features/lightspeed/vue/views/webviewMessageHandlers.ts
+++ b/src/features/lightspeed/vue/views/webviewMessageHandlers.ts
@@ -66,8 +66,46 @@ import {
 
 export interface WebviewMessage {
   type: string;
-  data?: any;
-  payload?: any;
+  command?: string;
+  data?: unknown;
+  payload?: unknown;
+}
+
+function getPayloadDefaultPath(payload: unknown): string | undefined {
+  if (typeof payload !== "object" || payload === null) {
+    return undefined;
+  }
+  const defaultPath = (payload as { defaultPath?: unknown }).defaultPath;
+  return typeof defaultPath === "string" ? defaultPath : undefined;
+}
+
+function getMessageDataField<T extends string>(
+  data: unknown,
+  field: T,
+): unknown {
+  if (typeof data !== "object" || data === null) {
+    return undefined;
+  }
+  return (data as Record<string, unknown>)[field];
+}
+
+interface ExecutionEnvironmentDefinition {
+  version: number;
+  images: { base_image: { name?: string } };
+  dependencies: {
+    ansible_core: { package_pip: string };
+    ansible_runner: { package_pip: string };
+    galaxy?: { collections: Array<{ name: string }> };
+    system?: string[];
+    python?: string[];
+  };
+  options: {
+    tags?: string[];
+    package_manager_path?: string;
+  };
+  additional_build_steps?: {
+    prepend_base?: string[];
+  };
 }
 
 type MessageHandler = {
@@ -149,7 +187,11 @@ export class WebviewMessageHandlers {
     context: vscode.ExtensionContext,
   ) {
     // Support both 'type' and 'command' fields for message routing
-    const messageKey = message.type || (message as any).command;
+    const messageKey = message.type || message.command;
+    if (!messageKey) {
+      console.warn("Unknown message type/command: undefined");
+      return;
+    }
 
     const handler = this.handlers[messageKey];
     if (handler) {
@@ -203,7 +245,7 @@ export class WebviewMessageHandlers {
     message: WebviewMessage,
     webview: vscode.Webview,
   ) {
-    const defaultPath = message.payload?.defaultPath as string | undefined;
+    const defaultPath = getPayloadDefaultPath(message.payload);
     const uri = await window.showOpenDialog({
       canSelectFolders: true,
       canSelectFiles: false,
@@ -222,7 +264,7 @@ export class WebviewMessageHandlers {
     message: WebviewMessage,
     webview: vscode.Webview,
   ) {
-    const defaultPath = message.payload?.defaultPath as string | undefined;
+    const defaultPath = getPayloadDefaultPath(message.payload);
     const uri = await window.showOpenDialog({
       canSelectFolders: false,
       canSelectFiles: true,
@@ -238,8 +280,10 @@ export class WebviewMessageHandlers {
   }
 
   private async handleOpenEditor(message: WebviewMessage) {
-    const content = message.data.content as string;
-    await openNewPlaybookEditor(content);
+    const content = getMessageDataField(message.data, "content");
+    if (typeof content === "string") {
+      await openNewPlaybookEditor(content);
+    }
   }
 
   // Creator Handlers
@@ -611,7 +655,11 @@ export class WebviewMessageHandlers {
   }
 
   private async handleFeedback(message: WebviewMessage) {
-    const request = message.data.request as FeedbackRequestParams;
+    const requestField = getMessageDataField(message.data, "request");
+    if (typeof requestField !== "object" || requestField === null) {
+      return;
+    }
+    const request = requestField as FeedbackRequestParams;
     const provider =
       lightSpeedManager.settingsManager.settings.lightSpeedService.provider;
 
@@ -621,7 +669,7 @@ export class WebviewMessageHandlers {
         const telemetry = lightSpeedManager.telemetry;
 
         // Prepare telemetry data - exclude inlineSuggestion (WCA-only feature)
-        const telemetryData: any = {
+        const telemetryData: Record<string, unknown> = {
           provider: provider,
           model:
             lightSpeedManager.settingsManager.settings.lightSpeedService
@@ -629,9 +677,11 @@ export class WebviewMessageHandlers {
         };
 
         // Copy all fields except inlineSuggestion
-        for (const key in request) {
+        for (const key of Object.keys(request) as Array<
+          keyof FeedbackRequestParams
+        >) {
           if (key !== "inlineSuggestion" && Object.hasOwn(request, key)) {
-            telemetryData[key] = (request as any)[key];
+            telemetryData[key] = request[key];
           }
         }
 
@@ -1003,7 +1053,7 @@ export class WebviewMessageHandlers {
         commandOutput += `${message}\n`;
         commandResult = "failed";
       } else {
-        const jsonData: any = {
+        const jsonData: ExecutionEnvironmentDefinition = {
           version: 3,
           images: {
             base_image: {

--- a/src/features/quickLinks/utils/quickLinksViewProvider.ts
+++ b/src/features/quickLinks/utils/quickLinksViewProvider.ts
@@ -81,8 +81,12 @@ export class QuickLinksWebviewViewProvider implements WebviewViewProvider {
 
   private _setWebviewMessageListener(webview: Webview) {
     let currentSystemInfo;
-    webview.onDidReceiveMessage(async (message) => {
-      const command = message.message || message.command;
+    webview.onDidReceiveMessage(async (message: unknown) => {
+      if (typeof message !== "object" || message === null) {
+        return;
+      }
+      const msg = message as { message?: string; command?: string };
+      const command = msg.message || msg.command;
       if (command === "set-system-status-view") {
         currentSystemInfo = await getSystemDetails();
         webview.postMessage({

--- a/src/features/utils/ansible.ts
+++ b/src/features/utils/ansible.ts
@@ -15,7 +15,7 @@ export function getAnsibleFileType(
   filePath: string,
   documentContent: string,
 ): IAnsibleFileType {
-  let parsedAnsibleDocument;
+  let parsedAnsibleDocument: unknown;
   for (const pattern in AnsibleFileTypes) {
     if (Object.prototype.hasOwnProperty.call(AnsibleFileTypes, pattern)) {
       if (minimatch(filePath, pattern)) {
@@ -31,7 +31,10 @@ export function getAnsibleFileType(
     console.log(err);
     return "other";
   }
-  if (!parsedAnsibleDocument || parsedAnsibleDocument.length === 0) {
+  if (
+    !Array.isArray(parsedAnsibleDocument) ||
+    parsedAnsibleDocument.length === 0
+  ) {
     return "other";
   }
   const lastObject = parsedAnsibleDocument[parsedAnsibleDocument.length - 1];

--- a/src/features/utils/ansibleCfg.ts
+++ b/src/features/utils/ansibleCfg.ts
@@ -107,7 +107,16 @@ async function getValueByCfg(
     return undefined;
   }
 
-  const parsedConfig = ini.parse(await fs.promises.readFile(path, "utf-8"));
+  interface AnsibleIniDefaults {
+    vault_identity_list?: string;
+    vault_password_file?: string;
+  }
+  interface AnsibleIniConfig {
+    defaults?: AnsibleIniDefaults;
+  }
+  const parsedConfig = ini.parse(
+    await fs.promises.readFile(path, "utf-8"),
+  ) as AnsibleIniConfig;
   const vault_identity_list = parsedConfig.defaults?.vault_identity_list;
   const vault_password_file = parsedConfig.defaults?.vault_password_file;
 

--- a/src/features/utils/applyModelines.ts
+++ b/src/features/utils/applyModelines.ts
@@ -64,9 +64,13 @@ async function applyModeLines(
   }
 
   try {
-    const modelineOptions: any = searchModelines(editor.document);
-
-    const language = modelineOptions.language;
+    const modelineOptions = searchModelines(editor.document);
+    const language =
+      typeof modelineOptions === "object" &&
+      modelineOptions !== null &&
+      "language" in modelineOptions
+        ? (modelineOptions as { language: unknown }).language
+        : undefined;
 
     if (typeof language === "string" && language.length > 0) {
       if (language === "ansible" || language === "yaml") {

--- a/src/features/utils/data.ts
+++ b/src/features/utils/data.ts
@@ -1,5 +1,7 @@
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function compareObjects(baseObject: any, newObject: any): boolean {
+export function compareObjects(
+  baseObject: unknown,
+  newObject: unknown,
+): boolean {
   if (!isObject(baseObject) || !isObject(newObject)) {
     return false;
   }
@@ -12,8 +14,10 @@ export function compareObjects(baseObject: any, newObject: any): boolean {
   }
 
   // compare the values for each key
+  const baseRecord = baseObject as Record<string, unknown>;
+  const newRecord = newObject as Record<string, unknown>;
   for (const key of baseObjectKeys) {
-    if (baseObject[key] !== newObject[key]) {
+    if (baseRecord[key] !== newRecord[key]) {
       return false;
     }
   }
@@ -22,17 +26,15 @@ export function compareObjects(baseObject: any, newObject: any): boolean {
   return true;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function isObject(object: any): boolean {
+function isObject(object: unknown): boolean {
   return object != null && typeof object === "object";
 }
 
-/* eslint-disable @typescript-eslint/no-unsafe-return -- nested dynamic path access; return type is intentionally loose */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function getValueFromObject(obj: any, path: string[]): any {
-  return path.reduce(
-    (acc, key) => (acc && acc[key] ? acc[key] : undefined),
-    obj,
-  );
+export function getValueFromObject(obj: unknown, path: string[]): unknown {
+  return path.reduce<unknown>((acc, key) => {
+    if (acc && typeof acc === "object" && key in acc) {
+      return (acc as Record<string, unknown>)[key];
+    }
+    return undefined;
+  }, obj);
 }
-/* eslint-enable @typescript-eslint/no-unsafe-return */

--- a/src/features/utils/formatAnsibleMetaData.ts
+++ b/src/features/utils/formatAnsibleMetaData.ts
@@ -8,7 +8,17 @@ const asRecord = (value: unknown): Record<string, unknown> =>
     ? (value as Record<string, unknown>)
     : {};
 
-export function formatAnsibleMetaData(ansibleMetaData: any) {
+export interface FormattedAnsibleMetaData {
+  metaData: Record<string, unknown>;
+  markdown: MarkdownString;
+  ansiblePresent: boolean;
+  ansibleLintPresent: boolean;
+  eeEnabled?: boolean;
+}
+
+export function formatAnsibleMetaData(
+  ansibleMetaData: unknown,
+): FormattedAnsibleMetaData {
   let mdString = "";
   let ansiblePresent = true;
   let ansibleLintPresent = true;
@@ -18,13 +28,17 @@ export function formatAnsibleMetaData(ansibleMetaData: any) {
   const WARNING_STYLE = `style="color:${WARNING_COLOR};"`;
 
   // check if ansible is missing
-  const ansibleInfo = asRecord(ansibleMetaData?.["ansible information"]);
+  const ansibleInfo = asRecord(
+    asRecord(ansibleMetaData)["ansible information"],
+  );
   if (Object.keys(ansibleInfo).length === 0) {
     ansiblePresent = false;
     mdString += "#### $(close) Ansible not found in the environment\n";
 
     // if python exists
-    const pythonInfo = asRecord(ansibleMetaData?.["python information"]);
+    const pythonInfo = asRecord(
+      asRecord(ansibleMetaData)["python information"],
+    );
     if (Object.keys(pythonInfo).length !== 0) {
       const obj = pythonInfo;
       mdString += `Python version used: \`${String(obj["version"])}\` from \`${String(obj["location"])}\``;
@@ -35,22 +49,23 @@ export function formatAnsibleMetaData(ansibleMetaData: any) {
     markdown.isTrusted = true;
 
     return {
-      metaData: ansibleMetaData,
+      metaData: asRecord(ansibleMetaData),
       markdown,
       ansiblePresent,
       ansibleLintPresent,
     };
   }
 
+  const metaDataRoot = asRecord(ansibleMetaData);
+
   // check if ee is enabled or not
-  if (ansibleMetaData["execution environment information"]) {
+  if (metaDataRoot["execution environment information"]) {
     eeEnabled = true;
   }
 
   // check is ansible-lint is missing
   if (
-    Object.keys(asRecord(ansibleMetaData?.["ansible-lint information"]))
-      .length === 0
+    Object.keys(asRecord(metaDataRoot["ansible-lint information"])).length === 0
   ) {
     ansibleLintPresent = false;
   }
@@ -67,7 +82,7 @@ export function formatAnsibleMetaData(ansibleMetaData: any) {
     .getConfiguration("ansible.validation.lint")
     .get("enabled");
 
-  const root = asRecord(ansibleMetaData);
+  const root = metaDataRoot;
   Object.keys(root).forEach((mainKey) => {
     const section = asRecord(root[mainKey]);
     if (Object.keys(section).length === 0) {
@@ -141,7 +156,7 @@ export function formatAnsibleMetaData(ansibleMetaData: any) {
   }
 
   return {
-    metaData: ansibleMetaData,
+    metaData: metaDataRoot,
     markdown,
     ansiblePresent,
     ansibleLintPresent,

--- a/src/features/utils/getSystemDetails.ts
+++ b/src/features/utils/getSystemDetails.ts
@@ -1,15 +1,25 @@
-/* eslint-disable  @typescript-eslint/no-explicit-any */
-
 import { getBinDetail } from "@src/features/contentCreator/utils";
 import * as ini from "ini";
 
+interface SystemInfo {
+  "ansible version"?: string;
+  "ansible location"?: string;
+  "python version"?: string;
+  "python location"?: string;
+  "ansible-creator version"?: string;
+  "ansible-dev-environment version"?: string;
+}
+
 export async function getSystemDetails() {
-  const systemInfo: any = {};
+  const systemInfo: SystemInfo = {};
 
   // get ansible version and path
   const ansibleVersion = await getBinDetail("ansible", "--version");
   if (ansibleVersion !== "failed") {
-    const versionInfo = ini.parse(ansibleVersion.toString());
+    const versionInfo = ini.parse(ansibleVersion.toString()) as Record<
+      string,
+      string
+    >;
 
     const versionInfoObjKeys = Object.keys(versionInfo);
 
@@ -69,5 +79,5 @@ export async function getSystemDetails() {
       .toString()
       .trim();
   }
-  return systemInfo as Record<string, string | undefined>;
+  return systemInfo;
 }

--- a/src/features/welcomePage/welcomePagePanel.ts
+++ b/src/features/welcomePage/welcomePagePanel.ts
@@ -20,6 +20,12 @@ interface Walkthrough {
   icon?: string;
 }
 
+interface ExtensionPackageManifest {
+  contributes?: {
+    walkthroughs?: Walkthrough[];
+  };
+}
+
 export class WelcomePagePanel {
   public static currentPanel: WelcomePagePanel | undefined;
   private readonly _panel: WebviewPanel;
@@ -186,10 +192,12 @@ export class WelcomePagePanel {
   private getWalkthroughs() {
     try {
       const extension = vscode.extensions.getExtension("redhat.ansible");
-      const walkthroughs =
-        extension?.packageJSON?.contributes?.walkthroughs || [];
+      const manifest = extension?.packageJSON as
+        | ExtensionPackageManifest
+        | undefined;
+      const walkthroughs = manifest?.contributes?.walkthroughs || [];
 
-      return walkthroughs.map((walkthrough: Walkthrough) => ({
+      return walkthroughs.map((walkthrough) => ({
         id: walkthrough.id,
         title: walkthrough.title,
         description: walkthrough.description,

--- a/src/services/TerminalService.ts
+++ b/src/services/TerminalService.ts
@@ -238,18 +238,31 @@ export class TerminalService implements vscode.Disposable {
   ): Promise<CommandResult> {
     terminal.sendText(command);
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const shellIntegration = (terminal as any).shellIntegration;
+    interface ShellIntegrationCommandEndEvent {
+      exitCode?: number;
+    }
 
-    if (shellIntegration?.onDidEndCommandExecution) {
+    interface TerminalShellIntegrationLike {
+      onDidEndCommandExecution?: (
+        callback: (event: ShellIntegrationCommandEndEvent) => void,
+      ) => vscode.Disposable;
+    }
+
+    const shellIntegration = (
+      terminal as vscode.Terminal & {
+        shellIntegration?: TerminalShellIntegrationLike;
+      }
+    ).shellIntegration;
+    const onDidEndCommandExecution = shellIntegration?.onDidEndCommandExecution;
+
+    if (onDidEndCommandExecution) {
       return new Promise((resolve) => {
         const timeoutId = setTimeout(() => {
           listener.dispose();
           resolve({ output: "", exitCode: undefined, success: false });
         }, timeout);
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const listener = shellIntegration.onDidEndCommandExecution((e: any) => {
+        const listener = onDidEndCommandExecution((e) => {
           clearTimeout(timeoutId);
           listener.dispose();
           resolve({

--- a/src/webview/apps/common/editableList.ts
+++ b/src/webview/apps/common/editableList.ts
@@ -1,15 +1,19 @@
+interface WindowLike {
+  document: Document;
+  getSelection(): Selection | null;
+}
+
 export class EditableList {
   doc: Document;
-  win: Window;
+  win: WindowLike;
   element: HTMLElement;
   observer: MutationObserver | undefined;
   savedValues: string[];
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  constructor(id: string, win?: any) {
+  constructor(id: string, win?: WindowLike) {
     // win is an optional parameter for unit tests with JSDOM
     this.win = win ? win : window;
-    this.doc = win ? win?.document : document;
+    this.doc = win ? win.document : document;
     const element = this.doc.getElementById(id);
     if (!element) {
       throw new Error(`Element ${id} is not found`);

--- a/test/unit/lightspeed/providers/base.test.ts
+++ b/test/unit/lightspeed/providers/base.test.ts
@@ -1,49 +1,30 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import * as Module from "module";
 
-// Create mock implementations
-const mockEnhancePromptForAnsible = vi.fn(
-  (prompt: string, context?: string) => {
-    return `enhanced: ${prompt} with context: ${context || "none"}`;
+const { mockEnhancePromptForAnsible, mockCleanAnsibleOutput } = vi.hoisted(
+  () => {
+    const mockEnhancePromptForAnsible = vi.fn(
+      (prompt: string, context?: string) => {
+        return `enhanced: ${prompt} with context: ${context || "none"}`;
+      },
+    );
+
+    const mockCleanAnsibleOutput = vi.fn((output: string) => {
+      return output
+        .trim()
+        .replace(/^```ya?ml\s*/i, "")
+        .replace(/```\s*$/, "");
+    });
+
+    return { mockEnhancePromptForAnsible, mockCleanAnsibleOutput };
   },
 );
 
-const mockCleanAnsibleOutput = vi.fn((output: string) => {
-  return output
-    .trim()
-    .replace(/^```ya?ml\s*/i, "")
-    .replace(/```\s*$/, "");
-});
-
-const mockAnsibleContextModule = {
+vi.mock("@src/features/lightspeed/ansibleContext", () => ({
   AnsibleContextProcessor: {
     enhancePromptForAnsible: mockEnhancePromptForAnsible,
     cleanAnsibleOutput: mockCleanAnsibleOutput,
   },
-};
-
-// Store original require as the import uses require()
-const originalRequire = Module.prototype.require.bind(Module.prototype);
-
-Module.prototype.require = function (
-  this: Module,
-  id: string,
-): ReturnType<typeof originalRequire> {
-  // Intercept the require call for "../ansibleContext"
-  const normalizedId = id.replace(/\\/g, "/");
-  if (
-    id === "../ansibleContext" ||
-    normalizedId === "../ansibleContext" ||
-    normalizedId.endsWith("/ansibleContext") ||
-    normalizedId.endsWith("/ansibleContext.js") ||
-    normalizedId.includes("/ansibleContext") ||
-    normalizedId.includes("ansibleContext.js")
-  ) {
-    return mockAnsibleContextModule;
-  }
-  // For all other requires, use the original
-  return originalRequire.call(this, id);
-};
+}));
 
 // Reset mocks before each test
 beforeEach(() => {

--- a/test/unit/lightspeed/providers/google.test.ts
+++ b/test/unit/lightspeed/providers/google.test.ts
@@ -1,48 +1,30 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import * as Module from "module";
 
-// Mock AnsibleContextProcessor
-const mockEnhancePromptForAnsible = vi.fn(
-  (prompt: string, context?: string) => {
-    return `enhanced: ${prompt} with context: ${context || "none"}`;
+const { mockEnhancePromptForAnsible, mockCleanAnsibleOutput } = vi.hoisted(
+  () => {
+    const mockEnhancePromptForAnsible = vi.fn(
+      (prompt: string, context?: string) => {
+        return `enhanced: ${prompt} with context: ${context || "none"}`;
+      },
+    );
+
+    const mockCleanAnsibleOutput = vi.fn((output: string) => {
+      return output
+        .trim()
+        .replace(/^```ya?ml\s*/i, "")
+        .replace(/```\s*$/, "");
+    });
+
+    return { mockEnhancePromptForAnsible, mockCleanAnsibleOutput };
   },
 );
 
-const mockCleanAnsibleOutput = vi.fn((output: string) => {
-  return output
-    .trim()
-    .replace(/^```ya?ml\s*/i, "")
-    .replace(/```\s*$/, "");
-});
-
-const mockAnsibleContextModule = {
+vi.mock("@src/features/lightspeed/ansibleContext", () => ({
   AnsibleContextProcessor: {
     enhancePromptForAnsible: mockEnhancePromptForAnsible,
     cleanAnsibleOutput: mockCleanAnsibleOutput,
   },
-};
-
-// Store original require
-const originalRequire = Module.prototype.require.bind(Module.prototype);
-
-// Patch require() to intercept module imports - must happen before imports
-Module.prototype.require = function (
-  this: Module,
-  id: string,
-): ReturnType<typeof originalRequire> {
-  const normalizedId = id.replace(/\\/g, "/");
-  if (
-    id === "../ansibleContext" ||
-    normalizedId === "../ansibleContext" ||
-    normalizedId.endsWith("/ansibleContext") ||
-    normalizedId.endsWith("/ansibleContext.js") ||
-    normalizedId.includes("/ansibleContext") ||
-    normalizedId.includes("ansibleContext.js")
-  ) {
-    return mockAnsibleContextModule;
-  }
-  return originalRequire.call(this, id);
-};
+}));
 
 vi.mock("@google/genai", () => {
   // Create a proper constructor class that can be instantiated with 'new'

--- a/test/unit/lightspeed/providers/rhcustom.test.ts
+++ b/test/unit/lightspeed/providers/rhcustom.test.ts
@@ -1,68 +1,30 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import * as Module from "module";
-import { RHCustomProvider } from "@src/features/lightspeed/providers/rhcustom.js";
-import type { CompletionRequestParams } from "@src/interfaces/lightspeed.js";
-import type {
-  ChatRequestParams,
-  GenerationRequestParams,
-} from "@src/features/lightspeed/providers/base.js";
-import {
-  TEST_API_KEYS,
-  MODEL_NAMES,
-  TEST_PROMPTS,
-  TEST_CONTENT,
-  RHCUSTOM_PROVIDER,
-  HTTP_STATUS_CODES,
-  API_ENDPOINTS,
-  DEFAULT_TIMEOUTS,
-} from "@test/unit/lightspeed/testConstants.js";
-import { OpenAIClientError } from "@src/features/lightspeed/clients/openaiCompatibleClient.js";
-import { getLightspeedLogger } from "@src/utils/logger.js";
-import {
-  generateOutlineFromPlaybook,
-  generateOutlineFromRole,
-} from "@src/features/lightspeed/utils/outlineGenerator.js";
 
-// Mock AnsibleContextProcessor
-const mockEnhancePromptForAnsible = vi.fn(
-  (prompt: string, context?: string) => {
-    return `enhanced: ${prompt} with context: ${context || "none"}`;
+const { mockEnhancePromptForAnsible, mockCleanAnsibleOutput } = vi.hoisted(
+  () => {
+    const mockEnhancePromptForAnsible = vi.fn(
+      (prompt: string, context?: string) => {
+        return `enhanced: ${prompt} with context: ${context || "none"}`;
+      },
+    );
+
+    const mockCleanAnsibleOutput = vi.fn((output: string) => {
+      return output
+        .trim()
+        .replace(/^```ya?ml\s*/i, "")
+        .replace(/```\s*$/, "");
+    });
+
+    return { mockEnhancePromptForAnsible, mockCleanAnsibleOutput };
   },
 );
 
-const mockCleanAnsibleOutput = vi.fn((output: string) => {
-  return output
-    .trim()
-    .replace(/^```ya?ml\s*/i, "")
-    .replace(/```\s*$/, "");
-});
-
-const mockAnsibleContextModule = {
+vi.mock("@src/features/lightspeed/ansibleContext", () => ({
   AnsibleContextProcessor: {
     enhancePromptForAnsible: mockEnhancePromptForAnsible,
     cleanAnsibleOutput: mockCleanAnsibleOutput,
   },
-};
-
-const originalRequire = Module.prototype.require.bind(Module.prototype);
-
-Module.prototype.require = function (
-  this: Module,
-  id: string,
-): ReturnType<typeof originalRequire> {
-  const normalizedId = id.replace(/\\/g, "/");
-  if (
-    id === "../ansibleContext" ||
-    normalizedId === "../ansibleContext" ||
-    normalizedId.endsWith("/ansibleContext") ||
-    normalizedId.endsWith("/ansibleContext.js") ||
-    normalizedId.includes("/ansibleContext") ||
-    normalizedId.includes("ansibleContext.js")
-  ) {
-    return mockAnsibleContextModule;
-  }
-  return originalRequire.call(this, id);
-};
+}));
 
 const { mockChatCompletion, MockOpenAICompatibleClient } = vi.hoisted(() => {
   const mockChatCompletion = vi.fn();
@@ -155,6 +117,29 @@ beforeEach(() => {
     },
   });
 });
+
+import { RHCustomProvider } from "@src/features/lightspeed/providers/rhcustom.js";
+import type { CompletionRequestParams } from "@src/interfaces/lightspeed.js";
+import type {
+  ChatRequestParams,
+  GenerationRequestParams,
+} from "@src/features/lightspeed/providers/base.js";
+import {
+  TEST_API_KEYS,
+  MODEL_NAMES,
+  TEST_PROMPTS,
+  TEST_CONTENT,
+  RHCUSTOM_PROVIDER,
+  HTTP_STATUS_CODES,
+  API_ENDPOINTS,
+  DEFAULT_TIMEOUTS,
+} from "@test/unit/lightspeed/testConstants.js";
+import { OpenAIClientError } from "@src/features/lightspeed/clients/openaiCompatibleClient.js";
+import { getLightspeedLogger } from "@src/utils/logger.js";
+import {
+  generateOutlineFromPlaybook,
+  generateOutlineFromRole,
+} from "@src/features/lightspeed/utils/outlineGenerator.js";
 
 const mockedGenerateOutlineFromPlaybook = vi.mocked(
   generateOutlineFromPlaybook,


### PR DESCRIPTION
Related: AAP-66052


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Enforce `@typescript-eslint/no-unsafe-member-access` by replacing unsafe any usage with unknown, adding runtime type guards and typed interfaces across the codebase to prevent unsafe property access.

- enable rule in eslint.config.mjs with test/webview overrides
- typed completion resolve + hasCompletionDocumentUri
- tighten parsing/handlers, utilities, webviews, lightspeed, MCP, and extension metadata

related: AAP-66052
<!-- end of auto-generated comment: release notes by coderabbit.ai -->