### PR TITLE
docs: enforce 100% JSDoc coverage with eslint-plugin-jsdoc

### DIFF
--- a/.sdlc/adrs/ADR-009-jsdoc-enforcement.md
+++ b/.sdlc/adrs/ADR-009-jsdoc-enforcement.md
@@ -1,0 +1,151 @@
+# ADR-009: Mandatory JSDoc on All Functions and Methods
+
+## Status
+
+Implemented
+
+## Date
+
+2026-06-10
+
+## Context
+
+The `next` branch had roughly 26% JSDoc coverage — ~164 of ~634
+functions and methods had documentation. Coverage was unevenly
+distributed: `@ansible/core` services were ~58% documented while the
+language server and MCP server packages were under 5%.
+
+### Why docstrings matter in an AI-assisted workflow
+
+TypeScript's type system conveys the *shape* of data (parameter types,
+return types, generics) but not the *intent*: why a function exists,
+what side effects it has, what invariants it maintains, or what callers
+should expect. This intent gap affects:
+
+- **AI agents**: Language models operating on the codebase (Copilot,
+  Cursor, MCP-connected agents) use docstrings as primary context for
+  understanding function behavior. Without them, agents must infer
+  intent from implementation details, which is slower and error-prone.
+- **Human contributors**: New contributors and reviewers rely on
+  function-level documentation to understand the API surface without
+  reading every implementation.
+- **API consumers**: The `@ansible/core` package is consumed by the
+  extension, language server, and MCP server. Undocumented public APIs
+  force consumers to read source code.
+
+### Why 100% coverage (not just exported)
+
+Internal/private functions are equally important for AI agents and
+future maintainers. A private helper's docstring explains *why* it was
+extracted, what edge cases it handles, and how it fits into the calling
+function's logic. Partial coverage creates inconsistent context —
+agents cannot predict which functions will have documentation.
+
+## Decision
+
+Enforce JSDoc on **every** function declaration, method definition, and
+class declaration using `eslint-plugin-jsdoc` with the following rules
+set to `error`:
+
+| Rule | Purpose |
+|------|---------|
+| `jsdoc/require-jsdoc` | Require a JSDoc block on all functions, methods, classes, constructors, getters, and setters. |
+| `jsdoc/require-param` | Require `@param` for every function parameter. |
+| `jsdoc/require-param-description` | Require a description on each `@param` tag. |
+| `jsdoc/require-returns` | Require `@returns` on functions with non-void return types. |
+| `jsdoc/require-returns-description` | Require a description on the `@returns` tag. |
+| `jsdoc/check-param-names` | Validate that `@param` names match the actual signature. |
+| `jsdoc/check-tag-names` | Only allow standard JSDoc tags. |
+| `jsdoc/no-types` | Disallow type annotations in JSDoc (TypeScript provides the types). |
+
+### No test file exemptions
+
+Test files follow the same rules. Test helper functions benefit from
+documentation just as production code does — especially for AI agents
+that need to understand test fixtures and setup patterns.
+
+### No type annotations in JSDoc
+
+The `jsdoc/no-types` rule prevents `@param {string} name` syntax.
+TypeScript already provides type information; duplicating it in JSDoc
+creates a maintenance burden where types go stale. JSDoc should describe
+*intent and constraints*, not types:
+
+```typescript
+// Good — describes intent, TypeScript provides the type
+/** @param name - Display name shown in the environment picker */
+
+// Bad — duplicates TypeScript's type information
+/** @param {string} name - Display name shown in the environment picker */
+```
+
+## Alternatives Considered
+
+### eslint-plugin-tsdoc (TSDoc standard)
+
+TSDoc is a stricter specification used by the TypeScript compiler and
+VS Code APIs. However, `eslint-plugin-tsdoc` only validates syntax of
+*existing* comments — it does not enforce *presence*. We need both
+presence enforcement and syntax validation, which `eslint-plugin-jsdoc`
+provides.
+
+### Exported-only enforcement
+
+Only requiring JSDoc on exported/public symbols would reduce the initial
+effort but create a two-tier system where internal code remains
+undocumented. AI agents do not distinguish between exported and internal
+functions when building context.
+
+### Documentation generation tool (TypeDoc) without lint enforcement
+
+TypeDoc generates API docs from existing JSDoc but does not enforce
+coverage. Without a lint rule, coverage would degrade over time as new
+functions are added without documentation.
+
+## Consequences
+
+### Positive
+
+- **Consistent AI context**: Every function in the codebase provides
+  intent documentation that language models can consume.
+- **Enforced at CI**: Missing or malformed JSDoc fails the lint check,
+  preventing undocumented code from being merged.
+- **Self-documenting codebase**: Contributors can understand any
+  function's purpose from its JSDoc without reading the implementation.
+- **Accurate parameter docs**: `check-param-names` catches stale
+  `@param` tags when signatures change.
+
+### Negative
+
+- **Initial effort**: ~490 functions needed JSDoc added in the initial
+  enforcement PR.
+- **Ongoing cost**: Every new function requires a JSDoc block. This adds
+  ~10-30 seconds per function during development.
+- **Potential for low-quality docstrings**: Enforcement guarantees
+  *presence* but not *quality*. Code review must still check that
+  descriptions are meaningful, not just boilerplate to satisfy the linter.
+
+### Neutral
+
+- Lint run time is unaffected — `eslint-plugin-jsdoc` does not require
+  type information (unlike `@typescript-eslint` type-checked rules).
+- Existing accurate JSDoc is preserved; only missing or incomplete
+  blocks are added.
+
+## Implementation Notes
+
+- Plugin: `eslint-plugin-jsdoc` added as a devDependency.
+- Configuration: Rules added to the main config block in
+  `eslint.config.mjs` (applies to all `.ts`/`.js` files).
+- `ArrowFunctionExpression` and `FunctionExpression` are not required
+  to have standalone JSDoc when used as inline callbacks — only named
+  function declarations, method definitions, and class declarations
+  are enforced.
+
+## Related Decisions
+
+- [ADR-008](ADR-008-strict-eslint-configuration.md) — Strict ESLint
+  configuration (the JSDoc rules build on this foundation)
+- [ADR-001](ADR-001-service-based-architecture.md) — Service-based
+  architecture (the `@ansible/core` package API surface benefits most
+  from documentation)

--- a/.sdlc/adrs/README.md
+++ b/.sdlc/adrs/README.md
@@ -13,6 +13,7 @@ Decisions that are fully reflected in the codebase.
 | [ADR-002](ADR-002-centralized-plugin-doc-cache.md) | Centralized Plugin Documentation Cache | 2026-05-26 |
 | [ADR-007](ADR-007-npm-exec-over-npx.md) | Use `npm exec` Instead of `npx` | 2026-06-10 |
 | [ADR-008](ADR-008-strict-eslint-configuration.md) | Strict ESLint Configuration with Type-Checked Presets | 2026-06-10 |
+| [ADR-009](ADR-009-jsdoc-enforcement.md) | Mandatory JSDoc on All Functions and Methods | 2026-06-10 |
 
 ## Accepted
 
@@ -35,7 +36,7 @@ Decisions under consideration — not yet accepted or implemented.
 ## Creating New ADRs
 
 1. Copy the template from `../templates/adr.md`
-2. Use the next available number (currently ADR-009)
+2. Use the next available number (currently ADR-010)
 3. Include:
    - Status (Proposed → Accepted → Implemented)
    - Date

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,6 +10,7 @@ import { fileURLToPath } from 'url';
 import { defineConfig } from 'eslint/config';
 import { createRequire } from 'module';
 import importPlugin from 'eslint-plugin-import';
+import jsdocPlugin from 'eslint-plugin-jsdoc';
 import { includeIgnoreFile } from '@eslint/config-helpers';
 
 const require = createRequire(import.meta.url);
@@ -60,6 +61,7 @@ export default defineConfig(
         },
         plugins: {
             local: eslintPluginLocal,
+            jsdoc: jsdocPlugin,
         },
         rules: {
             eqeqeq: ['error', 'smart'],
@@ -81,6 +83,28 @@ export default defineConfig(
             'no-control-regex': 'error',
             'no-empty-function': 'error',
             'no-prototype-builtins': 'error',
+            'jsdoc/require-jsdoc': [
+                'error',
+                {
+                    require: {
+                        FunctionDeclaration: true,
+                        MethodDefinition: true,
+                        ClassDeclaration: true,
+                        ArrowFunctionExpression: false,
+                        FunctionExpression: false,
+                    },
+                    checkConstructors: true,
+                    checkGetters: true,
+                    checkSetters: true,
+                },
+            ],
+            'jsdoc/require-param': 'error',
+            'jsdoc/require-param-description': 'error',
+            'jsdoc/require-returns': 'error',
+            'jsdoc/require-returns-description': 'error',
+            'jsdoc/check-param-names': 'error',
+            'jsdoc/check-tag-names': 'error',
+            'jsdoc/no-types': 'error',
         },
         settings: {
             'import/core-modules': ['vscode'],
@@ -96,6 +120,8 @@ export default defineConfig(
             '@typescript-eslint/no-base-to-string': 'off',
             '@typescript-eslint/no-unsafe-return': 'off',
             '@typescript-eslint/no-unsafe-member-access': 'off',
+            '@typescript-eslint/no-unsafe-assignment': 'off',
+            '@typescript-eslint/no-unsafe-call': 'off',
         },
     },
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "zod-to-json-schema": "^3.25.1"
       },
       "bin": {
-        "ansible-environments-mcp": "packages/mcp-server/out/server.js"
+        "ansible-environments-mcp": "dist/mcp-server.js"
       },
       "devDependencies": {
         "@eslint/compat": "^2.1.0",
@@ -49,6 +49,7 @@
         "eslint-config-prettier": "^10.1.8",
         "eslint-import-resolver-typescript": "^4.4.5",
         "eslint-plugin-import": "^2.32.0",
+        "eslint-plugin-jsdoc": "^62.9.0",
         "eslint-plugin-prettier": "^5.5.6",
         "globals": "^17.6.0",
         "prettier": "^3.8.4",
@@ -391,6 +392,33 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@es-joy/jsdoccomment": {
+      "version": "0.86.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.86.0.tgz",
+      "integrity": "sha512-ukZmRQ81WiTpDWO6D/cTBM7XbrNtutHKvAVnZN/8pldAwLoJArGOvkNyxPTBGsPjsoaQBJxlH+tE2TNA/92Qgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.8",
+        "@typescript-eslint/types": "^8.58.0",
+        "comment-parser": "1.4.6",
+        "esquery": "^1.7.0",
+        "jsdoc-type-pratt-parser": "~7.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@es-joy/resolve.exports": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/resolve.exports/-/resolve.exports-1.2.0.tgz",
+      "integrity": "sha512-Q9hjxWI5xBM+qW2enxfe8wDKdFWMfd0Z29k5ZJnuBqD/CasY5Zryj09aCA6owbGATWz+39p5uIdaHXpopOcG8g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -2345,6 +2373,19 @@
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
       "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
       "dev": true
+    },
+    "node_modules/@sindresorhus/base62": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/base62/-/base62-1.0.0.tgz",
+      "integrity": "sha512-TeheYy0ILzBEI/CO55CP6zJCSdSWeRtGnHy8U8dWSUH4I68iqTsy7HkMktR4xakThc9jotkPQUXT4ITdbV7cHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/@sindresorhus/is": {
       "version": "5.6.0",
@@ -5220,6 +5261,16 @@
         "streamx": "^2.15.0"
       }
     },
+    "node_modules/are-docs-informative": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/are-docs-informative/-/are-docs-informative-0.0.2.tgz",
+      "integrity": "sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
@@ -6414,6 +6465,16 @@
       "dev": true,
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/comment-parser": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.6.tgz",
+      "integrity": "sha512-ObxuY6vnbWTN6Od72xfwN9DbzC7Y2vv8u1Soi9ahRKL37gb6y1qk6/dgjs+3JWuXJHWvsg3BXIwzd/rkmAwavg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/compress-commons": {
@@ -7842,6 +7903,46 @@
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc": {
+      "version": "62.9.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-62.9.0.tgz",
+      "integrity": "sha512-PY7/X4jrVgoIDncUmITlUqK546Ltmx/Pd4Hdsu4CvSjryQZJI2mEV4vrdMufyTetMiZ5taNSqvK//BTgVUlNkA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@es-joy/jsdoccomment": "~0.86.0",
+        "@es-joy/resolve.exports": "1.2.0",
+        "are-docs-informative": "^0.0.2",
+        "comment-parser": "1.4.6",
+        "debug": "^4.4.3",
+        "escape-string-regexp": "^4.0.0",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
+        "html-entities": "^2.6.0",
+        "object-deep-merge": "^2.0.0",
+        "parse-imports-exports": "^0.2.4",
+        "semver": "^7.7.4",
+        "spdx-expression-parse": "^4.0.0",
+        "to-valid-identifier": "^1.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/spdx-expression-parse": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-4.0.0.tgz",
+      "integrity": "sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
     "node_modules/eslint-plugin-prettier": {
@@ -9621,6 +9722,23 @@
         "node": ">=14"
       }
     },
+    "node_modules/html-entities": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
+      "integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mdevils"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/mdevils"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -10692,6 +10810,16 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdoc-type-pratt-parser": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-7.2.0.tgz",
+      "integrity": "sha512-dh140MMgjyg3JhJZY/+iEzW+NO5xR2gpbDFKHqotCmexElVntw7GjWjt511+C/Ef02RU5TKYrJo/Xlzk+OLaTw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/json-buffer": {
@@ -11973,6 +12101,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/object-deep-merge": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/object-deep-merge/-/object-deep-merge-2.0.1.tgz",
+      "integrity": "sha512-aKttDKcU3pyZqKcCkDhsMn70WmZFG2JGDQLP9EcLyTSIFQRCPWLAmBZRLJnrVUrhPG1jETEEbfdgbNtJf1LyMg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -12323,6 +12458,16 @@
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
       "dev": true
     },
+    "node_modules/parse-imports-exports": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/parse-imports-exports/-/parse-imports-exports-0.2.4.tgz",
+      "integrity": "sha512-4s6vd6dx1AotCx/RCI2m7t7GCh5bDRUtGNvRfHSP2wbBQdMi67pPe7mtzmgwcaQ8VKK/6IB7Glfyu3qdZJPybQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse-statements": "1.0.11"
+      }
+    },
     "node_modules/parse-json": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
@@ -12378,6 +12523,13 @@
       "bin": {
         "semver": "bin/semver"
       }
+    },
+    "node_modules/parse-statements": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/parse-statements/-/parse-statements-1.0.11.tgz",
+      "integrity": "sha512-HlsyYdMBnbPQ9Jr/VgJ1YF4scnldvJpJxCVx6KgqPL4dxppsWrJHCIIxQXMJrqGnsRkNPATbeMJ8Yxu7JMsYcA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/parse5": {
       "version": "7.3.0",
@@ -13427,6 +13579,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/reserved-identifiers": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/reserved-identifiers/-/reserved-identifiers-1.2.0.tgz",
+      "integrity": "sha512-yE7KUfFvaBFzGPs5H3Ops1RevfUEsDc5Iz65rOwWg4lE8HJSYtle77uul3+573457oHvBKuHYDl/xqUkKpEEdw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/resolve": {
       "version": "2.0.0-next.7",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.7.tgz",
@@ -13913,9 +14078,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -15161,6 +15326,23 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/to-valid-identifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-valid-identifier/-/to-valid-identifier-1.0.0.tgz",
+      "integrity": "sha512-41wJyvKep3yT2tyPqX/4blcfybknGB4D+oETKLs7Q76UiPqRpUJK3hr1nxelyYO0PHKVzJwlu0aCeEAsGI6rpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/base62": "^1.0.0",
+        "reserved-identifiers": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/toad-cache": {

--- a/package.json
+++ b/package.json
@@ -830,6 +830,7 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-import-resolver-typescript": "^4.4.5",
     "eslint-plugin-import": "^2.32.0",
+    "eslint-plugin-jsdoc": "^62.9.0",
     "eslint-plugin-prettier": "^5.5.6",
     "globals": "^17.6.0",
     "prettier": "^3.8.4",

--- a/packages/core/src/services/CollectionsService.ts
+++ b/packages/core/src/services/CollectionsService.ts
@@ -143,7 +143,9 @@ type AdeInspectOutput = Record<string, AdeCollectionInfo>;
 // Command execution is now handled by CommandService
 
 /**
- * Get the workspace root directory
+ * Resolves the workspace root from VS Code or the current working directory.
+ *
+ * @returns Absolute workspace path, or null when no folder is open.
  */
 function getWorkspaceRoot(): string | null {
     if (vscode?.workspace.workspaceFolders?.[0]) {
@@ -157,7 +159,9 @@ function getWorkspaceRoot(): string | null {
 }
 
 /**
- * Get the collections cache file path
+ * Builds the path to the collections plugin cache file for the workspace.
+ *
+ * @returns Absolute cache file path, or null when no workspace root exists.
  */
 function getCollectionsCachePath(): string | null {
     const workspaceRoot = getWorkspaceRoot();
@@ -168,7 +172,9 @@ function getCollectionsCachePath(): string | null {
 }
 
 /**
- * Ensure the cache directory exists
+ * Creates the collections cache directory under the workspace when missing.
+ *
+ * @returns True when the directory exists or was created successfully.
  */
 function ensureCacheDir(): boolean {
     const workspaceRoot = getWorkspaceRoot();
@@ -188,7 +194,9 @@ function ensureCacheDir(): boolean {
 }
 
 /**
- * Read the collections cache
+ * Reads and parses the collections plugin cache from disk.
+ *
+ * @returns Parsed cache payload, or null when the file is missing or unreadable.
  */
 function readCollectionsCache(): CollectionsCache | null {
     const cachePath = getCollectionsCachePath();
@@ -223,14 +231,20 @@ function readCollectionsCache(): CollectionsCache | null {
 }
 
 /**
- * Log a message via shared logging (extension or console fallback)
+ * Log a message via shared logging (extension or console fallback).
+ *
+ * @param message - Diagnostic text prefixed with CollectionsService.
  */
 function logMessage(message: string): void {
     log(`CollectionsService: ${message}`);
 }
 
 /**
- * Write the collections cache
+ * Persists collection metadata and plugin docs to the workspace cache file.
+ *
+ * @param collections - In-memory collection map to serialize.
+ * @param pluginDocs - In-memory plugin documentation map to serialize.
+ * @returns True when the cache file was written successfully.
  */
 function writeCollectionsCache(
     collections: Map<string, CollectionData>,
@@ -278,7 +292,10 @@ interface CacheResult {
 }
 
 /**
- * Convert cached data back to Map structures
+ * Converts serialized cache data back into in-memory Map structures.
+ *
+ * @param cache - Parsed collections cache read from disk.
+ * @returns Collection and plugin documentation maps ready for service use.
  */
 function cacheToMaps(cache: CollectionsCache): CacheResult {
     const collections = new Map<string, CollectionData>();
@@ -318,6 +335,9 @@ export class CollectionsService {
     private _onDidChange: SimpleEventEmitter<void> | { fire: () => void; event: unknown };
     public readonly onDidChange: unknown;
 
+    /**
+     * Initializes change notifications using VS Code or a standalone event emitter.
+     */
     private constructor() {
         // Use VS Code EventEmitter if available, otherwise use simple implementation
         if (vscode) {
@@ -331,52 +351,77 @@ export class CollectionsService {
         }
     }
 
+    /**
+     * Returns the shared CollectionsService instance.
+     *
+     * @returns Singleton service for collection and plugin documentation.
+     */
     public static getInstance(): CollectionsService {
         CollectionsService._instance ??= new CollectionsService();
         return CollectionsService._instance;
     }
 
+    /**
+     * Indicates whether the service is running inside the VS Code extension host.
+     *
+     * @returns True when the vscode module is available.
+     */
     public isInVSCode(): boolean {
         return vscode !== undefined;
     }
 
     /**
-     * Check if the service is currently loading data
+     * Check if the service is currently loading data.
+     *
+     * @returns True while a full collection index load is in progress.
      */
     public isLoading(): boolean {
         return this._loading;
     }
 
     /**
-     * Check if the service has loaded data
+     * Check if the service has loaded data.
+     *
+     * @returns True after collections are available from cache or a full load.
      */
     public isLoaded(): boolean {
         return this._loaded;
     }
 
     /**
-     * Get all loaded collections
+     * Get all loaded collections.
+     *
+     * @returns Map of collection FQCN to metadata and plugin type index.
      */
     public getCollections(): Map<string, CollectionData> {
         return this._collections;
     }
 
     /**
-     * Get a specific collection by name
+     * Get a specific collection by name.
+     *
+     * @param name - Fully qualified collection name.
+     * @returns Collection metadata and plugin index, or undefined when not loaded.
      */
     public getCollection(name: string): CollectionData | undefined {
         return this._collections.get(name);
     }
 
     /**
-     * List all collection names
+     * List all collection names.
+     *
+     * @returns Sorted fully qualified collection names from the loaded index.
      */
     public listCollectionNames(): string[] {
         return Array.from(this._collections.keys()).sort();
     }
 
     /**
-     * Get plugins for a specific collection and type
+     * Get plugins for a specific collection and type.
+     *
+     * @param collectionName - Fully qualified collection name.
+     * @param pluginType - Plugin category such as module or lookup.
+     * @returns Plugin entries for the collection and type, or an empty array.
      */
     public getPlugins(collectionName: string, pluginType: string): PluginInfo[] {
         const collection = this._collections.get(collectionName);
@@ -387,7 +432,10 @@ export class CollectionsService {
     }
 
     /**
-     * List all plugin types for a collection
+     * List all plugin types for a collection.
+     *
+     * @param collectionName - Fully qualified collection name.
+     * @returns Sorted plugin type names available in the collection.
      */
     public listPluginTypes(collectionName: string): string[] {
         const collection = this._collections.get(collectionName);
@@ -398,7 +446,10 @@ export class CollectionsService {
     }
 
     /**
-     * Search for plugins across all collections
+     * Search for plugins across all collections.
+     *
+     * @param query - Case-insensitive match against plugin name, FQCN, or description.
+     * @returns Matching plugins with their collection and plugin type context.
      */
     public searchPlugins(
         query: string,
@@ -423,6 +474,11 @@ export class CollectionsService {
         return results;
     }
 
+    /**
+     * Writes a diagnostic message through the shared CollectionsService logger.
+     *
+     * @param message - Log text forwarded to logMessage.
+     */
     private _log(message: string): void {
         logMessage(message);
     }
@@ -599,6 +655,10 @@ export class CollectionsService {
      * Returns instantly from the in-memory cache (populated from
      * ansible-doc --metadata-dump). Falls back to a per-plugin
      * ansible-doc subprocess only if the plugin is not in the cache.
+     *
+     * @param pluginFullName - Fully qualified plugin name.
+     * @param pluginType - Plugin category used to build the ansible-doc type flag.
+     * @returns Plugin documentation object, or null when lookup fails.
      */
     public async getPluginDocumentation(
         pluginFullName: string,
@@ -651,15 +711,12 @@ export class CollectionsService {
     }
 
     /**
-     * Install a collection using ade install
-     * Runs as a background process and returns output when complete
-     */
-    /**
-     * Install an Ansible collection from Galaxy
+     * Install an Ansible collection from Galaxy via ade and refresh the local index.
      *
-     * @param collectionName - FQCN of the collection (e.g., "community.docker")
-     * @param version - Optional version to install (e.g., "1.0.0")
-     * @param force - If true, force reinstall/upgrade
+     * @param collectionName - FQCN of the collection (e.g., "community.docker").
+     * @param version - Optional version to install (e.g., "1.0.0").
+     * @param force - When true, force reinstall or upgrade of the collection.
+     * @returns Install command stdout or a success message when stdout is empty.
      */
     public async installCollection(
         collectionName: string,
@@ -782,6 +839,12 @@ export class CollectionsService {
         return collections;
     }
 
+    /**
+     * Maps a plugin type to the corresponding ansible-doc -t flag fragment.
+     *
+     * @param pluginType - Plugin category such as module or lookup.
+     * @returns ansible-doc type flag string, or empty when the type is unknown.
+     */
     private _getTypeFlag(pluginType: string): string {
         const typeMap: Record<string, string> = {
             module: '-t module',
@@ -805,6 +868,12 @@ export class CollectionsService {
         return typeMap[pluginType] || '';
     }
 
+    /**
+     * Loads collection metadata via ade inspect and plugin docs via ansible-doc.
+     *
+     * @param targetMap - Optional map to populate instead of the service instance maps.
+     * @param targetDocs - Optional plugin doc map used during background refresh.
+     */
     private async _loadCollectionsWithCommandService(
         targetMap?: Map<string, CollectionData>,
         targetDocs?: Map<string, PluginData>,

--- a/packages/core/src/services/CommandService.ts
+++ b/packages/core/src/services/CommandService.ts
@@ -54,10 +54,18 @@ export class CommandService {
     private static _instance: CommandService | undefined;
     private _binDirResolver: BinDirResolver | undefined;
 
+    /**
+     * Private constructor for singleton access via getInstance().
+     */
     private constructor() {
         // singleton
     }
 
+    /**
+     * Returns the shared CommandService instance.
+     *
+     * @returns Singleton service for venv-aware command execution.
+     */
     public static getInstance(): CommandService {
         CommandService._instance ??= new CommandService();
         return CommandService._instance;
@@ -66,13 +74,18 @@ export class CommandService {
     /**
      * Inject a bin dir resolver. Called by the extension at startup to wire
      * PythonEnvironmentService into the core package without a hard vscode dep.
+     *
+     * @param resolver - Async callback that returns the active environment bin dir.
      */
     public setBinDirResolver(resolver: BinDirResolver): void {
         this._binDirResolver = resolver;
     }
 
     /**
-     * Get the bin directory for the current Python environment
+     * Get the bin directory for the current Python environment.
+     *
+     * @param workspaceUri - Optional VS Code workspace URI passed to the injected resolver.
+     * @returns Absolute bin directory path, or null when none can be resolved.
      */
     public async getBinDir(workspaceUri?: unknown): Promise<string | null> {
         if (this._binDirResolver) {
@@ -98,8 +111,12 @@ export class CommandService {
     }
 
     /**
-     * Get the full path to a tool (e.g., 'ade', 'ansible-doc')
-     * Checks venv first, then cached environment, then PATH
+     * Get the full path to a tool (e.g., 'ade', 'ansible-doc').
+     * Checks venv first, then cached environment, then PATH.
+     *
+     * @param toolName - Executable name to resolve.
+     * @param workspaceUri - Optional workspace URI for bin dir resolution.
+     * @returns Absolute tool path, or null when the executable is not found.
      */
     public async getToolPath(toolName: string, workspaceUri?: unknown): Promise<string | null> {
         // Try to get from current venv
@@ -127,7 +144,9 @@ export class CommandService {
     }
 
     /**
-     * Get the workspace root directory
+     * Get the workspace root directory.
+     *
+     * @returns Absolute workspace path from VS Code, ANSIBLE_ENV_WORKSPACE, or cwd.
      */
     public getWorkspaceRoot(): string | null {
         if (vscode?.workspace.workspaceFolders?.[0]) {
@@ -140,8 +159,13 @@ export class CommandService {
     }
 
     /**
-     * Run a tool from the venv (e.g., 'ade install collection-name')
-     * Automatically resolves the tool path from the environment
+     * Run a tool from the venv (e.g., 'ade install collection-name').
+     * Automatically resolves the tool path from the environment.
+     *
+     * @param toolName - Executable name to run.
+     * @param args - Command-line arguments passed to the tool.
+     * @param options - Execution options such as cwd, env, and timeout.
+     * @returns Captured stdout, stderr, and exit code from the subprocess.
      */
     public async runTool(
         toolName: string,
@@ -162,7 +186,11 @@ export class CommandService {
     }
 
     /**
-     * Run a raw command string
+     * Run a raw command string with venv-aware PATH and workspace cwd defaults.
+     *
+     * @param command - Full shell command to execute.
+     * @param options - Execution options such as cwd, env, and timeout.
+     * @returns Captured stdout, stderr, and exit code from the subprocess.
      */
     public async runCommand(command: string, options: CommandOptions = {}): Promise<ExecResult> {
         const cwd = options.cwd ?? this.getWorkspaceRoot() ?? process.cwd();
@@ -202,35 +230,50 @@ export class CommandService {
     }
 
     /**
-     * Run ade install for a collection
+     * Run ade install for a collection.
+     *
+     * @param collectionName - Fully qualified collection name to install.
+     * @returns Captured stdout, stderr, and exit code from ade install.
      */
     public async installCollection(collectionName: string): Promise<ExecResult> {
         return this.runTool('ade', ['install', collectionName]);
     }
 
     /**
-     * Run ansible-doc command
+     * Run ansible-doc command.
+     *
+     * @param args - Arguments passed to ansible-doc.
+     * @returns Captured stdout, stderr, and exit code from ansible-doc.
      */
     public async runAnsibleDoc(args: string[]): Promise<ExecResult> {
         return this.runTool('ansible-doc', args);
     }
 
     /**
-     * Run ansible-creator command
+     * Run ansible-creator command.
+     *
+     * @param args - Arguments passed to ansible-creator.
+     * @returns Captured stdout, stderr, and exit code from ansible-creator.
      */
     public async runAnsibleCreator(args: string[]): Promise<ExecResult> {
         return this.runTool('ansible-creator', args);
     }
 
     /**
-     * Run ansible-navigator command
+     * Run ansible-navigator command.
+     *
+     * @param args - Arguments passed to ansible-navigator.
+     * @returns Captured stdout, stderr, and exit code from ansible-navigator.
      */
     public async runAnsibleNavigator(args: string[]): Promise<ExecResult> {
         return this.runTool('ansible-navigator', args);
     }
 
     /**
-     * Check if a tool is available
+     * Check if a tool is available in the active environment or PATH.
+     *
+     * @param toolName - Executable name to check.
+     * @returns True when getToolPath resolves a valid executable.
      */
     public async isToolAvailable(toolName: string): Promise<boolean> {
         const toolPath = await this.getToolPath(toolName);
@@ -238,7 +281,11 @@ export class CommandService {
     }
 }
 
-// Export singleton getter for convenience
+/**
+ * Returns the shared CommandService singleton.
+ *
+ * @returns CommandService instance for venv-aware command execution.
+ */
 export function getCommandService(): CommandService {
     return CommandService.getInstance();
 }

--- a/packages/core/src/services/CreatorService.ts
+++ b/packages/core/src/services/CreatorService.ts
@@ -42,6 +42,9 @@ export interface SchemaNode {
  */
 export type CreatorStatus = 'unknown' | 'not-installed' | 'outdated' | 'ready';
 
+/**
+ * Loads ansible-creator schema and runs scaffolding commands in VS Code or standalone mode.
+ */
 export class CreatorService {
     private static _instance: CreatorService | undefined;
     private _schema: SchemaNode | null = null;
@@ -53,6 +56,9 @@ export class CreatorService {
     public readonly onDidChange: unknown;
     private _logFn: (message: string) => void = console.error;
 
+    /**
+     * Initializes change notifications using VS Code or a standalone event emitter.
+     */
     private constructor() {
         // Use VS Code EventEmitter if available, otherwise use simple implementation
         if (vscode) {
@@ -66,54 +72,84 @@ export class CreatorService {
         }
     }
 
+    /**
+     * Returns the shared CreatorService instance.
+     *
+     * @returns Singleton service for ansible-creator schema and commands.
+     */
     public static getInstance(): CreatorService {
         CreatorService._instance ??= new CreatorService();
         return CreatorService._instance;
     }
 
     /**
-     * Check if running in VS Code
+     * Check if running in VS Code.
+     *
+     * @returns True when the vscode module is available.
      */
     public isInVSCode(): boolean {
         return vscode !== undefined;
     }
 
     /**
-     * Set a custom logging function
+     * Set a custom logging function.
+     *
+     * @param fn - Callback invoked for CreatorService diagnostic messages.
      */
     public setLogFunction(fn: (message: string) => void): void {
         this._logFn = fn;
     }
 
+    /**
+     * Writes a prefixed diagnostic message through the configured log function.
+     *
+     * @param message - Log text without the CreatorService prefix.
+     */
     private _log(message: string): void {
         this._logFn(`CreatorService: ${message}`);
     }
 
     /**
-     * Check if the service is currently loading data
+     * Check if the service is currently loading data.
+     *
+     * @returns True while schema discovery is in progress.
      */
     public isLoading(): boolean {
         return this._loading;
     }
 
     /**
-     * Check if the service has loaded data
+     * Check if the service has loaded data.
+     *
+     * @returns True after schema loading completes successfully.
      */
     public isLoaded(): boolean {
         return this._loaded;
     }
 
     /**
-     * Get the loaded schema
+     * Get the loaded schema.
+     *
+     * @returns Parsed ansible-creator schema tree, or null when not yet loaded.
      */
     public getSchema(): SchemaNode | null {
         return this._schema;
     }
 
+    /**
+     * Returns the ansible-creator readiness status derived from schema loading.
+     *
+     * @returns Installation state: unknown, not-installed, outdated, or ready.
+     */
     public getStatus(): CreatorStatus {
         return this._status;
     }
 
+    /**
+     * Returns the detected ansible-creator version when installed but outdated.
+     *
+     * @returns Version string from --version output, or undefined when unknown.
+     */
     public getInstalledVersion(): string | undefined {
         return this._installedVersion;
     }
@@ -130,7 +166,9 @@ export class CreatorService {
     }
 
     /**
-     * Load the ansible-creator schema
+     * Load the ansible-creator schema.
+     *
+     * @returns Parsed schema node, or null when ansible-creator is unavailable.
      */
     public async loadSchema(): Promise<SchemaNode | null> {
         if (this._loading) {
@@ -197,7 +235,10 @@ export class CreatorService {
     }
 
     /**
-     * Get available commands at a given path
+     * Get available commands at a given path.
+     *
+     * @param path - Command path segments (e.g. ['init', 'playbook']).
+     * @returns Subcommands at the path with descriptions and subcommand flags.
      */
     public getCommands(
         path: string[] = [],
@@ -228,7 +269,10 @@ export class CreatorService {
     }
 
     /**
-     * Get command parameters for a given command path
+     * Get command parameters for a given command path.
+     *
+     * @param path - Command path segments identifying the target subcommand.
+     * @returns Required, optional, and property schemas, or null when not found.
      */
     public getCommandParameters(path: string[]): {
         required: string[];
@@ -261,7 +305,10 @@ export class CreatorService {
     }
 
     /**
-     * Get command description for a given path
+     * Get command description for a given path.
+     *
+     * @param path - Command path segments identifying the target subcommand.
+     * @returns Human-readable description from the schema, or undefined when missing.
      */
     public getCommandDescription(path: string[]): string | undefined {
         if (!this._schema || path.length === 0) {
@@ -281,13 +328,12 @@ export class CreatorService {
     }
 
     /**
-     * Run an ansible-creator command
-     * In VS Code: opens a terminal
-     * Standalone: executes via child_process and returns output
+     * Run an ansible-creator command via CommandService and return captured output.
      *
-     * @param path - Command path like ['init', 'playbook']
-     * @param args - Arguments (positional args first, then flags)
-     * @param positionalArgs - Ordered list of positional argument keys to extract from args
+     * @param path - Command path like ['init', 'playbook'].
+     * @param args - Flag and positional argument values keyed by schema parameter name.
+     * @param positionalArgs - Ordered positional parameter keys to emit before flags.
+     * @returns Command stdout, or a success message when stdout is empty.
      */
     public async runCommand(
         path: string[],
@@ -345,7 +391,12 @@ export class CreatorService {
     }
 
     /**
-     * Build the command string for a creator command (useful for MCP)
+     * Build the command string for a creator command (useful for MCP).
+     *
+     * @param path - Command path segments appended after ansible-creator.
+     * @param args - Flag and positional argument values keyed by schema parameter name.
+     * @param positionalArgs - Ordered positional parameter keys to emit before flags.
+     * @returns Shell-ready ansible-creator command string.
      */
     public buildCommandString(
         path: string[],
@@ -386,8 +437,11 @@ export class CreatorService {
     }
 
     /**
-     * Get positional argument names for a command from the schema
-     * Positional args are those without 'aliases' in the schema
+     * Get positional argument names for a command from the schema.
+     * Positional args are those without aliases in the schema.
+     *
+     * @param path - Command path segments identifying the target subcommand.
+     * @returns Parameter names that should be passed positionally.
      */
     public getPositionalArgs(path: string[]): string[] {
         if (!this._schema) {
@@ -416,6 +470,12 @@ export class CreatorService {
         return positionalArgs;
     }
 
+    /**
+     * Executes a raw shell command and returns stdout on success.
+     *
+     * @param command - Full shell command to run via CommandService.
+     * @returns Captured stdout, or null when the command fails.
+     */
     private async _runCommand(command: string): Promise<string | null> {
         try {
             const { getCommandService } = await import('./CommandService');

--- a/packages/core/src/services/DevToolsService.ts
+++ b/packages/core/src/services/DevToolsService.ts
@@ -31,6 +31,9 @@ interface TerminalServiceLike {
     };
 }
 
+/**
+ * Discovers and manages ansible-dev-tools packages in the active Python environment.
+ */
 export class DevToolsService {
     private static terminalServiceFactory: (() => TerminalServiceLike) | undefined;
 
@@ -42,6 +45,9 @@ export class DevToolsService {
     private _onDidChange: SimpleEventEmitter<void> | { fire: () => void; event: unknown };
     public readonly onDidChange: unknown;
 
+    /**
+     * Initializes change notifications using VS Code or a standalone event emitter.
+     */
     private constructor() {
         if (vscode) {
             const emitter = new vscode.EventEmitter<void>();
@@ -54,6 +60,11 @@ export class DevToolsService {
         }
     }
 
+    /**
+     * Returns the shared DevToolsService instance.
+     *
+     * @returns Singleton service for ansible-dev-tools discovery.
+     */
     public static getInstance(): DevToolsService {
         DevToolsService._instance ??= new DevToolsService();
         return DevToolsService._instance;
@@ -61,6 +72,8 @@ export class DevToolsService {
 
     /**
      * Register how to obtain TerminalService from the extension host (VS Code only).
+     *
+     * @param factory - Callback that returns a TerminalService-like instance.
      */
     public static setTerminalServiceFactory(factory: () => TerminalServiceLike): void {
         DevToolsService.terminalServiceFactory = factory;
@@ -69,35 +82,71 @@ export class DevToolsService {
     /**
      * Inject a package installer callback. The extension sets this when the
      * full PythonEnvironmentApi (managePackages) is available.
+     *
+     * @param installer - Async callback that installs ansible-dev-tools.
      */
     public setPackageInstaller(installer: PackageInstaller): void {
         this._packageInstaller = installer;
     }
 
+    /**
+     * Indicates whether the service is running inside the VS Code extension host.
+     *
+     * @returns True when the vscode module is available.
+     */
     public isInVSCode(): boolean {
         return vscode !== undefined;
     }
 
+    /**
+     * Indicates whether a package refresh is currently in progress.
+     *
+     * @returns True while adt package discovery is running.
+     */
     public isLoading(): boolean {
         return this._loading;
     }
 
+    /**
+     * Indicates whether packages have been loaded at least once.
+     *
+     * @returns True after a successful refresh completes.
+     */
     public isLoaded(): boolean {
         return this._loaded;
     }
 
+    /**
+     * Returns the discovered ansible-dev-tools packages.
+     *
+     * @returns Installed tool packages with name, version, and optional path.
+     */
     public getPackages(): DevToolPackage[] {
         return this._packages;
     }
 
+    /**
+     * Indicates whether any dev tool packages were discovered.
+     *
+     * @returns True when at least one package is loaded.
+     */
     public hasPackages(): boolean {
         return this._packages.length > 0;
     }
 
+    /**
+     * Looks up a dev tool package by executable name.
+     *
+     * @param name - Package or tool name reported by adt --version.
+     * @returns Matching package metadata, or undefined when not found.
+     */
     public getPackage(name: string): DevToolPackage | undefined {
         return this._packages.find((p) => p.name === name);
     }
 
+    /**
+     * Reloads ansible-dev-tools packages from the active environment via adt --version.
+     */
     public async refresh(): Promise<void> {
         if (this._loading) {
             return;

--- a/packages/core/src/services/EnvironmentCache.ts
+++ b/packages/core/src/services/EnvironmentCache.ts
@@ -32,7 +32,9 @@ const CACHE_DIR = '.cache/ansible-environments';
 const CACHE_FILE = 'environment.json';
 
 /**
- * Get the workspace root directory
+ * Resolves the workspace root from VS Code, ANSIBLE_ENV_WORKSPACE, or cwd.
+ *
+ * @returns Absolute workspace path, or null when no root can be determined.
  */
 function getWorkspaceRoot(): string | null {
     if (vscode?.workspace.workspaceFolders?.[0]) {
@@ -46,7 +48,9 @@ function getWorkspaceRoot(): string | null {
 }
 
 /**
- * Get the cache file path
+ * Builds the path to the environment cache file for the current workspace.
+ *
+ * @returns Absolute cache file path, or null when no workspace root exists.
  */
 function getCacheFilePath(): string | null {
     const workspaceRoot = getWorkspaceRoot();
@@ -57,7 +61,9 @@ function getCacheFilePath(): string | null {
 }
 
 /**
- * Ensure the cache directory exists
+ * Creates the cache directory under the workspace when it is missing.
+ *
+ * @returns True when the directory exists or was created successfully.
  */
 function ensureCacheDir(): boolean {
     const workspaceRoot = getWorkspaceRoot();
@@ -77,7 +83,9 @@ function ensureCacheDir(): boolean {
 }
 
 /**
- * Read the cache file
+ * Reads and parses the environment cache file from disk.
+ *
+ * @returns Parsed cache contents, or null when the file is missing or unreadable.
  */
 function readCache(): CacheFile | null {
     const cachePath = getCacheFilePath();
@@ -98,7 +106,10 @@ function readCache(): CacheFile | null {
 }
 
 /**
- * Write to the cache file
+ * Persists cache data to the workspace environment cache file.
+ *
+ * @param cache - Cache payload to write.
+ * @returns True when the file was written successfully.
  */
 function writeCache(cache: CacheFile): boolean {
     if (!ensureCacheDir()) {
@@ -120,7 +131,11 @@ function writeCache(cache: CacheFile): boolean {
 }
 
 /**
- * Save the selected environment to cache (called from VS Code extension)
+ * Saves the selected Python environment to the workspace cache (VS Code extension).
+ *
+ * @param pythonPath - Absolute path to the Python interpreter.
+ * @param displayName - Optional human-readable environment label.
+ * @returns True when the cache file was written successfully.
  */
 export function cacheSelectedEnvironment(pythonPath: string, displayName?: string): boolean {
     const binDir = path.dirname(pythonPath);
@@ -142,7 +157,9 @@ export function cacheSelectedEnvironment(pythonPath: string, displayName?: strin
 }
 
 /**
- * Get the cached environment (called from standalone MCP server)
+ * Returns the cached Python environment (used by the standalone MCP server).
+ *
+ * @returns Cached environment metadata, or null when no selection is stored.
  */
 export function getCachedEnvironment(): CachedEnvironment | null {
     const cache = readCache();
@@ -150,8 +167,9 @@ export function getCachedEnvironment(): CachedEnvironment | null {
 }
 
 /**
- * Get the bin directory for tools (ansible-doc, etc.)
- * Returns cached environment's bin dir, or null if not cached
+ * Returns the bin directory from the cached environment for tool resolution.
+ *
+ * @returns Absolute bin directory path, or null when no environment is cached.
  */
 export function getCachedBinDir(): string | null {
     const env = getCachedEnvironment();
@@ -159,7 +177,10 @@ export function getCachedBinDir(): string | null {
 }
 
 /**
- * Get path to a tool in the cached environment
+ * Resolves an executable within the cached environment's bin directory.
+ *
+ * @param toolName - Executable name to look up (e.g. ansible-doc).
+ * @returns Absolute tool path when it exists in the cached bin dir, otherwise null.
  */
 export function getCachedToolPath(toolName: string): string | null {
     const binDir = getCachedBinDir();
@@ -176,7 +197,9 @@ export function getCachedToolPath(toolName: string): string | null {
 }
 
 /**
- * Clear the cached environment
+ * Removes the selected environment entry from the workspace cache.
+ *
+ * @returns True when the updated cache was written successfully.
  */
 export function clearCachedEnvironment(): boolean {
     const cache = readCache() ?? {};
@@ -185,7 +208,10 @@ export function clearCachedEnvironment(): boolean {
 }
 
 /**
- * Find an executable - first checks cached environment, then PATH
+ * Locates an executable in the cached environment bin dir, then on PATH.
+ *
+ * @param name - Executable name to resolve.
+ * @returns Absolute path to the executable, or null when not found.
  */
 export async function findExecutableWithCache(name: string): Promise<string | null> {
     // First try cached environment
@@ -199,7 +225,10 @@ export async function findExecutableWithCache(name: string): Promise<string | nu
 }
 
 /**
- * Find an executable in PATH
+ * Locates an executable using the system which/where command.
+ *
+ * @param name - Executable name to search for on PATH.
+ * @returns Absolute path to the first match, or null when not found.
  */
 async function findInPath(name: string): Promise<string | null> {
     const { exec } = await import('child_process');

--- a/packages/core/src/services/ExecutionEnvService.ts
+++ b/packages/core/src/services/ExecutionEnvService.ts
@@ -66,6 +66,9 @@ export class ExecutionEnvService {
     public readonly onDidChange: unknown;
     private _logFn: (message: string) => void = console.error;
 
+    /**
+     * Initializes change notifications using VS Code or a standalone event emitter.
+     */
     private constructor() {
         // Use VS Code EventEmitter if available, otherwise use simple implementation
         if (vscode) {
@@ -79,66 +82,94 @@ export class ExecutionEnvService {
         }
     }
 
+    /**
+     * Returns the shared ExecutionEnvService instance.
+     *
+     * @returns Singleton service for execution environment discovery.
+     */
     public static getInstance(): ExecutionEnvService {
         ExecutionEnvService._instance ??= new ExecutionEnvService();
         return ExecutionEnvService._instance;
     }
 
     /**
-     * Check if running in VS Code
+     * Check if running in VS Code.
+     *
+     * @returns True when the vscode module is available.
      */
     public isInVSCode(): boolean {
         return vscode !== undefined;
     }
 
     /**
-     * Set a custom logging function
+     * Set a custom logging function.
+     *
+     * @param fn - Callback invoked for ExecutionEnvService diagnostic messages.
      */
     public setLogFunction(fn: (message: string) => void): void {
         this._logFn = fn;
     }
 
+    /**
+     * Writes a prefixed diagnostic message through the configured log function.
+     *
+     * @param message - Log text without the ExecutionEnvService prefix.
+     */
     private _log(message: string): void {
         this._logFn(`ExecutionEnvService: ${message}`);
     }
 
     /**
-     * Check if the service is currently loading data
+     * Check if the service is currently loading data.
+     *
+     * @returns True while ansible-navigator discovery is in progress.
      */
     public isLoading(): boolean {
         return this._loading;
     }
 
     /**
-     * Check if the service has loaded data
+     * Check if the service has loaded data.
+     *
+     * @returns True after execution environments are loaded at least once.
      */
     public isLoaded(): boolean {
         return this._loaded;
     }
 
     /**
-     * Get all loaded execution environments
+     * Get all loaded execution environments.
+     *
+     * @returns Container images flagged as execution environments.
      */
     public getExecutionEnvironments(): ExecutionEnvironment[] {
         return this._executionEnvironments;
     }
 
     /**
-     * Get a specific execution environment by name
+     * Get a specific execution environment by name.
+     *
+     * @param fullName - Full image name reported by ansible-navigator.
+     * @returns Matching environment metadata, or undefined when not loaded.
      */
     public getExecutionEnvironment(fullName: string): ExecutionEnvironment | undefined {
         return this._executionEnvironments.find((ee) => ee.full_name === fullName);
     }
 
     /**
-     * Get cached details for an execution environment
+     * Get cached details for an execution environment.
+     *
+     * @param fullName - Full image name to look up in the details cache.
+     * @returns Cached inspection details, or undefined when not yet loaded.
      */
     public getCachedDetails(fullName: string): EEDetails | undefined {
         return this._detailsCache.get(fullName);
     }
 
     /**
-     * Refresh the execution environments list
+     * Clears in-memory execution environment data and signals consumers to reload.
+     *
+     * @returns Promise that resolves after caches are cleared and listeners notified.
      */
     public refresh(): Promise<void> {
         this._executionEnvironments = [];
@@ -149,7 +180,9 @@ export class ExecutionEnvService {
     }
 
     /**
-     * Load execution environments from ansible-navigator
+     * Load execution environments from ansible-navigator.
+     *
+     * @returns Filtered list of images marked as execution environments.
      */
     public async loadExecutionEnvironments(): Promise<ExecutionEnvironment[]> {
         if (this._loading) {
@@ -207,7 +240,10 @@ export class ExecutionEnvService {
     }
 
     /**
-     * Load detailed information for a specific execution environment
+     * Load detailed information for a specific execution environment.
+     *
+     * @param fullName - Full image name to inspect with ansible-navigator.
+     * @returns Parsed inspection details, or null when the command yields no output.
      */
     public async loadDetails(fullName: string): Promise<EEDetails | null> {
         // Check cache first
@@ -249,7 +285,10 @@ export class ExecutionEnvService {
     }
 
     /**
-     * Get Ansible collections installed in an execution environment
+     * Get Ansible collections installed in an execution environment.
+     *
+     * @param fullName - Full image name to inspect.
+     * @returns Sorted collection name and version pairs from EE details.
      */
     public async getCollections(fullName: string): Promise<{ name: string; version: string }[]> {
         const details = await this.loadDetails(fullName);
@@ -263,7 +302,10 @@ export class ExecutionEnvService {
     }
 
     /**
-     * Get Python packages installed in an execution environment
+     * Get Python packages installed in an execution environment.
+     *
+     * @param fullName - Full image name to inspect.
+     * @returns Sorted Python package entries from EE details.
      */
     public async getPythonPackages(
         fullName: string,
@@ -277,7 +319,10 @@ export class ExecutionEnvService {
     }
 
     /**
-     * Get OS and Ansible version info for an execution environment
+     * Get OS and Ansible version info for an execution environment.
+     *
+     * @param fullName - Full image name to inspect.
+     * @returns Summary of Ansible version, OS name, and image name when available.
      */
     public async getInfo(
         fullName: string,
@@ -305,6 +350,12 @@ export class ExecutionEnvService {
         return info;
     }
 
+    /**
+     * Executes a raw shell command and returns stdout when available.
+     *
+     * @param command - Full shell command to run via CommandService.
+     * @returns Captured stdout, or null when the command fails.
+     */
     private async _runCommand(command: string): Promise<string | null> {
         try {
             const { getCommandService } = await import('./CommandService');

--- a/packages/core/src/services/GalaxyCollectionCache.ts
+++ b/packages/core/src/services/GalaxyCollectionCache.ts
@@ -55,6 +55,12 @@ interface ExtensionContextLike {
     globalStorageUri: { fsPath: string };
 }
 
+/**
+ * Type guard that validates parsed JSON matches the on-disk cache shape.
+ *
+ * @param value - Parsed JSON value read from the cache file.
+ * @returns True when value contains a timestamp and collections array.
+ */
 function isCacheData(value: unknown): value is CacheData {
     return (
         typeof value === 'object' &&
@@ -65,6 +71,9 @@ function isCacheData(value: unknown): value is CacheData {
     );
 }
 
+/**
+ * Caches Ansible Galaxy collection metadata from the public API with file persistence.
+ */
 export class GalaxyCollectionCache {
     private static _instance: GalaxyCollectionCache | undefined;
     private _collections: GalaxyCollection[] = [];
@@ -84,6 +93,9 @@ export class GalaxyCollectionCache {
     private _cacheTimestamp = 0;
     private _standaloneMode = !vscode;
 
+    /**
+     * Creates the cache and optional VS Code status bar item for load progress.
+     */
     private constructor() {
         if (vscode) {
             this._statusBarItem = vscode.window.createStatusBarItem(
@@ -93,10 +105,20 @@ export class GalaxyCollectionCache {
         }
     }
 
+    /**
+     * Stores the VS Code extension context used to resolve global storage paths.
+     *
+     * @param context - Extension context providing globalStorageUri.
+     */
     public setExtensionContext(context: ExtensionContextLike): void {
         this._extensionContext = context;
     }
 
+    /**
+     * Resolves the on-disk cache file path for extension or standalone mode.
+     *
+     * @returns Absolute cache file path, or undefined when no location is available.
+     */
     private get _cacheFilePath(): string | undefined {
         // In extension mode, use extension context's global storage
         if (this._extensionContext) {
@@ -138,27 +160,57 @@ export class GalaxyCollectionCache {
         return undefined;
     }
 
+    /**
+     * Returns the current Galaxy API pagination progress counters.
+     *
+     * @returns Loaded and total collection counts from the in-flight fetch.
+     */
     public getProgress(): { loaded: number; total: number } {
         return { loaded: this._loadedCount, total: this._totalCount };
     }
 
+    /**
+     * Returns the shared GalaxyCollectionCache instance.
+     *
+     * @returns Singleton cache for Galaxy collection metadata.
+     */
     public static getInstance(): GalaxyCollectionCache {
         GalaxyCollectionCache._instance ??= new GalaxyCollectionCache();
         return GalaxyCollectionCache._instance;
     }
 
+    /**
+     * Indicates whether collection metadata has been loaded into memory.
+     *
+     * @returns True after a successful file or API load completes.
+     */
     public isLoaded(): boolean {
         return this._loaded;
     }
 
+    /**
+     * Indicates whether a Galaxy API fetch is currently in progress.
+     *
+     * @returns True while collections are being downloaded or parsed.
+     */
     public isLoading(): boolean {
         return this._loading;
     }
 
+    /**
+     * Returns the cached Galaxy collections sorted by popularity.
+     *
+     * @returns In-memory collection list from the latest successful load.
+     */
     public getCollections(): GalaxyCollection[] {
         return this._collections;
     }
 
+    /**
+     * Returns a human-readable age string for the current cache timestamp.
+     *
+     * @returns Relative age such as "3 days ago", or "never" when uncached.
+     */
     public getCacheAge(): string {
         if (this._cacheTimestamp === 0) {
             return 'never';
@@ -176,6 +228,11 @@ export class GalaxyCollectionCache {
         }
     }
 
+    /**
+     * Ensures collections are loaded, awaiting any in-flight background fetch.
+     *
+     * @returns Promise that resolves when collections are available in memory.
+     */
     public async ensureLoaded(): Promise<void> {
         if (this._loaded) {
             return;
@@ -187,12 +244,18 @@ export class GalaxyCollectionCache {
         await this._loadPromise;
     }
 
+    /**
+     * Starts a non-blocking background load when none is already running.
+     */
     public startBackgroundLoad(): void {
         if (!this._loading) {
             this._loadPromise = this._loadCollections(false);
         }
     }
 
+    /**
+     * Clears in-memory and on-disk state, then reloads collections from the Galaxy API.
+     */
     public async forceRefresh(): Promise<void> {
         log('GalaxyCollectionCache: Force refresh requested');
         this._loaded = false;
@@ -203,6 +266,11 @@ export class GalaxyCollectionCache {
         await this._loadPromise;
     }
 
+    /**
+     * Attempts to hydrate collections from the persisted file cache.
+     *
+     * @returns True when a valid, non-expired cache file was loaded.
+     */
     private _loadFromFileCache(): boolean {
         const cacheFile = this._cacheFilePath;
         if (!cacheFile) {
@@ -247,6 +315,9 @@ export class GalaxyCollectionCache {
         }
     }
 
+    /**
+     * Persists the in-memory collection list and timestamp to disk.
+     */
     private _saveToFileCache(): void {
         const cacheFile = this._cacheFilePath;
         if (!cacheFile) {
@@ -278,6 +349,11 @@ export class GalaxyCollectionCache {
         }
     }
 
+    /**
+     * Loads collections from file cache or the Galaxy API with progress events.
+     *
+     * @param forceRefresh - When true, bypasses file cache and refetches from the API.
+     */
     private async _loadCollections(forceRefresh: boolean): Promise<void> {
         if (this._loading) {
             return;
@@ -412,6 +488,13 @@ export class GalaxyCollectionCache {
         }
     }
 
+    /**
+     * Fetches a single paginated Galaxy API page with retry and redirect handling.
+     *
+     * @param url - Absolute Galaxy API URL to request.
+     * @param retries - Number of attempts before failing the request.
+     * @returns Parsed Galaxy API response for the requested page.
+     */
     private _fetchPage(url: string, retries = 3): Promise<GalaxyApiResponse> {
         return new Promise((resolve, reject) => {
             const makeRequest = (attemptsLeft: number) => {
@@ -568,6 +651,12 @@ export class GalaxyCollectionCache {
         });
     }
 
+    /**
+     * Searches cached collections by namespace, name, or FQCN.
+     *
+     * @param query - Case-insensitive search string; empty returns top 100 by popularity.
+     * @returns Up to 100 matching collections from the in-memory cache.
+     */
     public search(query: string): GalaxyCollection[] {
         if (!query) {
             // Return top 100 by popularity

--- a/packages/core/src/services/GitHubCollectionCache.ts
+++ b/packages/core/src/services/GitHubCollectionCache.ts
@@ -44,35 +44,56 @@ export class GitHubCollectionCache {
     private _refreshInProgress = new Set<string>();
     private _log: (msg: string) => void = console.log;
 
+    /**
+     * Private constructor for singleton access via getInstance().
+     */
     private constructor() {
         // singleton
     }
 
+    /**
+     * Returns the shared GitHubCollectionCache instance.
+     *
+     * @returns Singleton cache for GitHub organization collections.
+     */
     public static getInstance(): GitHubCollectionCache {
         GitHubCollectionCache._instance ??= new GitHubCollectionCache();
         return GitHubCollectionCache._instance;
     }
 
+    /**
+     * Sets the logging callback used for cache diagnostics.
+     *
+     * @param logFn - Function invoked with formatted cache log messages.
+     */
     public setLogFunction(logFn: (msg: string) => void): void {
         this._log = logFn;
     }
 
     /**
-     * Get the cache directory path (global, in ~/.cache/ansible-environments/)
+     * Get the cache directory path (global, in ~/.cache/ansible-environments/).
+     *
+     * @returns Absolute path to the global ansible-environments cache directory.
      */
     private _getCacheDir(): string {
         return path.join(os.homedir(), '.cache', 'ansible-environments');
     }
 
     /**
-     * Get the cache file path for an org
+     * Get the cache file path for an org.
+     *
+     * @param org - GitHub organization slug used in the cache filename.
+     * @returns Absolute path to the org-specific cache JSON file.
      */
     private _getCacheFilePath(org: string): string {
         return path.join(this._getCacheDir(), `github-${org}.json`);
     }
 
     /**
-     * Load cache from disk for an org
+     * Load cache from disk for an org.
+     *
+     * @param org - GitHub organization whose cache file should be read.
+     * @returns Parsed org cache when the file exists and is valid, otherwise undefined.
      */
     public loadFromDisk(org: string): GitHubOrgCache | undefined {
         const filePath = this._getCacheFilePath(org);
@@ -101,7 +122,10 @@ export class GitHubCollectionCache {
     }
 
     /**
-     * Save cache to disk for an org
+     * Save cache to disk for an org.
+     *
+     * @param org - GitHub organization slug for the cache filename.
+     * @param cache - Org cache payload to persist.
      */
     private _saveToDisk(org: string, cache: GitHubOrgCache): void {
         const cacheDir = this._getCacheDir();
@@ -123,7 +147,10 @@ export class GitHubCollectionCache {
     }
 
     /**
-     * Format age in human-readable format
+     * Format age in human-readable format.
+     *
+     * @param ms - Elapsed milliseconds since the cache was last updated.
+     * @returns Relative age string such as "2 hours ago".
      */
     private _formatAge(ms: number): string {
         const hours = Math.floor(ms / (1000 * 60 * 60));
@@ -141,7 +168,10 @@ export class GitHubCollectionCache {
     }
 
     /**
-     * Get collections for an org (from cache)
+     * Get collections for an org (from cache).
+     *
+     * @param org - GitHub organization whose cached collections are requested.
+     * @returns Collection list for the org, or an empty array when not cached.
      */
     public getCollections(org: string): GitHubCollection[] {
         const cache = this._caches.get(org);
@@ -149,7 +179,9 @@ export class GitHubCollectionCache {
     }
 
     /**
-     * Get all collections from all cached orgs
+     * Get all collections from all cached orgs.
+     *
+     * @returns Flattened list of collections across every loaded organization.
      */
     public getAllCollections(): GitHubCollection[] {
         const all: GitHubCollection[] = [];
@@ -160,14 +192,20 @@ export class GitHubCollectionCache {
     }
 
     /**
-     * Get collection count for an org
+     * Get collection count for an org.
+     *
+     * @param org - GitHub organization whose cached collection count is requested.
+     * @returns Number of collections stored for the org, or zero when not cached.
      */
     public getCount(org: string): number {
         return this._caches.get(org)?.collections.length ?? 0;
     }
 
     /**
-     * Get last updated time for an org
+     * Get last updated time for an org.
+     *
+     * @param org - GitHub organization whose cache timestamp is requested.
+     * @returns Last refresh time, or undefined when the org is not cached.
      */
     public getLastUpdated(org: string): Date | undefined {
         const cache = this._caches.get(org);
@@ -175,14 +213,19 @@ export class GitHubCollectionCache {
     }
 
     /**
-     * Check if a refresh is in progress for an org
+     * Check if a refresh is in progress for an org.
+     *
+     * @param org - GitHub organization to check for an active refresh.
+     * @returns True when a background scan is running for the org.
      */
     public isRefreshing(org: string): boolean {
         return this._refreshInProgress.has(org);
     }
 
     /**
-     * Refresh collections for a GitHub org
+     * Refresh collections for a GitHub org using authenticated GitHub API access.
+     *
+     * @param org - GitHub organization to scan for galaxy.yml repositories.
      */
     public async refresh(org: string): Promise<void> {
         if (!vscode) {
@@ -228,7 +271,11 @@ export class GitHubCollectionCache {
     }
 
     /**
-     * Scan a GitHub org for Ansible collections
+     * Scan a GitHub org for Ansible collections via code search or repo listing.
+     *
+     * @param org - GitHub organization to scan.
+     * @param token - GitHub API bearer token for authenticated requests.
+     * @returns Discovered collections with metadata parsed from galaxy.yml files.
      */
     private async _scanOrg(org: string, token: string): Promise<GitHubCollection[]> {
         const collections: GitHubCollection[] = [];
@@ -295,7 +342,11 @@ export class GitHubCollectionCache {
     }
 
     /**
-     * Fallback: scan org repos directly
+     * Fallback: scan org repos directly when code search is unavailable.
+     *
+     * @param org - GitHub organization whose repositories should be enumerated.
+     * @param token - GitHub API bearer token for authenticated requests.
+     * @returns Collections discovered by checking each repository for galaxy.yml.
      */
     private async _scanOrgRepos(org: string, token: string): Promise<GitHubCollection[]> {
         const collections: GitHubCollection[] = [];
@@ -349,7 +400,12 @@ export class GitHubCollectionCache {
     }
 
     /**
-     * Fetch and parse galaxy.yml from a repo
+     * Fetch and parse galaxy.yml from a repo.
+     *
+     * @param repoFullName - GitHub repository in org/repo form.
+     * @param token - GitHub API bearer token for raw content requests.
+     * @param org - Owning organization stored on the returned collection record.
+     * @returns Parsed collection metadata, or null when galaxy.yml is absent.
      */
     private async _fetchCollectionMetadata(
         repoFullName: string,
@@ -391,7 +447,12 @@ export class GitHubCollectionCache {
     }
 
     /**
-     * Parse galaxy.yml content using proper YAML parser
+     * Parse galaxy.yml content using proper YAML parser.
+     *
+     * @param content - Raw galaxy.yml file contents.
+     * @param repoFullName - GitHub repository in org/repo form.
+     * @param org - Owning organization stored on the returned collection record.
+     * @returns Parsed GitHubCollection, or null when required fields are missing.
      */
     private _parseGalaxyYml(
         content: string,
@@ -440,7 +501,10 @@ export class GitHubCollectionCache {
     }
 
     /**
-     * Search collections across all cached orgs
+     * Search collections across all cached orgs.
+     *
+     * @param query - Case-insensitive match against FQCN or description.
+     * @returns Matching collections from every loaded organization cache.
      */
     public search(query: string): GitHubCollection[] {
         const q = query.toLowerCase();
@@ -462,7 +526,9 @@ export class GitHubCollectionCache {
     }
 
     /**
-     * Initialize caches for configured orgs
+     * Initialize caches for configured orgs.
+     *
+     * @param orgs - GitHub organizations to load from disk or refresh when missing.
      */
     public async initialize(orgs: string[]): Promise<void> {
         for (const org of orgs) {
@@ -477,7 +543,9 @@ export class GitHubCollectionCache {
     }
 
     /**
-     * Refresh all configured orgs
+     * Refresh all configured orgs sequentially.
+     *
+     * @param orgs - GitHub organizations to rescan and persist to disk.
      */
     public async refreshAll(orgs: string[]): Promise<void> {
         for (const org of orgs) {

--- a/packages/core/src/utils/SimpleEventEmitter.ts
+++ b/packages/core/src/utils/SimpleEventEmitter.ts
@@ -2,6 +2,9 @@ export interface Disposable {
     dispose: () => void;
 }
 
+/**
+ * Lightweight publish-subscribe event emitter for environments without VS Code.
+ */
 export class SimpleEventEmitter<T> {
     private listeners: ((e: T) => void)[] = [];
 
@@ -17,6 +20,11 @@ export class SimpleEventEmitter<T> {
         };
     };
 
+    /**
+     * Notifies all registered listeners with the given event payload.
+     *
+     * @param e - Event payload delivered to each listener.
+     */
     public fire(e: T): void {
         this.listeners.forEach((l) => {
             l(e);

--- a/packages/core/src/utils/logging.ts
+++ b/packages/core/src/utils/logging.ts
@@ -1,9 +1,19 @@
 let logFunction: ((message: string) => void) | undefined;
 
+/**
+ * Registers the function used for diagnostic logging throughout core.
+ *
+ * @param logFn - Callback invoked when log() is called.
+ */
 export function setLogFunction(logFn: (message: string) => void): void {
     logFunction = logFn;
 }
 
+/**
+ * Writes a message using the registered log function, or console.log as fallback.
+ *
+ * @param message - Text to log.
+ */
 export function log(message: string): void {
     if (logFunction) {
         logFunction(message);
@@ -12,6 +22,11 @@ export function log(message: string): void {
     }
 }
 
+/**
+ * Returns the currently registered log function, if any.
+ *
+ * @returns The active log callback, or undefined when using the console fallback.
+ */
 export function getLogFunction(): ((message: string) => void) | undefined {
     return logFunction;
 }

--- a/packages/core/test/services/CollectionsService.test.ts
+++ b/packages/core/test/services/CollectionsService.test.ts
@@ -15,6 +15,7 @@ vi.mock('../../src/services/CommandService', () => ({
 
 import { CollectionsService } from '../../src/services/CollectionsService';
 
+/** Clears the CollectionsService singleton so each test starts with a fresh instance. */
 function resetCollectionsSingleton(): void {
     (CollectionsService as unknown as { _instance: CollectionsService | undefined })._instance =
         undefined;

--- a/packages/core/test/services/CommandService.test.ts
+++ b/packages/core/test/services/CommandService.test.ts
@@ -3,7 +3,12 @@ import * as os from 'os';
 import * as path from 'path';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
-/** Node may call exec(cmd, cb) or exec(cmd, opts, cb); promisify uses the latter. */
+/**
+ * Node may call exec(cmd, cb) or exec(cmd, opts, cb); promisify uses the latter.
+ * @param arg2 - Callback or options argument from the exec call.
+ * @param arg3 - Callback when arg2 is options.
+ * @returns The exec completion callback.
+ */
 function asExecCallback(
     arg2: unknown,
     arg3?: unknown,

--- a/packages/core/test/services/CreatorService.test.ts
+++ b/packages/core/test/services/CreatorService.test.ts
@@ -74,6 +74,7 @@ vi.mock('../../src/services/CommandService', () => ({
 
 import { CreatorService } from '../../src/services/CreatorService';
 
+/** Clears the CreatorService singleton so each test starts with a fresh instance. */
 function resetCreatorSingleton(): void {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (CreatorService as any)._instance = undefined;

--- a/packages/core/test/services/DevToolsService.test.ts
+++ b/packages/core/test/services/DevToolsService.test.ts
@@ -27,6 +27,7 @@ vi.mock('../../src/services/CommandService', () => ({
 
 import { DevToolsService } from '../../src/services/DevToolsService';
 
+/** Clears the DevToolsService singleton and terminal factory for test isolation. */
 function resetDevToolsSingleton(): void {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (DevToolsService as any)._instance = undefined;

--- a/packages/core/test/services/ExecutionEnvService.test.ts
+++ b/packages/core/test/services/ExecutionEnvService.test.ts
@@ -60,6 +60,7 @@ vi.mock('../../src/services/CommandService', () => ({
 
 import { ExecutionEnvService } from '../../src/services/ExecutionEnvService';
 
+/** Clears the ExecutionEnvService singleton so each test starts with a fresh instance. */
 function resetExecutionEnvSingleton(): void {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (ExecutionEnvService as any)._instance = undefined;

--- a/packages/core/test/services/GalaxyCollectionCache.test.ts
+++ b/packages/core/test/services/GalaxyCollectionCache.test.ts
@@ -12,11 +12,16 @@ vi.mock('https', () => ({
 
 import { GalaxyCollectionCache } from '../../src/services/GalaxyCollectionCache';
 
+/** Clears the GalaxyCollectionCache singleton so each test starts with a fresh instance. */
 function resetGalaxySingleton(): void {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (GalaxyCollectionCache as any)._instance = undefined;
 }
 
+/**
+ * Configures the mocked HTTPS client to return a single successful Galaxy API response.
+ * @param body - JSON-serializable response body to emit.
+ */
 function installMockGalaxyResponse(body: object): void {
     httpsGetMock.mockImplementation(
         (_url: unknown, _options: unknown, cb: (res: EventEmitter) => void) => {
@@ -39,6 +44,10 @@ function installMockGalaxyResponse(body: object): void {
     );
 }
 
+/**
+ * Configures the mocked HTTPS client to return a sequence of Galaxy API responses.
+ * @param responses - Ordered list of status codes and response bodies.
+ */
 function installMockGalaxySequence(responses: { statusCode: number; body: string }[]): void {
     let index = 0;
     httpsGetMock.mockImplementation(

--- a/packages/core/test/services/GitHubCollectionCache.test.ts
+++ b/packages/core/test/services/GitHubCollectionCache.test.ts
@@ -26,10 +26,16 @@ interface GitHubCollectionCachePrivate {
     ): Promise<GitHubCollection | null>;
 }
 
+/**
+ * Exposes private GitHubCollectionCache methods for unit testing.
+ * @param svc - Cache service instance under test.
+ * @returns The service cast to its private method interface.
+ */
 function privateCache(svc: GitHubCollectionCache): GitHubCollectionCachePrivate {
     return svc as unknown as GitHubCollectionCachePrivate;
 }
 
+/** Clears the GitHubCollectionCache singleton so each test starts with a fresh instance. */
 function resetGitHubCacheSingleton(): void {
     (
         GitHubCollectionCache as unknown as { _instance: GitHubCollectionCache | undefined }

--- a/packages/language-server/src/ansibleLanguageService.ts
+++ b/packages/language-server/src/ansibleLanguageService.ts
@@ -17,6 +17,9 @@ import { WorkspaceManager } from './services/workspaceManager';
 import { getAnsibleMetaData } from './utils/getAnsibleMetaData';
 import { CollectionsService } from '@ansible/core/out/services/CollectionsService';
 
+/**
+ * Wires LSP lifecycle events to Ansible language features for a workspace.
+ */
 export class AnsibleLanguageService {
     private connection: Connection;
     private documents: TextDocuments<TextDocument>;
@@ -24,6 +27,12 @@ export class AnsibleLanguageService {
     private workspaceManager: WorkspaceManager;
     private validationManager: ValidationManager;
 
+    /**
+     * Creates the language service and its workspace and validation managers.
+     *
+     * @param connection - LSP connection used to register handlers.
+     * @param documents - Managed text document collection.
+     */
     constructor(connection: Connection, documents: TextDocuments<TextDocument>) {
         this.connection = connection;
         this.documents = documents;
@@ -31,11 +40,17 @@ export class AnsibleLanguageService {
         this.validationManager = new ValidationManager(connection, documents);
     }
 
+    /**
+     * Registers initialization handlers and document lifecycle listeners.
+     */
     public initialize(): void {
         this.initializeConnection();
         this.registerLifecycleEventHandlers();
     }
 
+    /**
+     * Configures server capabilities and workspace folder support on initialize.
+     */
     private initializeConnection(): void {
         this.connection.onInitialize((params: InitializeParams) => {
             this.workspaceManager.setWorkspaceFolders(params.workspaceFolders ?? []);
@@ -92,6 +107,9 @@ export class AnsibleLanguageService {
         });
     }
 
+    /**
+     * Subscribes to document, configuration, and feature request events.
+     */
     private registerLifecycleEventHandlers(): void {
         this.connection.onDidChangeConfiguration((params) => {
             void (async () => {
@@ -270,6 +288,12 @@ export class AnsibleLanguageService {
         });
     }
 
+    /**
+     * Logs handler failures to the LSP console with context and stack traces.
+     *
+     * @param error - Thrown value or error object.
+     * @param contextName - Name of the handler where the error occurred.
+     */
     private handleError(error: unknown, contextName: string): void {
         const lead = `An error occurred in '${contextName}' handler: `;
         if (error instanceof Error) {

--- a/packages/language-server/src/cli.ts
+++ b/packages/language-server/src/cli.ts
@@ -1,6 +1,9 @@
 #!/usr/bin/env node
 import process from 'node:process';
 
+/**
+ * Entry point for the Ansible language server CLI.
+ */
 async function main(): Promise<void> {
     const args = new Set(process.argv.slice(2));
 

--- a/packages/language-server/src/providers/completionProvider.ts
+++ b/packages/language-server/src/providers/completionProvider.ts
@@ -61,6 +61,14 @@ const priorityMap = {
 let dummyMappingCharacter: string;
 let isAnsiblePlaybook: boolean;
 
+/**
+ * Provides Ansible-aware completion items for the cursor position in a document.
+ *
+ * @param document - Text document being completed.
+ * @param position - Cursor position in the document.
+ * @param context - Workspace folder context for settings and inventory.
+ * @returns Completion items for keywords, modules, options, hosts, or variables.
+ */
 export async function doCompletion(
     document: TextDocument,
     position: Position,
@@ -271,6 +279,17 @@ export async function doCompletion(
     return [];
 }
 
+/**
+ * Builds completion items for all modules in installed collections.
+ *
+ * @param collectionsService - Source of installed collection and module metadata.
+ * @param useFqcn - Whether to insert fully qualified collection names.
+ * @param cursorAtEnd - Whether the cursor is at the end of the line.
+ * @param cursorAtFirst - Whether the cursor is on the first list item.
+ * @param textEdit - Optional text edit range for the current token.
+ * @param documentUri - URI of the document receiving completions.
+ * @returns Module completion items with snippet insert text when appropriate.
+ */
 function getModuleCompletions(
     collectionsService: CollectionsService,
     useFqcn: boolean,
@@ -323,6 +342,13 @@ function getModuleCompletions(
     return items;
 }
 
+/**
+ * Enriches a completion item with module documentation and snippet insert text.
+ *
+ * @param completionItem - Completion item to resolve.
+ * @param context - Workspace folder context for settings lookup.
+ * @returns The completion item with documentation and insert text applied.
+ */
 export async function doCompletionResolve(
     completionItem: CompletionItem,
     context: WorkspaceFolderContext,
@@ -381,6 +407,15 @@ export async function doCompletionResolve(
     return completionItem;
 }
 
+/**
+ * Returns completion items for undocumented keywords in the current YAML map.
+ *
+ * @param document - Text document being completed.
+ * @param position - Cursor position in the document.
+ * @param path - YAML node path at the cursor.
+ * @param keywords - Map of keyword names to documentation.
+ * @returns Completion items for keywords not yet present in the map.
+ */
 function getKeywordCompletion(
     document: TextDocument,
     position: Position,
@@ -416,6 +451,12 @@ function getKeywordCompletion(
     });
 }
 
+/**
+ * Converts inventory host entries into completion items.
+ *
+ * @param hostObjectList - Hosts and groups from the Ansible inventory.
+ * @returns Completion items labeled by host or group name.
+ */
 function getHostCompletion(hostObjectList: HostType[]): CompletionItem[] {
     return hostObjectList.map(({ host, priority }) => ({
         label: host,
@@ -424,6 +465,13 @@ function getHostCompletion(hostObjectList: HostType[]): CompletionItem[] {
     }));
 }
 
+/**
+ * Computes the LSP range for a YAML node, excluding dummy completion characters.
+ *
+ * @param node - YAML node whose source range is mapped.
+ * @param document - Text document containing the node.
+ * @returns LSP range for the visible token, or undefined when unavailable.
+ */
 function getNodeRange(node: Node, document: TextDocument): Range | undefined {
     const range = getOrigRange(node);
     if (range && isScalar(node) && typeof node.value === 'string') {
@@ -438,11 +486,25 @@ function getNodeRange(node: Node, document: TextDocument): Range | undefined {
     }
 }
 
+/**
+ * Determines whether the cursor sits immediately before a line break.
+ *
+ * @param document - Text document being completed.
+ * @param position - Cursor position to test.
+ * @returns True when the next character is a newline.
+ */
 function atEndOfLine(document: TextDocument, position: Position): boolean {
     const charAfterCursor = `${document.getText()}\n`[document.offsetAt(position)];
     return charAfterCursor === '\n' || charAfterCursor === '\r';
 }
 
+/**
+ * Checks whether the node range begins the first element of a YAML sequence.
+ *
+ * @param document - Text document containing the list.
+ * @param nodeRange - Range of the node being completed.
+ * @returns True when a list marker appears on the same line before the node.
+ */
 function firstElementOfList(document: TextDocument, nodeRange: Range | undefined): boolean {
     if (!nodeRange) return false;
     const checkRange = {
@@ -452,6 +514,14 @@ function firstElementOfList(document: TextDocument, nodeRange: Range | undefined
     return document.getText(checkRange).trim() === '-';
 }
 
+/**
+ * Returns the snippet suffix to append after a completed option key.
+ *
+ * @param optionType - Ansible option type controlling indentation.
+ * @param isFirstElement - Whether the option is the first item in a list.
+ * @param isDocPlaybook - Whether the document is a playbook.
+ * @returns Whitespace or newline snippet suffix for insert text.
+ */
 export function resolveSuffix(
     optionType: string,
     isFirstElement: boolean,

--- a/packages/language-server/src/providers/completionProviderUtils.ts
+++ b/packages/language-server/src/providers/completionProviderUtils.ts
@@ -22,14 +22,33 @@ interface PlayNodeJson {
     vars_files?: string[];
 }
 
+/**
+ * Type guard for play-level JSON nodes that may contain vars definitions.
+ *
+ * @param value - Parsed YAML JSON value.
+ * @returns True when the value is a non-null object.
+ */
 function isPlayNodeJson(value: unknown): value is PlayNodeJson {
     return typeof value === 'object' && value !== null;
 }
 
+/**
+ * Narrows a parsed YAML value to a play node when possible.
+ *
+ * @param value - Parsed YAML JSON value.
+ * @returns Play node object, or undefined when the value is not an object.
+ */
 function asPlayNodeJson(value: unknown): PlayNodeJson | undefined {
     return isPlayNodeJson(value) ? value : undefined;
 }
 
+/**
+ * Collects Jinja variable completion items from play scope, prompts, and vars files.
+ *
+ * @param documentUri - URI of the document being completed.
+ * @param path - YAML node path at the cursor inside Jinja brackets.
+ * @returns Variable completion items sorted by scope priority.
+ */
 export function getVarsCompletion(documentUri: string, path: Node[]): CompletionItem[] {
     const varsCompletion: VarEntry[] = [];
     let varPriority = 0;
@@ -115,6 +134,13 @@ export function getVarsCompletion(documentUri: string, path: Node[]): Completion
     }));
 }
 
+/**
+ * Recursively extracts variable names from a vars object or list into the result.
+ *
+ * @param varsObject - vars mapping or list from a play node.
+ * @param result - Accumulator for discovered variable entries.
+ * @param priority - Sort priority assigned to variables from this scope.
+ */
 function collectVars(varsObject: unknown, result: VarEntry[], priority: number): void {
     if (Array.isArray(varsObject)) {
         for (const element of varsObject) {

--- a/packages/language-server/src/providers/hoverProvider.ts
+++ b/packages/language-server/src/providers/hoverProvider.ts
@@ -23,6 +23,14 @@ import {
 } from '../utils/yaml';
 import { CollectionsService } from '@ansible/core/out/services/CollectionsService';
 
+/**
+ * Resolves hover documentation for Ansible keywords, modules, and options.
+ *
+ * @param document - Text document under the cursor.
+ * @param position - Cursor position in the document.
+ * @param collectionsService - Source of cached plugin documentation.
+ * @returns Hover content for the symbol at the position, or null when unknown.
+ */
 export async function doHover(
     document: TextDocument,
     position: Position,
@@ -77,6 +85,12 @@ export async function doHover(
     return null;
 }
 
+/**
+ * Normalizes a short module name to its fully qualified collection name.
+ *
+ * @param name - Module name from the playbook YAML.
+ * @returns FQCN suitable for documentation lookup.
+ */
 function resolveFqcn(name: string): string {
     const dotCount = (name.match(/\./g) ?? []).length;
     if (dotCount >= 2) {
@@ -85,6 +99,14 @@ function resolveFqcn(name: string): string {
     return `ansible.builtin.${name}`;
 }
 
+/**
+ * Builds hover content for a reserved Ansible keyword scalar node.
+ *
+ * @param document - Text document containing the keyword.
+ * @param node - YAML scalar node at the hover position.
+ * @param keywords - Map of keyword names to documentation.
+ * @returns Hover for the keyword, or null when undocumented.
+ */
 function getKeywordHover(
     document: TextDocument,
     node: Scalar,

--- a/packages/language-server/src/providers/semanticTokenProvider.ts
+++ b/packages/language-server/src/providers/semanticTokenProvider.ts
@@ -32,6 +32,13 @@ export const tokenModifiers = [SemanticTokenModifiers.definition] as const;
 
 const tokenModifiersLegend = new Map(tokenModifiers.map((value, index) => [value, index]));
 
+/**
+ * Builds semantic token data for Ansible playbook YAML structure and modules.
+ *
+ * @param document - Text document to tokenize.
+ * @param collectionsService - Source of module documentation for classification.
+ * @returns Encoded semantic tokens for the document.
+ */
 export async function doSemanticTokens(
     document: TextDocument,
     collectionsService: CollectionsService,
@@ -46,6 +53,14 @@ export async function doSemanticTokens(
     return builder.build();
 }
 
+/**
+ * Recursively walks a YAML path and pushes semantic tokens to the builder.
+ *
+ * @param path - YAML node ancestry path being visited.
+ * @param builder - Semantic token builder accumulating encoded tokens.
+ * @param document - Text document whose positions are resolved.
+ * @param collectionsService - Source of module documentation for classification.
+ */
 async function markSemanticTokens(
     path: Node[],
     builder: SemanticTokensBuilder,
@@ -146,11 +161,25 @@ async function markSemanticTokens(
     }
 }
 
+/**
+ * Normalizes a short module name to its fully qualified collection name.
+ *
+ * @param name - Module name from the playbook YAML.
+ * @returns FQCN suitable for documentation lookup.
+ */
 function resolveFqcn(name: string): string {
     const dotCount = (name.match(/\./g) ?? []).length;
     return dotCount >= 2 ? name : `ansible.builtin.${name}`;
 }
 
+/**
+ * Marks module option keys and nested suboptions with semantic token types.
+ *
+ * @param moduleParamMap - YAML map of module parameters at the current level.
+ * @param options - Option specifications from plugin documentation.
+ * @param builder - Semantic token builder receiving token entries.
+ * @param document - Text document whose positions are resolved.
+ */
 function markModuleParameters(
     moduleParamMap: YAMLMap,
     options: Record<string, PluginOption>,
@@ -184,6 +213,13 @@ function markModuleParameters(
     }
 }
 
+/**
+ * Marks all scalar keys in a subtree as ordinary property definitions.
+ *
+ * @param node - YAML node subtree to traverse.
+ * @param builder - Semantic token builder receiving token entries.
+ * @param document - Text document whose positions are resolved.
+ */
 function markAllNestedKeysAsOrdinary(
     node: Node,
     builder: SemanticTokensBuilder,
@@ -209,10 +245,24 @@ function markAllNestedKeysAsOrdinary(
     }
 }
 
+/**
+ * Marks a scalar node as an Ansible keyword token.
+ *
+ * @param node - YAML scalar keyword node.
+ * @param builder - Semantic token builder receiving the token.
+ * @param document - Text document whose positions are resolved.
+ */
 function markKeyword(node: Scalar, builder: SemanticTokensBuilder, document: TextDocument): void {
     markNode(node, SemanticTokenTypes.keyword, [], builder, document);
 }
 
+/**
+ * Marks a scalar key as a generic property definition token.
+ *
+ * @param node - YAML scalar key node.
+ * @param builder - Semantic token builder receiving the token.
+ * @param document - Text document whose positions are resolved.
+ */
 function markOrdinaryKey(
     node: Scalar,
     builder: SemanticTokensBuilder,
@@ -227,6 +277,15 @@ function markOrdinaryKey(
     );
 }
 
+/**
+ * Pushes a semantic token for a scalar node when its source range is known.
+ *
+ * @param node - YAML scalar node to tokenize.
+ * @param tokenType - Semantic token type from the legend.
+ * @param modifiers - Token modifiers to encode.
+ * @param builder - Semantic token builder receiving the token.
+ * @param document - Text document whose positions are resolved.
+ */
 function markNode(
     node: Scalar,
     tokenType: SemanticTokenTypes,
@@ -248,6 +307,12 @@ function markNode(
     }
 }
 
+/**
+ * Maps a semantic token type to its legend index.
+ *
+ * @param tokenType - Token type declared in the server legend.
+ * @returns Numeric index used by the semantic tokens builder.
+ */
 function encodeTokenType(tokenType: SemanticTokenTypes): number {
     const index = tokenTypesLegend.get(tokenType as (typeof tokenTypes)[number]);
     if (index === undefined) {
@@ -256,6 +321,12 @@ function encodeTokenType(tokenType: SemanticTokenTypes): number {
     return index;
 }
 
+/**
+ * Bit-packs semantic token modifiers into the encoded modifier field.
+ *
+ * @param modifiers - Modifier list to encode.
+ * @returns Bitmask of modifier indices.
+ */
 function encodeTokenModifiers(modifiers: SemanticTokenModifiers[]): number {
     let encoded = 0;
     for (const modifier of modifiers) {

--- a/packages/language-server/src/providers/validationProvider.ts
+++ b/packages/language-server/src/providers/validationProvider.ts
@@ -6,6 +6,16 @@ import type { WorkspaceFolderContext } from '../services/workspaceManager';
 import { isPlaybook, parseAllDocuments } from '../utils/yaml';
 import { getCommandService } from '@ansible/core/out/services/CommandService';
 
+/**
+ * Runs Ansible and YAML validation for a document and publishes diagnostics.
+ *
+ * @param textDocument - Document to validate.
+ * @param validationManager - Manager that caches and publishes diagnostics.
+ * @param quick - When true, returns cached diagnostics without re-running tools.
+ * @param context - Workspace context providing lint and playbook services.
+ * @param connection - Optional LSP connection for logging and user messages.
+ * @returns Diagnostics grouped by affected file URI.
+ */
 export async function doValidate(
     textDocument: TextDocument,
     validationManager: ValidationManager,
@@ -72,6 +82,12 @@ export async function doValidate(
     return diagnosticsByFile;
 }
 
+/**
+ * Extracts YAML parse errors and warnings from a document as LSP diagnostics.
+ *
+ * @param textDocument - Document whose YAML content is parsed.
+ * @returns Diagnostics for YAML syntax issues.
+ */
 export function getYamlValidation(textDocument: TextDocument): Diagnostic[] {
     const diagnostics: Diagnostic[] = [];
     const yDocuments = parseAllDocuments(textDocument.getText());

--- a/packages/language-server/src/services/ansibleConfig.ts
+++ b/packages/language-server/src/services/ansibleConfig.ts
@@ -8,6 +8,9 @@ import type { WorkspaceFolderContext } from './workspaceManager';
 
 export type AnsibleMetaData = Record<string, string | undefined>;
 
+/**
+ * Loads Ansible configuration and version metadata for a workspace folder.
+ */
 export class AnsibleConfig {
     private connection: Connection;
     private context: WorkspaceFolderContext;
@@ -17,11 +20,20 @@ export class AnsibleConfig {
     private _defaultHostList: string[] = [];
     private _ansibleMetaData: AnsibleMetaData = {};
 
+    /**
+     * Binds the config service to an LSP connection and workspace context.
+     *
+     * @param connection - LSP connection for error reporting.
+     * @param context - Workspace folder whose Ansible config is loaded.
+     */
     constructor(connection: Connection, context: WorkspaceFolderContext) {
         this.connection = connection;
         this.context = context;
     }
 
+    /**
+     * Fetches ansible-config dump and ansible --version output for the workspace.
+     */
     public async initialize(): Promise<void> {
         try {
             const commandService = getCommandService();
@@ -64,27 +76,58 @@ export class AnsibleConfig {
         }
     }
 
+    /**
+     * Collection search paths from ansible-config.
+     *
+     * @returns Configured collection search paths.
+     */
     get collectionPaths(): string[] {
         return this._collectionPaths;
     }
 
+    /**
+     * Default inventory sources from ansible-config.
+     *
+     * @returns Default host list paths from configuration.
+     */
     get defaultHostList(): string[] {
         return this._defaultHostList;
     }
 
+    /**
+     * Module search paths reported by ansible --version.
+     *
+     * @returns Module directories Ansible searches for plugins.
+     */
     get moduleLocations(): string[] {
         return this._moduleLocations;
     }
 
+    /**
+     * Path to the ansible Python module installation.
+     *
+     * @returns Ansible Python package location from version output.
+     */
     get ansibleLocation(): string {
         return this._ansibleLocation;
     }
 
+    /**
+     * Parsed ansible --version metadata key-value pairs.
+     *
+     * @returns Version and configuration metadata from ansible --version.
+     */
     get ansibleMetaData(): AnsibleMetaData {
         return this._ansibleMetaData;
     }
 }
 
+/**
+ * Parses a Python list literal string into an array of path strings.
+ *
+ * @param stringList - Bracketed, comma-separated quoted paths from ansible-config.
+ * @returns Unquoted path entries.
+ */
 function parsePythonStringArray(stringList: string): string[] {
     if (!stringList || stringList.length < 2) return [];
     const cleaned = stringList.slice(1, stringList.length - 1);

--- a/packages/language-server/src/services/ansibleInventory.ts
+++ b/packages/language-server/src/services/ansibleInventory.ts
@@ -15,16 +15,28 @@ interface InventoryHostEntry {
 
 type InventoryData = Record<string, InventoryHostEntry | undefined>;
 
+/**
+ * Loads and parses the Ansible inventory for a workspace folder.
+ */
 export class AnsibleInventory {
     private connection: Connection;
     private context: WorkspaceFolderContext;
     private _hostList: HostType[] = [];
 
+    /**
+     * Binds the inventory service to an LSP connection and workspace context.
+     *
+     * @param connection - LSP connection for error logging.
+     * @param context - Workspace folder whose inventory is loaded.
+     */
     constructor(connection: Connection, context: WorkspaceFolderContext) {
         this.connection = connection;
         this.context = context;
     }
 
+    /**
+     * Runs ansible-inventory --list and builds the host completion list.
+     */
     public async initialize(): Promise<void> {
         const commandService = getCommandService();
         const workingDirectory = URI.parse(this.context.workspaceFolder.uri).path;
@@ -51,11 +63,22 @@ export class AnsibleInventory {
         }
     }
 
+    /**
+     * Hosts and groups available for playbook completion, with sort priorities.
+     *
+     * @returns Prioritized inventory hosts and groups.
+     */
     get hostList(): HostType[] {
         return this._hostList;
     }
 }
 
+/**
+ * Flattens ansible-inventory JSON into prioritized host and group entries.
+ *
+ * @param hostObj - Parsed inventory tree from ansible-inventory --list.
+ * @returns Host entries ordered for completion sorting.
+ */
 function parseInventoryHosts(hostObj: InventoryData): HostType[] {
     if (
         !('all' in hostObj) ||
@@ -107,6 +130,14 @@ function parseInventoryHosts(hostObj: InventoryData): HostType[] {
     return [...allGroups, ...allHosts];
 }
 
+/**
+ * Recursively collects leaf group names from nested inventory children.
+ *
+ * @param groupList - Top-level group names to traverse.
+ * @param hostObj - Full inventory data tree.
+ * @param result - Accumulator for discovered leaf groups.
+ * @returns Leaf group names found under the given groups.
+ */
 function getChildGroups(
     groupList: string[],
     hostObj: InventoryData,

--- a/packages/language-server/src/services/ansibleLint.ts
+++ b/packages/language-server/src/services/ansibleLint.ts
@@ -28,18 +28,33 @@ interface CodeClimateItem {
     url?: string;
 }
 
+/**
+ * Validates Ansible content by running ansible-lint and parsing Code Climate output.
+ */
 export class AnsibleLint {
     private connection: Connection;
     private context: WorkspaceFolderContext;
     private useProgressTracker = false;
     private _ansibleLintConfigFilePath: string | undefined;
 
+    /**
+     * Binds the lint service to an LSP connection and workspace context.
+     *
+     * @param connection - LSP connection for progress and error reporting.
+     * @param context - Workspace folder providing settings and working directory.
+     */
     constructor(connection: Connection, context: WorkspaceFolderContext) {
         this.connection = connection;
         this.context = context;
         this.useProgressTracker = !!context.clientCapabilities.window?.workDoneProgress;
     }
 
+    /**
+     * Runs ansible-lint on the document and returns parsed diagnostics.
+     *
+     * @param textDocument - Document to lint.
+     * @returns Diagnostics keyed by affected file URI.
+     */
     public async doValidate(textDocument: TextDocument): Promise<Map<string, Diagnostic[]>> {
         let diagnostics = new Map<string, Diagnostic[]>();
 
@@ -110,6 +125,13 @@ export class AnsibleLint {
         return diagnostics;
     }
 
+    /**
+     * Parses ansible-lint Code Climate JSON into LSP diagnostics.
+     *
+     * @param result - Standard output from ansible-lint.
+     * @param workingDirectory - Workspace root used to resolve relative paths.
+     * @returns Diagnostics keyed by file URI.
+     */
     private processReport(result: string, workingDirectory: string): Map<string, Diagnostic[]> {
         const diagnostics = new Map<string, Diagnostic[]>();
         if (!result) {
@@ -184,6 +206,12 @@ export class AnsibleLint {
         return diagnostics;
     }
 
+    /**
+     * Walks upward from the document path to find a .ansible-lint config file.
+     *
+     * @param uri - Document URI to start the search from.
+     * @returns Absolute path to the config file, or undefined when not found.
+     */
     private async findAnsibleLintConfigFile(uri: string): Promise<string | undefined> {
         const workspacePath = URI.parse(this.context.workspaceFolder.uri).path;
         let dir = path.dirname(URI.parse(uri).path);
@@ -200,13 +228,21 @@ export class AnsibleLint {
         return undefined;
     }
 
+    /**
+     * Path to the .ansible-lint config used in the last lint run.
+     *
+     * @returns Resolved config file path, or undefined when none was used.
+     */
     get ansibleLintConfigFilePath(): string | undefined {
         return this._ansibleLintConfigFilePath;
     }
 }
 
 /**
- * Splits a shell-like argument string, respecting single and double quotes.
+ * Type guard for ansible-lint Code Climate JSON report items.
+ *
+ * @param value - Parsed JSON value to test.
+ * @returns True when the value matches the Code Climate item shape.
  */
 function isCodeClimateItem(value: unknown): value is CodeClimateItem {
     if (typeof value !== 'object' || value === null) {
@@ -222,6 +258,12 @@ function isCodeClimateItem(value: unknown): value is CodeClimateItem {
     );
 }
 
+/**
+ * Extracts a one-based line number from a Code Climate position value.
+ *
+ * @param begin - Line position object or bare line number.
+ * @returns One-based line number, defaulting to 1.
+ */
 function getLineNumber(begin: CodeClimatePosition | number | undefined): number {
     if (begin === undefined) {
         return 1;
@@ -229,6 +271,12 @@ function getLineNumber(begin: CodeClimatePosition | number | undefined): number 
     return typeof begin === 'number' ? begin : begin.line;
 }
 
+/**
+ * Extracts a one-based column number from a Code Climate position value.
+ *
+ * @param begin - Column position object or bare line number.
+ * @returns One-based column number, defaulting to 1.
+ */
 function getColumnNumber(begin: CodeClimatePosition | number | undefined): number {
     if (begin === undefined || typeof begin === 'number') {
         return 1;
@@ -236,6 +284,12 @@ function getColumnNumber(begin: CodeClimatePosition | number | undefined): numbe
     return begin.column ?? 1;
 }
 
+/**
+ * Splits a shell-like argument string, respecting single and double quotes.
+ *
+ * @param input - Raw argument string from lint settings.
+ * @returns Tokenized argument list.
+ */
 function parseArgv(input: string): string[] {
     const args: string[] = [];
     let current = '';

--- a/packages/language-server/src/services/ansiblePlaybook.ts
+++ b/packages/language-server/src/services/ansiblePlaybook.ts
@@ -4,17 +4,32 @@ import { TextDocument } from 'vscode-languageserver-textdocument';
 import { getCommandService } from '@ansible/core/out/services/CommandService';
 import type { WorkspaceFolderContext } from './workspaceManager';
 
+/**
+ * Validates playbooks by running ansible-playbook --syntax-check.
+ */
 export class AnsiblePlaybook {
     private connection: Connection;
     private context: WorkspaceFolderContext;
     private useProgressTracker = false;
 
+    /**
+     * Binds the playbook validator to an LSP connection and workspace context.
+     *
+     * @param connection - LSP connection for progress and error reporting.
+     * @param context - Workspace folder used as the working directory.
+     */
     constructor(connection: Connection, context: WorkspaceFolderContext) {
         this.connection = connection;
         this.context = context;
         this.useProgressTracker = !!context.clientCapabilities.window?.workDoneProgress;
     }
 
+    /**
+     * Runs syntax-check on the document and converts stderr into diagnostics.
+     *
+     * @param textDocument - Playbook document to validate.
+     * @returns Diagnostics keyed by affected file URI.
+     */
     public async doValidate(textDocument: TextDocument): Promise<Map<string, Diagnostic[]>> {
         const docPath = URI.parse(textDocument.uri).path;
         let diagnostics = new Map<string, Diagnostic[]>();
@@ -66,6 +81,15 @@ export class AnsiblePlaybook {
         return diagnostics;
     }
 
+    /**
+     * Parses ansible-playbook stderr into a single error diagnostic.
+     *
+     * @param result - Raw stderr output from ansible-playbook.
+     * @param fileName - Path of the file referenced in the error.
+     * @param line - One-based line number from the error message.
+     * @param column - One-based column number from the error message.
+     * @returns Diagnostics keyed by the error file URI.
+     */
     private processReport(
         result: string,
         fileName: string,

--- a/packages/language-server/src/services/settingsManager.ts
+++ b/packages/language-server/src/services/settingsManager.ts
@@ -7,6 +7,9 @@ import type {
     SettingsEntry,
 } from '../interfaces/extensionSettings';
 
+/**
+ * Resolves per-document Ansible extension settings from the client or defaults.
+ */
 export class SettingsManager {
     private connection: Connection | null;
     private clientSupportsConfigRequests: boolean;
@@ -77,15 +80,33 @@ export class SettingsManager {
 
     public globalSettings: ExtensionSettings = this.defaultSettings;
 
+    /**
+     * Creates a settings manager for a workspace folder context.
+     *
+     * @param connection - LSP connection for configuration requests, or null.
+     * @param clientSupportsConfigRequests - Whether the client supports scoped config.
+     */
     constructor(connection: Connection | null, clientSupportsConfigRequests: boolean) {
         this.connection = connection;
         this.clientSupportsConfigRequests = clientSupportsConfigRequests;
     }
 
+    /**
+     * Registers a callback to run when settings change for a workspace URI.
+     *
+     * @param uri - Workspace folder URI to watch.
+     * @param handler - Function invoked after settings are updated.
+     */
     public onConfigurationChanged(uri: string, handler: () => void): void {
         this.configurationChangeHandlers.set(uri, handler);
     }
 
+    /**
+     * Returns merged extension settings for a document URI.
+     *
+     * @param uri - Document URI whose scoped settings are requested.
+     * @returns Resolved extension settings for the document.
+     */
     public async get(uri: string): Promise<ExtensionSettings> {
         if (!this.clientSupportsConfigRequests) {
             return this.globalSettings;
@@ -109,10 +130,20 @@ export class SettingsManager {
         return result;
     }
 
+    /**
+     * Drops cached settings when a document is closed.
+     *
+     * @param uri - URI of the closed document.
+     */
     public handleDocumentClosed(uri: string): void {
         this.documentSettings.delete(uri);
     }
 
+    /**
+     * Refreshes cached settings and notifies registered handlers on change.
+     *
+     * @param params - Configuration change notification from the client.
+     */
     public async handleConfigurationChanged(params: DidChangeConfigurationParams): Promise<void> {
         if (this.clientSupportsConfigRequests) {
             const newDocumentSettings = new Map<string, Thenable<ExtensionSettings>>();
@@ -148,6 +179,12 @@ export class SettingsManager {
         }
     }
 
+    /**
+     * Flattens default/description settings objects into plain value trees.
+     *
+     * @param settingsObject - Settings object that may nest default values.
+     * @returns Settings object with defaults promoted to leaf values.
+     */
     private settingsAdjustment(
         settingsObject: ExtensionSettingsWithDescription | SettingsEntry,
     ): ExtensionSettingsWithDescription {

--- a/packages/language-server/src/services/validationManager.ts
+++ b/packages/language-server/src/services/validationManager.ts
@@ -20,11 +20,23 @@ export class ValidationManager {
     private referencedFilesByOrigin = new Map<string, Set<string>>();
     private referencedFileRefCounter = new Map<string, number>();
 
+    /**
+     * Creates a validation manager bound to the LSP connection and documents.
+     *
+     * @param connection - LSP connection used to publish diagnostics.
+     * @param documents - Open document collection for origin tracking.
+     */
     constructor(connection: Connection, documents: TextDocuments<TextDocument>) {
         this.connection = connection;
         this.documents = documents;
     }
 
+    /**
+     * Publishes diagnostics and updates cross-file reference tracking.
+     *
+     * @param originFileUri - URI of the document that triggered validation.
+     * @param diagnosticsByFile - Diagnostics grouped by affected file URI.
+     */
     public processDiagnostics(
         originFileUri: string,
         diagnosticsByFile: Map<string, Diagnostic[]>,
@@ -61,6 +73,12 @@ export class ValidationManager {
         }
     }
 
+    /**
+     * Stores diagnostics in an interval tree for incremental invalidation.
+     *
+     * @param originFileUri - URI of the document that produced the diagnostics.
+     * @param cacheableDiagnostics - Diagnostics to cache by file URI.
+     */
     public cacheDiagnostics(
         originFileUri: string,
         cacheableDiagnostics: Map<string, Diagnostic[]>,
@@ -81,6 +99,12 @@ export class ValidationManager {
         }
     }
 
+    /**
+     * Invalidates or shifts cached diagnostics when document content changes.
+     *
+     * @param fileUri - URI of the changed document.
+     * @param changes - Incremental content change events from the client.
+     */
     public reconcileCacheItems(fileUri: string, changes: TextDocumentContentChangeEvent[]): void {
         const diagnosticTree = this.validationCache.get(fileUri);
         if (!diagnosticTree) return;
@@ -124,6 +148,12 @@ export class ValidationManager {
         }
     }
 
+    /**
+     * Returns cached diagnostics for quick validation without re-running tools.
+     *
+     * @param fileUri - URI of the document requesting cached diagnostics.
+     * @returns Cached diagnostics by file URI, or undefined when absent.
+     */
     public getValidationFromCache(fileUri: string): Map<string, Diagnostic[]> | undefined {
         const referencedFiles = this.referencedFilesByOrigin.get(fileUri);
         if (referencedFiles) {
@@ -143,6 +173,11 @@ export class ValidationManager {
         }
     }
 
+    /**
+     * Clears reference tracking and diagnostics when an origin document closes.
+     *
+     * @param fileUri - URI of the closed document.
+     */
     public handleDocumentClosed(fileUri: string): void {
         const referencedFiles = this.referencedFilesByOrigin.get(fileUri);
         if (referencedFiles) {
@@ -153,10 +188,20 @@ export class ValidationManager {
         }
     }
 
+    /**
+     * Increments the reference count for a file receiving external diagnostics.
+     *
+     * @param fileUri - URI of the referenced file.
+     */
     private handleFileReferenced(fileUri: string): void {
         this.referencedFileRefCounter.set(fileUri, this.getRefCounter(fileUri) + 1);
     }
 
+    /**
+     * Decrements references and clears diagnostics when a file is no longer cited.
+     *
+     * @param fileUri - URI of the unreferenced file.
+     */
     private handleFileUnreferenced(fileUri: string): void {
         const counter = this.getRefCounter(fileUri) - 1;
         if (counter <= 0) {
@@ -168,6 +213,12 @@ export class ValidationManager {
         }
     }
 
+    /**
+     * Returns how many origin documents currently reference a file.
+     *
+     * @param fileUri - URI of the referenced file.
+     * @returns Current reference count, or zero when untracked.
+     */
     private getRefCounter(fileUri: string): number {
         return this.referencedFileRefCounter.get(fileUri) ?? 0;
     }

--- a/packages/language-server/src/services/workspaceManager.ts
+++ b/packages/language-server/src/services/workspaceManager.ts
@@ -14,24 +14,48 @@ import { AnsibleInventory } from './ansibleInventory';
 import { SettingsManager } from './settingsManager';
 import { IDocumentMetadata } from '../interfaces/documentMeta';
 
+/**
+ * Maps document URIs to workspace folders and their per-folder service contexts.
+ */
 export class WorkspaceManager {
     public connection: Connection;
     private sortedWorkspaceFolders: WorkspaceFolder[] = [];
     private folderContexts = new Map<string, WorkspaceFolderContext>();
     public clientCapabilities: ClientCapabilities = {};
 
+    /**
+     * Creates a workspace manager for the given LSP connection.
+     *
+     * @param connection - LSP connection used for logging and notifications.
+     */
     constructor(connection: Connection) {
         this.connection = connection;
     }
 
+    /**
+     * Replaces the sorted workspace folder list from initialize or change events.
+     *
+     * @param workspaceFolders - Workspace folders reported by the client.
+     */
     public setWorkspaceFolders(workspaceFolders: WorkspaceFolder[]): void {
         this.sortedWorkspaceFolders = this.sortWorkspaceFolders(workspaceFolders);
     }
 
+    /**
+     * Stores client capabilities used by per-folder contexts.
+     *
+     * @param capabilities - Client capabilities from the initialize request.
+     */
     public setCapabilities(capabilities: ClientCapabilities): void {
         this.clientCapabilities = capabilities;
     }
 
+    /**
+     * Returns or lazily creates the service context for a document URI.
+     *
+     * @param uri - Document URI whose workspace context is needed.
+     * @returns Per-folder context, or undefined when no folder matches.
+     */
     public getContext(uri: string): WorkspaceFolderContext | undefined {
         const workspaceFolder = this.getWorkspaceFolder(uri);
         if (workspaceFolder) {
@@ -44,6 +68,11 @@ export class WorkspaceManager {
         }
     }
 
+    /**
+     * Invokes a callback for every active workspace folder context.
+     *
+     * @param callbackfn - Function run for each folder context.
+     */
     public async forEachContext(
         callbackfn: (value: WorkspaceFolderContext) => Promise<void> | void,
     ): Promise<void> {
@@ -54,6 +83,12 @@ export class WorkspaceManager {
         );
     }
 
+    /**
+     * Resolves the workspace folder containing a URI, or synthesizes one from its path.
+     *
+     * @param uri - Document or resource URI to locate.
+     * @returns Matching workspace folder, or a folder derived from the file path.
+     */
     public getWorkspaceFolder(uri: string): WorkspaceFolder | undefined {
         for (const workspaceFolder of this.sortedWorkspaceFolders) {
             if (URI.parse(uri).toString().startsWith(workspaceFolder.uri)) {
@@ -76,6 +111,11 @@ export class WorkspaceManager {
         return workspaceFolder;
     }
 
+    /**
+     * Removes stale contexts and merges added folders after a workspace change.
+     *
+     * @param event - Workspace folders added and removed by the client.
+     */
     public handleWorkspaceChanged(event: WorkspaceFoldersChangeEvent): void {
         const removedUris = new Set(event.removed.map((folder) => folder.uri));
 
@@ -90,11 +130,20 @@ export class WorkspaceManager {
         this.sortedWorkspaceFolders = this.sortWorkspaceFolders(newWorkspaceFolders);
     }
 
+    /**
+     * Sorts folders longest-uri-first so nested folders match before parents.
+     *
+     * @param workspaceFolders - Folders to sort.
+     * @returns Sorted copy of the folder list.
+     */
     private sortWorkspaceFolders(workspaceFolders: WorkspaceFolder[]): WorkspaceFolder[] {
         return workspaceFolders.sort((a, b) => b.uri.length - a.uri.length);
     }
 }
 
+/**
+ * Per-workspace-folder cache of Ansible services, settings, and document metadata.
+ */
 export class WorkspaceFolderContext {
     private connection: Connection;
     public clientCapabilities: ClientCapabilities;
@@ -107,6 +156,13 @@ export class WorkspaceFolderContext {
     private _ansibleLint: AnsibleLint | undefined;
     private _ansiblePlaybook: AnsiblePlaybook | undefined;
 
+    /**
+     * Initializes settings and invalidation hooks for a workspace folder.
+     *
+     * @param connection - LSP connection for service construction.
+     * @param workspaceFolder - Folder this context represents.
+     * @param workspaceManager - Parent manager providing client capabilities.
+     */
     constructor(
         connection: Connection,
         workspaceFolder: WorkspaceFolder,
@@ -125,6 +181,11 @@ export class WorkspaceFolderContext {
         });
     }
 
+    /**
+     * Clears cached Ansible config when watched config files change.
+     *
+     * @param params - Watched file change notification from the client.
+     */
     public handleWatchedDocumentChange(params: DidChangeWatchedFilesParams): void {
         for (const fileEvent of params.changes) {
             if (fileEvent.uri.startsWith(this.workspaceFolder.uri)) {
@@ -133,6 +194,11 @@ export class WorkspaceFolderContext {
         }
     }
 
+    /**
+     * Lazily loaded Ansible configuration for this workspace folder.
+     *
+     * @returns Promise that resolves to the initialized config service.
+     */
     public get ansibleConfig(): Thenable<AnsibleConfig> {
         if (!this._ansibleConfig) {
             const config = new AnsibleConfig(this.connection, this);
@@ -141,6 +207,11 @@ export class WorkspaceFolderContext {
         return this._ansibleConfig;
     }
 
+    /**
+     * Lazily loaded Ansible inventory for this workspace folder.
+     *
+     * @returns Promise that resolves to the initialized inventory service.
+     */
     public get ansibleInventory(): Thenable<AnsibleInventory> {
         if (!this._ansibleInventory) {
             const inventory = new AnsibleInventory(this.connection, this);
@@ -149,20 +220,32 @@ export class WorkspaceFolderContext {
         return this._ansibleInventory;
     }
 
+    /** Forces the inventory cache to reload on the next access. */
     public clearAnsibleInventory(): void {
         this._ansibleInventory = undefined;
     }
 
+    /** Clears lazily initialized Ansible config and inventory services. */
     public clearCachedServices(): void {
         this._ansibleConfig = undefined;
         this._ansibleInventory = undefined;
     }
 
+    /**
+     * Shared ansible-lint validator instance for this workspace folder.
+     *
+     * @returns Cached AnsibleLint service for the folder.
+     */
     public get ansibleLint(): AnsibleLint {
         this._ansibleLint ??= new AnsibleLint(this.connection, this);
         return this._ansibleLint;
     }
 
+    /**
+     * Shared ansible-playbook syntax-check instance for this workspace folder.
+     *
+     * @returns Cached AnsiblePlaybook service for the folder.
+     */
     public get ansiblePlaybook(): AnsiblePlaybook {
         this._ansiblePlaybook ??= new AnsiblePlaybook(this.connection, this);
         return this._ansiblePlaybook;

--- a/packages/language-server/src/utils/ansible.ts
+++ b/packages/language-server/src/utils/ansible.ts
@@ -622,6 +622,12 @@ export const playWithoutTaskKeywords = new Map(
     [...playKeywords].filter(([k]) => !taskKeywords.has(k)),
 );
 
+/**
+ * Determines whether a YAML key is a reserved Ansible task keyword.
+ *
+ * @param value - Key name to test.
+ * @returns True for built-in task keywords and legacy `with_` loops.
+ */
 export function isTaskKeyword(value: string): boolean {
     return taskKeywords.has(value) || value.startsWith('with_');
 }

--- a/packages/language-server/src/utils/docsFormatter.ts
+++ b/packages/language-server/src/utils/docsFormatter.ts
@@ -3,6 +3,12 @@ import { MarkupContent, MarkupKind } from 'vscode-languageserver';
 import { parse, toMD } from 'antsibull-docs';
 import type { PluginDoc, PluginOption } from '@ansible/core/out/services/CollectionsService';
 
+/**
+ * Formats Ansible module documentation as LSP markdown hover content.
+ *
+ * @param doc - Plugin documentation from the collections cache.
+ * @returns Markdown markup content for display in hovers.
+ */
 export function formatModule(doc: PluginDoc): MarkupContent {
     const sections: string[] = [];
 
@@ -28,6 +34,14 @@ export function formatModule(doc: PluginDoc): MarkupContent {
     };
 }
 
+/**
+ * Formats a single module option as LSP markdown hover content.
+ *
+ * @param option - Option specification from plugin documentation.
+ * @param name - Canonical option name.
+ * @param withDetails - Whether to include type and required metadata.
+ * @returns Markdown markup content for the option.
+ */
 export function formatOption(
     option: PluginOption,
     name: string,
@@ -67,6 +81,12 @@ export function formatOption(
     };
 }
 
+/**
+ * Builds a compact type and requirement summary for a module option.
+ *
+ * @param option - Option specification to summarize.
+ * @returns A parenthetical detail string, or undefined when empty.
+ */
 export function getDetails(option: PluginOption): string | undefined {
     const details: string[] = [];
 
@@ -84,6 +104,13 @@ export function getDetails(option: PluginOption): string | undefined {
     return details.length > 0 ? details.join(' ') : undefined;
 }
 
+/**
+ * Normalizes plugin description text into markdown, optionally as a bullet list.
+ *
+ * @param doc - Raw description string or list of paragraphs.
+ * @param asList - When true, array entries are rendered as list items.
+ * @returns Formatted markdown text.
+ */
 function formatDescription(doc?: string | string[], asList = true): string {
     if (!doc) return '';
 
@@ -101,6 +128,12 @@ function formatDescription(doc?: string | string[], asList = true): string {
     return '';
 }
 
+/**
+ * Converts antsibull-docs macro syntax in a string to markdown.
+ *
+ * @param text - Raw documentation text that may contain macros.
+ * @returns Markdown-safe text.
+ */
 function replaceMacros(text: unknown): string {
     const safeText = typeof text === 'string' ? text : JSON.stringify(text);
     return toMD(parse(safeText));

--- a/packages/language-server/src/utils/getAnsibleMetaData.ts
+++ b/packages/language-server/src/utils/getAnsibleMetaData.ts
@@ -14,6 +14,13 @@ export interface AnsibleMetaDataType {
     ansibleLintVersion?: string;
 }
 
+/**
+ * Collects installed Ansible and ansible-lint version metadata for a workspace.
+ *
+ * @param ctx - Workspace folder context used to resolve tool paths.
+ * @param connection - LSP connection for logging failures.
+ * @returns Metadata entries keyed by tool name.
+ */
 export async function getAnsibleMetaData(
     ctx: WorkspaceFolderContext,
     connection: Connection,

--- a/packages/language-server/src/utils/misc.ts
+++ b/packages/language-server/src/utils/misc.ts
@@ -3,16 +3,36 @@ import { promises as fs } from 'fs';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { Range } from 'vscode-languageserver-types';
 
+/**
+ * Checks whether a file exists at the given path.
+ *
+ * @param filePath - Absolute or relative path to test.
+ * @returns True when the path refers to an existing file.
+ */
 export async function fileExists(filePath: string): Promise<boolean> {
     return !!(await fs.stat(filePath).catch(() => false));
 }
 
+/**
+ * Converts a byte offset range into an LSP range for the given document.
+ *
+ * @param range - Start and end byte offsets in the document text.
+ * @param textDocument - Document whose positions are resolved.
+ * @returns The corresponding LSP range.
+ */
 export function toLspRange(range: [number, number], textDocument: TextDocument): Range {
     const start = textDocument.positionAt(range[0]);
     const end = textDocument.positionAt(range[1]);
     return Range.create(start, end);
 }
 
+/**
+ * Narrows an object type when it owns the given property key.
+ *
+ * @param obj - Value to inspect.
+ * @param prop - Property key to test.
+ * @returns True when the object owns the property.
+ */
 export function hasOwnProperty<X, Y extends PropertyKey>(
     obj: X,
     prop: Y,
@@ -20,16 +40,36 @@ export function hasOwnProperty<X, Y extends PropertyKey>(
     return isObject(obj) && Object.prototype.hasOwnProperty.call(obj, prop);
 }
 
+/**
+ * Narrows a value to a non-null object record.
+ *
+ * @param obj - Value to test.
+ * @returns True when the value is a non-null object.
+ */
 export function isObject<X>(obj: X): obj is X & Record<PropertyKey, unknown> {
     return obj !== null && obj !== undefined && typeof obj === 'object';
 }
 
+/**
+ * Inserts a substring at the given index within a string.
+ *
+ * @param str - Source string.
+ * @param index - Zero-based insertion offset.
+ * @param val - Text to insert.
+ * @returns The string with the inserted value.
+ */
 export function insert(str: string, index: number, val: string): string {
     return `${str.substring(0, index)}${val}${str.substring(index)}`;
 }
 
 /**
  * Adjusts the command and environment for a Python virtual-environment.
+ *
+ * @param executable - Ansible or lint executable name or path.
+ * @param args - Command-line arguments to append.
+ * @param interpreterPath - Path to the Python interpreter in the venv.
+ * @param activationScript - Optional shell script that activates the venv.
+ * @returns The shell command and environment variables to use.
  */
 export function withInterpreter(
     executable: string,
@@ -69,6 +109,8 @@ export function withInterpreter(
 
 /**
  * Returns an error message when the LS runs on an unsupported platform.
+ *
+ * @returns A user-facing error message, or undefined when the platform is supported.
  */
 export function getUnsupportedError(): string | undefined {
     if (process.platform === 'win32') {

--- a/packages/language-server/src/utils/yaml.ts
+++ b/packages/language-server/src/utils/yaml.ts
@@ -26,15 +26,30 @@ import type {
 
 type Options = ParseOptions & DocumentOptions & SchemaOptions;
 
+/**
+ * Walks a YAML node path upward to inspect parents, keys, and values.
+ */
 export class AncestryBuilder<N extends Node | Pair = Node> {
     private _path: Node[];
     private _index: number;
 
+    /**
+     * Positions the builder at the end of a YAML node path.
+     *
+     * @param path - Ancestry path from the document root, or null for empty.
+     * @param index - Optional starting index within the path.
+     */
     constructor(path: Node[] | null, index?: number) {
         this._path = path ?? [];
         this._index = index ?? this._path.length - 1;
     }
 
+    /**
+     * Moves to the parent node, optionally requiring a specific node type.
+     *
+     * @param type - Expected parent constructor; invalid parents invalidate the path.
+     * @returns This builder narrowed to the parent node type.
+     */
     parent<X extends Node | Pair>(type?: new (...args: Schema[]) => X): AncestryBuilder<X> {
         this._index--;
         if (isPair(this.get())) {
@@ -50,6 +65,11 @@ export class AncestryBuilder<N extends Node | Pair = Node> {
         return this as unknown as AncestryBuilder<X>;
     }
 
+    /**
+     * Moves from a key or value to the containing YAML map.
+     *
+     * @returns Builder positioned on the parent map of the current key.
+     */
     parentOfKey(): AncestryBuilder<YAMLMap> {
         const node = this.get();
         this.parent(Pair);
@@ -62,6 +82,11 @@ export class AncestryBuilder<N extends Node | Pair = Node> {
         return this as unknown as AncestryBuilder<YAMLMap>;
     }
 
+    /**
+     * Returns the node at the current path index.
+     *
+     * @returns Current node, or null when the index is out of range.
+     */
     get(): N | null {
         if (this._index < 0 || this._index >= this._path.length) {
             return null;
@@ -69,6 +94,11 @@ export class AncestryBuilder<N extends Node | Pair = Node> {
         return this._path[this._index] as N;
     }
 
+    /**
+     * Reads the string key of the pair immediately after a map node.
+     *
+     * @returns Key string when the child pair has a scalar key.
+     */
     getStringKey(this: AncestryBuilder<YAMLMap>): string | null {
         const node = this._path[this._index + 1];
         if (isPair(node) && isScalar(node.key) && typeof node.key.value === 'string') {
@@ -77,6 +107,11 @@ export class AncestryBuilder<N extends Node | Pair = Node> {
         return null;
     }
 
+    /**
+     * Reads the value node of the pair immediately after a map node.
+     *
+     * @returns Value node when the child is a YAML pair.
+     */
     getValue(this: AncestryBuilder<YAMLMap>): Node | null {
         const node = this._path[this._index + 1];
         if (isPair(node)) {
@@ -85,11 +120,21 @@ export class AncestryBuilder<N extends Node | Pair = Node> {
         return null;
     }
 
+    /**
+     * Returns the ancestry path truncated at the current index.
+     *
+     * @returns Path prefix, or null when the index is invalid.
+     */
     getPath(): Node[] | null {
         if (this._index < 0) return null;
         return this._path.slice(0, this._index + 1);
     }
 
+    /**
+     * Extends the current path through the child pair and its key node.
+     *
+     * @returns Path ending at the key scalar, or null when no child pair exists.
+     */
     getKeyPath(this: AncestryBuilder<YAMLMap>): Node[] | null {
         if (this._index < 0) return null;
         const path = this._path.slice(0, this._index + 1);
@@ -103,6 +148,15 @@ export class AncestryBuilder<N extends Node | Pair = Node> {
     }
 }
 
+/**
+ * Resolves the YAML node path at a document position across parsed documents.
+ *
+ * @param document - Text document containing the position.
+ * @param position - Cursor position to resolve.
+ * @param docs - Parsed YAML documents to search.
+ * @param inclusive - When true, positions at range end match the node.
+ * @returns Node ancestry path at the position, or null when not found.
+ */
 export function getPathAt(
     document: TextDocument,
     position: Position,
@@ -117,6 +171,14 @@ export function getPathAt(
     return null;
 }
 
+/**
+ * Tests whether a byte offset lies within a node's source range.
+ *
+ * @param node - YAML node whose range is tested.
+ * @param offset - Byte offset in the document text.
+ * @param inclusive - When true, offsets equal to the range end match.
+ * @returns True when the offset falls inside the node range.
+ */
 function contains(node: Node | null, offset: number, inclusive: boolean): boolean {
     const range = getOrigRange(node);
     return !!(
@@ -126,6 +188,15 @@ function contains(node: Node | null, offset: number, inclusive: boolean): boolea
     );
 }
 
+/**
+ * Recursively descends a YAML tree to find the deepest node at an offset.
+ *
+ * @param path - Current ancestry path while descending.
+ * @param offset - Byte offset in the document text.
+ * @param inclusive - When true, offsets at range end match child nodes.
+ * @param doc - YAML document used to synthesize placeholder nodes.
+ * @returns Deepest matching node path, including synthetic gap nodes.
+ */
 function getPathAtOffset(
     path: Node[],
     offset: number,
@@ -182,6 +253,12 @@ function getPathAtOffset(
 
 const tasksKey = /^(tasks|pre_tasks|post_tasks|block|rescue|always|handlers)$/;
 
+/**
+ * Determines whether a YAML path refers to a task parameter map.
+ *
+ * @param path - YAML node ancestry path to test.
+ * @returns True when the path is inside a tasks, handlers, or block list item.
+ */
 export function isTaskParam(path: Node[]): boolean {
     const taskListPath = new AncestryBuilder(path).parentOfKey().parent(YAMLSeq).getPath();
     if (taskListPath) {
@@ -199,6 +276,12 @@ export function isTaskParam(path: Node[]): boolean {
     return false;
 }
 
+/**
+ * Collects collection names declared on enclosing plays, blocks, and tasks.
+ *
+ * @param modulePath - YAML path at a module or task parameter.
+ * @returns Deduplicated collection names from collections keys in scope.
+ */
 export function getDeclaredCollections(modulePath: Node[] | null): string[] {
     const declaredCollections: string[] = [];
     const taskParamsNode = new AncestryBuilder(modulePath).parent(YAMLMap).get();
@@ -222,6 +305,12 @@ export function getDeclaredCollections(modulePath: Node[] | null): string[] {
     return [...new Set(declaredCollections)];
 }
 
+/**
+ * Extracts collection names from a collections sequence on a YAML map.
+ *
+ * @param playNode - YAML map that may contain a collections key.
+ * @returns Collection names declared on the map.
+ */
 function getDeclaredCollectionsForMap(playNode: YAMLMap | null): string[] {
     const declaredCollections: string[] = [];
     const collectionsPair = _.find(
@@ -241,6 +330,13 @@ function getDeclaredCollectionsForMap(playNode: YAMLMap | null): string[] {
     return declaredCollections;
 }
 
+/**
+ * Determines whether a YAML path refers to a play-level parameter map.
+ *
+ * @param path - YAML node ancestry path to test.
+ * @param fileUri - Optional document URI used to exclude role task files.
+ * @returns True for play maps, false for non-play contexts, or undefined when ambiguous.
+ */
 export function isPlayParam(path: Node[], fileUri?: string): boolean | undefined {
     const isAtRoot =
         new AncestryBuilder(path).parentOfKey().parent(YAMLSeq).getPath()?.length === 1;
@@ -265,6 +361,12 @@ export function isPlayParam(path: Node[], fileUri?: string): boolean | undefined
     }
 }
 
+/**
+ * Determines whether a YAML path refers to a block/rescue/always parameter map.
+ *
+ * @param path - YAML node ancestry path to test.
+ * @returns True when the map contains a block key inside a sequence.
+ */
 export function isBlockParam(path: Node[]): boolean {
     const builder = new AncestryBuilder(path).parentOfKey();
     const mapNode = builder.get();
@@ -276,6 +378,12 @@ export function isBlockParam(path: Node[]): boolean {
     return false;
 }
 
+/**
+ * Determines whether a YAML path refers to an entry in a roles list.
+ *
+ * @param path - YAML node ancestry path to test.
+ * @returns True when the enclosing sequence belongs to a roles key.
+ */
 export function isRoleParam(path: Node[]): boolean {
     const rolesKey = new AncestryBuilder(path)
         .parentOfKey()
@@ -289,6 +397,11 @@ export function isRoleParam(path: Node[]): boolean {
  * Resolves a module name to its FQCN and plugin data using CollectionsService.
  * Uses a simple heuristic: if the name looks like a FQCN (has 2+ dots), look up
  * directly; otherwise try ansible.builtin.<name>.
+ *
+ * @param taskParamPath - YAML path inside a task parameter map.
+ * @param document - Text document containing the task.
+ * @param collectionsService - Source of cached plugin documentation.
+ * @returns Plugin data for the first resolvable module in the map, or null.
  */
 export async function findProvidedModule(
     taskParamPath: Node[],
@@ -308,6 +421,13 @@ export async function findProvidedModule(
     return null;
 }
 
+/**
+ * Looks up plugin documentation for a module name, inferring ansible.builtin when needed.
+ *
+ * @param name - Module name from the task YAML.
+ * @param collectionsService - Source of cached plugin documentation.
+ * @returns Plugin data when the module exists, or null.
+ */
 async function resolveModuleName(
     name: string,
     collectionsService: CollectionsService,
@@ -321,6 +441,11 @@ async function resolveModuleName(
 
 /**
  * Returns possible options/suboptions at the current path level.
+ *
+ * @param path - YAML node ancestry path at the cursor.
+ * @param document - Text document containing the task.
+ * @param collectionsService - Source of cached plugin documentation.
+ * @returns Option map for the current dict level, or null when not applicable.
  */
 export async function getPossibleOptionsForPath(
     path: Node[],
@@ -359,6 +484,12 @@ export async function getPossibleOptionsForPath(
     return options;
 }
 
+/**
+ * Walks upward from a nested option path to the enclosing task and records dict/list steps.
+ *
+ * @param path - YAML node ancestry path starting inside a task option.
+ * @returns Task parameter path and reversed trace of parent option types.
+ */
 function getTaskParamPathWithTrace(path: Node[]): [Node[], [string, 'list' | 'dict'][]] {
     const trace: [string, 'list' | 'dict'][] = [];
     while (!isTaskParam(path)) {
@@ -389,6 +520,12 @@ function getTaskParamPathWithTrace(path: Node[]): [Node[], [string, 'list' | 'di
     return [path, trace];
 }
 
+/**
+ * Collects string keys from all pairs in a YAML map.
+ *
+ * @param mapNode - YAML map whose keys are extracted.
+ * @returns Scalar key values as strings.
+ */
 export function getYamlMapKeys(mapNode: YAMLMap): string[] {
     return mapNode.items
         .map((pair) => {
@@ -400,6 +537,12 @@ export function getYamlMapKeys(mapNode: YAMLMap): string[] {
         .filter((e): e is string => !!e);
 }
 
+/**
+ * Returns the source byte range for a YAML node when available.
+ *
+ * @param node - YAML node whose range is read.
+ * @returns Start and end byte offsets, or undefined when absent.
+ */
 export function getOrigRange(node: Node | null | undefined): [number, number] | undefined {
     if (node?.range) {
         return [node.range[0], node.range[1]];
@@ -407,6 +550,13 @@ export function getOrigRange(node: Node | null | undefined): [number, number] | 
     return undefined;
 }
 
+/**
+ * Parses YAML text into documents, preserving source tokens for range mapping.
+ *
+ * @param str - Raw YAML text to parse.
+ * @param options - Optional parse, document, and schema options.
+ * @returns Parsed documents, or an empty array for blank input.
+ */
 export function parseAllDocuments(str: string, options?: Options): Document[] {
     if (!str) {
         return [];
@@ -414,6 +564,12 @@ export function parseAllDocuments(str: string, options?: Options): Document[] {
     return [parseDocument(str, { keepSourceTokens: true, ...options })];
 }
 
+/**
+ * Heuristically detects whether a document is an Ansible playbook.
+ *
+ * @param textDocument - Text document whose root structure is inspected.
+ * @returns True when the document root is a sequence with play-level keys.
+ */
 export function isPlaybook(textDocument: TextDocument): boolean {
     if (textDocument.getText().trim().length === 0) {
         return false;
@@ -443,6 +599,14 @@ export function isPlaybook(textDocument: TextDocument): boolean {
     return [...playbookKeysSet].some((r) => filteredList.includes(r));
 }
 
+/**
+ * Tests whether the cursor sits inside an unclosed `{{ }}` Jinja expression.
+ *
+ * @param document - Text document containing the cursor.
+ * @param position - Cursor position to test.
+ * @param path - YAML node path at the cursor.
+ * @returns True when the cursor is between opening and closing Jinja delimiters.
+ */
 export function isCursorInsideJinjaBrackets(
     document: TextDocument,
     position: Position,

--- a/packages/language-server/test/services/ansibleConfig.test.ts
+++ b/packages/language-server/test/services/ansibleConfig.test.ts
@@ -5,6 +5,10 @@ vi.mock('@ansible/core/out/services/CommandService', () => ({
     getCommandService: () => ({ runTool: runToolMock }),
 }));
 
+/**
+ * Builds a minimal language-server connection stub for AnsibleConfig tests.
+ * @returns A stub connection with window and console helpers.
+ */
 function mockConnection() {
     return {
         window: { showErrorMessage: vi.fn() },
@@ -12,6 +16,11 @@ function mockConnection() {
     };
 }
 
+/**
+ * Builds a minimal document context with an optional workspace folder URI.
+ * @param folderUri - Workspace folder URI for the test context.
+ * @returns A stub document context with the given workspace folder.
+ */
 function mockContext(folderUri = 'file:///workspace') {
     return {
         workspaceFolder: { uri: folderUri, name: 'ws' },

--- a/packages/language-server/test/services/ansibleInventory.test.ts
+++ b/packages/language-server/test/services/ansibleInventory.test.ts
@@ -5,6 +5,10 @@ vi.mock('@ansible/core/out/services/CommandService', () => ({
     getCommandService: () => ({ runTool: runToolMock }),
 }));
 
+/**
+ * Builds a minimal language-server connection stub for AnsibleInventory tests.
+ * @returns A stub connection with console and window helpers.
+ */
 function mockConnection() {
     return {
         console: { error: vi.fn(), log: vi.fn(), info: vi.fn() },
@@ -12,6 +16,11 @@ function mockConnection() {
     };
 }
 
+/**
+ * Builds a minimal document context with an optional workspace folder URI.
+ * @param folderUri - Workspace folder URI for the test context.
+ * @returns A stub document context with the given workspace folder.
+ */
 function mockContext(folderUri = 'file:///workspace') {
     return {
         workspaceFolder: { uri: folderUri, name: 'ws' },

--- a/packages/language-server/test/services/ansibleLint.test.ts
+++ b/packages/language-server/test/services/ansibleLint.test.ts
@@ -12,6 +12,10 @@ vi.mock('../../src/utils/misc', async (importOriginal) => {
     return { ...orig, fileExists: vi.fn().mockResolvedValue(false) };
 });
 
+/**
+ * Builds a minimal language-server connection stub for AnsibleLint tests.
+ * @returns A stub connection with window, console, and progress helpers.
+ */
 function mockConnection() {
     return {
         window: {
@@ -30,6 +34,12 @@ function mockConnection() {
     };
 }
 
+/**
+ * Builds a document context with optional workspace folder and validation settings.
+ * @param folderUri - Workspace folder URI for the test context.
+ * @param settings - Partial validation settings to merge into defaults.
+ * @returns A stub document context with workspace folder and settings accessors.
+ */
 function mockContext(
     folderUri = 'file:///workspace',
     settings?: Partial<{
@@ -54,6 +64,12 @@ function mockContext(
     };
 }
 
+/**
+ * Creates a TextDocument for ansible-lint validation tests.
+ * @param content - YAML playbook content.
+ * @param uri - Document URI.
+ * @returns A language-server TextDocument instance.
+ */
 function makeDoc(
     content = '---\n- hosts: all\n  tasks: []',
     uri = 'file:///workspace/playbook.yml',

--- a/packages/language-server/test/services/ansiblePlaybook.test.ts
+++ b/packages/language-server/test/services/ansiblePlaybook.test.ts
@@ -7,6 +7,10 @@ vi.mock('@ansible/core/out/services/CommandService', () => ({
     getCommandService: () => ({ runTool: runToolMock }),
 }));
 
+/**
+ * Builds a minimal language-server connection stub for AnsiblePlaybook tests.
+ * @returns A stub connection with window and console helpers.
+ */
 function mockConnection() {
     return {
         window: {
@@ -20,6 +24,12 @@ function mockConnection() {
     };
 }
 
+/**
+ * Builds a document context with optional workspace folder and progress support.
+ * @param folderUri - Workspace folder URI for the test context.
+ * @param progressSupport - Whether the client advertises work-done progress.
+ * @returns A stub document context with workspace folder and client capabilities.
+ */
 function mockContext(folderUri = 'file:///workspace', progressSupport = false) {
     return {
         workspaceFolder: { uri: folderUri, name: 'ws' },
@@ -29,6 +39,12 @@ function mockContext(folderUri = 'file:///workspace', progressSupport = false) {
     };
 }
 
+/**
+ * Creates a TextDocument for ansible-playbook validation tests.
+ * @param content - YAML playbook content.
+ * @param uri - Document URI.
+ * @returns A language-server TextDocument instance.
+ */
 function makeDoc(
     content = '---\n- hosts: all\n  tasks: []',
     uri = 'file:///workspace/playbook.yml',

--- a/packages/language-server/test/utils/yaml.test.ts
+++ b/packages/language-server/test/utils/yaml.test.ts
@@ -16,6 +16,11 @@ import {
     isCursorInsideJinjaBrackets,
 } from '../../src/utils/yaml';
 
+/**
+ * Creates a TextDocument from YAML content for utility tests.
+ * @param content - YAML source text.
+ * @returns A language-server TextDocument instance.
+ */
 function doc(content: string): TextDocument {
     return TextDocument.create('file:///test.yml', 'ansible', 1, content);
 }

--- a/packages/mcp-server/src/creatorTools.ts
+++ b/packages/mcp-server/src/creatorTools.ts
@@ -8,11 +8,13 @@ import { CreatorService } from '@ansible/core';
 import type { SchemaNode } from '@ansible/core';
 import { McpToolDefinition, McpToolResult } from './tools';
 
+/** Generates and dispatches MCP tools from the ansible-creator command schema. */
 export class CreatorToolGenerator {
     private _tools: McpToolDefinition[] = [];
     private _toolPathMap = new Map<string, string[]>();
     private _initialized = false;
 
+    /** Loads the ansible-creator schema and builds MCP tool definitions from it. */
     async initialize(): Promise<void> {
         if (this._initialized) {
             return;
@@ -37,18 +39,41 @@ export class CreatorToolGenerator {
         }
     }
 
+    /**
+     * Whether the creator schema has been loaded and tools are available.
+     *
+     * @returns True after `initialize()` has successfully built tool definitions
+     */
     isInitialized(): boolean {
         return this._initialized;
     }
 
+    /**
+     * All dynamically generated ansible-creator MCP tool definitions.
+     *
+     * @returns Creator tools derived from the loaded schema (empty until initialized)
+     */
     getTools(): McpToolDefinition[] {
         return this._tools;
     }
 
+    /**
+     * Checks whether a tool name belongs to the ansible-creator tool set.
+     *
+     * @param name - MCP tool name to check
+     * @returns True when the name uses the `ac_` creator prefix
+     */
     isCreatorTool(name: string): boolean {
         return name.startsWith('ac_');
     }
 
+    /**
+     * Runs an ansible-creator command for the given MCP tool.
+     *
+     * @param name - Creator tool name (e.g. `ac_coll_init`)
+     * @param args - Tool arguments mapped to CLI flags and positional values
+     * @returns MCP result with command output or an error message
+     */
     async handleTool(name: string, args: Record<string, unknown>): Promise<McpToolResult> {
         const toolPath = this._toolPathMap.get(name);
         if (!toolPath) {
@@ -130,6 +155,13 @@ export class CreatorToolGenerator {
         }
     }
 
+    /**
+     * Recursively walks the schema tree and collects MCP tools for leaf commands.
+     *
+     * @param schema - Current schema node in the ansible-creator tree
+     * @param path - Command path segments accumulated from the root
+     * @returns Tool definitions for all leaf commands under this node
+     */
     private _generateTools(schema: SchemaNode, path: string[] = []): McpToolDefinition[] {
         const tools: McpToolDefinition[] = [];
 
@@ -152,6 +184,13 @@ export class CreatorToolGenerator {
         return tools;
     }
 
+    /**
+     * Builds a single MCP tool definition from a leaf ansible-creator command.
+     *
+     * @param path - Full command path (e.g. `['collection', 'init']`)
+     * @param schema - Schema node describing parameters for the leaf command
+     * @returns MCP tool definition with input schema derived from CLI parameters
+     */
     private _createTool(path: string[], schema: SchemaNode): McpToolDefinition {
         // Shorten tool names to avoid exceeding MCP's 60 char limit for server:tool
         // "ansible-environments:" is 21 chars, leaving 39 for the tool name
@@ -205,7 +244,10 @@ export class CreatorToolGenerator {
     }
 
     /**
-     * Shorten path segments to keep tool names under the MCP limit
+     * Shortens a schema path segment so the combined tool name stays within MCP limits.
+     *
+     * @param segment - Raw command segment from the ansible-creator schema path
+     * @returns Abbreviated segment when a known mapping exists, otherwise the original
      */
     private _shortenPathSegment(segment: string): string {
         const abbreviations: Record<string, string> = {
@@ -223,6 +265,7 @@ export class CreatorToolGenerator {
         return abbreviations[segment] || segment;
     }
 
+    /** Clears cached tools and reloads the ansible-creator schema from scratch. */
     async refresh(): Promise<void> {
         this._initialized = false;
         this._tools = [];

--- a/packages/mcp-server/src/handlers.ts
+++ b/packages/mcp-server/src/handlers.ts
@@ -22,7 +22,12 @@ import {
 } from '@ansible/core';
 import type { PluginOption, SchemaNode } from '@ansible/core';
 
-// Helper to convert string | string[] to string[]
+/**
+ * Normalizes ansible-doc fields that may be a single string or string array.
+ *
+ * @param value - Raw field value from plugin documentation
+ * @returns Array of strings, empty when the value is undefined
+ */
 function toArray(value: string | string[] | undefined): string[] {
     if (!value) {
         return [];
@@ -33,21 +38,35 @@ function toArray(value: string | string[] | undefined): string[] {
     return [value];
 }
 
+/** Routes MCP tool invocations to Ansible core services and local generators. */
 export class McpToolHandler {
     private _searchIndex = PluginSearchIndex.getInstance();
     private _taskGenerator = new TaskGenerator();
     private _taskBuilder = new TaskBuilder();
     private _creatorTools = new CreatorToolGenerator();
 
+    /** Warms the plugin search index and loads ansible-creator tool definitions. */
     async initialize(): Promise<void> {
         await this._searchIndex.ensureBuilt();
         await this._creatorTools.initialize();
     }
 
+    /**
+     * Dynamic ansible-creator tool generator used when listing and invoking `ac_*` tools.
+     *
+     * @returns Shared CreatorToolGenerator instance owned by this handler
+     */
     getCreatorTools(): CreatorToolGenerator {
         return this._creatorTools;
     }
 
+    /**
+     * Dispatches an MCP tool call to the matching handler implementation.
+     *
+     * @param name - Registered MCP tool name
+     * @param args - Tool arguments from the MCP client
+     * @returns Text content suitable for the MCP tool response
+     */
     async handleTool(name: string, args: Record<string, unknown>): Promise<McpToolResult> {
         try {
             // Creator tools
@@ -119,6 +138,12 @@ export class McpToolHandler {
 
     // === Discovery Handlers ===
 
+    /**
+     * Handles `search_ansible_plugins` by querying the plugin search index.
+     *
+     * @param args - Tool args: `query` (required), optional `plugin_type`, `collection`, `limit`
+     * @returns Formatted list of matching plugins or guidance when none match
+     */
     private async _handleSearchPlugins(args: Record<string, unknown>): Promise<McpToolResult> {
         const query = args.query as string;
         if (!query) {
@@ -161,6 +186,12 @@ export class McpToolHandler {
         };
     }
 
+    /**
+     * Handles `get_plugin_documentation` by formatting full ansible-doc output.
+     *
+     * @param args - Tool args: `plugin` (required), optional `plugin_type` (default `module`)
+     * @returns Markdown documentation sections for the requested plugin
+     */
     private async _handleGetPluginDoc(args: Record<string, unknown>): Promise<McpToolResult> {
         const plugin = args.plugin as string;
         if (!plugin) {
@@ -229,6 +260,12 @@ export class McpToolHandler {
         };
     }
 
+    /**
+     * Formats plugin option metadata as a readable parameter list.
+     *
+     * @param options - Documented module parameters keyed by name
+     * @returns Markdown bullet list with types, defaults, and short descriptions
+     */
     private _formatParameters(options: Record<string, PluginOption>): string {
         const lines: string[] = [];
 
@@ -263,6 +300,12 @@ export class McpToolHandler {
         return lines.join('\n');
     }
 
+    /**
+     * Handles `list_ansible_collections` after refreshing the installed collection cache.
+     *
+     * @param args - Optional `filter` substring to narrow FQCN results
+     * @returns Installed collections with versions
+     */
     private async _handleListCollections(args: Record<string, unknown>): Promise<McpToolResult> {
         const service = CollectionsService.getInstance();
 
@@ -310,6 +353,12 @@ export class McpToolHandler {
         };
     }
 
+    /**
+     * Handles `install_ansible_collection` via ADE and rebuilds the plugin search index.
+     *
+     * @param args - Tool args: `name` (FQCN or Git URL, required)
+     * @returns Success confirmation or installation error details
+     */
     private async _handleInstallCollection(args: Record<string, unknown>): Promise<McpToolResult> {
         const name = args.name as string;
         if (!name) {
@@ -348,6 +397,12 @@ export class McpToolHandler {
         }
     }
 
+    /**
+     * Handles `search_available_collections` across Galaxy and configured GitHub orgs.
+     *
+     * @param args - Tool args: `query` (required), optional `source` and `limit`
+     * @returns Ranked installable collections with source metadata
+     */
     private async _handleSearchAvailableCollections(
         args: Record<string, unknown>,
     ): Promise<McpToolResult> {
@@ -477,6 +532,12 @@ export class McpToolHandler {
         }
     }
 
+    /**
+     * Handles `list_source_collections` for one Galaxy or GitHub organization.
+     *
+     * @param args - Tool args: `source` (required), optional `limit`
+     * @returns Collections available from the named source
+     */
     private async _handleListSourceCollections(
         args: Record<string, unknown>,
     ): Promise<McpToolResult> {
@@ -572,6 +633,12 @@ export class McpToolHandler {
         }
     }
 
+    /**
+     * Handles `get_collection_plugins` by listing plugins in an installed collection.
+     *
+     * @param args - Tool args: `collection` (required), optional `plugin_type` filter
+     * @returns Markdown inventory of plugins grouped by type
+     */
     private async _handleGetCollectionPlugins(
         args: Record<string, unknown>,
     ): Promise<McpToolResult> {
@@ -668,6 +735,12 @@ export class McpToolHandler {
 
     // === Task Generation Handlers ===
 
+    /**
+     * Handles `generate_ansible_task` using the one-shot TaskGenerator.
+     *
+     * @param args - Tool args: `plugin` and `params` (required), plus optional task options
+     * @returns YAML task block and any validation warnings
+     */
     private async _handleGenerateTask(args: Record<string, unknown>): Promise<McpToolResult> {
         const plugin = args.plugin as string;
         const params = args.params;
@@ -708,6 +781,12 @@ export class McpToolHandler {
         return { content: [{ type: 'text', text: response }] };
     }
 
+    /**
+     * Handles `build_ansible_task` for interactive, session-based task construction.
+     *
+     * @param args - Session and parameter fields accepted by TaskBuilder
+     * @returns Session prompts, generated YAML, or an error message
+     */
     private async _handleBuildTask(args: Record<string, unknown>): Promise<McpToolResult> {
         const result = await this._taskBuilder.build({
             plugin: args.plugin as string,
@@ -739,6 +818,12 @@ export class McpToolHandler {
         };
     }
 
+    /**
+     * Handles `generate_ansible_playbook` by composing multiple generated tasks.
+     *
+     * @param args - Tool args: `name`, `hosts`, and `tasks` (required), plus optional play options
+     * @returns Full playbook YAML and aggregated task warnings
+     */
     private async _handleGeneratePlaybook(args: Record<string, unknown>): Promise<McpToolResult> {
         const name = args.name as string;
         const hosts = args.hosts as string;
@@ -807,6 +892,11 @@ export class McpToolHandler {
 
     // === Execution Environment Handlers ===
 
+    /**
+     * Handles `list_execution_environments` from ansible-navigator image metadata.
+     *
+     * @returns Summary of discovered execution environment images
+     */
     private async _handleListEEs(): Promise<McpToolResult> {
         const service = ExecutionEnvService.getInstance();
 
@@ -852,6 +942,12 @@ export class McpToolHandler {
         }
     }
 
+    /**
+     * Handles `get_ee_details` with full package and collection inventory for one EE.
+     *
+     * @param args - Tool args: `ee_name` (required)
+     * @returns Detailed execution environment report or a not-found error
+     */
     private async _handleGetEEDetails(args: Record<string, unknown>): Promise<McpToolResult> {
         const eeName = args.ee_name as string;
         if (!eeName) {
@@ -944,6 +1040,11 @@ export class McpToolHandler {
 
     // === Dev Tools Handlers ===
 
+    /**
+     * Handles `list_ansible_dev_tools` by reporting installed ansible-dev-tools packages.
+     *
+     * @returns Installed dev-tool package names and versions
+     */
     private async _handleListDevTools(): Promise<McpToolResult> {
         const service = DevToolsService.getInstance();
 
@@ -978,6 +1079,11 @@ export class McpToolHandler {
 
     // === Creator Handlers ===
 
+    /**
+     * Handles `get_ansible_creator_schema` with a human-readable schema summary.
+     *
+     * @returns Formatted ansible-creator command tree or an availability error
+     */
     private async _handleGetCreatorSchema(): Promise<McpToolResult> {
         const service = CreatorService.getInstance();
 
@@ -1046,6 +1152,12 @@ export class McpToolHandler {
         };
     }
 
+    /**
+     * Handles `get_ansible_best_practices` from local cache or upstream documentation.
+     *
+     * @param args - Optional `section` key to return one document slice instead of the full guide
+     * @returns Best-practices markdown for the requested section
+     */
     private async _handleGetBestPractices(args: Record<string, unknown>): Promise<McpToolResult> {
         const section = (args.section as string | undefined) ?? 'full';
 
@@ -1110,8 +1222,11 @@ export class McpToolHandler {
     }
 
     /**
-     * Load the best practices document. Checks local cache paths first,
-     * then fetches from the canonical upstream URL and caches for next time.
+     * Loads the best practices document from local paths or the upstream URL.
+     *
+     * Checks bundled resources and a temp-file cache before fetching remotely.
+     *
+     * @returns Markdown document text, or undefined when no source is available
      */
     private async _loadBestPractices(): Promise<string | undefined> {
         const UPSTREAM_URL =

--- a/packages/mcp-server/src/pluginSearch.ts
+++ b/packages/mcp-server/src/pluginSearch.ts
@@ -15,17 +15,20 @@ export interface PluginSearchResult {
     shortDescription: string;
 }
 
+/** In-memory keyword search index over installed Ansible plugin documentation. */
 export class PluginSearchIndex {
     private static _instance: PluginSearchIndex | undefined;
     private _entries: PluginSearchResult[] = [];
     private _built = false;
     private _subscribed = false;
 
+    /** Creates the singleton index and subscribes to collection change events. */
     private constructor() {
         // Subscribe to CollectionsService changes
         this._subscribeToChanges();
     }
 
+    /** Marks the index stale when CollectionsService reports installed collections changed. */
     private _subscribeToChanges(): void {
         if (this._subscribed) {
             return;
@@ -69,15 +72,26 @@ export class PluginSearchIndex {
         }
     }
 
+    /**
+     * Returns the shared PluginSearchIndex singleton.
+     *
+     * @returns Lazily constructed PluginSearchIndex instance
+     */
     public static getInstance(): PluginSearchIndex {
         PluginSearchIndex._instance ??= new PluginSearchIndex();
         return PluginSearchIndex._instance;
     }
 
+    /**
+     * Whether the index has been populated from the current collection cache.
+     *
+     * @returns True when `rebuild()` has completed without a subsequent invalidation
+     */
     public isBuilt(): boolean {
         return this._built;
     }
 
+    /** Builds the index on first use without rebuilding when already current. */
     public async ensureBuilt(): Promise<void> {
         if (this._built) {
             return;
@@ -85,6 +99,7 @@ export class PluginSearchIndex {
         await this.rebuild();
     }
 
+    /** Rebuilds the search index from all plugins in CollectionsService. */
     public async rebuild(): Promise<void> {
         const service = CollectionsService.getInstance();
 
@@ -120,6 +135,16 @@ export class PluginSearchIndex {
         this._built = true;
     }
 
+    /**
+     * Searches indexed plugins by keyword relevance with optional filters.
+     *
+     * @param query - Free-text search terms matched against name, FQCN, and description
+     * @param options - Optional search filters
+     * @param options.pluginType - Restrict results to one Ansible plugin type
+     * @param options.collection - Substring filter on collection FQCN
+     * @param options.limit - Maximum number of results (capped at 50)
+     * @returns Ranked plugin matches, highest relevance first
+     */
     public search(
         query: string,
         options?: {
@@ -161,6 +186,12 @@ export class PluginSearchIndex {
         return results;
     }
 
+    /**
+     * Splits search text into lowercase terms for matching.
+     *
+     * @param text - Raw query string from the caller
+     * @returns Non-trivial tokens after splitting on whitespace and punctuation
+     */
     private _tokenize(text: string): string[] {
         return text
             .toLowerCase()
@@ -168,6 +199,13 @@ export class PluginSearchIndex {
             .filter((t) => t.length > 1);
     }
 
+    /**
+     * Scores how well a plugin entry matches the tokenized query.
+     *
+     * @param queryTerms - Lowercase search tokens
+     * @param entry - Plugin index entry to score
+     * @returns Relevance score; zero means no meaningful match
+     */
     private _scoreMatch(queryTerms: string[], entry: PluginSearchResult): number {
         let score = 0;
         const nameLower = entry.name.toLowerCase();
@@ -217,6 +255,11 @@ export class PluginSearchIndex {
         return score;
     }
 
+    /**
+     * Number of plugin entries currently held in the index.
+     *
+     * @returns Count of indexed plugins (zero before the first rebuild)
+     */
     public getCount(): number {
         return this._entries.length;
     }

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -198,6 +198,7 @@ process.on('SIGTERM', () => {
 });
 
 // Start the server
+/** Initializes services and connects the MCP server over stdio transport. */
 async function main() {
     console.error('[MCP Server] Starting Ansible Environments MCP server...');
 

--- a/packages/mcp-server/src/taskBuilder.ts
+++ b/packages/mcp-server/src/taskBuilder.ts
@@ -53,10 +53,17 @@ export interface TaskBuilderResult {
     message: string;
 }
 
+/** Stateful, multi-step Ansible task builder with guided parameter collection. */
 export class TaskBuilder {
     private _sessions = new Map<string, TaskBuilderSession>();
     private _sessionTimeout = 10 * 60 * 1000; // 10 minutes
 
+    /**
+     * Starts, continues, or completes an interactive task-building session.
+     *
+     * @param input - Session controls, plugin selection, parameters, and generate/cancel flags
+     * @returns Session progress, prompts for missing parameters, or generated YAML when complete
+     */
     async build(input: TaskBuilderInput): Promise<TaskBuilderResult> {
         // Clean up old sessions
         this._cleanupSessions();
@@ -150,6 +157,13 @@ export class TaskBuilder {
         return this._buildPrompt(session);
     }
 
+    /**
+     * Opens a new session by loading plugin documentation and required parameters.
+     *
+     * @param plugin - FQCN or short plugin name
+     * @param pluginType - Ansible plugin type (e.g. `module`)
+     * @returns Initialized session tracking collected and missing parameters
+     */
     private async _startSession(plugin: string, pluginType: string): Promise<TaskBuilderSession> {
         const service = CollectionsService.getInstance();
         const doc = await service.getPluginDocumentation(plugin, pluginType);
@@ -187,6 +201,12 @@ export class TaskBuilder {
         };
     }
 
+    /**
+     * Returns the plugin documentation body for a session.
+     *
+     * @param session - Active task builder session
+     * @returns Non-null plugin doc content from the cached PluginData
+     */
     private _getDocContent(session: TaskBuilderSession): NonNullable<PluginData['doc']> {
         const docContent = session.doc.doc;
         if (!docContent) {
@@ -195,6 +215,11 @@ export class TaskBuilder {
         return docContent;
     }
 
+    /**
+     * Recomputes which required parameters are still unset in the session.
+     *
+     * @param session - Session whose missing-required list should be refreshed
+     */
     private _updateMissingRequired(session: TaskBuilderSession): void {
         const options = this._getDocContent(session).options ?? {};
         session.missingRequired = session.requiredParams.filter((param) => {
@@ -209,6 +234,12 @@ export class TaskBuilder {
         });
     }
 
+    /**
+     * Builds an in-progress result with current state and user-facing prompts.
+     *
+     * @param session - Active session to summarize
+     * @returns TaskBuilderResult prompting for the next required or optional parameters
+     */
     private _buildPrompt(session: TaskBuilderSession): TaskBuilderResult {
         return {
             status: 'in_progress',
@@ -224,6 +255,13 @@ export class TaskBuilder {
         };
     }
 
+    /**
+     * Formats a markdown message describing collected, missing, and optional parameters.
+     *
+     * @param session - Active session to describe
+     * @param prefix - Optional leading message (e.g. when generation is blocked)
+     * @returns Human-readable prompt text for the MCP tool response
+     */
     private _buildPromptMessage(session: TaskBuilderSession, prefix?: string): string {
         const docContent = this._getDocContent(session);
         const options = docContent.options ?? {};
@@ -310,6 +348,12 @@ export class TaskBuilder {
         return lines.join('\n');
     }
 
+    /**
+     * Extracts a truncated parameter description for display in prompts.
+     *
+     * @param spec - Plugin option metadata from ansible-doc
+     * @returns First description line, trimmed to a readable length
+     */
     private _getShortDescription(spec?: PluginOption): string {
         if (!spec?.description) {
             return '';
@@ -318,6 +362,12 @@ export class TaskBuilder {
         return desc.length > 100 ? desc.substring(0, 97) + '...' : desc;
     }
 
+    /**
+     * Renders the collected session state as a single Ansible task YAML block.
+     *
+     * @param session - Completed session with all required parameters collected
+     * @returns YAML string for one Ansible task
+     */
     private _generateYaml(session: TaskBuilderSession): string {
         const lines: string[] = [];
         const pluginName = session.plugin.split('.').pop() ?? session.plugin;
@@ -360,6 +410,13 @@ export class TaskBuilder {
         return lines.join('\n');
     }
 
+    /**
+     * Converts a JavaScript value to a YAML-safe scalar or block representation.
+     *
+     * @param value - Parameter or task option value to serialize
+     * @param indent - Nesting depth for multiline block scalars
+     * @returns YAML fragment suitable for embedding in generated task output
+     */
     private _formatYamlValue(value: unknown, indent = 0): string {
         const prefix = '    '.repeat(indent);
 
@@ -417,10 +474,16 @@ export class TaskBuilder {
         return JSON.stringify(value);
     }
 
+    /**
+     * Creates a unique session identifier.
+     *
+     * @returns Opaque session ID prefixed with `task_`
+     */
     private _generateId(): string {
         return `task_${String(Date.now())}_${Math.random().toString(36).slice(2, 11)}`;
     }
 
+    /** Removes sessions that have exceeded the inactivity timeout. */
     private _cleanupSessions(): void {
         const now = Date.now();
         for (const [id, session] of this._sessions) {
@@ -430,6 +493,11 @@ export class TaskBuilder {
         }
     }
 
+    /**
+     * Number of task-building sessions currently held in memory.
+     *
+     * @returns Active session count before expired sessions are cleaned up
+     */
     getActiveSessionCount(): number {
         return this._sessions.size;
     }

--- a/packages/mcp-server/src/taskGenerator.ts
+++ b/packages/mcp-server/src/taskGenerator.ts
@@ -25,9 +25,16 @@ export interface TaskGeneratorResult {
     warnings: string[];
 }
 
+/** One-shot Ansible task and playbook YAML generator backed by plugin documentation. */
 export class TaskGenerator {
     private _docCache = new Map<string, PluginData>();
 
+    /**
+     * Generates a single Ansible task YAML block from plugin parameters.
+     *
+     * @param input - Plugin identity, module parameters, and task-level options
+     * @returns Generated YAML and any validation warnings
+     */
     async generate(input: TaskGeneratorInput): Promise<TaskGeneratorResult> {
         const pluginType = input.plugin_type ?? 'module';
         const warnings: string[] = [];
@@ -51,6 +58,18 @@ export class TaskGenerator {
         return { yaml, warnings };
     }
 
+    /**
+     * Assembles a multi-task playbook by generating each task individually.
+     *
+     * @param input - Play definition including hosts, tasks, and play-level options
+     * @param input.name - Playbook play name shown in the generated YAML
+     * @param input.hosts - Inventory host pattern for the play
+     * @param input.tasks - Task definitions passed to `generate()` for each entry
+     * @param input.become - When true, adds `become: true` at the play level
+     * @param input.vars - Optional play-level variables merged into the output
+     * @param input.gather_facts - When false, emits `gather_facts: false` on the play
+     * @returns Complete playbook YAML and aggregated warnings from each task
+     */
     async generatePlaybook(input: {
         name: string;
         hosts: string;
@@ -102,6 +121,13 @@ export class TaskGenerator {
         return { yaml: lines.join('\n'), warnings };
     }
 
+    /**
+     * Fetches plugin documentation, using an in-memory cache per plugin and type.
+     *
+     * @param plugin - FQCN or short plugin name
+     * @param pluginType - Ansible plugin type (e.g. `module`)
+     * @returns Cached or freshly loaded PluginData, or null when not found
+     */
     private async _getPluginDoc(plugin: string, pluginType: string): Promise<PluginData | null> {
         const cacheKey = `${plugin}:${pluginType}`;
 
@@ -120,6 +146,13 @@ export class TaskGenerator {
         return doc;
     }
 
+    /**
+     * Checks supplied parameters against documented plugin options.
+     *
+     * @param params - Caller-supplied module parameters
+     * @param options - Documented option specs from ansible-doc
+     * @returns Soft validation warnings (e.g. missing required parameters)
+     */
     private _validateParams(
         params: Record<string, unknown>,
         options: Record<string, PluginOption>,
@@ -150,6 +183,13 @@ export class TaskGenerator {
         return { warnings };
     }
 
+    /**
+     * Builds the YAML lines for one Ansible task from input and plugin metadata.
+     *
+     * @param input - Task generator input including parameters and task options
+     * @param doc - Plugin documentation used for default task naming
+     * @returns Single-task YAML string
+     */
     private _buildYaml(input: TaskGeneratorInput, doc: PluginData): string {
         const lines: string[] = [];
 
@@ -208,6 +248,13 @@ export class TaskGenerator {
         return lines.join('\n');
     }
 
+    /**
+     * Derives a human-readable task name from plugin docs or the module name.
+     *
+     * @param plugin - FQCN or short plugin name
+     * @param doc - Plugin documentation for short_description fallback
+     * @returns Title-cased task name suitable for the `name` field
+     */
     private _generateTaskName(plugin: string, doc: PluginData): string {
         if (doc.doc?.short_description) {
             const desc = doc.doc.short_description;
@@ -221,6 +268,12 @@ export class TaskGenerator {
             .join(' ');
     }
 
+    /**
+     * Serializes a value as a YAML scalar or compact JSON representation.
+     *
+     * @param value - Arbitrary parameter or task option value
+     * @returns YAML-safe string for inline task output
+     */
     private _formatValue(value: unknown): string {
         if (value === null || value === undefined) {
             return 'null';
@@ -266,6 +319,12 @@ export class TaskGenerator {
         return JSON.stringify(value);
     }
 
+    /**
+     * Quotes or block-formats a string when YAML syntax requires it.
+     *
+     * @param value - Raw string parameter value
+     * @returns Unquoted, quoted, or block-scalar YAML representation
+     */
     private _formatString(value: string): string {
         if (
             value === '' ||
@@ -291,6 +350,13 @@ export class TaskGenerator {
         return value;
     }
 
+    /**
+     * Renders a nested object as indented YAML mapping lines.
+     *
+     * @param obj - Object-valued module parameter
+     * @param indent - Current YAML indentation level
+     * @returns Lines to append under the parent key
+     */
     private _formatObject(obj: Record<string, unknown>, indent: number): string[] {
         const lines: string[] = [];
         const prefix = '  '.repeat(indent);
@@ -307,6 +373,13 @@ export class TaskGenerator {
         return lines;
     }
 
+    /**
+     * Renders one list element as YAML list-item lines.
+     *
+     * @param item - Object or scalar list entry
+     * @param indent - Current YAML indentation level
+     * @returns Lines representing a single `-` list item and nested keys
+     */
     private _formatListItem(item: unknown, indent: number): string[] {
         const lines: string[] = [];
         const prefix = '  '.repeat(indent);
@@ -329,6 +402,7 @@ export class TaskGenerator {
         return lines;
     }
 
+    /** Clears cached plugin documentation so the next lookup refetches from CollectionsService. */
     clearCache(): void {
         this._docCache.clear();
     }

--- a/packages/mcp-server/test/pluginSearch.test.ts
+++ b/packages/mcp-server/test/pluginSearch.test.ts
@@ -26,6 +26,10 @@ vi.mock('@ansible/core', () => ({
     },
 }));
 
+/**
+ * Builds a sample collection map with ansible.builtin plugins for search tests.
+ * @returns A map of collection names to collection metadata and plugin types.
+ */
 function makeCollectionMap(): Map<
     string,
     {

--- a/packages/mcp-server/test/taskBuilder.test.ts
+++ b/packages/mcp-server/test/taskBuilder.test.ts
@@ -13,6 +13,11 @@ vi.mock('@ansible/core', () => ({
 import { TaskBuilder } from '../src/taskBuilder';
 import type { TaskBuilderResult } from '../src/taskBuilder';
 
+/**
+ * Asserts that a TaskBuilder result includes a session ID and returns it.
+ * @param result - TaskBuilder response to validate.
+ * @returns The session ID from the result.
+ */
 function requireSessionId(result: TaskBuilderResult): string {
     if (!result.session_id) {
         throw new Error('expected session_id');
@@ -20,6 +25,10 @@ function requireSessionId(result: TaskBuilderResult): string {
     return result.session_id;
 }
 
+/**
+ * Returns mock ansible.builtin.copy plugin documentation for TaskBuilder tests.
+ * @returns Mock plugin documentation with copy module options.
+ */
 function copyPluginDoc() {
     return {
         doc: {

--- a/packages/mcp-server/test/taskGenerator.test.ts
+++ b/packages/mcp-server/test/taskGenerator.test.ts
@@ -12,6 +12,10 @@ vi.mock('@ansible/core', () => ({
 
 import { TaskGenerator } from '../src/taskGenerator';
 
+/**
+ * Returns mock ansible.builtin.copy plugin documentation for TaskGenerator tests.
+ * @returns Mock plugin documentation with copy module options.
+ */
 function copyPluginDoc() {
     return {
         doc: {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -59,6 +59,11 @@ let _logFilePath: string | undefined;
 let _logStream: fs.WriteStream | undefined;
 const _LOG_MAX_SIZE = 512 * 1024; // 512 KB — rotate when exceeded
 
+/**
+ * Ensure the extension log file exists and rotate it when oversized.
+ * @param context - Extension context providing the log directory URI
+ * @returns Absolute path to the active extension log file
+ */
 function _ensureLogFile(context: vscode.ExtensionContext): string {
     if (_logFilePath) {
         return _logFilePath;
@@ -82,10 +87,19 @@ function _ensureLogFile(context: vscode.ExtensionContext): string {
     return _logFilePath;
 }
 
+/**
+ * Convert an unknown thrown value into a log-safe error message.
+ * @param error - Error object or value to stringify
+ * @returns Human-readable error message text
+ */
 function formatError(error: unknown): string {
     return error instanceof Error ? error.message : String(error);
 }
 
+/**
+ * Write a timestamped message to the output channel and log file.
+ * @param message - Log message to record
+ */
 export function log(message: string) {
     const timestamp = new Date().toISOString();
     const line = `[${timestamp}] ${message}`;
@@ -93,7 +107,10 @@ export function log(message: string) {
     _logStream?.write(line + '\n');
 }
 
-/** Path to the current log file (available after activation). */
+/**
+ * Path to the current log file (available after activation).
+ * @returns Absolute log file path, or undefined before activation
+ */
 export function getLogFilePath(): string | undefined {
     return _logFilePath;
 }
@@ -102,6 +119,7 @@ export function getLogFilePath(): string | undefined {
  * Open the AI chat with a prompt pre-filled.
  * Uses the configured chat provider (vscode or openllm).
  * Falls back to clipboard if the command doesn't support the query parameter.
+ * @param prompt - Prompt text to send to the configured chat provider
  */
 async function openChatWithPrompt(prompt: string): Promise<void> {
     const config = vscode.workspace.getConfiguration('ansibleEnvironments');
@@ -154,6 +172,10 @@ async function openChatWithPrompt(prompt: string): Promise<void> {
     }
 }
 
+/**
+ * Activate the Ansible Environments extension and register providers and commands.
+ * @param context - VS Code extension activation context
+ */
 export function activate(context: vscode.ExtensionContext) {
     // Initialize file-based logging (before anything else so all messages are captured)
     const logFile = _ensureLogFile(context);
@@ -1234,6 +1256,7 @@ Please:
     );
 }
 
+/** Shut down extension logging resources on deactivation. */
 export function deactivate(): void {
     _logStream?.end();
     outputChannel.dispose();

--- a/src/features/ansibleCfg.ts
+++ b/src/features/ansibleCfg.ts
@@ -10,11 +10,21 @@ export interface VaultConfig {
     vaultPasswordFile: string | undefined;
 }
 
+/**
+ * Expand a leading tilde in a path to the current user's home directory.
+ * @param p - Path that may start with `~`
+ * @returns The path with `~` replaced by the home directory when present
+ */
 function untildify(p: string): string {
     const home = os.homedir();
     return home ? p.replace(/^~(?=$|\/|\\)/, home) : p;
 }
 
+/**
+ * Read vault-related settings from an ansible.cfg file when it exists and is readable.
+ * @param cfgPath - Path to the ansible.cfg file to parse
+ * @returns Parsed vault configuration, or undefined when unavailable or empty
+ */
 async function readCfg(cfgPath: string): Promise<VaultConfig | undefined> {
     const resolved = untildify(cfgPath);
     try {
@@ -52,6 +62,8 @@ async function readCfg(cfgPath: string): Promise<VaultConfig | undefined> {
  *   3. ansible.cfg in the workspace/project root
  *   4. ~/.ansible.cfg
  *   5. /etc/ansible/ansible.cfg
+ * @param workspaceRoot - Optional workspace root used to locate project ansible.cfg
+ * @returns The first matching vault configuration, or undefined when none is found
  */
 export async function getVaultConfig(workspaceRoot?: string): Promise<VaultConfig | undefined> {
     if (process.env.ANSIBLE_VAULT_IDENTITY_LIST) {
@@ -84,6 +96,8 @@ export async function getVaultConfig(workspaceRoot?: string): Promise<VaultConfi
 /**
  * Parse the vault_identity_list into individual identity labels.
  * Format: "id1@script1, id2@script2"
+ * @param identityList - Raw vault_identity_list value from ansible.cfg
+ * @returns Vault identity labels with script paths removed
  */
 export function parseVaultIdentities(identityList: string): string[] {
     return identityList
@@ -96,6 +110,9 @@ export function parseVaultIdentities(identityList: string): string[] {
  * Walk up from a document's directory looking for ansible.cfg, stopping at
  * the workspace root. Returns the directory containing ansible.cfg, or the
  * workspace root if none is found.
+ * @param documentDir - Directory containing the active document
+ * @param workspaceRoot - Workspace boundary to stop searching at
+ * @returns The project root directory, or undefined when no boundary is available
  */
 export function findProjectRoot(
     documentDir: string,

--- a/src/features/fileAssociation.ts
+++ b/src/features/fileAssociation.ts
@@ -7,6 +7,11 @@ import {
 
 const SUPPORTED_LANGUAGES = new Set(['ansible', 'yaml']);
 
+/**
+ * Apply a modeline language directive from the document when one is present.
+ * @param doc - Document whose modeline should be evaluated
+ * @returns True when a modeline was found, even if the language is unsupported
+ */
 async function applyModeline(doc: vscode.TextDocument): Promise<boolean> {
     const lang = searchModelineLanguage(doc.getText());
     if (!lang) {
@@ -26,6 +31,10 @@ async function applyModeline(doc: vscode.TextDocument): Promise<boolean> {
     return true;
 }
 
+/**
+ * Set the document language to ansible when YAML content looks like a playbook.
+ * @param doc - Document to inspect for playbook-shaped YAML
+ */
 async function applyKeywordInspection(doc: vscode.TextDocument): Promise<void> {
     if (doc.isUntitled) {
         return;
@@ -45,6 +54,10 @@ async function applyKeywordInspection(doc: vscode.TextDocument): Promise<void> {
     }
 }
 
+/**
+ * Determine the appropriate language for a document using modeline and heuristics.
+ * @param doc - Document to classify on open or save
+ */
 async function inspectDocument(doc: vscode.TextDocument): Promise<void> {
     if (doc.isUntitled) {
         return;
@@ -58,6 +71,7 @@ async function inspectDocument(doc: vscode.TextDocument): Promise<void> {
 /**
  * Register file-association heuristics that dynamically set a document's
  * language to "ansible" based on modeline comments or playbook-shaped content.
+ * @param context - Extension context used to register workspace listeners
  */
 export function registerFileAssociation(context: vscode.ExtensionContext): void {
     context.subscriptions.push(

--- a/src/features/fileDetection.ts
+++ b/src/features/fileDetection.ts
@@ -10,6 +10,8 @@ const ANSIBLE_TOP_LEVEL_KEYS = ['hosts', 'import_playbook', 'ansible.builtin.imp
 /**
  * Parse a VS Code-style modeline (e.g. `# code: language=ansible`) and return
  * the language value, or undefined if no valid language directive is found.
+ * @param line - A single line that may contain a modeline directive
+ * @returns The language identifier, or undefined when absent or invalid
  */
 export function parseModelineLanguage(line: string): string | undefined {
     const match = MODELINE_REGEX.exec(line);
@@ -34,6 +36,8 @@ export function parseModelineLanguage(line: string): string | undefined {
 /**
  * Search the first and last N lines of a document for a modeline language
  * directive. Returns the language string if found, undefined otherwise.
+ * @param text - Full document text to scan for modeline directives
+ * @returns The language from the first matching modeline, or undefined
  */
 export function searchModelineLanguage(text: string): string | undefined {
     const lines = text.split(/\n/g);
@@ -59,6 +63,8 @@ export function searchModelineLanguage(text: string): string | undefined {
  * Inspect a YAML document's content to determine if it looks like an Ansible
  * playbook. Returns true when the top-level structure is an array and the
  * first element contains a recognized Ansible key (hosts, import_playbook, etc.).
+ * @param text - YAML document content to inspect
+ * @returns True when the structure matches a typical Ansible playbook
  */
 export function looksLikePlaybook(text: string): boolean {
     try {
@@ -81,6 +87,8 @@ export function looksLikePlaybook(text: string): boolean {
 
 /**
  * Returns true if the given file extension (without dot) is a YAML extension.
+ * @param ext - File extension without the leading dot
+ * @returns True for `yaml` or `yml` extensions
  */
 export function isYamlExtension(ext: string | undefined): boolean {
     return ext === 'yaml' || ext === 'yml';

--- a/src/features/vault.ts
+++ b/src/features/vault.ts
@@ -11,6 +11,10 @@ import { getVaultConfig, parseVaultIdentities, findProjectRoot } from '@src/feat
 // FIFO-based password passing — password never touches disk
 // ---------------------------------------------------------------------------
 
+/**
+ * Build a unique FIFO path in the system temp directory for vault passwords.
+ * @returns Absolute path to a temporary named pipe file
+ */
 function fifoPath(): string {
     return path.join(os.tmpdir(), `ansible-vault-pw-${crypto.randomBytes(8).toString('hex')}`);
 }
@@ -20,6 +24,8 @@ function fifoPath(): string {
  * The write completes once ansible-vault opens the FIFO for reading,
  * so the caller must spawn ansible-vault after calling this.
  * The password only exists in memory (kernel pipe buffer) — never on disk.
+ * @param password - Vault password to write into the FIFO
+ * @returns FIFO path and a cleanup function that removes the pipe file
  */
 function createPasswordFifo(password: string): {
     fifo: string;
@@ -50,6 +56,11 @@ function createPasswordFifo(password: string): {
 // Password resolution
 // ---------------------------------------------------------------------------
 
+/**
+ * Resolve ansible-vault password arguments from config or user input.
+ * @param projectRoot - Project root used to locate ansible.cfg settings
+ * @returns CLI password arguments, or undefined when resolution is cancelled
+ */
 async function resolvePasswordArgs(projectRoot: string | undefined): Promise<string[] | undefined> {
     const cfg = await getVaultConfig(projectRoot);
 
@@ -100,6 +111,10 @@ interface PasswordArgs extends Array<string> {
     __cleanup?: () => void;
 }
 
+/**
+ * Remove any temporary FIFO created for inline password passing.
+ * @param args - Password arguments that may carry an attached cleanup callback
+ */
 function cleanupArgs(args: string[] | undefined): void {
     if (args) {
         (args as PasswordArgs).__cleanup?.();
@@ -110,6 +125,13 @@ function cleanupArgs(args: string[] | undefined): void {
 // Spawn helper — runs ansible-vault with stdin piping
 // ---------------------------------------------------------------------------
 
+/**
+ * Spawn ansible-vault and capture stdout for inline encrypt/decrypt operations.
+ * @param args - ansible-vault CLI arguments excluding the executable path
+ * @param stdin - Optional stdin payload for encrypt_string or decrypt operations
+ * @param cwd - Working directory for the child process
+ * @returns Command stdout on success
+ */
 async function spawnVault(
     args: string[],
     stdin: string | undefined,
@@ -164,15 +186,30 @@ async function spawnVault(
 // Encrypt / decrypt helpers
 // ---------------------------------------------------------------------------
 
+/**
+ * Detect whether selected inline YAML text is ansible-vault encrypted.
+ * @param text - Selected editor text that may include a `!vault |` prefix
+ * @returns True when the selection contains an inline vault payload
+ */
 function isEncryptedInline(text: string): boolean {
     const stripped = text.replace('!vault |', '').trim();
     return stripped.startsWith('$ANSIBLE_VAULT;');
 }
 
+/**
+ * Detect whether a whole file begins with an ansible-vault header.
+ * @param text - Full document text to inspect
+ * @returns True when the file starts with `$ANSIBLE_VAULT;`
+ */
 function isEncryptedFile(text: string): boolean {
     return text.startsWith('$ANSIBLE_VAULT;');
 }
 
+/**
+ * Remove the `!vault |` prefix and normalize whitespace from inline vault text.
+ * @param text - Inline vault selection from the editor
+ * @returns Vault ciphertext suitable for ansible-vault decrypt stdin
+ */
 function stripInlineVaultPrefix(text: string): string {
     return text
         .replace('!vault |', '')
@@ -222,6 +259,14 @@ export async function toggleVaultEncrypt(): Promise<void> {
     }
 }
 
+/**
+ * Encrypt or decrypt the current editor selection as inline vault content.
+ * @param editor - Active text editor containing the selection
+ * @param selection - Selected range to encrypt or decrypt
+ * @param text - Selected text content
+ * @param passwordArgs - Resolved ansible-vault password arguments
+ * @param cwd - Working directory passed to ansible-vault
+ */
 async function handleInline(
     editor: vscode.TextEditor,
     selection: vscode.Selection,
@@ -262,6 +307,12 @@ async function handleInline(
     }
 }
 
+/**
+ * Encrypt or decrypt the entire active file using ansible-vault file commands.
+ * @param doc - Document to encrypt or decrypt on disk
+ * @param passwordArgs - Resolved ansible-vault password arguments
+ * @param cwd - Working directory passed to ansible-vault
+ */
 async function handleFile(
     doc: vscode.TextDocument,
     passwordArgs: string[],
@@ -287,6 +338,12 @@ async function handleFile(
 // Indentation / multiline helpers
 // ---------------------------------------------------------------------------
 
+/**
+ * Compute the YAML indentation level at the start of the selection.
+ * @param editor - Active text editor used to read tab size and line text
+ * @param selection - Selection whose starting line determines indentation
+ * @returns Indentation level measured in tab stops
+ */
 function getIndentLevel(editor: vscode.TextEditor, selection: vscode.Selection): number {
     const tabSize = Number(editor.options.tabSize) || 2;
     const line = editor.document.lineAt(selection.start.line).text;
@@ -294,6 +351,13 @@ function getIndentLevel(editor: vscode.TextEditor, selection: vscode.Selection):
     return Math.floor(leading / tabSize);
 }
 
+/**
+ * Normalize multiline YAML block content before encrypt_string processing.
+ * @param text - Selected plaintext or block scalar content
+ * @param indentLevel - Current YAML indentation level in tab stops
+ * @param tabSize - Editor tab size used to compute leading spaces
+ * @returns Text prepared for ansible-vault encrypt_string stdin
+ */
 function prepareForEncrypt(text: string, indentLevel: number, tabSize: number): string {
     const lines = text.replace(/\r\n/g, '\n').split('\n');
     if (lines.length <= 1) {
@@ -321,6 +385,12 @@ function prepareForEncrypt(text: string, indentLevel: number, tabSize: number): 
     return applyChomp(joined, chomp);
 }
 
+/**
+ * Apply YAML block chomping indicators to encrypted block scalar content.
+ * @param text - Block body text after indentation normalization
+ * @param chomp - Chomping indicator from the original block scalar header
+ * @returns Text with trailing newlines adjusted for the chomp style
+ */
 function applyChomp(text: string, chomp: string): string {
     if (chomp === '-') {
         return text.replace(/\n*$/, '');
@@ -331,6 +401,13 @@ function applyChomp(text: string, chomp: string): string {
     return text.replace(/\n*$/, '\n');
 }
 
+/**
+ * Re-wrap decrypted plaintext as an indented YAML literal block scalar.
+ * @param text - Decrypted plaintext returned by ansible-vault
+ * @param indentLevel - YAML indentation level where the block should be inserted
+ * @param tabSize - Editor tab size used to compute leading spaces
+ * @returns YAML literal block scalar with appropriate chomping indicator
+ */
 function reindentDecrypted(text: string, indentLevel: number, tabSize: number): string {
     const lines = text.split('\n');
     if (lines.length <= 1) {
@@ -360,6 +437,7 @@ function reindentDecrypted(text: string, indentLevel: number, tabSize: number): 
 
 /**
  * Register the vault toggle command.
+ * @param context - Extension context used to register the command
  */
 export function registerVaultCommand(context: vscode.ExtensionContext): void {
     context.subscriptions.push(

--- a/src/mcp/cursorConfig.ts
+++ b/src/mcp/cursorConfig.ts
@@ -5,6 +5,10 @@ import * as os from 'os';
 
 let _outputChannel: vscode.OutputChannel | undefined;
 
+/**
+ * Append a timestamped message to the Ansible Environments output channel.
+ * @param message - Log message to record
+ */
 function log(message: string): void {
     _outputChannel ??= vscode.window.createOutputChannel('Ansible Environments');
     _outputChannel.appendLine(`[${new Date().toISOString()}] ${message}`);
@@ -30,6 +34,10 @@ interface CursorNamespace {
     mcp?: CursorMcpApi;
 }
 
+/**
+ * Return Cursor's MCP registration API when running inside Cursor.
+ * @returns Cursor MCP API object, or undefined when unavailable
+ */
 function getCursorMcpApi(): CursorMcpApi | undefined {
     const cursor = (vscode as any).cursor as CursorNamespace | undefined;
     if (cursor?.mcp && typeof cursor.mcp.registerServer === 'function') {
@@ -46,6 +54,8 @@ function getCursorMcpApi(): CursorMcpApi | undefined {
  * Register the MCP server via Cursor's extension API.
  * The server is immediately available and enabled -- no config files,
  * no manual toggle needed.
+ * @param serverPath - Absolute path to the MCP server entry script
+ * @returns True when registration succeeds through the Cursor API
  */
 function registerViaCursorApi(serverPath: string): boolean {
     const api = getCursorMcpApi();
@@ -83,6 +93,8 @@ function registerViaCursorApi(serverPath: string): boolean {
  * Automatically register the MCP server when running in Cursor.
  * Called during extension activation, mirrors registerMcpServerProvider()
  * for VS Code.
+ * @param context - Extension context used to resolve the MCP server path
+ * @returns True when the server was registered successfully
  */
 export function registerCursorMcpServer(context: vscode.ExtensionContext): boolean {
     const serverPath = context.asAbsolutePath(
@@ -114,6 +126,7 @@ interface McpConfig {
 /**
  * Write the MCP server entry to a Cursor mcp.json file.
  * Used as a fallback when the Cursor extension API is unavailable.
+ * @param context - Extension context used to resolve the MCP server path
  */
 async function configureViaMcpJson(context: vscode.ExtensionContext): Promise<void> {
     const serverPath = context.asAbsolutePath(
@@ -242,6 +255,7 @@ async function configureViaMcpJson(context: vscode.ExtensionContext): Promise<vo
 /**
  * Configure Cursor to use the Ansible Environments MCP server.
  * Tries the Cursor extension API first; falls back to mcp.json.
+ * @param context - Extension context used to resolve the MCP server path
  */
 export async function configureCursorMcp(context: vscode.ExtensionContext): Promise<void> {
     const serverPath = context.asAbsolutePath(
@@ -267,6 +281,9 @@ export async function configureCursorMcp(context: vscode.ExtensionContext): Prom
 // Settings helper
 // -------------------------------------------------------------------------
 
+/**
+ * Open Cursor MCP settings, falling back to guidance when the command is unavailable.
+ */
 async function openCursorMcpSettings(): Promise<void> {
     try {
         await vscode.commands.executeCommand('workbench.action.openSettings', 'mcp');
@@ -281,6 +298,11 @@ async function openCursorMcpSettings(): Promise<void> {
 // Status
 // -------------------------------------------------------------------------
 
+/**
+ * Escape user-controlled text before embedding it in webview HTML.
+ * @param text - Raw text that may contain HTML metacharacters
+ * @returns HTML-safe text for status panel rendering
+ */
 function escapeHtml(text: string): string {
     return text
         .replace(/&/g, '&amp;')
@@ -292,6 +314,7 @@ function escapeHtml(text: string): string {
 
 /**
  * Show the current Cursor MCP configuration status
+ * @param context - Extension context used to resolve the MCP server path
  */
 export function showCursorMcpStatus(context: vscode.ExtensionContext): void {
     const serverPath = context.asAbsolutePath(
@@ -399,6 +422,10 @@ export function showCursorMcpStatus(context: vscode.ExtensionContext): void {
 
 export type IdeType = 'cursor' | 'vscode' | 'unknown';
 
+/**
+ * Detect whether the extension is running in Cursor, VS Code, or another host.
+ * @returns Identified IDE type based on the application name
+ */
 export function detectIde(): IdeType {
     const appName = vscode.env.appName.toLowerCase();
     if (appName.includes('cursor')) {
@@ -420,6 +447,11 @@ export interface McpStatus {
     isConfigured: boolean;
 }
 
+/**
+ * Summarize MCP availability and configuration for the current IDE.
+ * @param context - Extension context used to resolve the MCP server path
+ * @returns Status flags for IDE type, APIs, config files, and server presence
+ */
 export function getMcpStatus(context: vscode.ExtensionContext): McpStatus {
     const serverPath = context.asAbsolutePath(
         path.join('packages', 'mcp-server', 'out', 'server.js'),

--- a/src/mcp/vscodeProvider.ts
+++ b/src/mcp/vscodeProvider.ts
@@ -76,6 +76,7 @@ export function registerMcpServerProvider(context: vscode.ExtensionContext): voi
 
 /**
  * Check if VS Code MCP is available
+ * @returns True when the MCP server definition provider API is present
  */
 export function isMcpAvailable(): boolean {
     /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access -- VS Code MCP API is not yet stable/typed */

--- a/src/panels/CreatorFormPanel.ts
+++ b/src/panels/CreatorFormPanel.ts
@@ -28,6 +28,7 @@ interface CreatorFormMessage {
     theme?: string;
 }
 
+/** Webview panel that renders an ansible-creator command form from schema metadata. */
 export class CreatorFormPanel {
     public static currentPanel: CreatorFormPanel | undefined;
     private readonly _panel: vscode.WebviewPanel;
@@ -36,6 +37,12 @@ export class CreatorFormPanel {
     private readonly _schema: SchemaNode;
     private _disposables: vscode.Disposable[] = [];
 
+    /**
+     * Show or replace the creator form panel for a schema command.
+     * @param extensionUri - Extension root used for webview resources
+     * @param commandPath - ansible-creator command path segments
+     * @param schema - Schema definition used to build the form
+     */
     public static show(extensionUri: vscode.Uri, commandPath: string[], schema: SchemaNode): void {
         const column = vscode.ViewColumn.One;
 
@@ -59,6 +66,13 @@ export class CreatorFormPanel {
         );
     }
 
+    /**
+     * Create the creator form panel and wire webview message handlers.
+     * @param panel - Webview panel hosting the creator form
+     * @param extensionUri - Extension root used for webview resources
+     * @param commandPath - ansible-creator command path segments
+     * @param schema - Schema definition used to build the form
+     */
     private constructor(
         panel: vscode.WebviewPanel,
         extensionUri: vscode.Uri,
@@ -114,6 +128,10 @@ export class CreatorFormPanel {
         );
     }
 
+    /**
+     * Build and run the ansible-creator command from submitted form values.
+     * @param values - Form field values keyed by schema parameter name
+     */
     private async _executeCommand(values: Record<string, unknown>): Promise<void> {
         try {
             // Build the command
@@ -143,6 +161,11 @@ export class CreatorFormPanel {
         }
     }
 
+    /**
+     * Convert form values into ansible-creator CLI arguments.
+     * @param values - Form field values keyed by schema parameter name
+     * @returns Shell-ready argument string for ansible-creator
+     */
     private _buildCommandArgs(values: Record<string, unknown>): string {
         const args: string[] = [];
         const properties = this._schema.parameters?.properties ?? {};
@@ -185,6 +208,11 @@ export class CreatorFormPanel {
         return args.join(' ');
     }
 
+    /**
+     * Convert a form value into a CLI-safe string representation.
+     * @param value - Form value of any supported schema type
+     * @returns String value suitable for command-line arguments
+     */
     private _valueToString(value: unknown): string {
         if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
             return String(value);
@@ -192,6 +220,11 @@ export class CreatorFormPanel {
         return JSON.stringify(value);
     }
 
+    /**
+     * Quote argument values that contain shell-sensitive characters.
+     * @param value - Argument value to escape when needed
+     * @returns Quoted or unchanged argument text
+     */
     private _quoteIfNeeded(value: string): string {
         if (value.includes(' ') || value.includes('"') || value.includes("'")) {
             return `"${value.replace(/"/g, '\\"')}"`;
@@ -199,6 +232,10 @@ export class CreatorFormPanel {
         return value;
     }
 
+    /**
+     * Generate the creator form webview HTML and client-side script.
+     * @returns Complete HTML document rendered in the webview
+     */
     private _getHtml(): string {
         const schemaJson = JSON.stringify(this._schema);
         const commandPathJson = JSON.stringify(this._commandPath);
@@ -814,6 +851,7 @@ export class CreatorFormPanel {
 </html>`;
     }
 
+    /** Dispose the panel, listeners, and static current-panel reference. */
     public dispose(): void {
         CreatorFormPanel.currentPanel = undefined;
         this._panel.dispose();

--- a/src/panels/PlaybookConfigPanel.ts
+++ b/src/panels/PlaybookConfigPanel.ts
@@ -10,6 +10,7 @@ interface PlaybookConfigMessage {
     theme?: string;
 }
 
+/** Webview panel for editing global or per-playbook ansible-playbook settings. */
 export class PlaybookConfigPanel {
     public static currentPanel: PlaybookConfigPanel | undefined;
     private readonly _panel: vscode.WebviewPanel;
@@ -18,6 +19,11 @@ export class PlaybookConfigPanel {
     private readonly _isGlobal: boolean;
     private _disposables: vscode.Disposable[] = [];
 
+    /**
+     * Show or replace the playbook configuration panel.
+     * @param extensionUri - Extension root used for webview resources
+     * @param playbook - Playbook to configure, or undefined for global defaults
+     */
     public static show(extensionUri: vscode.Uri, playbook?: PlaybookInfo): void {
         const isGlobal = !playbook;
         const title = isGlobal ? 'Playbook Defaults' : `Config: ${playbook.name}`;
@@ -46,6 +52,13 @@ export class PlaybookConfigPanel {
         );
     }
 
+    /**
+     * Create the playbook configuration panel and wire webview message handlers.
+     * @param panel - Webview panel hosting the configuration form
+     * @param extensionUri - Extension root used for webview resources
+     * @param playbook - Playbook being configured, if not editing global defaults
+     * @param isGlobal - Whether the panel edits workspace-wide defaults
+     */
     private constructor(
         panel: vscode.WebviewPanel,
         extensionUri: vscode.Uri,
@@ -130,6 +143,10 @@ export class PlaybookConfigPanel {
         );
     }
 
+    /**
+     * Build and run ansible-playbook with the submitted configuration.
+     * @param config - Playbook run settings from the webview form
+     */
     private async _runPlaybook(config: PlaybookConfig): Promise<void> {
         try {
             const service = PlaybooksService.getInstance();
@@ -152,6 +169,10 @@ export class PlaybookConfigPanel {
         }
     }
 
+    /**
+     * Generate the playbook configuration webview HTML and client-side script.
+     * @returns Complete HTML document rendered in the webview
+     */
     private _getHtml(): string {
         const service = PlaybooksService.getInstance();
         const config = this._isGlobal
@@ -796,6 +817,7 @@ export class PlaybookConfigPanel {
 </html>`;
     }
 
+    /** Dispose the panel, listeners, and static current-panel reference. */
     public dispose(): void {
         PlaybookConfigPanel.currentPanel = undefined;
         this._panel.dispose();

--- a/src/panels/PlaybookProgressPanel.ts
+++ b/src/panels/PlaybookProgressPanel.ts
@@ -43,6 +43,7 @@ interface PlaybookProgressMessage {
     path?: string;
 }
 
+/** Webview panel that streams ansible-playbook execution progress over a local socket. */
 export class PlaybookProgressPanel {
     private static _currentPanel: PlaybookProgressPanel | undefined;
 
@@ -55,6 +56,12 @@ export class PlaybookProgressPanel {
     private _isRunning = false;
     private _terminal: vscode.Terminal | undefined;
 
+    /**
+     * Show or reuse the playbook progress panel and start a new run.
+     * @param extensionUri - Extension root used for webview resources
+     * @param options - Playbook path, command, and workspace metadata
+     * @returns The active progress panel instance
+     */
     public static async show(
         extensionUri: vscode.Uri,
         options: PlaybookRunOptions,
@@ -84,6 +91,11 @@ export class PlaybookProgressPanel {
         return progressPanel;
     }
 
+    /**
+     * Create the progress panel and register webview message handlers.
+     * @param panel - Webview panel hosting the progress UI
+     * @param extensionUri - Extension root used for webview resources
+     */
     private constructor(panel: vscode.WebviewPanel, extensionUri: vscode.Uri) {
         this._panel = panel;
         this._extensionUri = extensionUri;
@@ -143,6 +155,10 @@ export class PlaybookProgressPanel {
         this._updateHtml();
     }
 
+    /**
+     * Start a playbook run and stream callback events into the webview.
+     * @param options - Playbook path, command, and workspace metadata
+     */
     private async _startRun(options: PlaybookRunOptions): Promise<void> {
         this._events = [];
         this._isRunning = true;
@@ -194,6 +210,9 @@ export class PlaybookProgressPanel {
         );
     }
 
+    /**
+     * Create a Unix domain socket server for ansible callback plugin events.
+     */
     private async _createSocketServer(): Promise<void> {
         // Clean up existing server
         if (this._socketServer) {
@@ -256,6 +275,10 @@ export class PlaybookProgressPanel {
         });
     }
 
+    /**
+     * Record a progress event and forward it to the webview.
+     * @param event - Parsed callback event from the socket server
+     */
     private _handleEvent(event: ProgressEvent): void {
         this._events.push(event);
 
@@ -271,6 +294,7 @@ export class PlaybookProgressPanel {
         });
     }
 
+    /** Re-render the progress webview using the current theme settings. */
     private _updateHtml(): void {
         const config = vscode.workspace.getConfiguration('ansibleEnvironments');
         const themeSetting = config.get<string>('pluginDocTheme', 'auto');
@@ -284,6 +308,11 @@ export class PlaybookProgressPanel {
         this._panel.webview.html = this._getHtml(resolvedTheme);
     }
 
+    /**
+     * Generate the playbook progress webview HTML and client-side script.
+     * @param theme - Resolved light or dark theme for the webview
+     * @returns Complete HTML document rendered in the webview
+     */
     private _getHtml(theme: string): string {
         const isDark = theme === 'dark';
 
@@ -1651,6 +1680,10 @@ export class PlaybookProgressPanel {
 </html>`;
     }
 
+    /**
+     * Open the task source file at the reported line number.
+     * @param taskPath - Source path in `file.yml:line` format
+     */
     private async _openSource(taskPath: string): Promise<void> {
         // taskPath is in format "file.yml:line"
         const match = /^(.+):(\d+)$/.exec(taskPath);
@@ -1669,6 +1702,10 @@ export class PlaybookProgressPanel {
         }
     }
 
+    /**
+     * Build and send an AI analysis prompt for a task result.
+     * @param data - Task execution details captured from the progress UI
+     */
     private async _generateAiPrompt(data: AiAnalyzeData): Promise<void> {
         const { taskName, module, host, status, args, result, path: taskPath } = data;
 
@@ -1727,6 +1764,7 @@ ${JSON.stringify(cleanResult, null, 2)}
         }
     }
 
+    /** Dispose the panel, socket server, and static current-panel reference. */
     public dispose(): void {
         PlaybookProgressPanel._currentPanel = undefined;
 

--- a/src/panels/PluginDocPanel.ts
+++ b/src/panels/PluginDocPanel.ts
@@ -9,6 +9,11 @@ interface PluginDocMessage {
     theme?: string;
 }
 
+/**
+ * Normalize documentation fields that may be a string or string array.
+ * @param value - Single value or list from plugin documentation metadata
+ * @returns Array form of the value, or an empty array when absent
+ */
 function toArray(value: string | string[] | undefined): string[] {
     if (!value) {
         return [];
@@ -19,6 +24,7 @@ function toArray(value: string | string[] | undefined): string[] {
     return [value];
 }
 
+/** Webview panel that renders Ansible plugin documentation with interactive samples. */
 export class PluginDocPanel {
     private static _panels = new Map<string, PluginDocPanel>();
     public static readonly viewType = 'pluginDocPanel';
@@ -28,6 +34,12 @@ export class PluginDocPanel {
     private readonly _pluginKey: string;
     private _disposables: vscode.Disposable[] = [];
 
+    /**
+     * Show or reveal plugin documentation for the requested plugin.
+     * @param extensionUri - Extension root used for webview resources
+     * @param pluginFullName - Fully qualified plugin name
+     * @param pluginType - Plugin type such as module or lookup
+     */
     public static async show(extensionUri: vscode.Uri, pluginFullName: string, pluginType: string) {
         const pluginKey = `${pluginFullName}:${pluginType}`;
 
@@ -55,6 +67,12 @@ export class PluginDocPanel {
         await docPanel._loadPluginDoc(pluginFullName, pluginType);
     }
 
+    /**
+     * Create the plugin documentation panel and wire webview message handlers.
+     * @param panel - Webview panel hosting the documentation view
+     * @param extensionUri - Extension root used for webview resources
+     * @param pluginKey - Stable key used to track open documentation panels
+     */
     private constructor(panel: vscode.WebviewPanel, extensionUri: vscode.Uri, pluginKey: string) {
         this._panel = panel;
         this._extensionUri = extensionUri;
@@ -108,6 +126,11 @@ export class PluginDocPanel {
         );
     }
 
+    /**
+     * Load plugin documentation from the collections cache and render the panel.
+     * @param pluginFullName - Fully qualified plugin name
+     * @param pluginType - Plugin type such as module or lookup
+     */
     private async _loadPluginDoc(pluginFullName: string, pluginType: string) {
         this._panel.webview.html = this._getLoadingHtml();
 
@@ -150,6 +173,10 @@ export class PluginDocPanel {
         }
     }
 
+    /**
+     * Generate the loading placeholder HTML for the documentation webview.
+     * @returns Minimal HTML shown while documentation is loading
+     */
     private _getLoadingHtml(): string {
         return `<!DOCTYPE html>
 <html lang="en">
@@ -193,6 +220,11 @@ export class PluginDocPanel {
 </html>`;
     }
 
+    /**
+     * Generate an error page for the documentation webview.
+     * @param message - Error text to display to the user
+     * @returns HTML error page rendered in the webview
+     */
     private _getErrorHtml(message: string): string {
         return `<!DOCTYPE html>
 <html lang="en">
@@ -215,6 +247,17 @@ export class PluginDocPanel {
 </html>`;
     }
 
+    /**
+     * Generate the full plugin documentation webview HTML.
+     * @param pluginFullName - Fully qualified plugin name
+     * @param pluginType - Plugin type such as module or lookup
+     * @param data - Cached plugin documentation payload
+     * @param initialZoom - Initial zoom percentage for the webview
+     * @param themeSetting - Saved theme preference including auto mode
+     * @param resolvedTheme - Resolved light or dark theme for rendering
+     * @param enableAiFeatures - Whether AI helper actions should be shown
+     * @returns Complete HTML document rendered in the webview
+     */
     private _getDocHtml(
         pluginFullName: string,
         pluginType: string,
@@ -1132,6 +1175,12 @@ export class PluginDocPanel {
 </html>`;
     }
 
+    /**
+     * Render plugin parameter documentation as nested HTML.
+     * @param options - Parameter schema map for the plugin
+     * @param depth - Current nesting depth for suboptions
+     * @returns HTML fragment for the parameter tree
+     */
     private _renderParameters(options: Record<string, PluginOption>, depth = 0): string {
         if (Object.keys(options).length === 0) {
             return '<p style="color: var(--text-dim);">No parameters</p>';
@@ -1148,6 +1197,13 @@ export class PluginDocPanel {
         return `<div class="suboptions" id="sub-${String(Date.now())}-${Math.random().toString(36).substring(2, 11)}">${items}</div>`;
     }
 
+    /**
+     * Render a single parameter item and its nested suboptions.
+     * @param name - Parameter name
+     * @param opt - Parameter schema metadata
+     * @param depth - Current nesting depth for suboptions
+     * @returns HTML fragment for one parameter row
+     */
     private _renderParamItem(name: string, opt: PluginOption, depth: number): string {
         const typeStr = opt.type ?? 'str';
         const elementsStr = opt.elements ? `/${opt.elements}` : '';
@@ -1179,6 +1235,12 @@ export class PluginDocPanel {
         </div>`;
     }
 
+    /**
+     * Render parameter choices or default values beneath a parameter header.
+     * @param opt - Parameter schema metadata
+     * @param depth - Current nesting depth used for indentation
+     * @returns HTML fragment for choices and defaults
+     */
     private _renderChoicesDefaults(opt: PluginOption, depth = 0): string {
         let html = '';
         const marginLeft = depth > 0 ? '' : 'margin-left: 22px;';
@@ -1199,6 +1261,11 @@ export class PluginDocPanel {
         return html;
     }
 
+    /**
+     * Render documented return values for the plugin.
+     * @param returnVals - Return value schema map from plugin documentation
+     * @returns HTML fragment for the return values section
+     */
     private _renderReturnValues(returnVals: PluginReturn): string {
         const entries = Object.entries(returnVals);
         if (entries.length === 0) {
@@ -1221,6 +1288,11 @@ export class PluginDocPanel {
         </div>`;
     }
 
+    /**
+     * Render plugin examples as structured sections with copy buttons.
+     * @param examples - Raw examples text from plugin documentation
+     * @returns HTML fragment for the examples section
+     */
     private _renderExamples(examples: string): string {
         // Parse examples into sections based on the pattern
         const sections = this._parseExamples(examples);
@@ -1283,6 +1355,11 @@ ${this._escapeHtml(section.afterState)}</div>`;
             .join('');
     }
 
+    /**
+     * Parse raw example text into titled task sections and context blocks.
+     * @param examples - Raw examples text from plugin documentation
+     * @returns Parsed example sections used by the examples renderer
+     */
     private _parseExamples(examples: string): {
         title: string;
         beforeState?: string;
@@ -1431,6 +1508,11 @@ ${this._escapeHtml(section.afterState)}</div>`;
         return sections;
     }
 
+    /**
+     * Convert example or task titles into title case for display.
+     * @param text - Raw title text from plugin documentation
+     * @returns Title-cased display text
+     */
     private _capitalizeTitle(text: string): string {
         if (!text) {
             return text;
@@ -1442,6 +1524,12 @@ ${this._escapeHtml(section.afterState)}</div>`;
             .join(' ');
     }
 
+    /**
+     * Render the interactive sample task builder with comment mode toggles.
+     * @param pluginFullName - Fully qualified plugin name
+     * @param options - Parameter schema map for the plugin
+     * @returns HTML fragment for the sample task section
+     */
     private _renderSampleTask(
         pluginFullName: string,
         options: Record<string, PluginOption>,
@@ -1481,6 +1569,11 @@ ${this._escapeHtml(section.afterState)}</div>`;
         </div>`;
     }
 
+    /**
+     * Escape text for safe use inside HTML attribute values.
+     * @param text - Raw text to embed in a data attribute
+     * @returns HTML-escaped attribute-safe text
+     */
     private _escapeAttr(text: string): string {
         return text
             .replace(/'/g, '&#39;')
@@ -1489,6 +1582,13 @@ ${this._escapeHtml(section.afterState)}</div>`;
             .replace(/>/g, '&gt;');
     }
 
+    /**
+     * Generate sample task YAML for the requested comment mode.
+     * @param pluginFullName - Fully qualified plugin name
+     * @param options - Parameter schema map for the plugin
+     * @param commentMode - Comment style to apply to generated YAML
+     * @returns Sample task YAML text
+     */
     private _generateSampleYaml(
         pluginFullName: string,
         options: Record<string, PluginOption>,
@@ -1517,6 +1617,15 @@ ${this._escapeHtml(section.afterState)}</div>`;
         return lines.join('\n');
     }
 
+    /**
+     * Append one parameter and its suboptions to generated sample YAML lines.
+     * @param lines - Accumulated YAML lines for the sample task
+     * @param name - Parameter name
+     * @param opt - Parameter schema metadata
+     * @param indent - Current indentation level in spaces
+     * @param isFirstInList - Whether this parameter starts a YAML list item
+     * @param commentMode - Comment style to apply to generated YAML
+     */
     private _addParamToYaml(
         lines: string[],
         name: string,
@@ -1586,6 +1695,12 @@ ${this._escapeHtml(section.afterState)}</div>`;
         }
     }
 
+    /**
+     * Choose a representative example value for a parameter.
+     * @param name - Parameter name
+     * @param opt - Parameter schema metadata
+     * @returns Example YAML value text for the parameter
+     */
     private _getExampleValue(name: string, opt: PluginOption): string {
         // If there's a default, use it
         if (opt.default !== undefined && opt.default !== null) {
@@ -1624,6 +1739,12 @@ ${this._escapeHtml(section.afterState)}</div>`;
         }
     }
 
+    /**
+     * Choose an example list element value for a list-typed parameter.
+     * @param name - Parameter name
+     * @param opt - Parameter schema metadata
+     * @returns Example YAML list item value
+     */
     private _getElementValue(name: string, opt: PluginOption): string {
         if (opt.elements) {
             switch (opt.elements) {
@@ -1644,6 +1765,11 @@ ${this._escapeHtml(section.afterState)}</div>`;
         return `"${name}_item"`;
     }
 
+    /**
+     * Generate a contextual string example based on common parameter names.
+     * @param name - Parameter name used to infer a realistic example
+     * @returns Quoted example string for the parameter
+     */
     private _getContextualExample(name: string): string {
         // Provide contextual examples based on common parameter names
         const lowerName = name.toLowerCase();
@@ -1735,6 +1861,11 @@ ${this._escapeHtml(section.afterState)}</div>`;
         return `"${name}_value"`;
     }
 
+    /**
+     * Format a JavaScript value as YAML literal text.
+     * @param value - Value to render into sample YAML
+     * @returns YAML-safe literal representation
+     */
     private _formatYamlValue(value: unknown): string {
         if (value === null || value === undefined) {
             return 'null';
@@ -1781,6 +1912,11 @@ ${this._escapeHtml(section.afterState)}</div>`;
         return JSON.stringify(value);
     }
 
+    /**
+     * Apply lightweight syntax highlighting to YAML example text.
+     * @param yaml - YAML text to highlight
+     * @returns HTML with span-wrapped YAML tokens
+     */
     private _highlightYaml(yaml: string): string {
         const lines = yaml.split('\n');
         return lines
@@ -1887,6 +2023,11 @@ ${this._escapeHtml(section.afterState)}</div>`;
             .join('\n');
     }
 
+    /**
+     * Highlight inline YAML comments, including structured parameter comments.
+     * @param comment - Comment text including leading spaces and `#`
+     * @returns HTML with styled comment spans
+     */
     private _highlightComment(comment: string): string {
         // Check for structured comment: # (type, required/optional) description
         const structuredMatch = /^( {2}# \()([^,]+)(, )(required|optional)(\) )(.*)$/.exec(comment);
@@ -1907,6 +2048,11 @@ ${this._escapeHtml(section.afterState)}</div>`;
         return `<span class="yaml-comment-dim">${this._escapeHtml(comment)}</span>`;
     }
 
+    /**
+     * Convert ansible-doc text markup into HTML for parameter descriptions.
+     * @param text - Raw documentation text with ansible-doc formatting
+     * @returns HTML-safe formatted description text
+     */
     private _formatText(text: string): string {
         // Convert Ansible doc formatting to HTML
         let html = this._escapeHtml(text);
@@ -1927,6 +2073,11 @@ ${this._escapeHtml(section.afterState)}</div>`;
         return html;
     }
 
+    /**
+     * Escape raw text for safe embedding in generated HTML.
+     * @param text - Raw text that may contain HTML metacharacters
+     * @returns HTML-safe text
+     */
     private _escapeHtml(text: string): string {
         return text
             .replace(/&/g, '&amp;')
@@ -1936,6 +2087,7 @@ ${this._escapeHtml(section.afterState)}</div>`;
             .replace(/'/g, '&#039;');
     }
 
+    /** Dispose the panel, listeners, and cached panel registry entry. */
     public dispose() {
         PluginDocPanel._panels.delete(this._pluginKey);
         this._panel.dispose();

--- a/src/panels/webviewStyles.ts
+++ b/src/panels/webviewStyles.ts
@@ -314,6 +314,7 @@ export const BADGE_STYLES = `
 
 /**
  * Get all common styles combined
+ * @returns Concatenated CSS for shared webview panel styling
  */
 export function getCommonStyles(): string {
     return `
@@ -332,6 +333,7 @@ export function getCommonStyles(): string {
 
 /**
  * Generate zoom/theme control HTML
+ * @returns HTML markup for zoom and theme toggle buttons
  */
 export function getZoomThemeControls(): string {
     return `
@@ -346,6 +348,7 @@ export function getZoomThemeControls(): string {
 /**
  * Generate zoom/theme control JavaScript
  * @param settingsKey - Unique key for storing settings (e.g., 'pluginDoc', 'creatorForm')
+ * @returns Inline script that persists zoom and theme preferences in localStorage
  */
 export function getZoomThemeScript(settingsKey: string): string {
     return `
@@ -427,6 +430,7 @@ export const THEME_OVERRIDE_STYLES = `
 
 /**
  * Get complete styles including theme overrides
+ * @returns Shared webview styles plus manual light/dark theme overrides
  */
 export function getFullStyles(): string {
     return getCommonStyles() + THEME_OVERRIDE_STYLES;
@@ -557,6 +561,7 @@ export const AGENT_PROGRESS_STYLES = `
  * Generate Agent Progress Panel HTML
  * @param title - Title for the progress panel
  * @param showLoading - Whether to show the panel initially
+ * @returns HTML for the agent progress overlay and log panel
  */
 export function getAgentProgressHtml(title: string, showLoading: boolean): string {
     return `
@@ -578,6 +583,7 @@ export function getAgentProgressHtml(title: string, showLoading: boolean): strin
  * Handles 'agentProgress' messages from extension
  * @param completionTitle - Title to show when complete
  * @param autoHideDelay - Delay in ms before auto-hiding (0 to disable)
+ * @returns Inline script that renders agent progress log entries
  */
 export function getAgentProgressScript(completionTitle: string, autoHideDelay = 2000): string {
     return `
@@ -644,6 +650,9 @@ export function getAgentProgressScript(completionTitle: string, autoHideDelay = 
 /**
  * Format log message for agent progress
  * Returns "SYMBOL message" where SYMBOL is a Unicode icon
+ * @param message - Raw progress message from the agent
+ * @param type - Progress entry type such as tool_call or error
+ * @returns A compact, icon-prefixed message for the progress log
  */
 export function formatAgentLogMessage(message: string, type: string): string {
     // Unicode symbols that work well in monospace fonts

--- a/src/services/LlmService.ts
+++ b/src/services/LlmService.ts
@@ -55,12 +55,14 @@ export class LlmService {
     private _lastModelCheck = 0;
     private readonly MODEL_CACHE_TTL = 60000; // 1 minute
 
+    /** Private constructor for the singleton LLM service. */
     private constructor() {
         /* singleton */
     }
 
     /**
      * Get singleton instance
+     * @returns Shared LlmService instance
      */
     public static getInstance(): LlmService {
         LlmService._instance ??= new LlmService();
@@ -73,6 +75,7 @@ export class LlmService {
 
     /**
      * Get all available models grouped by vendor
+     * @returns Models grouped by provider vendor name
      */
     public async getAvailableModels(): Promise<Map<string, LlmModelInfo[]>> {
         if (typeof vscode.lm.selectChatModels !== 'function') {
@@ -104,6 +107,7 @@ export class LlmService {
 
     /**
      * Get list of available providers (vendors)
+     * @returns Sorted list of available LLM provider names
      */
     public async getAvailableProviders(): Promise<string[]> {
         const grouped = await this.getAvailableModels();
@@ -117,6 +121,7 @@ export class LlmService {
     /**
      * Show quick pick to select LLM provider and model
      * Saves selection to settings
+     * @returns True when the user saved a provider or model selection
      */
     public async showModelPicker(): Promise<boolean> {
         if (typeof vscode.lm.selectChatModels !== 'function') {
@@ -304,6 +309,7 @@ export class LlmService {
 
     /**
      * Show current LLM configuration status
+     * @returns Promise that resolves after the status webview is shown
      */
     public async showStatus(): Promise<void> {
         const config = vscode.workspace.getConfiguration('ansibleEnvironments');
@@ -403,6 +409,7 @@ export class LlmService {
      * 3. Claude Opus 4.5 from any provider
      * 4. Any Claude model
      * 5. First available model
+     * @returns Selected language model, or undefined when none is available
      */
     public async selectModel(): Promise<vscode.LanguageModelChat | undefined> {
         // Return cached model if still valid
@@ -503,6 +510,9 @@ export class LlmService {
 
     /**
      * Find model by legacy preferredLlmModel setting
+     * @param models - Available language models from VS Code
+     * @param legacyId - Legacy preferred model identifier from settings
+     * @returns Matching model, or undefined when no legacy match exists
      */
     private _findModelByLegacyId(
         models: vscode.LanguageModelChat[],
@@ -627,6 +637,11 @@ export class LlmService {
 
     /**
      * Generate content with iteration and validation
+     * @param prompt - Initial generation prompt
+     * @param validator - Async validator that reports whether content is acceptable
+     * @param maxIterations - Maximum number of correction attempts
+     * @param options - Additional LLM request options
+     * @returns Final validated response or the last failed attempt
      */
     public async generateWithValidation(
         prompt: string,
@@ -698,6 +713,8 @@ Generate the corrected version:`;
 
     /**
      * Extract JSON from a response that may contain markdown or other text
+     * @param content - Raw LLM response text
+     * @returns Parsed JSON string when found, or null when extraction fails
      */
     private _extractJson(content: string): string | null {
         // Try to find JSON in code blocks
@@ -727,6 +744,8 @@ Generate the corrected version:`;
 
     /**
      * Sleep helper for backoff
+     * @param ms - Delay duration in milliseconds
+     * @returns Promise that resolves after the delay elapses
      */
     private _sleep(ms: number): Promise<void> {
         return new Promise((resolve) => setTimeout(resolve, ms));
@@ -743,6 +762,7 @@ Generate the corrected version:`;
 
     /**
      * Check if LLM is available
+     * @returns True when a language model can be selected
      */
     public async isAvailable(): Promise<boolean> {
         const model = await this.selectModel();
@@ -751,6 +771,7 @@ Generate the corrected version:`;
 
     /**
      * Get current model info for display
+     * @returns Human-readable provider and model name
      */
     public async getCurrentModelInfo(): Promise<string> {
         const model = await this.selectModel();
@@ -763,6 +784,7 @@ Generate the corrected version:`;
 
 /**
  * Get the singleton LlmService instance
+ * @returns Shared LlmService instance
  */
 export function getLlmService(): LlmService {
     return LlmService.getInstance();

--- a/src/services/PlaybooksService.ts
+++ b/src/services/PlaybooksService.ts
@@ -71,6 +71,7 @@ const CACHE_DIR = '.cache/ansible-environments';
 const GLOBAL_CONFIG_FILE = 'playbook-defaults.json';
 const PLAYBOOKS_CONFIG_DIR = 'playbooks';
 
+/** Service for discovering workspace playbooks and managing run configuration. */
 export class PlaybooksService {
     private static _instance: PlaybooksService | undefined;
     private _playbooks = new Map<string, PlaybookInfo>();
@@ -80,33 +81,56 @@ export class PlaybooksService {
     private readonly _onDidChange = new vscode.EventEmitter<void>();
     public readonly onDidChange = this._onDidChange.event;
 
+    /** Private constructor for the singleton playbooks service. */
     private constructor() {
         /* singleton */
     }
 
+    /**
+     * Return the shared playbooks service instance.
+     * @returns Singleton PlaybooksService instance
+     */
     public static getInstance(): PlaybooksService {
         PlaybooksService._instance ??= new PlaybooksService();
         return PlaybooksService._instance;
     }
 
+    /**
+     * Whether a playbook discovery pass is currently running.
+     * @returns True while discovery is in progress
+     */
     public isLoading(): boolean {
         return this._loading;
     }
 
+    /**
+     * Whether at least one discovery pass has completed.
+     * @returns True after the first successful refresh
+     */
     public isLoaded(): boolean {
         return this._loaded;
     }
 
+    /**
+     * Return discovered playbooks sorted by relative path.
+     * @returns Playbook metadata for all discovered files
+     */
     public getPlaybooks(): PlaybookInfo[] {
         return Array.from(this._playbooks.values()).sort((a, b) =>
             a.relativePath.localeCompare(b.relativePath),
         );
     }
 
+    /**
+     * Look up a single playbook by its workspace-relative path.
+     * @param relativePath - Workspace-relative path of the playbook
+     * @returns The playbook info, or undefined if not found
+     */
     public getPlaybook(relativePath: string): PlaybookInfo | undefined {
         return this._playbooks.get(relativePath);
     }
 
+    /** Scan workspace folders for playbooks and refresh the cache. */
     public async refresh(): Promise<void> {
         if (this._loading) {
             return;
@@ -129,6 +153,7 @@ export class PlaybooksService {
         }
     }
 
+    /** Walk workspace folders to find Ansible playbook files and populate the cache. */
     private async _discoverPlaybooks(): Promise<void> {
         const workspaceFolders = vscode.workspace.workspaceFolders;
         if (!workspaceFolders || workspaceFolders.length === 0) {
@@ -174,6 +199,11 @@ export class PlaybooksService {
         }
     }
 
+    /**
+     * Parse playbook YAML content into play summaries.
+     * @param content - Raw playbook file content
+     * @returns Parsed plays with names, hosts, and line numbers
+     */
     private _parsePlaybook(content: string): PlaybookPlay[] {
         const plays: PlaybookPlay[] = [];
         const lines = content.split('\n');
@@ -264,6 +294,10 @@ export class PlaybooksService {
     }
 
     // Configuration management
+    /**
+     * Resolve the workspace cache directory for playbook configuration files.
+     * @returns Cache directory path, or null when no workspace is open
+     */
     private _getConfigDir(): string | null {
         const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
         if (!workspaceRoot) {
@@ -272,6 +306,7 @@ export class PlaybooksService {
         return path.join(workspaceRoot, CACHE_DIR);
     }
 
+    /** Ensure playbook configuration directories exist under the workspace cache. */
     private _ensureConfigDir(): void {
         const configDir = this._getConfigDir();
         if (!configDir) {
@@ -284,6 +319,10 @@ export class PlaybooksService {
         }
     }
 
+    /**
+     * Load workspace-wide default ansible-playbook settings.
+     * @returns Global playbook configuration merged with defaults
+     */
     public getGlobalConfig(): PlaybookConfig {
         const configDir = this._getConfigDir();
         if (!configDir) {
@@ -307,6 +346,10 @@ export class PlaybooksService {
         return { ...DEFAULT_CONFIG };
     }
 
+    /**
+     * Persist workspace-wide default ansible-playbook settings.
+     * @param config - Global playbook configuration to save
+     */
     public saveGlobalConfig(config: PlaybookConfig): void {
         this._ensureConfigDir();
         const configDir = this._getConfigDir();
@@ -325,6 +368,11 @@ export class PlaybooksService {
         }
     }
 
+    /**
+     * Load per-playbook settings merged over global defaults.
+     * @param relativePath - Workspace-relative or multi-root display path
+     * @returns Effective playbook configuration for the requested file
+     */
     public getPlaybookConfig(relativePath: string): PlaybookConfig {
         const globalConfig = this.getGlobalConfig();
         const configDir = this._getConfigDir();
@@ -350,6 +398,11 @@ export class PlaybooksService {
         return globalConfig;
     }
 
+    /**
+     * Persist per-playbook settings under the workspace cache directory.
+     * @param relativePath - Workspace-relative or multi-root display path
+     * @param config - Playbook-specific configuration to save
+     */
     public savePlaybookConfig(relativePath: string, config: PlaybookConfig): void {
         this._ensureConfigDir();
         const configDir = this._getConfigDir();
@@ -375,12 +428,24 @@ export class PlaybooksService {
         }
     }
 
+    /**
+     * Map a playbook path to its cached JSON configuration file path.
+     * @param configDir - Workspace cache directory root
+     * @param relativePath - Workspace-relative or multi-root display path
+     * @returns Absolute path to the playbook config JSON file
+     */
     private _getPlaybookConfigPath(configDir: string, relativePath: string): string {
         // Preserve directory hierarchy: deploy/app.yml → playbooks/deploy/app.json
         const configRelPath = relativePath.replace(/\.ya?ml$/, '') + '.json';
         return path.join(configDir, PLAYBOOKS_CONFIG_DIR, configRelPath);
     }
 
+    /**
+     * Build an ansible-playbook shell command from saved configuration.
+     * @param playbookPath - Playbook file path passed to ansible-playbook
+     * @param config - Effective playbook run settings
+     * @returns Shell-ready ansible-playbook command string
+     */
     public buildCommand(playbookPath: string, config: PlaybookConfig): string {
         const args: string[] = ['ansible-playbook'];
 
@@ -512,6 +577,11 @@ export class PlaybooksService {
         return args.join(' ');
     }
 
+    /**
+     * Build an AI analysis prompt for a discovered playbook.
+     * @param playbook - Playbook metadata discovered in the workspace
+     * @returns Prompt text suitable for chat injection
+     */
     public generateAiPrompt(playbook: PlaybookInfo): string {
         return `Please analyze the Ansible playbook at "${playbook.relativePath}" and provide a comprehensive summary.
 

--- a/src/services/PythonEnvironmentService.ts
+++ b/src/services/PythonEnvironmentService.ts
@@ -29,10 +29,16 @@ const PYTHON_ENVS_EXTENSION_ID = 'ms-python.vscode-python-envs';
 const PYTHON_EXT_ID = 'ms-python.python';
 const READY_TIMEOUT_MS = 5000;
 
+/**
+ * Convert an unknown thrown value into a log-safe error message.
+ * @param error - Error object or value to stringify
+ * @returns Human-readable error message text
+ */
 function formatError(error: unknown): string {
     return error instanceof Error ? error.message : String(error);
 }
 
+/** Centralized wrapper around Python environment extension APIs with fallbacks. */
 export class PythonEnvironmentService implements vscode.Disposable {
     private static _instance: PythonEnvironmentService | undefined;
     private _pythonEnvApi: PythonEnvironmentApi | undefined;
@@ -45,10 +51,15 @@ export class PythonEnvironmentService implements vscode.Disposable {
     private _onDidChangeEnvironment = new vscode.EventEmitter<DidChangeEnvironmentEventArgs>();
     public readonly onDidChangeEnvironment = this._onDidChangeEnvironment.event;
 
+    /** Private constructor for the singleton Python environment service. */
     private constructor() {
         /* singleton */
     }
 
+    /**
+     * Return the shared Python environment service instance.
+     * @returns Singleton PythonEnvironmentService instance
+     */
     public static getInstance(): PythonEnvironmentService {
         PythonEnvironmentService._instance ??= new PythonEnvironmentService();
         return PythonEnvironmentService._instance;
@@ -61,6 +72,7 @@ export class PythonEnvironmentService implements vscode.Disposable {
      * createEnvironment / managePackages work regardless of PET. If PET is
      * missing, ms-python.python is also initialized for environment discovery
      * (hybrid mode).
+     * @returns True when at least one Python environment API is available
      */
     public async initialize(): Promise<boolean> {
         if (this._initPromise) {
@@ -70,6 +82,10 @@ export class PythonEnvironmentService implements vscode.Disposable {
         return this._initPromise;
     }
 
+    /**
+     * Resolve and initialize the best available Python environment API.
+     * @returns True when at least one backend was successfully initialized
+     */
     private async _doInitialize(): Promise<boolean> {
         log(`Looking for Python Environments extension: ${PYTHON_ENVS_EXTENSION_ID}`);
 
@@ -98,6 +114,11 @@ export class PythonEnvironmentService implements vscode.Disposable {
     // PET detection
     // -------------------------------------------------------------------------
 
+    /**
+     * Check whether the Python Environment Tools binary is installed.
+     * @param extensionPath - Installed Python Environments extension path
+     * @returns True when the PET binary exists for the current platform
+     */
     private _isPetAvailable(extensionPath: string): boolean {
         const binary = process.platform === 'win32' ? 'pet.exe' : 'pet';
         const petPath = path.join(extensionPath, 'python-env-tools', 'bin', binary);
@@ -110,6 +131,10 @@ export class PythonEnvironmentService implements vscode.Disposable {
     // Primary: ms-python.vscode-python-envs
     // -------------------------------------------------------------------------
 
+    /**
+     * Initialize from the primary ms-python.vscode-python-envs extension.
+     * @param ext - The VS Code extension instance for Python Environments
+     */
     private async _initFromEnvsExtension(
         ext: vscode.Extension<PythonEnvironmentApi>,
     ): Promise<void> {
@@ -145,6 +170,7 @@ export class PythonEnvironmentService implements vscode.Disposable {
     // Fallback: ms-python.python
     // -------------------------------------------------------------------------
 
+    /** Initialize from the fallback ms-python.python extension. */
     private async _initFromPythonExtension(): Promise<void> {
         try {
             const pythonExt = vscode.extensions.getExtension(PYTHON_EXT_ID);
@@ -188,6 +214,11 @@ export class PythonEnvironmentService implements vscode.Disposable {
     // Adapter: map ms-python.python's ResolvedEnvironment → PythonEnvironment
     // -------------------------------------------------------------------------
 
+    /**
+     * Map a ms-python.python ResolvedEnvironment to the PythonEnvironment interface.
+     * @param resolved - Resolved environment from the Python extension
+     * @returns Normalized PythonEnvironment with display metadata
+     */
     private _adaptResolvedEnvironment(resolved: ResolvedEnvironment): PythonEnvironment {
         const rawPath = resolved.executable.uri?.fsPath ?? '';
         const isVirtualEnv = !!resolved.environment?.folderUri;
@@ -235,6 +266,8 @@ export class PythonEnvironmentService implements vscode.Disposable {
      * Shorten an executable path for display. Keeps the last three
      * segments (e.g. "/home/user/.pyenv/versions/3.9.7/bin/python"
      * → "3.9.7/bin/python"). Returns the full path when already short.
+     * @param fullPath - Absolute path to the Python executable
+     * @returns Shortened display path
      */
     private _shortenPath(fullPath: string): string {
         const segments = fullPath.split(path.sep).filter(Boolean);
@@ -250,6 +283,7 @@ export class PythonEnvironmentService implements vscode.Disposable {
 
     private static readonly _CHANGE_DEBOUNCE_MS = 1500;
 
+    /** Coalesce rapid environment change events into a single notification. */
     private _fireChangeDebounced(): void {
         if (this._changeDebounce) {
             clearTimeout(this._changeDebounce);
@@ -264,6 +298,10 @@ export class PythonEnvironmentService implements vscode.Disposable {
     // Public API
     // -------------------------------------------------------------------------
 
+    /**
+     * Whether any Python environment API backend is available.
+     * @returns True if at least one backend was initialized
+     */
     public isAvailable(): boolean {
         return this._pythonEnvApi !== undefined || this._pythonExtApi !== undefined;
     }
@@ -271,6 +309,7 @@ export class PythonEnvironmentService implements vscode.Disposable {
     /**
      * Whether the full Environments extension API is active with PET
      * working. When true, environment discovery is fast and complete.
+     * @returns True when PET-backed discovery is active
      */
     public hasFullApi(): boolean {
         return this._pythonEnvApi !== undefined && this._petAvailable;
@@ -279,6 +318,7 @@ export class PythonEnvironmentService implements vscode.Disposable {
     /**
      * Whether environment creation and package management are available
      * (envs extension active, PET not required for these operations).
+     * @returns True when the Environments extension API is available
      */
     public hasEnvsExtension(): boolean {
         return this._pythonEnvApi !== undefined;
@@ -287,11 +327,17 @@ export class PythonEnvironmentService implements vscode.Disposable {
     /**
      * Get the raw PythonEnvironmentApi. Returns undefined when only the
      * fallback is active or no Python extension is available.
+     * @returns The raw API, or undefined when unavailable
      */
     public getApi(): PythonEnvironmentApi | undefined {
         return this._pythonEnvApi;
     }
 
+    /**
+     * Resolve the active Python environment for a workspace scope.
+     * @param scope - Workspace URI to query, defaults to first workspace folder
+     * @returns The active environment, or undefined if none is configured
+     */
     public async getEnvironment(
         scope?: GetEnvironmentScope,
     ): Promise<PythonEnvironment | undefined> {
@@ -331,6 +377,11 @@ export class PythonEnvironmentService implements vscode.Disposable {
         return undefined;
     }
 
+    /**
+     * List all discovered Python environments, deduplicated by executable path.
+     * @param scope - Filter scope: a workspace URI, 'all', or 'global'
+     * @returns Array of discovered Python environments
+     */
     public async getEnvironments(
         scope: vscode.Uri | 'all' | 'global' = 'all',
     ): Promise<PythonEnvironment[]> {
@@ -385,6 +436,8 @@ export class PythonEnvironmentService implements vscode.Disposable {
 
     /**
      * Resolve symlinks to a canonical path. Returns the original path on error.
+     * @param p - File system path to resolve
+     * @returns Canonical path with symlinks resolved
      */
     private _realPath(p: string): string {
         try {
@@ -394,11 +447,21 @@ export class PythonEnvironmentService implements vscode.Disposable {
         }
     }
 
+    /**
+     * Get the Python executable path for a workspace scope.
+     * @param scope - Workspace URI to query
+     * @returns Absolute path to the Python binary, or undefined
+     */
     public async getExecutablePath(scope?: GetEnvironmentScope): Promise<string | undefined> {
         const env = await this.getEnvironment(scope);
         return env?.execInfo.run.executable;
     }
 
+    /**
+     * Switch the active Python environment for a workspace scope.
+     * @param scope - Workspace URI or scope to update
+     * @param environment - Environment to activate, or undefined to open the picker
+     */
     public async setEnvironment(
         scope: SetEnvironmentScope,
         environment?: PythonEnvironment,
@@ -446,6 +509,12 @@ export class PythonEnvironmentService implements vscode.Disposable {
         log('setEnvironment: no API available to set environment');
     }
 
+    /**
+     * Create a new Python virtual environment via the Environments extension.
+     * @param scope - Workspace URI(s) or 'global' for the environment location
+     * @param options - Creation options (manager, packages, etc.)
+     * @returns The newly created environment, or undefined if creation was cancelled
+     */
     public async createEnvironment(
         scope: vscode.Uri | vscode.Uri[] | 'global',
         options?: CreateEnvironmentOptions,
@@ -459,6 +528,12 @@ export class PythonEnvironmentService implements vscode.Disposable {
         return this._pythonEnvApi.createEnvironment(scope, options);
     }
 
+    /**
+     * Install or uninstall packages in a Python environment.
+     * @param environment - Target environment for package operations
+     * @param options - Package management options (install, uninstall, etc.)
+     * @returns Resolves when the package operation completes
+     */
     public async managePackages(
         environment: PythonEnvironment,
         options: PackageManagementOptions,
@@ -471,6 +546,12 @@ export class PythonEnvironmentService implements vscode.Disposable {
         return this._pythonEnvApi.managePackages(environment, options);
     }
 
+    /**
+     * Create a terminal activated with the given Python environment.
+     * @param environment - Python environment to activate in the terminal
+     * @param options - VS Code terminal creation options
+     * @returns The created terminal instance
+     */
     public async createTerminal(
         environment: PythonEnvironment,
         options: vscode.TerminalOptions,
@@ -484,11 +565,13 @@ export class PythonEnvironmentService implements vscode.Disposable {
     /**
      * Event for terminal activation state changes. Only available with the
      * full Environments extension API.
+     * @returns The event, or undefined when the Environments API is not active
      */
     public get onDidChangeTerminalActivationState() {
         return this._pythonEnvApi?.onDidChangeTerminalActivationState;
     }
 
+    /** Release all subscriptions and timers held by this service. */
     public dispose(): void {
         if (this._changeDebounce) {
             clearTimeout(this._changeDebounce);

--- a/src/services/TerminalService.ts
+++ b/src/services/TerminalService.ts
@@ -36,15 +36,21 @@ export interface CreateTerminalOptions {
     activationTimeout?: number;
 }
 
+/** Central dispatcher for terminal operations with Python venv support. */
 export class TerminalService {
     private static _instance: TerminalService | undefined;
     private _disposables: vscode.Disposable[] = [];
     private _pythonEnvService: PythonEnvironmentService | undefined;
 
+    /** Private constructor for the singleton terminal service. */
     private constructor() {
         /* singleton */
     }
 
+    /**
+     * Return the shared terminal service instance.
+     * @returns Singleton TerminalService instance
+     */
     public static getInstance(): TerminalService {
         TerminalService._instance ??= new TerminalService();
         return TerminalService._instance;
@@ -52,6 +58,7 @@ export class TerminalService {
 
     /**
      * Inject the centralized Python environment service.
+     * @param service - Service used to create activated Python terminals
      */
     public setPythonEnvService(service: PythonEnvironmentService): void {
         this._pythonEnvService = service;
@@ -59,6 +66,8 @@ export class TerminalService {
 
     /**
      * Create a terminal with Python venv activated, waiting for activation to complete
+     * @param options - Terminal name, cwd, visibility, and activation timeout
+     * @returns Managed terminal with helpers to send commands and dispose resources
      */
     public async createActivatedTerminal(options: CreateTerminalOptions): Promise<ManagedTerminal> {
         const workspaceFolder = options.cwd ?? vscode.workspace.workspaceFolders?.[0]?.uri;
@@ -129,6 +138,11 @@ export class TerminalService {
         return { terminal, sendCommand, dispose };
     }
 
+    /**
+     * Wait until Python environment activation completes for a terminal.
+     * @param terminal - Terminal whose activation state should be observed
+     * @param timeout - Maximum time to wait for activation in milliseconds
+     */
     private async _waitForActivation(terminal: vscode.Terminal, timeout: number): Promise<void> {
         const activationEvent = this._pythonEnvService?.onDidChangeTerminalActivationState;
         if (activationEvent) {
@@ -150,10 +164,22 @@ export class TerminalService {
         await new Promise((resolve) => setTimeout(resolve, Math.min(timeout, 3000)));
     }
 
+    /**
+     * Wait briefly for a plain terminal shell to become ready.
+     * @param _terminal - Terminal being prepared, unused because no activation event exists
+     * @param timeout - Upper bound used to derive the readiness delay
+     */
     private async _waitForShellReady(_terminal: vscode.Terminal, timeout: number): Promise<void> {
         await new Promise((resolve) => setTimeout(resolve, Math.min(timeout, 1000)));
     }
 
+    /**
+     * Send a command to a terminal and wait for shell integration completion.
+     * @param terminal - Terminal that should execute the command
+     * @param command - Shell command to send
+     * @param timeout - Maximum time to wait for completion in milliseconds
+     * @returns Captured exit status when shell integration is available
+     */
     private async _sendAndCapture(
         terminal: vscode.Terminal,
         command: string,
@@ -194,6 +220,15 @@ export class TerminalService {
         return { output: '', exitCode: undefined, success: true };
     }
 
+    /**
+     * Create an activated terminal and run a command without waiting for output.
+     * @param name - Terminal display name
+     * @param command - Shell command to execute
+     * @param options - Optional terminal creation settings
+     * @param options.show - Whether to reveal the terminal after creation
+     * @param options.cwd - Working directory for the terminal session
+     * @returns The underlying VS Code terminal instance
+     */
     public async runInTerminal(
         name: string,
         command: string,
@@ -209,6 +244,7 @@ export class TerminalService {
         return managed.terminal;
     }
 
+    /** Dispose registered terminal service listeners. */
     public dispose(): void {
         for (const d of this._disposables) {
             d.dispose();

--- a/src/views/AnsibleDevToolsProvider.ts
+++ b/src/views/AnsibleDevToolsProvider.ts
@@ -4,6 +4,7 @@ import type { DevToolPackage } from '@ansible/core';
 import type { PythonEnvironmentService } from '@src/services/PythonEnvironmentService';
 import { log } from '@src/extension';
 
+/** Tree view provider for installed Ansible developer tool packages. */
 export class AnsibleDevToolsProvider implements vscode.TreeDataProvider<DevToolPackage> {
     private _onDidChangeTreeData: vscode.EventEmitter<DevToolPackage | undefined | null> =
         new vscode.EventEmitter<DevToolPackage | undefined | null>();
@@ -15,6 +16,10 @@ export class AnsibleDevToolsProvider implements vscode.TreeDataProvider<DevToolP
     private _serviceListener: vscode.Disposable | undefined;
     private _refreshDebounce: ReturnType<typeof setTimeout> | undefined;
 
+    /**
+     * Create the provider and refresh when the active Python environment changes.
+     * @param pythonEnvService - Service that reports Python environment changes
+     */
     constructor(pythonEnvService: PythonEnvironmentService) {
         this._service = DevToolsService.getInstance();
 
@@ -25,6 +30,10 @@ export class AnsibleDevToolsProvider implements vscode.TreeDataProvider<DevToolP
         void this._init(pythonEnvService);
     }
 
+    /**
+     * Subscribe to environment changes and defer the first refresh until discovery completes.
+     * @param pythonEnvService - Service used to observe environment changes
+     */
     private async _init(pythonEnvService: PythonEnvironmentService) {
         try {
             await pythonEnvService.initialize();
@@ -52,10 +61,16 @@ export class AnsibleDevToolsProvider implements vscode.TreeDataProvider<DevToolP
         }
     }
 
+    /** Reload developer tool packages from the active environment. */
     async refresh(): Promise<void> {
         await this._service.refresh();
     }
 
+    /**
+     * Render a developer tool package as a tree item.
+     * @param element - Package entry to display
+     * @returns Tree item showing package name, version, and install location
+     */
     getTreeItem(element: DevToolPackage): vscode.TreeItem {
         const item = new vscode.TreeItem(element.name, vscode.TreeItemCollapsibleState.None);
         item.description = element.version;
@@ -67,6 +82,11 @@ export class AnsibleDevToolsProvider implements vscode.TreeDataProvider<DevToolP
         return item;
     }
 
+    /**
+     * Return installed developer tool packages at the tree root.
+     * @param element - Parent node, which is unused because the tree is flat
+     * @returns Installed packages, or an empty list for nested nodes
+     */
     getChildren(element?: DevToolPackage): Thenable<DevToolPackage[]> {
         if (element) {
             return Promise.resolve([]);
@@ -74,10 +94,15 @@ export class AnsibleDevToolsProvider implements vscode.TreeDataProvider<DevToolP
         return Promise.resolve(this._service.getPackages());
     }
 
+    /**
+     * Whether any developer tool packages are currently available.
+     * @returns True when at least one package is installed
+     */
     hasPackages(): boolean {
         return this._service.hasPackages();
     }
 
+    /** Release listeners and pending refresh timers. */
     dispose() {
         if (this._refreshDebounce) {
             clearTimeout(this._refreshDebounce);

--- a/src/views/CollectionSourcesProvider.ts
+++ b/src/views/CollectionSourcesProvider.ts
@@ -4,6 +4,10 @@ import { GalaxyCollectionCache, GitHubCollectionCache } from '@ansible/core';
 // Logging function
 let extensionLog: (msg: string) => void = console.log;
 
+/**
+ * Configure the logging function used by collection source operations.
+ * @param logFn - Logger invoked for collection source status messages
+ */
 export function setCollectionSourcesLogFunction(logFn: (msg: string) => void): void {
     extensionLog = logFn;
 }
@@ -11,6 +15,7 @@ export function setCollectionSourcesLogFunction(logFn: (msg: string) => void): v
 /**
  * Open the AI chat with a prompt pre-filled.
  * Falls back to clipboard if the command doesn't support the query parameter.
+ * @param prompt - Prompt text to send to chat or copy to the clipboard
  */
 async function openChatWithPrompt(prompt: string): Promise<void> {
     try {
@@ -43,10 +48,12 @@ export interface CollectionSourceInfo {
     isRefreshing: boolean;
 }
 
-/**
- * Tree item representing a collection source
- */
+/** Tree item representing a Galaxy or GitHub collection source. */
 class CollectionSourceNode extends vscode.TreeItem {
+    /**
+     * Create a collection source node with count and refresh status.
+     * @param source - Metadata describing the collection source
+     */
     constructor(public readonly source: CollectionSourceInfo) {
         super(source.name, vscode.TreeItemCollapsibleState.None);
 
@@ -81,9 +88,7 @@ class CollectionSourceNode extends vscode.TreeItem {
     }
 }
 
-/**
- * Provider for the Collection Sources view
- */
+/** Tree view provider for Galaxy and GitHub collection sources. */
 export class CollectionSourcesProvider implements vscode.TreeDataProvider<CollectionSourceNode> {
     private _onDidChangeTreeData = new vscode.EventEmitter<
         CollectionSourceNode | undefined | null
@@ -94,6 +99,7 @@ export class CollectionSourcesProvider implements vscode.TreeDataProvider<Collec
     private _githubCache: GitHubCollectionCache;
     private _disposables: vscode.Disposable[] = [];
 
+    /** Create the provider and initialize configured collection source caches. */
     constructor() {
         this._galaxyCache = GalaxyCollectionCache.getInstance();
         this._githubCache = GitHubCollectionCache.getInstance();
@@ -113,6 +119,7 @@ export class CollectionSourcesProvider implements vscode.TreeDataProvider<Collec
         this._initialize();
     }
 
+    /** Load configured GitHub organizations and trigger an initial refresh. */
     private _initialize(): void {
         extensionLog('CollectionSourcesProvider: Initializing...');
 
@@ -122,6 +129,7 @@ export class CollectionSourcesProvider implements vscode.TreeDataProvider<Collec
         this.refresh();
     }
 
+    /** Load cached GitHub collection metadata for configured organizations. */
     private _initializeGitHubOrgs(): void {
         const orgs = this._getConfiguredOrgs();
         extensionLog(`CollectionSourcesProvider: Initializing GitHub orgs: ${orgs.join(', ')}`);
@@ -132,6 +140,10 @@ export class CollectionSourcesProvider implements vscode.TreeDataProvider<Collec
         }
     }
 
+    /**
+     * Read configured GitHub organization names from workspace settings.
+     * @returns GitHub organization names used as collection sources
+     */
     private _getConfiguredOrgs(): string[] {
         const config = vscode.workspace.getConfiguration('ansibleEnvironments');
         return (
@@ -143,10 +155,12 @@ export class CollectionSourcesProvider implements vscode.TreeDataProvider<Collec
         );
     }
 
+    /** Notify the tree that source metadata changed. */
     public refresh(): void {
         this._onDidChangeTreeData.fire(undefined);
     }
 
+    /** Refresh Galaxy and all configured GitHub collection sources. */
     public async refreshAll(): Promise<void> {
         extensionLog('CollectionSourcesProvider: Refreshing all sources...');
 
@@ -162,6 +176,10 @@ export class CollectionSourcesProvider implements vscode.TreeDataProvider<Collec
         vscode.window.showInformationMessage('All collection sources refreshed');
     }
 
+    /**
+     * Refresh a single collection source cache.
+     * @param source - Source metadata identifying Galaxy or a GitHub organization
+     */
     public async refreshSource(source: CollectionSourceInfo): Promise<void> {
         extensionLog(`CollectionSourcesProvider: Refreshing source: ${source.id}`);
 
@@ -177,6 +195,7 @@ export class CollectionSourcesProvider implements vscode.TreeDataProvider<Collec
         vscode.window.showInformationMessage(`${source.name} refreshed`);
     }
 
+    /** Prompt for a GitHub organization and add it to workspace settings. */
     public async addSource(): Promise<void> {
         const orgName = await vscode.window.showInputBox({
             prompt: 'Enter GitHub organization name',
@@ -214,10 +233,19 @@ export class CollectionSourcesProvider implements vscode.TreeDataProvider<Collec
         vscode.window.showInformationMessage(`Added GitHub organization: ${orgName}`);
     }
 
+    /**
+     * Return the tree item for a collection source node.
+     * @param element - Source node whose tree item should be displayed
+     * @returns The node itself because source nodes extend TreeItem
+     */
     getTreeItem(element: CollectionSourceNode): vscode.TreeItem {
         return element;
     }
 
+    /**
+     * Return Galaxy and configured GitHub collection sources.
+     * @returns Source nodes for all configured collection catalogs
+     */
     getChildren(): CollectionSourceNode[] {
         const sources: CollectionSourceNode[] = [];
 
@@ -270,6 +298,7 @@ export class CollectionSourcesProvider implements vscode.TreeDataProvider<Collec
 
     /**
      * Search within a specific source
+     * @param source - Collection source to search within
      */
     public async searchSource(source: CollectionSourceInfo): Promise<void> {
         const query = await vscode.window.showInputBox({
@@ -286,6 +315,7 @@ export class CollectionSourcesProvider implements vscode.TreeDataProvider<Collec
 
     /**
      * Install from a specific source
+     * @param source - Collection source whose catalog should be browsed
      */
     public async installFromSource(source: CollectionSourceInfo): Promise<void> {
         interface InstallItem extends vscode.QuickPickItem {
@@ -344,6 +374,8 @@ export class CollectionSourcesProvider implements vscode.TreeDataProvider<Collec
 
     /**
      * Show search results with install option
+     * @param query - Search text entered by the user
+     * @param source - Optional source limiting the search scope
      */
     private async _showSearchResults(query: string, source?: CollectionSourceInfo): Promise<void> {
         interface SearchResultItem extends vscode.QuickPickItem {
@@ -475,6 +507,8 @@ export class CollectionSourcesProvider implements vscode.TreeDataProvider<Collec
 
     /**
      * Install a collection using ade from the Python environment
+     * @param installUrl - Galaxy name or Git URL passed to `ade install`
+     * @param sourceType - Source type used only for logging and messaging
      */
     private async _installCollection(
         installUrl: string,
@@ -546,6 +580,7 @@ Do NOT suggest using \`ansible-galaxy collection install\` directly.`;
 
     /**
      * Generate AI summary for a specific source
+     * @param source - Collection source to summarize in chat
      */
     public async generateSourceAiSummary(source: CollectionSourceInfo): Promise<void> {
         let prompt: string;
@@ -586,6 +621,7 @@ Do NOT suggest using \`ansible-galaxy collection install\` directly.`;
         await openChatWithPrompt(prompt);
     }
 
+    /** Release configuration listeners registered by the provider. */
     dispose(): void {
         for (const d of this._disposables) {
             d.dispose();

--- a/src/views/CollectionsProvider.ts
+++ b/src/views/CollectionsProvider.ts
@@ -31,6 +31,7 @@ interface PluginNode {
     pluginType: string;
 }
 
+/** Tree view provider for installed Ansible collections and their plugins. */
 export class CollectionsProvider implements vscode.TreeDataProvider<TreeNode> {
     private _onDidChangeTreeData: vscode.EventEmitter<TreeNode | undefined | null> =
         new vscode.EventEmitter<TreeNode | undefined | null>();
@@ -42,6 +43,10 @@ export class CollectionsProvider implements vscode.TreeDataProvider<TreeNode> {
     private _serviceListener: vscode.Disposable | undefined;
     private _refreshDebounce: ReturnType<typeof setTimeout> | undefined;
 
+    /**
+     * Create the provider and refresh when collections or the environment change.
+     * @param pythonEnvService - Service that reports Python environment changes
+     */
     constructor(pythonEnvService: PythonEnvironmentService) {
         this._service = CollectionsService.getInstance();
 
@@ -59,6 +64,10 @@ export class CollectionsProvider implements vscode.TreeDataProvider<TreeNode> {
         void this._initEnvListener(pythonEnvService);
     }
 
+    /**
+     * Debounce collection refreshes when the active Python environment changes.
+     * @param pythonEnvService - Service used to observe environment changes
+     */
     private async _initEnvListener(pythonEnvService: PythonEnvironmentService) {
         try {
             await pythonEnvService.initialize();
@@ -79,10 +88,16 @@ export class CollectionsProvider implements vscode.TreeDataProvider<TreeNode> {
         }
     }
 
+    /** Reload installed collections and plugin metadata. */
     async refresh(): Promise<void> {
         await this._service.refresh();
     }
 
+    /**
+     * Render a collection, plugin type, plugin, or loading node.
+     * @param element - Tree node to display
+     * @returns Tree item with labels, icons, and commands for plugin nodes
+     */
     getTreeItem(element: TreeNode): vscode.TreeItem {
         if (element.type === 'loading') {
             const item = new vscode.TreeItem(
@@ -145,6 +160,11 @@ export class CollectionsProvider implements vscode.TreeDataProvider<TreeNode> {
         }
     }
 
+    /**
+     * Return root collections or the children of a collection or plugin type node.
+     * @param element - Parent node whose children should be listed
+     * @returns Child nodes for the requested tree level
+     */
     getChildren(element?: TreeNode): Thenable<TreeNode[]> {
         if (!element) {
             if (this._service.isLoading() || !this._service.isLoaded()) {
@@ -196,6 +216,7 @@ export class CollectionsProvider implements vscode.TreeDataProvider<TreeNode> {
         return Promise.resolve([]);
     }
 
+    /** Release listeners and pending refresh timers. */
     dispose() {
         if (this._refreshDebounce) {
             clearTimeout(this._refreshDebounce);

--- a/src/views/CreatorProvider.ts
+++ b/src/views/CreatorProvider.ts
@@ -5,7 +5,17 @@ import { log } from '@src/extension';
 
 type TreeNode = CategoryNode | CommandNode | MessageNode;
 
+/** Tree item that displays informational or actionable creator messages. */
 class MessageNode extends vscode.TreeItem {
+    /**
+     * Create a non-collapsible message node for the creator tree.
+     * @param label - Primary message text shown in the tree
+     * @param options - Optional presentation and command settings
+     * @param options.description - Secondary text shown inline in the tree
+     * @param options.tooltip - Hover text with additional detail
+     * @param options.icon - Theme icon name for the node
+     * @param options.command - VS Code command launched when the node is clicked
+     */
     constructor(
         label: string,
         options?: {
@@ -30,7 +40,15 @@ class MessageNode extends vscode.TreeItem {
     }
 }
 
+/** Collapsible tree item representing a creator schema category. */
 class CategoryNode extends vscode.TreeItem {
+    /**
+     * Create a category node that groups related creator commands.
+     * @param label - Category label shown in the tree
+     * @param children - Child nodes contained in this category
+     * @param commandPath - Schema path prefix for commands in this category
+     * @param description - Optional tooltip description from the schema
+     */
     constructor(
         public readonly label: string,
         public readonly children: TreeNode[],
@@ -48,7 +66,14 @@ class CategoryNode extends vscode.TreeItem {
     }
 }
 
+/** Leaf tree item that opens a creator form for a schema command. */
 class CommandNode extends vscode.TreeItem {
+    /**
+     * Create a command node that launches the creator form on click.
+     * @param label - Command label shown in the tree
+     * @param schema - Schema definition for the command form
+     * @param commandPath - Schema path used to invoke ansible-creator
+     */
     constructor(
         public readonly label: string,
         public readonly schema: SchemaNode,
@@ -77,6 +102,7 @@ class CommandNode extends vscode.TreeItem {
     }
 }
 
+/** Tree view provider for ansible-creator init and add commands. */
 export class CreatorProvider implements vscode.TreeDataProvider<TreeNode> {
     private _onDidChangeTreeData = new vscode.EventEmitter<TreeNode | undefined | null>();
     readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
@@ -84,6 +110,7 @@ export class CreatorProvider implements vscode.TreeDataProvider<TreeNode> {
     private _service: CreatorService;
     private _serviceListener: vscode.Disposable | undefined;
 
+    /** Create the provider and load the ansible-creator schema. */
     constructor() {
         this._service = CreatorService.getInstance();
         this._service.setLogFunction(log);
@@ -97,14 +124,25 @@ export class CreatorProvider implements vscode.TreeDataProvider<TreeNode> {
         void this._service.loadSchema();
     }
 
+    /** Reload the ansible-creator schema and refresh the tree. */
     refresh(): void {
         void this._service.refresh();
     }
 
+    /**
+     * Return the tree item for a creator node.
+     * @param element - Node whose tree item should be displayed
+     * @returns The node itself because creator nodes extend TreeItem
+     */
     getTreeItem(element: TreeNode): vscode.TreeItem {
         return element;
     }
 
+    /**
+     * Return root categories or the children of a category node.
+     * @param element - Parent node whose children should be listed
+     * @returns Creator categories, commands, or status messages
+     */
     getChildren(element?: TreeNode): TreeNode[] | Promise<TreeNode[]> {
         if (!element) {
             // Root level - show Init and Add categories
@@ -167,6 +205,13 @@ export class CreatorProvider implements vscode.TreeDataProvider<TreeNode> {
         return [];
     }
 
+    /**
+     * Build a category node and recursively attach child commands or subcategories.
+     * @param label - Category label shown in the tree
+     * @param schema - Schema subtree for this category
+     * @param path - Command path prefix accumulated from parent categories
+     * @returns A populated category node for the creator tree
+     */
     private _buildCategoryNode(label: string, schema: SchemaNode, path: string[]): CategoryNode {
         const children: TreeNode[] = [];
 
@@ -193,6 +238,11 @@ export class CreatorProvider implements vscode.TreeDataProvider<TreeNode> {
         return new CategoryNode(label, children, path, schema.description);
     }
 
+    /**
+     * Convert a schema key into a human-readable tree label.
+     * @param name - Schema key in snake_case or kebab-case
+     * @returns Title-cased label for display in the tree
+     */
     private _formatLabel(name: string): string {
         // Convert snake_case to Title Case
         return name
@@ -201,10 +251,15 @@ export class CreatorProvider implements vscode.TreeDataProvider<TreeNode> {
             .join(' ');
     }
 
+    /**
+     * Expose the loaded ansible-creator schema for other extension components.
+     * @returns The current creator schema, or null when unavailable
+     */
     public getSchema(): SchemaNode | null {
         return this._service.getSchema();
     }
 
+    /** Release service listeners and tree event emitters. */
     dispose() {
         this._serviceListener?.dispose();
         this._onDidChangeTreeData.dispose();

--- a/src/views/EnvironmentManagersProvider.ts
+++ b/src/views/EnvironmentManagersProvider.ts
@@ -17,6 +17,7 @@ interface EnvironmentNode {
     managerId: string;
 }
 
+/** Tree view provider for Python environment managers and their environments. */
 export class EnvironmentManagersProvider implements vscode.TreeDataProvider<TreeNode> {
     private _onDidChangeTreeData: vscode.EventEmitter<TreeNode | undefined | null> =
         new vscode.EventEmitter<TreeNode | undefined | null>();
@@ -30,11 +31,16 @@ export class EnvironmentManagersProvider implements vscode.TreeDataProvider<Tree
     private _currentManagerId: string | undefined;
     private _refreshDebounce: ReturnType<typeof setTimeout> | undefined;
 
+    /**
+     * Create the provider and load environments from the Python extension.
+     * @param pythonEnvService - Service used to discover Python environments
+     */
     constructor(pythonEnvService: PythonEnvironmentService) {
         this._pythonEnvService = pythonEnvService;
         void this._init();
     }
 
+    /** Initialize environment discovery and subscribe to environment changes. */
     private async _init() {
         try {
             await this._pythonEnvService.initialize();
@@ -49,6 +55,10 @@ export class EnvironmentManagersProvider implements vscode.TreeDataProvider<Tree
         }
     }
 
+    /**
+     * Reload Python environments and refresh the tree.
+     * @returns Resolves when the refresh is complete
+     */
     async refresh(): Promise<void> {
         return this._doRefresh();
     }
@@ -67,6 +77,7 @@ export class EnvironmentManagersProvider implements vscode.TreeDataProvider<Tree
         }, 500);
     }
 
+    /** Reload environments and notify tree listeners of the update. */
     private async _doRefresh(): Promise<void> {
         try {
             await this._loadEnvironments();
@@ -75,6 +86,7 @@ export class EnvironmentManagersProvider implements vscode.TreeDataProvider<Tree
         }
     }
 
+    /** Populate manager groups from the Python environment service. */
     private async _loadEnvironments(): Promise<void> {
         const managers = new Map<string, PythonEnvironment[]>();
 
@@ -105,6 +117,11 @@ export class EnvironmentManagersProvider implements vscode.TreeDataProvider<Tree
         this._managers = managers;
     }
 
+    /**
+     * Whether the environment matches the currently selected interpreter.
+     * @param env - Python environment to compare against the active selection
+     * @returns True when the environment executable matches the current one
+     */
     private _isCurrent(env: PythonEnvironment): boolean {
         if (!this._currentExecPath) {
             return false;
@@ -112,6 +129,11 @@ export class EnvironmentManagersProvider implements vscode.TreeDataProvider<Tree
         return env.execInfo.run.executable === this._currentExecPath;
     }
 
+    /**
+     * Convert a manager identifier into a user-friendly tree label.
+     * @param managerId - Raw manager ID from the Python extension
+     * @returns Display name for the environment manager group
+     */
     private _getManagerDisplayName(managerId: string): string {
         const parts = managerId.split(':');
         const name = parts[parts.length - 1] || managerId;
@@ -140,16 +162,31 @@ export class EnvironmentManagersProvider implements vscode.TreeDataProvider<Tree
         return name.charAt(0).toUpperCase() + name.slice(1);
     }
 
+    /**
+     * Whether the manager ID represents a virtual environment manager.
+     * @param managerId - Raw manager ID from the Python extension
+     * @returns True for venv-style managers
+     */
     private _isVenvManager(managerId: string): boolean {
         const name = managerId.split(':').pop()?.toLowerCase() ?? '';
         return name === 'venv' || name === 'virtualenv' || name === 'virtualenvwrapper';
     }
 
+    /**
+     * Whether the manager ID represents a global/system Python installation.
+     * @param managerId - Raw manager ID from the Python extension
+     * @returns True for global or unknown system managers
+     */
     private _isGlobalManager(managerId: string): boolean {
         const name = managerId.split(':').pop()?.toLowerCase() ?? '';
         return name === 'system' || name === 'unknown';
     }
 
+    /**
+     * Render a manager group or individual Python environment node.
+     * @param element - Tree node to display
+     * @returns Tree item with warnings for discouraged global environments
+     */
     getTreeItem(element: TreeNode): vscode.TreeItem {
         if (element.type === 'manager') {
             const isVenv = this._isVenvManager(element.id);
@@ -230,6 +267,11 @@ export class EnvironmentManagersProvider implements vscode.TreeDataProvider<Tree
         }
     }
 
+    /**
+     * Return manager groups at the root or environments within a manager.
+     * @param element - Parent node whose children should be listed
+     * @returns Manager nodes or environment nodes for the requested level
+     */
     getChildren(element?: TreeNode): Thenable<TreeNode[]> {
         if (!element) {
             const managers: ManagerNode[] = [];
@@ -273,6 +315,7 @@ export class EnvironmentManagersProvider implements vscode.TreeDataProvider<Tree
         return Promise.resolve([]);
     }
 
+    /** Release listeners and pending refresh timers. */
     dispose() {
         if (this._refreshDebounce) {
             clearTimeout(this._refreshDebounce);

--- a/src/views/ExecutionEnvironmentsProvider.ts
+++ b/src/views/ExecutionEnvironmentsProvider.ts
@@ -5,7 +5,17 @@ import { log } from '@src/extension';
 
 type TreeNode = EENode | EEDetailCategoryNode | EEDetailItemNode | MessageNode;
 
+/** Tree item that displays informational or actionable execution environment messages. */
 class MessageNode extends vscode.TreeItem {
+    /**
+     * Create a non-collapsible message node for the execution environments tree.
+     * @param label - Primary message text shown in the tree
+     * @param options - Optional presentation and command settings
+     * @param options.description - Secondary text shown inline in the tree
+     * @param options.tooltip - Hover text with additional detail
+     * @param options.icon - Theme icon name for the node
+     * @param options.command - VS Code command launched when the node is clicked
+     */
     constructor(
         label: string,
         options?: {
@@ -30,7 +40,12 @@ class MessageNode extends vscode.TreeItem {
     }
 }
 
+/** Collapsible tree item representing a single execution environment image. */
 class EENode extends vscode.TreeItem {
+    /**
+     * Create a tree node for an execution environment summary.
+     * @param ee - Execution environment metadata returned by ansible-navigator
+     */
     constructor(public readonly ee: ExecutionEnvironment) {
         super(ee.full_name, vscode.TreeItemCollapsibleState.Collapsed);
         this.description = ee.created;
@@ -43,7 +58,14 @@ class EENode extends vscode.TreeItem {
     }
 }
 
+/** Collapsible category node for execution environment detail sections. */
 class EEDetailCategoryNode extends vscode.TreeItem {
+    /**
+     * Create a detail category such as collections, packages, or info.
+     * @param label - Category label shown in the tree
+     * @param items - Detail items contained in this category
+     * @param eeName - Execution environment name that owns these details
+     */
     constructor(
         public readonly label: string,
         public readonly items: EEDetailItemNode[],
@@ -70,7 +92,14 @@ class EEDetailCategoryNode extends vscode.TreeItem {
     }
 }
 
+/** Leaf tree item for a single execution environment detail entry. */
 class EEDetailItemNode extends vscode.TreeItem {
+    /**
+     * Create a detail item with optional description and tooltip text.
+     * @param label - Primary label shown in the tree
+     * @param description - Optional secondary text shown inline
+     * @param tooltip - Optional hover text with additional detail
+     */
     constructor(label: string, description?: string, tooltip?: string) {
         super(label, vscode.TreeItemCollapsibleState.None);
         this.description = description;
@@ -81,6 +110,7 @@ class EEDetailItemNode extends vscode.TreeItem {
     }
 }
 
+/** Tree view provider for local execution environment images and their details. */
 export class ExecutionEnvironmentsProvider implements vscode.TreeDataProvider<TreeNode> {
     private _onDidChangeTreeData: vscode.EventEmitter<TreeNode | undefined | null> =
         new vscode.EventEmitter<TreeNode | undefined | null>();
@@ -90,6 +120,7 @@ export class ExecutionEnvironmentsProvider implements vscode.TreeDataProvider<Tr
     private _service: ExecutionEnvService;
     private _serviceListener: vscode.Disposable | undefined;
 
+    /** Create the provider and load execution environments from ansible-navigator. */
     constructor() {
         this._service = ExecutionEnvService.getInstance();
         this._service.setLogFunction(log);
@@ -103,14 +134,25 @@ export class ExecutionEnvironmentsProvider implements vscode.TreeDataProvider<Tr
         this.refresh();
     }
 
+    /** Reload execution environment images and refresh the tree. */
     refresh(): void {
         void this._service.refresh();
     }
 
+    /**
+     * Return the tree item for an execution environment node.
+     * @param element - Node whose tree item should be displayed
+     * @returns The node itself because EE nodes extend TreeItem
+     */
     getTreeItem(element: TreeNode): vscode.TreeItem {
         return element;
     }
 
+    /**
+     * Return root execution environments or the children of an EE node.
+     * @param element - Parent node whose children should be listed
+     * @returns Execution environments, detail categories, or detail items
+     */
     async getChildren(element?: TreeNode): Promise<TreeNode[]> {
         if (!element) {
             // Root level - load execution environments
@@ -130,6 +172,10 @@ export class ExecutionEnvironmentsProvider implements vscode.TreeDataProvider<Tr
         return [];
     }
 
+    /**
+     * Load execution environment images for the tree root.
+     * @returns EE nodes or status messages for loading, empty, and error states
+     */
     private async _getExecutionEnvironments(): Promise<TreeNode[]> {
         if (this._service.isLoading()) {
             return [
@@ -182,6 +228,11 @@ export class ExecutionEnvironmentsProvider implements vscode.TreeDataProvider<Tr
         }
     }
 
+    /**
+     * Load detail categories for a selected execution environment.
+     * @param ee - Execution environment whose details should be shown
+     * @returns Detail categories or an error item when loading fails
+     */
     private async _getEEDetailCategories(ee: ExecutionEnvironment): Promise<TreeNode[]> {
         try {
             const details = await this._service.loadDetails(ee.full_name);

--- a/src/views/McpToolsProvider.ts
+++ b/src/views/McpToolsProvider.ts
@@ -19,7 +19,14 @@ export interface ToolInfo {
     examplePrompt: string;
 }
 
+/** Collapsible tree item representing a category of MCP tools. */
 class ToolCategoryNode extends vscode.TreeItem {
+    /**
+     * Create a category node with a tool count description.
+     * @param categoryLabel - Display label for the category
+     * @param categoryId - Internal category identifier
+     * @param toolCount - Number of tools contained in the category
+     */
     constructor(
         public readonly categoryLabel: string,
         public readonly categoryId: ToolCategory,
@@ -41,9 +48,14 @@ class ToolCategoryNode extends vscode.TreeItem {
     }
 }
 
+/** Leaf tree item for a single MCP tool with chat injection command. */
 class ToolNode extends vscode.TreeItem {
     public readonly sortKey: string;
 
+    /**
+     * Create a tool node from MCP tool metadata and an example prompt.
+     * @param toolInfo - Tool definition, category, and example chat prompt
+     */
     constructor(public readonly toolInfo: ToolInfo) {
         // Use the first line of description as the label
         const firstLine = toolInfo.tool.description.split('\n')[0].trim();
@@ -65,6 +77,10 @@ class ToolNode extends vscode.TreeItem {
         };
     }
 
+    /**
+     * Build markdown tooltip content describing the tool and its parameters.
+     * @returns Markdown tooltip text for the tool node
+     */
     private _formatTooltip(): string {
         const tool = this.toolInfo.tool;
         const lines: string[] = [`### ${tool.name}`, '', tool.description, ''];
@@ -90,7 +106,12 @@ class ToolNode extends vscode.TreeItem {
     }
 }
 
+/** Warning node shown when MCP is not configured for the current IDE. */
 class McpWarningNode extends vscode.TreeItem {
+    /**
+     * Create a warning node that links to MCP configuration.
+     * @param status - Current MCP status for the active IDE
+     */
     constructor(status: McpStatus) {
         const ideName = status.ide === 'cursor' ? 'Cursor' : 'VS Code Copilot';
         super(`MCP not configured for ${ideName}`, vscode.TreeItemCollapsibleState.None);
@@ -111,6 +132,7 @@ class McpWarningNode extends vscode.TreeItem {
 
 type ToolTreeItem = ToolCategoryNode | ToolNode | McpWarningNode;
 
+/** Tree view provider for Ansible MCP tools and example chat prompts. */
 export class McpToolsProvider implements vscode.TreeDataProvider<ToolTreeItem> {
     private _onDidChangeTreeData = new vscode.EventEmitter<ToolTreeItem | undefined | null>();
     readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
@@ -121,6 +143,10 @@ export class McpToolsProvider implements vscode.TreeDataProvider<ToolTreeItem> {
     private _creatorServiceListener: vscode.Disposable | undefined;
     private _extensionContext: vscode.ExtensionContext;
 
+    /**
+     * Create the provider and load static and creator MCP tools.
+     * @param context - Extension context used to evaluate MCP configuration status
+     */
     constructor(context: vscode.ExtensionContext) {
         this._extensionContext = context;
         this._creatorToolGenerator = new CreatorToolGenerator();
@@ -137,14 +163,17 @@ export class McpToolsProvider implements vscode.TreeDataProvider<ToolTreeItem> {
         void this._loadTools();
     }
 
+    /** Release creator service listeners. */
     dispose(): void {
         this._creatorServiceListener?.dispose();
     }
 
+    /** Reload MCP tool definitions and refresh the tree. */
     refresh(): void {
         void this._loadTools();
     }
 
+    /** Load static and creator-generated MCP tools into the tree model. */
     private async _loadTools(): Promise<void> {
         if (this._isLoading) {
             return;
@@ -190,6 +219,11 @@ export class McpToolsProvider implements vscode.TreeDataProvider<ToolTreeItem> {
         }
     }
 
+    /**
+     * Assign a display category to a static MCP tool by name.
+     * @param name - MCP tool identifier
+     * @returns Category used to group the tool in the tree
+     */
     private _categorizeStaticTool(name: string): ToolCategory {
         if (
             name.includes('search') ||
@@ -210,6 +244,11 @@ export class McpToolsProvider implements vscode.TreeDataProvider<ToolTreeItem> {
         return 'discovery'; // default
     }
 
+    /**
+     * Build an example chat prompt that instructs an agent to use the tool.
+     * @param tool - MCP tool definition to describe in the prompt
+     * @returns Example prompt suitable for injection into chat
+     */
     private _generateExamplePrompt(tool: McpToolDefinition): string {
         const name = tool.name;
 
@@ -259,10 +298,20 @@ export class McpToolsProvider implements vscode.TreeDataProvider<ToolTreeItem> {
         }
     }
 
+    /**
+     * Return the tree item for an MCP tool tree node.
+     * @param element - Node whose tree item should be displayed
+     * @returns The node itself because MCP tool nodes extend TreeItem
+     */
     getTreeItem(element: ToolTreeItem): vscode.TreeItem {
         return element;
     }
 
+    /**
+     * Return MCP warning, categories, or tools within a selected category.
+     * @param element - Parent node whose children should be listed
+     * @returns Root categories, category tools, or an empty list
+     */
     getChildren(element?: ToolTreeItem): ToolTreeItem[] | Promise<ToolTreeItem[]> {
         if (!element) {
             const items: ToolTreeItem[] = [];
@@ -308,6 +357,7 @@ export class McpToolsProvider implements vscode.TreeDataProvider<ToolTreeItem> {
 
     /**
      * Get the CreatorToolGenerator instance for MCP handlers
+     * @returns Shared generator used to build dynamic creator MCP tools
      */
     getCreatorToolGenerator(): CreatorToolGenerator {
         return this._creatorToolGenerator;
@@ -315,6 +365,7 @@ export class McpToolsProvider implements vscode.TreeDataProvider<ToolTreeItem> {
 
     /**
      * Get all loaded tools
+     * @returns Copy of the currently loaded MCP tool metadata
      */
     getAllTools(): ToolInfo[] {
         return [...this._tools];
@@ -323,6 +374,7 @@ export class McpToolsProvider implements vscode.TreeDataProvider<ToolTreeItem> {
 
 /**
  * Inject a tool prompt into the chat
+ * @param toolInfo - Tool metadata containing the example prompt to send
  */
 export async function injectToolPromptIntoChat(toolInfo: ToolInfo): Promise<void> {
     const prompt = toolInfo.examplePrompt;

--- a/src/views/PlaybooksProvider.ts
+++ b/src/views/PlaybooksProvider.ts
@@ -5,11 +5,23 @@ import { log } from '@src/extension';
 
 type TreeNode = WorkspaceFolderNode | FolderNode | PlaybookNode | PlayNode | LoadingNode;
 
+/** Tree node representing a workspace folder in a multi-root workspace. */
 class WorkspaceFolderNode {
+    /**
+     * Create a workspace folder node for multi-root playbook browsing.
+     * @param folder - Workspace folder whose playbooks should be shown
+     */
     constructor(public readonly folder: vscode.WorkspaceFolder) {}
 }
 
+/** Tree node representing a subdirectory that contains playbooks. */
 class FolderNode {
+    /**
+     * Create a folder node within a workspace playbook hierarchy.
+     * @param name - Folder name shown in the tree
+     * @param fullPath - Absolute path to the folder on disk
+     * @param workspaceFolder - Workspace folder that owns this path
+     */
     constructor(
         public readonly name: string,
         public readonly fullPath: string,
@@ -17,26 +29,44 @@ class FolderNode {
     ) {}
 }
 
+/** Tree node representing a discovered Ansible playbook file. */
 class PlaybookNode {
+    /**
+     * Create a playbook node from discovered playbook metadata.
+     * @param playbook - Parsed playbook information from the workspace scan
+     */
     constructor(public readonly playbook: PlaybookInfo) {}
 }
 
+/** Tree node representing a single play within a playbook. */
 class PlayNode {
+    /**
+     * Create a play node linked back to its parent playbook.
+     * @param play - Parsed play metadata from the playbook
+     * @param playbook - Parent playbook containing the play
+     */
     constructor(
         public readonly play: PlaybookPlay,
         public readonly playbook: PlaybookInfo,
     ) {}
 }
 
+/** Placeholder tree node shown while playbooks are loading or absent. */
 class LoadingNode {
+    /**
+     * Create a loading or empty-state node with a status message.
+     * @param message - Status text shown in the tree
+     */
     constructor(public readonly message: string) {}
 }
 
+/** Tree view provider for workspace playbooks and their plays. */
 export class PlaybooksProvider implements vscode.TreeDataProvider<TreeNode> {
     private _service: PlaybooksService;
     private readonly _onDidChangeTreeData = new vscode.EventEmitter<TreeNode | undefined | null>();
     readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
 
+    /** Create the provider and trigger an initial playbook discovery pass. */
     constructor() {
         this._service = PlaybooksService.getInstance();
 
@@ -50,10 +80,16 @@ export class PlaybooksProvider implements vscode.TreeDataProvider<TreeNode> {
         void this._service.refresh();
     }
 
+    /** Reload playbooks from the workspace and refresh the tree. */
     public refresh(): void {
         void this._service.refresh();
     }
 
+    /**
+     * Render a workspace folder, folder, playbook, play, or loading node.
+     * @param element - Tree node to display
+     * @returns Tree item with icons, tooltips, and navigation commands
+     */
     getTreeItem(element: TreeNode): vscode.TreeItem {
         if (element instanceof LoadingNode) {
             const item = new vscode.TreeItem(element.message);
@@ -142,6 +178,11 @@ export class PlaybooksProvider implements vscode.TreeDataProvider<TreeNode> {
         return new vscode.TreeItem('Unknown');
     }
 
+    /**
+     * Return workspace roots, folder contents, plays, or loading placeholders.
+     * @param element - Parent node whose children should be listed
+     * @returns Child nodes for the requested tree level
+     */
     getChildren(element?: TreeNode): TreeNode[] | Promise<TreeNode[]> {
         if (!element) {
             // Root level
@@ -198,6 +239,12 @@ export class PlaybooksProvider implements vscode.TreeDataProvider<TreeNode> {
         return [];
     }
 
+    /**
+     * Build the folder and playbook hierarchy for a workspace root.
+     * @param playbooks - Playbooks discovered within the workspace
+     * @param workspaceFolder - Workspace folder used as the hierarchy root
+     * @returns Top-level folder and playbook nodes for the workspace
+     */
     private _buildFolderHierarchy(
         playbooks: PlaybookInfo[],
         workspaceFolder: vscode.WorkspaceFolder,
@@ -206,6 +253,13 @@ export class PlaybooksProvider implements vscode.TreeDataProvider<TreeNode> {
         return this._buildFolderContents(playbooks, rootPath, workspaceFolder);
     }
 
+    /**
+     * Build child folder and playbook nodes for a specific directory.
+     * @param playbooks - Playbooks that live under the target folder
+     * @param folderPath - Absolute path of the folder being expanded
+     * @param workspaceFolder - Workspace folder that owns the path
+     * @returns Sorted subfolder and playbook nodes for the directory
+     */
     private _buildFolderContents(
         playbooks: PlaybookInfo[],
         folderPath: string,

--- a/test/eslint/eslint-plugin-local.cjs
+++ b/test/eslint/eslint-plugin-local.cjs
@@ -18,9 +18,17 @@
 /** @typedef {import('estree').Node} EstreeNode */
 
 const rule = {
-    /** @param {import('eslint').Rule.RuleContext} context */
+    /**
+     * Create the rule listener.
+     * @param context - The ESLint rule context
+     * @returns An object mapping AST node types to visitor functions
+     */
     create(context) {
-        /** @param {CallExpression} node */
+        /**
+         * Extract the function name from a call expression's callee.
+         * @param node - The call expression AST node
+         * @returns The method or function name, or null if unresolvable
+         */
         function getMethodName(node) {
             const callee = node.callee;
             if (callee.type === 'Identifier') {
@@ -32,14 +40,22 @@ const rule = {
             return null;
         }
 
-        /** @param {EstreeNode} node */
+        /**
+         * Check whether a node is a call to spawn or spawnSync.
+         * @param node - The AST node to inspect
+         * @returns True when the node is a spawn/spawnSync call expression
+         */
         function isSpawnCall(node) {
             if (node.type !== 'CallExpression') return false;
             const name = getMethodName(node);
             return name === 'spawn' || name === 'spawnSync';
         }
 
-        /** @param {EstreeNode | null | undefined} optionsNode */
+        /**
+         * Determine whether an options argument contains `shell: true`.
+         * @param optionsNode - The AST node for the options object
+         * @returns True when the object has a `shell: true` property
+         */
         function hasShellTrue(optionsNode) {
             if (optionsNode?.type !== 'ObjectExpression') return false;
             return optionsNode.properties.some(
@@ -52,14 +68,21 @@ const rule = {
             );
         }
 
-        /** @param {CallExpression} node */
+        /**
+         * Check whether a spawn call violates DEP0190 (args + shell: true).
+         * @param node - The call expression AST node
+         * @returns True when the call has 3+ args and shell: true in options
+         */
         function isViolation(node) {
             const args = node.arguments;
             return args.length >= 3 && hasShellTrue(args[2]);
         }
 
         return {
-            /** @param {CallExpression} node */
+            /**
+             * Visit CallExpression nodes and report DEP0190 violations.
+             * @param node - The call expression AST node
+             */
             CallExpression(node) {
                 if (!isSpawnCall(node)) return;
                 if (isViolation(node)) {

--- a/test/ui/languageServerFullStack.spec.ts
+++ b/test/ui/languageServerFullStack.spec.ts
@@ -10,6 +10,12 @@ const VENV_BIN = path.join(VENV_DIR, 'bin');
 const VENV_PYTHON = path.join(VENV_BIN, 'python');
 const COMPLETION_PLAYBOOK = 'completion-test.ansible.yml';
 
+/**
+ * Runs a shell command synchronously and returns trimmed stdout.
+ * @param cmd - Shell command to execute.
+ * @param opts - Additional options passed to execSync.
+ * @returns Trimmed standard output from the command.
+ */
 function shell(cmd: string, opts: Record<string, unknown> = {}): string {
     return execSync(cmd, {
         encoding: 'utf-8',

--- a/test/unit/features/ansibleCfg.test.ts
+++ b/test/unit/features/ansibleCfg.test.ts
@@ -8,6 +8,10 @@ import {
     findProjectRoot,
 } from '../../../src/features/ansibleCfg';
 
+/**
+ * Creates a temporary directory for vault configuration tests.
+ * @returns Path to the newly created temporary directory.
+ */
 function tmpDir(): string {
     return fs.mkdtempSync(path.join(os.tmpdir(), 'vault-test-'));
 }


### PR DESCRIPTION
## Summary
- Install `eslint-plugin-jsdoc` and configure seven JSDoc rules as errors in `eslint.config.mjs`
- Add JSDoc comments to all functions and methods across `packages/core/`, `packages/language-server/`, `packages/mcp-server/`, `src/`, and all test files (~500 functions total)
- Write ADR-009 documenting the decision for mandatory JSDoc coverage

## Changes
- **eslint.config.mjs**: Add `eslint-plugin-jsdoc` plugin with `require-jsdoc`, `require-param`, `require-param-description`, `require-returns`, `require-returns-description`, `check-param-names`, `check-tag-names`, and `no-types` rules. Relax `no-unsafe-assignment` and `no-unsafe-call` in the test override (consistent with existing test relaxations)
- **package.json / package-lock.json**: Add `eslint-plugin-jsdoc@62.9.0` dev dependency (pinned to 62.x for Node 20 compatibility per Copilot review)
- **packages/core/src/** (10 files): JSDoc for ~115 functions
- **packages/language-server/src/** (19 files): JSDoc for ~144 functions
- **packages/mcp-server/src/** (6 files): JSDoc for ~70 functions
- **src/** (24 files): JSDoc for ~141 functions
- **test files** (17 files): JSDoc for test helper functions across all packages
- **test/eslint/eslint-plugin-local.cjs**: Replace typed `@param {Type}` with plain `@param` descriptions (satisfies `jsdoc/no-types`)
- **src/views/CollectionSourcesProvider.ts**: Remove duplicate JSDoc blocks on `CollectionSourceNode` and `CollectionSourcesProvider` (per Copilot review)
- **.sdlc/adrs/ADR-009-jsdoc-enforcement.md**: New ADR
- **.sdlc/adrs/README.md**: Updated index with ADR-009

## Quality of life
- AI-authored additions: ADR-009 (JSDoc enforcement decision record), JSDoc comments across all source and test files

## Test plan
- [x] `npm exec eslint -- .` passes (zero violations)
- [x] `npm exec tsc -- -b` compiles cleanly
- [x] `npm exec vitest -- run` passes (424 tests)
- [x] CI lint, build-and-test, integration, UI, WSL, Windows, package all pass