### PR TITLE
ci: increase ALS hookTimeout to fix WSL test flakiness

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -65,6 +65,7 @@ const alsVitestProject = {
     isolate: true, // required or will produce MaxListenersExceededWarning warnings
     root: als_root, // ensure reports have valid paths
     testTimeout: 60000, // same as mocha timeout (60 seconds)
+    hookTimeout: 30000, // self-hosted WSL runner needs more than the 10s default
     setupFiles: [`${als_root}/test/vitestSetup.ts`],
     sequence: {
       concurrent: false,


### PR DESCRIPTION
## Summary

Addresses the #1 CI failure source identified from analyzing all 103
CI workflow runs over the last 10 days (Jun 1–10, 2026). Human-guided, AI-assisted.

## CI Failure Analysis (Jun 4–10, post-chromedriver fix)

32 failed runs out of 103 total. Job failure counts:

| Job | Failures | Primary root cause |
|-----|----------|--------------------|
| test (wsl) | 16 | **Hook timeouts (8)**, package timeouts (4), build failures (3), e2e (2) |
| test (linux) | 12 | Build failures (4), codecov GPG (3, fixed by #2841), package timeouts (3) |
| test (macos) | 12 | Same as linux |
| preflight | 12 | Package timeouts (4, fixed by #2847), knip (3), build failures (3), setup (1) |
| test (linux-wdio) | 6 | Build failures (4), wdio flakes (2) |
| build (windows) | 4 | Build failures |

### This PR: vitest `hookTimeout` for ALS tests (addresses 8 of 16 WSL failures)

The same test fails in **every WSL unit test failure** from Jun 8–10:

```
completionProvider.test.ts > doCompletion() > module kind and documentation
  of completion item > @noee
Error: Hook timed out in 10000ms.
```

**Affected runs (8):**
- Jun 10: 27272431326
- Jun 9: 27190623007, 27188299273, 27187309178, 27184451766, 27176961548
- Jun 8: 27160027593, 27141488766

On worse runs, additional tests also time out:
- `ansibleLint.test.ts` (30s timeout exceeded)
- `performance.test.ts` (30s timeout exceeded)
- `ansibleNavigator.test.ts` (30s timeout exceeded)

**Root cause:** The `beforeAll` hooks in `completionProvider.test.ts` call
`doCompletion()` → `doCompletionResolve()`, exercising the full language
server completion pipeline. On the self-hosted WSL runner (15m 55s avg queue
time, slower I/O), these exceed vitest's default 10s `hookTimeout`. The ALS
project has `testTimeout: 60000` but never set `hookTimeout`, falling back to
the 10s default.

The `next` branch (PR #2838) avoids this entirely by using GitHub-hosted
`windows-2022` runners with Fedora WSL imported fresh, source copied to native
ext4 (avoiding 9P/NTFS overhead), and a completely different test suite without
the heavy ALS completionProvider `beforeAll` hooks.

**Fix:** Set `hookTimeout: 30000` for the ALS vitest project. This matches the
existing MCP `testTimeout` and gives 3× headroom over the default while still
catching genuinely hung hooks.

### Not included: preflight `task package` timeout

The preflight `task package` timeout issue (3–4 failures, Jun 8–9) was already
resolved by #2847 ("chore: build logic fixes to avoid duplicate runs"), which
eliminated redundant `als:package` invocations that were causing the step to
exceed its time limit. No further timeout bump is needed.

## Changes

- `vitest.config.ts`: Add `hookTimeout: 30000` to the ALS vitest project config

## Test plan

- [x] Change is minimal and isolated to timeout configuration
- [x] No logic changes — only timeout value affected
- [x] ALS `hookTimeout` (30s) is well below `testTimeout` (60s), consistent hierarchy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Increases the vitest `hookTimeout` for ALS (Ansible Language Server) unit tests from the default 10 seconds to 30 seconds to prevent test failures on self-hosted WSL runners. This addresses timeout issues in `completionProvider.test.ts` where `beforeAll`/`afterAll` hooks call the full ALS completion pipeline, which exceeds the default hook timeout limit on slower self-hosted runners. The ALS `testTimeout` remains at 60 seconds.

- Added `hookTimeout: 30000` to the ALS vitest project configuration in `vitest.config.ts`

related: `#2854`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->