### PR TITLE
chore(extension): enforce @src/ path aliases over relative imports

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -105,6 +105,35 @@ export default defineConfig(
         },
     },
     {
+        files: ['src/**/*.ts'],
+        rules: {
+            'no-restricted-imports': [
+                'error',
+                {
+                    paths: [
+                        {
+                            name: 'chai',
+                            message:
+                                'No direct import from chai, use vitest or node:assert alternatives.',
+                        },
+                    ],
+                    patterns: [
+                        {
+                            group: ['./*', '../*', '../../*', '../../../*', '../../../../*'],
+                            message: 'Do not use relative imports; use @src/ path aliases instead.',
+                        },
+                    ],
+                },
+            ],
+        },
+    },
+    {
+        files: ['**/test/**/*.{js,ts,tsx,cjs}'],
+        rules: {
+            'no-restricted-imports': 'off',
+        },
+    },
+    {
         ignores: ['scripts/**'],
     },
     {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,29 +7,29 @@ import {
     ServerOptions,
     TransportKind,
 } from 'vscode-languageclient/node';
-import { PluginDocPanel } from './panels/PluginDocPanel';
-import { AnsibleDevToolsProvider } from './views/AnsibleDevToolsProvider';
-import { EnvironmentManagersProvider } from './views/EnvironmentManagersProvider';
-import { CollectionsProvider } from './views/CollectionsProvider';
-import { ExecutionEnvironmentsProvider } from './views/ExecutionEnvironmentsProvider';
-import { CreatorProvider } from './views/CreatorProvider';
-import { CreatorFormPanel } from './panels/CreatorFormPanel';
-import { PlaybooksProvider } from './views/PlaybooksProvider';
-import { PlaybookConfigPanel } from './panels/PlaybookConfigPanel';
-import { PlaybookProgressPanel } from './panels/PlaybookProgressPanel';
-import { PlaybooksService, PlaybookInfo, PlaybookPlay } from './services/PlaybooksService';
-import { TerminalService } from './services/TerminalService';
-import { PythonEnvironmentService } from './services/PythonEnvironmentService';
+import { PluginDocPanel } from '@src/panels/PluginDocPanel';
+import { AnsibleDevToolsProvider } from '@src/views/AnsibleDevToolsProvider';
+import { EnvironmentManagersProvider } from '@src/views/EnvironmentManagersProvider';
+import { CollectionsProvider } from '@src/views/CollectionsProvider';
+import { ExecutionEnvironmentsProvider } from '@src/views/ExecutionEnvironmentsProvider';
+import { CreatorProvider } from '@src/views/CreatorProvider';
+import { CreatorFormPanel } from '@src/panels/CreatorFormPanel';
+import { PlaybooksProvider } from '@src/views/PlaybooksProvider';
+import { PlaybookConfigPanel } from '@src/panels/PlaybookConfigPanel';
+import { PlaybookProgressPanel } from '@src/panels/PlaybookProgressPanel';
+import { PlaybooksService, PlaybookInfo, PlaybookPlay } from '@src/services/PlaybooksService';
+import { TerminalService } from '@src/services/TerminalService';
+import { PythonEnvironmentService } from '@src/services/PythonEnvironmentService';
 import {
     McpToolsProvider,
     injectToolPromptIntoChat,
     type ToolInfo,
-} from './views/McpToolsProvider';
+} from '@src/views/McpToolsProvider';
 import {
     CollectionSourcesProvider,
     setCollectionSourcesLogFunction,
     type CollectionSourceInfo,
-} from './views/CollectionSourcesProvider';
+} from '@src/views/CollectionSourcesProvider';
 import {
     GalaxyCollectionCache,
     CollectionsService,
@@ -47,10 +47,10 @@ import {
     showCursorMcpStatus,
     getMcpStatus,
     detectIde,
-} from './mcp';
-import { getLlmService } from './services/LlmService';
-import { registerFileAssociation } from './features/fileAssociation';
-import { registerVaultCommand } from './features/vault';
+} from '@src/mcp';
+import { getLlmService } from '@src/services/LlmService';
+import { registerFileAssociation } from '@src/features/fileAssociation';
+import { registerVaultCommand } from '@src/features/vault';
 
 // Create output channel for extension logs
 export const outputChannel = vscode.window.createOutputChannel('Ansible Environments');

--- a/src/features/fileAssociation.ts
+++ b/src/features/fileAssociation.ts
@@ -1,5 +1,9 @@
 import * as vscode from 'vscode';
-import { searchModelineLanguage, looksLikePlaybook, isYamlExtension } from './fileDetection';
+import {
+    searchModelineLanguage,
+    looksLikePlaybook,
+    isYamlExtension,
+} from '@src/features/fileDetection';
 
 const SUPPORTED_LANGUAGES = new Set(['ansible', 'yaml']);
 

--- a/src/features/vault.ts
+++ b/src/features/vault.ts
@@ -5,7 +5,7 @@ import * as os from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { getCommandService } from '@ansible/core';
-import { getVaultConfig, parseVaultIdentities, findProjectRoot } from './ansibleCfg';
+import { getVaultConfig, parseVaultIdentities, findProjectRoot } from '@src/features/ansibleCfg';
 
 // ---------------------------------------------------------------------------
 // FIFO-based password passing — password never touches disk

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -19,7 +19,7 @@ export {
     CreatorToolGenerator,
     McpToolHandler,
 } from '@ansible/mcp-server';
-export { registerMcpServerProvider, isMcpAvailable } from './vscodeProvider';
+export { registerMcpServerProvider, isMcpAvailable } from '@src/mcp/vscodeProvider';
 export {
     registerCursorMcpServer,
     configureCursorMcp,
@@ -28,4 +28,4 @@ export {
     McpStatus,
     detectIde,
     IdeType,
-} from './cursorConfig';
+} from '@src/mcp/cursorConfig';

--- a/src/panels/CreatorFormPanel.ts
+++ b/src/panels/CreatorFormPanel.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
-import { log } from '../extension';
-import { TerminalService } from '../services/TerminalService';
+import { log } from '@src/extension';
+import { TerminalService } from '@src/services/TerminalService';
 
 interface SchemaNode {
     name: string;

--- a/src/panels/PlaybookConfigPanel.ts
+++ b/src/panels/PlaybookConfigPanel.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
-import { PlaybooksService, PlaybookInfo, PlaybookConfig } from '../services/PlaybooksService';
-import { TerminalService } from '../services/TerminalService';
-import { log } from '../extension';
+import { PlaybooksService, PlaybookInfo, PlaybookConfig } from '@src/services/PlaybooksService';
+import { TerminalService } from '@src/services/TerminalService';
+import { log } from '@src/extension';
 
 interface PlaybookConfigMessage {
     command: string;

--- a/src/panels/PlaybookProgressPanel.ts
+++ b/src/panels/PlaybookProgressPanel.ts
@@ -10,8 +10,8 @@ import * as net from 'net';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
-import { log } from '../extension';
-import { getZoomThemeScript } from './webviewStyles';
+import { log } from '@src/extension';
+import { getZoomThemeScript } from '@src/panels/webviewStyles';
 
 export interface PlaybookRunOptions {
     playbookPath: string;

--- a/src/services/PlaybooksService.ts
+++ b/src/services/PlaybooksService.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
-import { log } from '../extension';
+import { log } from '@src/extension';
 
 export interface PlaybookPlay {
     name: string;

--- a/src/services/PythonEnvironmentService.ts
+++ b/src/services/PythonEnvironmentService.ts
@@ -23,7 +23,7 @@ import type {
     PackageManagementOptions,
     SetEnvironmentScope,
 } from '@ansible/core';
-import { log } from '../extension';
+import { log } from '@src/extension';
 
 const PYTHON_ENVS_EXTENSION_ID = 'ms-python.vscode-python-envs';
 const PYTHON_EXT_ID = 'ms-python.python';

--- a/src/services/TerminalService.ts
+++ b/src/services/TerminalService.ts
@@ -6,7 +6,7 @@
  */
 
 import * as vscode from 'vscode';
-import type { PythonEnvironmentService } from './PythonEnvironmentService';
+import type { PythonEnvironmentService } from '@src/services/PythonEnvironmentService';
 
 export interface CommandResult {
     output: string;

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -13,13 +13,13 @@
 
 export * from '@ansible/core';
 
-export { TerminalService } from './TerminalService';
+export { TerminalService } from '@src/services/TerminalService';
 export type {
     CommandResult,
     ManagedTerminal,
     SendCommandOptions,
     CreateTerminalOptions,
-} from './TerminalService';
+} from '@src/services/TerminalService';
 
-export { PlaybooksService } from './PlaybooksService';
-export type { PlaybookPlay, PlaybookInfo, PlaybookConfig } from './PlaybooksService';
+export { PlaybooksService } from '@src/services/PlaybooksService';
+export type { PlaybookPlay, PlaybookInfo, PlaybookConfig } from '@src/services/PlaybooksService';

--- a/src/views/AnsibleDevToolsProvider.ts
+++ b/src/views/AnsibleDevToolsProvider.ts
@@ -1,8 +1,8 @@
 import * as vscode from 'vscode';
 import { DevToolsService } from '@ansible/core';
 import type { DevToolPackage } from '@ansible/core';
-import type { PythonEnvironmentService } from '../services/PythonEnvironmentService';
-import { log } from '../extension';
+import type { PythonEnvironmentService } from '@src/services/PythonEnvironmentService';
+import { log } from '@src/extension';
 
 export class AnsibleDevToolsProvider implements vscode.TreeDataProvider<DevToolPackage> {
     private _onDidChangeTreeData: vscode.EventEmitter<DevToolPackage | undefined | null> =

--- a/src/views/CollectionsProvider.ts
+++ b/src/views/CollectionsProvider.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import { CollectionsService, CollectionInfo, PluginInfo } from '@ansible/core';
-import type { PythonEnvironmentService } from '../services/PythonEnvironmentService';
-import { log } from '../extension';
+import type { PythonEnvironmentService } from '@src/services/PythonEnvironmentService';
+import { log } from '@src/extension';
 
 type TreeNode = CollectionNode | PluginTypeNode | PluginNode | LoadingNode;
 

--- a/src/views/CreatorProvider.ts
+++ b/src/views/CreatorProvider.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import { CreatorService } from '@ansible/core';
 import type { SchemaNode } from '@ansible/core';
-import { log } from '../extension';
+import { log } from '@src/extension';
 
 type TreeNode = CategoryNode | CommandNode | MessageNode;
 

--- a/src/views/EnvironmentManagersProvider.ts
+++ b/src/views/EnvironmentManagersProvider.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import type { PythonEnvironment } from '@ansible/core';
-import type { PythonEnvironmentService } from '../services/PythonEnvironmentService';
+import type { PythonEnvironmentService } from '@src/services/PythonEnvironmentService';
 
 type TreeNode = ManagerNode | EnvironmentNode;
 

--- a/src/views/ExecutionEnvironmentsProvider.ts
+++ b/src/views/ExecutionEnvironmentsProvider.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import { ExecutionEnvService } from '@ansible/core';
 import type { ExecutionEnvironment } from '@ansible/core';
-import { log } from '../extension';
+import { log } from '@src/extension';
 
 type TreeNode = EENode | EEDetailCategoryNode | EEDetailItemNode | MessageNode;
 

--- a/src/views/McpToolsProvider.ts
+++ b/src/views/McpToolsProvider.ts
@@ -8,8 +8,8 @@
 import * as vscode from 'vscode';
 import { STATIC_TOOLS, type McpToolDefinition, CreatorToolGenerator } from '@ansible/mcp-server';
 import { CreatorService } from '@ansible/core';
-import { log } from '../extension';
-import { getMcpStatus, McpStatus } from '../mcp/cursorConfig';
+import { log } from '@src/extension';
+import { getMcpStatus, McpStatus } from '@src/mcp/cursorConfig';
 
 type ToolCategory = 'discovery' | 'generation' | 'execution' | 'devtools' | 'creator';
 

--- a/src/views/PlaybooksProvider.ts
+++ b/src/views/PlaybooksProvider.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
-import { PlaybooksService, PlaybookInfo, PlaybookPlay } from '../services/PlaybooksService';
-import { log } from '../extension';
+import { PlaybooksService, PlaybookInfo, PlaybookPlay } from '@src/services/PlaybooksService';
+import { log } from '@src/extension';
 
 type TreeNode = WorkspaceFolderNode | FolderNode | PlaybookNode | PlayNode | LoadingNode;
 


### PR DESCRIPTION
## Summary
- Convert all relative imports in `src/` to `@src/*` path aliases (resolved by esbuild at bundle time).
- Add `no-restricted-imports` ESLint rule to enforce this convention going forward.
- Ban direct `chai` imports (use `vitest` or `node:assert` instead).

> **Stacked on #2858** — once that PR merges, this one will be rebased to show only the import changes.

## Changes
- **19 source files**: All `../` and `./` imports replaced with `@src/` aliases (e.g., `../services/PlaybooksService` → `@src/services/PlaybooksService`).
- **`eslint.config.mjs`**: Added `no-restricted-imports` rule for `src/**/*.ts` files, banning relative import patterns and direct `chai` imports. Tests are excluded from this rule.

## Quality of life
- Zero logic changes — only import path rewrites and ESLint configuration.

## Test plan
- [x] `npx tsc -b` compiles cleanly
- [x] `npx vitest run` — all 424 tests pass
- [x] `npx eslint src/` — clean (no relative imports remain)
- [x] `node scripts/build.mjs` — all 3 bundles succeed
- [ ] CI checks pass

Depends on: #2858