### PR TITLE
chore: replace npx with npm exec across project

### DIFF
--- a/.agents/skills/pr-review/SKILL.md
+++ b/.agents/skills/pr-review/SKILL.md
@@ -118,11 +118,11 @@ gh run view RUN_ID --log-failed 2>&1 | tail -80
 
 Common CI failures and how to fix them:
 
-- **lint (eslint)**: Run `npx eslint . --fix` locally. Common issues:
+- **lint (eslint)**: Run `npm exec eslint -- . --fix` locally. Common issues:
   unused imports, missing type annotations, inconsistent formatting.
-- **compile (tsc)**: Run `npx tsc -b` to check for type errors across all
+- **compile (tsc)**: Run `npm exec tsc -- -b` to check for type errors across all
   packages. Fix type mismatches, missing imports, and `any` type leaks.
-- **unit tests (vitest)**: Run `npx vitest run` to reproduce. Update tests
+- **unit tests (vitest)**: Run `npm exec vitest -- run` to reproduce. Update tests
   when behavior changes.
 - **e2e tests (wdio)**: Run `npm run test:ui` to reproduce. These tests
   launch a real VS Code instance — check for timing issues and flaky

--- a/.agents/skills/review-contributor-pr/SKILL.md
+++ b/.agents/skills/review-contributor-pr/SKILL.md
@@ -24,9 +24,9 @@ submitting your own PR (use `submit-pr` for that).
 
 - PR is **up to date with `next`** (no merge conflicts, clean rebase).
   See the `branching-strategy` skill for why `next` is the target branch.
-- **Lint and type checks pass**: `npx eslint .` and `npx tsc -b` on the full
+- **Lint and type checks pass**: `npm exec eslint -- .` and `npm exec tsc -- -b` on the full
   tree.
-- **Tests pass**: `npx vitest run` for unit tests.
+- **Tests pass**: `npm exec vitest -- run` for unit tests.
 - **PR description** follows the project template (Summary, Changes, Test
   plan) so reviewers and history have clear context.
 - Avoid pushing to the contributor's branch with failing CI or an outdated
@@ -64,9 +64,9 @@ If you are going to push changes to the contributor's branch:
 Run these checks on the **entire** tree, not only the changed files:
 
 ```bash
-npx eslint .
-npx tsc -b
-npx vitest run
+npm exec eslint -- .
+npm exec tsc -- -b
+npm exec vitest -- run
 ```
 
 All checks must pass. Fix any failures (unused imports, type errors, test
@@ -98,7 +98,7 @@ commit and then push so CI stays green.
 - Before pushing:
 
   1. Rebase onto `upstream/next` so the PR is up to date.
-  2. Ensure `npx eslint .` and `npx tsc -b` pass.
+  2. Ensure `npm exec eslint -- .` and `npm exec tsc -- -b` pass.
   3. Use `--force-with-lease` when pushing a rebased branch:
      `git push <remote> <local-branch>:<their-branch> --force-with-lease`.
 
@@ -141,9 +141,9 @@ When reviewing or preparing a contributor PR:
 - [ ] Fetched PR and know base/head and remotes.
 - [ ] PR targets `next` (not `main`). Retarget if needed.
 - [ ] Branch is up to date with `next` (rebase if needed before push).
-- [ ] `npx eslint .` passes.
-- [ ] `npx tsc -b` compiles cleanly.
-- [ ] `npx vitest run` passes.
+- [ ] `npm exec eslint -- .` passes.
+- [ ] `npm exec tsc -- -b` compiles cleanly.
+- [ ] `npm exec vitest -- run` passes.
 - [ ] PR description has Summary, Changes, and Test plan (submit-pr style).
 - [ ] If pushing to their branch: rebase onto upstream/next, checks green, then
       `git push <remote> <local>:<their-branch> --force-with-lease`.

--- a/.agents/skills/submit-pr/SKILL.md
+++ b/.agents/skills/submit-pr/SKILL.md
@@ -36,9 +36,9 @@ session), cherry-pick or rebase them onto the new branch.
 ### Step 2: Run lint and type checks
 
 ```bash
-npx eslint .
-npx tsc -b
-npx vitest run
+npm exec eslint -- .
+npm exec tsc -- -b
+npm exec vitest -- run
 ```
 
 **All checks must pass cleanly on all files** — not just the files you
@@ -46,7 +46,7 @@ changed. If the branch has pre-existing violations (e.g., from an old base),
 rebase onto `upstream/next` first.
 
 If violations are found:
-1. Run `npx eslint . --fix` to auto-fix what it can
+1. Run `npm exec eslint -- . --fix` to auto-fix what it can
 2. Manually fix remaining violations (type errors, test failures)
 3. Re-run until clean
 
@@ -118,9 +118,9 @@ gh pr create --base next --label "<type>" --title "conventional commit style tit
 - List each AI-generated artifact and its purpose
 
 ## Test plan
-- [ ] `npx eslint .` passes
-- [ ] `npx tsc -b` compiles cleanly
-- [ ] `npx vitest run` passes
+- [ ] `npm exec eslint -- .` passes
+- [ ] `npm exec tsc -- -b` compiles cleanly
+- [ ] `npm exec vitest -- run` passes
 - [ ] `npm run test:ui` passes (if e2e-relevant changes)
 
 related: #<issue_number>

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
       - run: npm ci
 
       - name: Build VSIX
-        run: npx vsce package --no-dependencies
+        run: npm exec vsce -- package --no-dependencies
 
       - name: Upload VSIX
         uses: actions/upload-artifact@v5

--- a/.github/workflows/release-vsix.yml
+++ b/.github/workflows/release-vsix.yml
@@ -27,7 +27,7 @@ jobs:
         run: npm ci
 
       - name: Build VSIX
-        run: npx vsce package --no-dependencies
+        run: npm exec vsce -- package --no-dependencies
 
       - name: Upload VSIX to release
         env:

--- a/.github/workflows/wsl2-ui.yml
+++ b/.github/workflows/wsl2-ui.yml
@@ -70,7 +70,7 @@ jobs:
         run: npm run pretest:ui
 
       - name: WDIO smoke tests
-        run: npx wdio run wdio.conf.wsl.ts
+        run: npm exec wdio -- run wdio.conf.wsl.ts
 
       - name: Integration tests
         run: npm run test:integration

--- a/.sdlc/adrs/ADR-007-npm-exec-over-npx.md
+++ b/.sdlc/adrs/ADR-007-npm-exec-over-npx.md
@@ -1,0 +1,119 @@
+# ADR-007: Use `npm exec` Instead of `npx`
+
+## Status
+
+Implemented
+
+## Date
+
+2026-06-10
+
+## Context
+
+The project's CI workflows, documentation, and agent skill files use `npx`
+to run locally installed CLI tools (`tsc`, `eslint`, `vitest`, `vsce`,
+`wdio`). While `npx` works, it has behaviors that conflict with the
+project's security and reproducibility requirements:
+
+### Silent remote package execution
+
+`npx` was designed for ad-hoc execution. When a package is not installed
+locally, `npx` downloads and runs it from the npm registry — potentially
+without prompting (behavior varies across npm versions). This creates a
+supply-chain attack vector: a typo like `npx eslitn` could execute a
+malicious package.
+
+### Inconsistent prompting across npm versions
+
+The `--yes`/`--no` flags and interactive prompts around remote packages
+have changed behavior across npm 7, 8, 9, and 10. CI environments that
+pin different Node/npm versions may behave differently.
+
+### Ambiguous intent
+
+`npx <tool>` does not make it clear whether the intent is to run a local
+devDependency or to fetch something from the registry. `npm exec` makes
+the intent explicit: run the tool from the project's `node_modules/.bin`.
+
+## Decision
+
+Replace all `npx` usage with `npm exec` across the project:
+
+- CI workflows (`.github/workflows/*.yml`)
+- Documentation (`AGENTS.md`, `README.md`)
+- Agent skills (`.agents/skills/`)
+- Source code comments
+
+### Syntax mapping
+
+| Before | After |
+|--------|-------|
+| `npx tsc -b` | `npm exec tsc -- -b` |
+| `npx eslint .` | `npm exec eslint -- .` |
+| `npx eslint . --fix` | `npm exec eslint -- . --fix` |
+| `npx vitest run` | `npm exec vitest -- run` |
+| `npx vsce package` | `npm exec vsce -- package` |
+| `npx wdio run ...` | `npm exec wdio -- run ...` |
+
+The `--` separator is required when passing arguments to the tool (as
+opposed to `npm exec` itself).
+
+## Alternatives Considered
+
+### Keep `npx` with `--no-install` flag
+
+`npx --no-install tsc -b` would prevent remote fetching. However, the
+flag name changed to `--no` in newer npm versions, the syntax is verbose,
+and it still signals the wrong intent.
+
+### Use `node_modules/.bin/` paths directly
+
+`./node_modules/.bin/tsc -b` is explicit and safe, but verbose and
+fragile (breaks on Windows without cross-platform scripting).
+
+### Use npm scripts for everything
+
+Define every tool invocation as an npm script (`npm run lint`, `npm run
+typecheck`). This works for CI but is too rigid for documentation and
+ad-hoc developer workflows where arguments vary.
+
+## Consequences
+
+### Positive
+
+- **Eliminates remote execution risk**: `npm exec` will not silently
+  download and run packages from the registry.
+- **Consistent behavior**: Works the same across npm 7+ regardless of
+  version-specific prompt changes.
+- **Clear intent**: Signals "run the locally installed tool" rather than
+  "run something, maybe from the internet."
+- **Aligns with npm team guidance**: The npm team recommends `npm exec`
+  for project-local tooling.
+
+### Negative
+
+- **Slightly more verbose**: `npm exec tsc -- -b` vs `npx tsc -b`.
+  The `--` separator is an extra token developers must remember.
+- **Requires npm 7+**: Not a concern for this project (Node 20+ is the
+  minimum), but could affect contributors with very old setups.
+
+### Neutral
+
+- No runtime or build behavior changes — both commands resolve to the
+  same `node_modules/.bin/` binaries.
+- Existing npm scripts (`npm run compile`, `npm run build`) are
+  unaffected.
+
+## Implementation Notes
+
+- All changes are in documentation, CI YAML, and source comments.
+- No functional code changes.
+- Agent skill files are updated so AI agents use the correct command
+  syntax when running quality gates.
+
+## Related Decisions
+
+- [ADR-005](ADR-005-architectural-invariants.md) — Architectural
+  invariants (quality gates reference these commands)
+- [ADR-006](ADR-006-esbuild-bundler.md) — esbuild bundler (build
+  pipeline context)

--- a/.sdlc/adrs/README.md
+++ b/.sdlc/adrs/README.md
@@ -11,6 +11,7 @@ Decisions that are fully reflected in the codebase.
 |-----|-------|------|
 | [ADR-001](ADR-001-service-based-architecture.md) | Service-Based Architecture with VS Code-Independent Core | 2026-05-26 |
 | [ADR-002](ADR-002-centralized-plugin-doc-cache.md) | Centralized Plugin Documentation Cache | 2026-05-26 |
+| [ADR-007](ADR-007-npm-exec-over-npx.md) | Use `npm exec` Instead of `npx` | 2026-06-10 |
 
 ## Accepted
 
@@ -33,7 +34,7 @@ Decisions under consideration — not yet accepted or implemented.
 ## Creating New ADRs
 
 1. Copy the template from `../templates/adr.md`
-2. Use the next available number (currently ADR-007)
+2. Use the next available number (currently ADR-008)
 3. Include:
    - Status (Proposed → Accepted → Implemented)
    - Date

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,9 +58,9 @@ See the `branching-strategy` skill for full details.
 
 Before committing:
 
-1. `npx tsc -b` — type check all packages
-2. `npx vitest run` — unit tests pass
-3. `npx eslint .` — no lint violations (when eslint config is available)
+1. `npm exec tsc -- -b` — type check all packages
+2. `npm exec vitest -- run` — unit tests pass
+3. `npm exec eslint -- .` — no lint violations (when eslint config is available)
 4. Verify no architectural invariants (above) were violated
 
 ## Commit Format

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ The test suite uses:
 ### Building
 
 ```bash
-npx vsce package      # Package the extension as a VSIX
+npm exec vsce -- package   # Package the extension as a VSIX
 ```
 
 ### Alpha releases (VSIX on GitHub)

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -8,8 +8,8 @@
  * Usage:
  *   node packages/mcp-server/out/server.js
  *
- * Or via npx (when published):
- *   npx @ansible/environments-mcp
+ * Or via npm exec (when published):
+ *   npm exec --package @ansible/mcp-server -- ansible-environments-mcp
  *
  * Configuration for Cursor (.cursor/mcp.json):
  * {


### PR DESCRIPTION
## Summary
- Replace all `npx` usage with `npm exec` to eliminate silent remote package execution risk and improve supply-chain security posture (ADR-007).

## Changes
- **CI workflows**: Updated `ci.yml`, `release-vsix.yml`, `wsl2-ui.yml` to use `npm exec` for `vsce` and `wdio` commands.
- **Documentation**: Updated `AGENTS.md` quality gates and `README.md` packaging instructions.
- **Agent skills**: Updated `submit-pr`, `pr-review`, and `review-contributor-pr` skills with `npm exec` syntax.
- **Source comments**: Updated MCP server usage example in `server.ts`.
- **ADR-007**: Documents the decision, rationale, alternatives considered, and syntax mapping.

## Quality of life
- ADR-007 (`npm exec` over `npx`) — documents the security rationale and provides a syntax mapping table for contributors.

## Test plan
- [x] `npm exec eslint -- .` passes
- [x] `npm exec tsc -- -b` compiles cleanly
- [x] `npm exec vitest -- run` passes
- [x] CI workflows execute correctly (no functional code changes, only command syntax in YAML and documentation)