### PR TITLE
fix: typescript-eslint/no-require-imports

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -77,7 +77,7 @@ export default defineConfig(
       "@typescript-eslint/no-namespace": "error",
       "@typescript-eslint/no-non-null-assertion": "error",
       "@typescript-eslint/no-base-to-string": "error",
-      "@typescript-eslint/no-require-imports": "off",
+      "@typescript-eslint/no-require-imports": "error",
       "local/node-DEP0190": "error",
       "no-case-declarations": "error",
       "no-constant-condition": "error",

--- a/packages/ansible-language-server/src/services/docsLibrary.ts
+++ b/packages/ansible-language-server/src/services/docsLibrary.ts
@@ -52,7 +52,7 @@ export class DocsLibrary {
       /* v8 ignore end */
       /* v8 ignore next */
       for (const modulesPath of ansibleConfig.module_locations) {
-        await this.findDocumentationInModulesPath(modulesPath);
+        this.findDocumentationInModulesPath(modulesPath);
       }
 
       (
@@ -175,31 +175,29 @@ export class DocsLibrary {
     return [module, hitFqcn];
   }
 
-  private async findDocumentationInModulesPath(modulesPath: string) {
-    (await findDocumentation(modulesPath, "builtin")).forEach((doc) => {
+  private findDocumentationInModulesPath(modulesPath: string) {
+    findDocumentation(modulesPath, "builtin").forEach((doc) => {
       this.modules.set(doc.fqcn, doc);
       this._moduleFqcns.add(doc.fqcn);
     });
 
-    (await findDocumentation(modulesPath, "builtin_doc_fragment")).forEach(
-      (doc) => {
-        this.docFragments.set(doc.fqcn, doc);
-      },
-    );
+    findDocumentation(modulesPath, "builtin_doc_fragment").forEach((doc) => {
+      this.docFragments.set(doc.fqcn, doc);
+    });
   }
 
   private async findDocumentationInCollectionsPath(collectionsPath: string) {
-    (await findDocumentation(collectionsPath, "collection")).forEach((doc) => {
+    findDocumentation(collectionsPath, "collection").forEach((doc) => {
       this.modules.set(doc.fqcn, doc);
       this._moduleFqcns.add(doc.fqcn);
     });
 
     /* v8 ignore start */
-    (
-      await findDocumentation(collectionsPath, "collection_doc_fragment")
-    ).forEach((doc) => {
-      this.docFragments.set(doc.fqcn, doc);
-    });
+    findDocumentation(collectionsPath, "collection_doc_fragment").forEach(
+      (doc) => {
+        this.docFragments.set(doc.fqcn, doc);
+      },
+    );
     /* v8 ignore end */
 
     /* v8 ignore start */

--- a/packages/ansible-language-server/src/services/docsLibraryUtilsForPAC.ts
+++ b/packages/ansible-language-server/src/services/docsLibraryUtilsForPAC.ts
@@ -37,18 +37,16 @@ export async function findModulesUtils(
   const playbookAdjacentDocFragments = new Map<string, IModuleMetadata>();
 
   // find documentation for PAC
-  (
-    await findDocumentation(playbookAdjacentCollectionsPath, "collection")
-  ).forEach((doc) => {
-    playbookAdjacentModules.set(doc.fqcn, doc);
-    playbookAdjacentModuleFqcns.add(doc.fqcn);
-  });
+  findDocumentation(playbookAdjacentCollectionsPath, "collection").forEach(
+    (doc) => {
+      playbookAdjacentModules.set(doc.fqcn, doc);
+      playbookAdjacentModuleFqcns.add(doc.fqcn);
+    },
+  );
 
-  (
-    await findDocumentation(
-      playbookAdjacentCollectionsPath,
-      "collection_doc_fragment",
-    )
+  findDocumentation(
+    playbookAdjacentCollectionsPath,
+    "collection_doc_fragment",
   ).forEach((doc) => {
     playbookAdjacentDocFragments.set(doc.fqcn, doc);
   });
@@ -126,18 +124,16 @@ export async function getModuleFqcnsUtils(
   const playbookAdjacentModuleFqcns = new Set<string>();
   const playbookAdjacentDocFragments = new Map<string, IModuleMetadata>();
 
-  (
-    await findDocumentation(playbookAdjacentCollectionsPath, "collection")
-  ).forEach((doc) => {
-    playbookAdjacentModules.set(doc.fqcn, doc);
-    playbookAdjacentModuleFqcns.add(doc.fqcn);
-  });
+  findDocumentation(playbookAdjacentCollectionsPath, "collection").forEach(
+    (doc) => {
+      playbookAdjacentModules.set(doc.fqcn, doc);
+      playbookAdjacentModuleFqcns.add(doc.fqcn);
+    },
+  );
 
-  (
-    await findDocumentation(
-      playbookAdjacentCollectionsPath,
-      "collection_doc_fragment",
-    )
+  findDocumentation(
+    playbookAdjacentCollectionsPath,
+    "collection_doc_fragment",
   ).forEach((doc) => {
     playbookAdjacentDocFragments.set(doc.fqcn, doc);
   });

--- a/packages/ansible-language-server/src/utils/docsFinder.ts
+++ b/packages/ansible-language-server/src/utils/docsFinder.ts
@@ -12,14 +12,14 @@ import {
 } from "@src/interfaces/pluginRouting.js";
 import { globArray } from "@src/utils/pathUtils.js";
 
-export async function findDocumentation(
+export function findDocumentation(
   dir: string,
   kind:
     | "builtin"
     | "collection"
     | "builtin_doc_fragment"
     | "collection_doc_fragment",
-): Promise<IModuleMetadata[]> {
+): IModuleMetadata[] {
   if (!fs.existsSync(dir) || fs.lstatSync(dir).isFile()) {
     return [];
   }

--- a/src/features/lightspeed/api.ts
+++ b/src/features/lightspeed/api.ts
@@ -46,6 +46,8 @@ const UNKNOWN_ERROR: string = "An unknown error occurred.";
 
 export function getFetch(): typeof globalThis.fetch {
   try {
+    // Do not remove this as this is a special exception for testing and web versions
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
     const electron = require("electron") as
       | { net?: { fetch?: typeof globalThis.fetch } }
       | undefined;

--- a/test/unit/lightspeed/contentmatches.test.ts
+++ b/test/unit/lightspeed/contentmatches.test.ts
@@ -1,5 +1,3 @@
-require("assert");
-
 import { ContentMatchesWebview } from "@src/features/lightspeed/contentMatchesWebview";
 import { SettingsManager } from "@src/settings";
 import sinon from "sinon";

--- a/test/unit/lightspeed/utils/handleApiError.test.ts
+++ b/test/unit/lightspeed/utils/handleApiError.test.ts
@@ -1,5 +1,3 @@
-require("assert");
-
 import { mapError } from "@src/features/lightspeed/handleApiError";
 import assert from "assert";
 import { integer } from "vscode-languageclient";

--- a/test/unit/lightspeed/utils/updateRolesContext.test.ts
+++ b/test/unit/lightspeed/utils/updateRolesContext.test.ts
@@ -1,5 +1,3 @@
-require("assert");
-
 import { updateRolesContext } from "@src/features/lightspeed/utils/updateRolesContext";
 import assert from "assert";
 import sinon from "sinon";


### PR DESCRIPTION
Related: AAP-66052


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Enforce the `@typescript-eslint/no-require-imports` ESLint rule across the codebase. The PR enables this rule in ESLint configuration and refactors code to use ES module imports instead of CommonJS require statements. Key changes include converting the `findDocumentation` function from async to synchronous, removing await calls in documentation loading utilities, updating test files to import from ES modules, and adding an eslint-disable comment for a necessary Electron require usage.

Changes:
- Enabled `@typescript-eslint/no-require-imports` rule with error severity in ESLint configuration
- Converted `findDocumentation` function from async to synchronous in docsFinder.ts
- Removed await calls from documentation loading functions in docsLibrary.ts and docsLibraryUtilsForPAC.ts
- Replaced CommonJS `require("assert")` with ES module imports in three test files
- Added eslint-disable comment for Electron require usage in lightspeed/api.ts

related: AAP-66052

<!-- end of auto-generated comment: release notes by coderabbit.ai -->