### PR TITLE
fix: @typescript-eslint/no-unsafe-assignment

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,6 +12,7 @@ import { createRequire } from "module";
 import importPlugin from "eslint-plugin-import";
 const require = createRequire(import.meta.url);
 /** @type {import('eslint').ESLint.Plugin} */
+// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- local CJS plugin loaded via require
 const eslintPluginLocal = require("./test/eslint/eslint-plugin-local.cjs");
 
 const __filename = fileURLToPath(import.meta.url); // get the resolved path to the file
@@ -28,6 +29,7 @@ export default defineConfig(
     tseslint.configs.strict,
     // TODO: enable later
     // tseslint.configs.stylistic,
+    // tseslint.configs.strictTypeChecked,
   ],
   {
     /** Files that use type-aware linting (TS/JS in src, packages, test). */
@@ -73,6 +75,7 @@ export default defineConfig(
       eqeqeq: ["error", "smart"],
       // "import/no-relative-parent-imports": "warn",
       // Needed for tseslint.configs.strictTypeChecked
+      "@typescript-eslint/no-unsafe-assignment": "error",
       "@typescript-eslint/no-deprecated": "error",
       "@typescript-eslint/no-namespace": "error",
       "@typescript-eslint/no-non-null-assertion": "error",
@@ -111,6 +114,7 @@ export default defineConfig(
       // Mocks and dynamic fixtures routinely return `any`
       "@typescript-eslint/no-unsafe-return": "off",
       "@typescript-eslint/no-unsafe-member-access": "off",
+      "@typescript-eslint/no-unsafe-assignment": "off",
     },
   },
   {
@@ -119,6 +123,7 @@ export default defineConfig(
     rules: {
       "no-restricted-imports": "off",
       "@typescript-eslint/no-unsafe-member-access": "off",
+      "@typescript-eslint/no-unsafe-assignment": "off",
     },
   },
   {

--- a/packages/ansible-language-server/src/providers/completionProviderUtils.ts
+++ b/packages/ansible-language-server/src/providers/completionProviderUtils.ts
@@ -164,7 +164,7 @@ export function getVarsCompletion(
 
           const contents = parseDocument(file).contents;
           if (contents !== null) {
-            const yamlDocContent = contents.toJSON();
+            const yamlDocContent: unknown = contents.toJSON();
 
             // variables declared in the file should be in list format only
             if (Array.isArray(yamlDocContent)) {

--- a/packages/ansible-language-server/src/services/schemaValidator.ts
+++ b/packages/ansible-language-server/src/services/schemaValidator.ts
@@ -24,7 +24,7 @@ export class SchemaValidator {
       return []; // YAML errors handled elsewhere
     }
 
-    const data = yamlDoc.toJSON();
+    const data: unknown = yamlDoc.toJSON();
     if (data == null) {
       return [];
     }

--- a/packages/ansible-language-server/src/services/settingsManager.ts
+++ b/packages/ansible-language-server/src/services/settingsManager.ts
@@ -161,14 +161,15 @@ export class SettingsManager {
     }
     let result = this.documentSettings.get(uri);
     if (!result && this.connection) {
-      const clientSettings = await this.connection.workspace.getConfiguration({
-        scopeUri: uri,
-        section: "ansible",
-      });
+      const clientSettings: unknown =
+        await this.connection.workspace.getConfiguration({
+          scopeUri: uri,
+          section: "ansible",
+        });
       // Recursively merge globalSettings with clientSettings to use:
       //  - setting from client when provided
       //  - default value of setting otherwise
-      const mergedSettings = _.merge(
+      const mergedSettings: ExtensionSettings = _.merge(
         _.cloneDeep(this.globalSettings),
         clientSettings,
       );

--- a/packages/ansible-language-server/src/utils/docsFinder.ts
+++ b/packages/ansible-language-server/src/utils/docsFinder.ts
@@ -121,7 +121,7 @@ export async function findPluginRouting(
     const runtimeContent = await fs.promises.readFile(file, {
       encoding: "utf8",
     });
-    const document = parseDocument(runtimeContent).toJSON();
+    const document: unknown = parseDocument(runtimeContent).toJSON();
     pluginRouting.set(collection, parseRawRouting(document));
   }
 

--- a/packages/ansible-language-server/src/utils/docsParser.ts
+++ b/packages/ansible-language-server/src/utils/docsParser.ts
@@ -28,10 +28,15 @@ export function processDocumentationFragments(
     mainDocumentationFragment &&
     hasOwnProperty(mainDocumentationFragment, "extends_documentation_fragment")
   ) {
-    const docFragmentNames: string[] =
-      mainDocumentationFragment.extends_documentation_fragment instanceof Array
-        ? mainDocumentationFragment.extends_documentation_fragment
-        : [mainDocumentationFragment.extends_documentation_fragment];
+    const rawFragments =
+      mainDocumentationFragment.extends_documentation_fragment;
+    const docFragmentNames: string[] = Array.isArray(rawFragments)
+      ? rawFragments.filter(
+          (fragment): fragment is string => typeof fragment === "string",
+        )
+      : typeof rawFragments === "string"
+        ? [rawFragments]
+        : [];
     const resultContents = {};
     for (const docFragmentName of docFragmentNames) {
       const fragmentNameArray = docFragmentName.split(".");

--- a/packages/ansible-language-server/src/utils/getAnsibleMetaData.ts
+++ b/packages/ansible-language-server/src/utils/getAnsibleMetaData.ts
@@ -215,7 +215,7 @@ async function getExecutionEnvironmentInfo() {
           encoding: "utf-8",
         },
       ),
-    );
+    ) as Record<string, unknown>;
     eeServiceWorking = true;
   } catch (error) {
     eeServiceWorking = false;

--- a/packages/ansible-language-server/src/utils/yaml.ts
+++ b/packages/ansible-language-server/src/utils/yaml.ts
@@ -615,7 +615,7 @@ export function isCursorInsideJinjaBrackets(
   let nodeObject: string | string[];
 
   try {
-    nodeObject = node.toJSON();
+    nodeObject = node.toJSON() as string | string[];
   } catch {
     // return early if invalid yaml syntax
     return false;

--- a/packages/ansible-mcp-server/src/tools/ansibleLint.ts
+++ b/packages/ansible-mcp-server/src/tools/ansibleLint.ts
@@ -85,7 +85,7 @@ async function runAnsibleLintWithoutFix(
 
       try {
         // Even with linting errors, valid JSON is printed to stdout.
-        const result = JSON.parse(stdoutData);
+        const result: unknown = JSON.parse(stdoutData);
         resolve({ result });
       } catch {
         reject(
@@ -171,7 +171,7 @@ async function runAnsibleLintOnFile(
       try {
         // Try to parse JSON output
         if (stdoutData.trim()) {
-          const result = JSON.parse(stdoutData);
+          const result: unknown = JSON.parse(stdoutData);
           resolve(result);
         } else {
           // If no JSON output, return empty array (no issues found)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,7 @@ sort_table_keys = true
 package = false
 default-groups = "all"
 # exclude-newer-package = { ansible-dev-tools = "0 seconds", ansible-navigator = "0 seconds", ansible-creator = "0 seconds", ansible-lint = "0 seconds", ansible-core = "0 seconds", ansible-dev-environment = "0 seconds", tox-ansible = "0 seconds", pytest-ansible = "0 seconds", molecule = "0 seconds", ansible-builder = "0 seconds", ansible-sign = "0 seconds" }
+python-downloads = "automatic"
 
 [tool.uv.pip]
 annotation-style = "line"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1468,7 +1468,7 @@ export function makeConfigurationMiddleware(
       }
 
       // Clone result array to avoid mutating the original
-      const result = [...originalResult];
+      const result = originalResult.slice();
 
       for (let i = 0; i < params.items.length; i++) {
         if (params.items[i].section !== "ansible") continue;

--- a/src/features/contentCreator/webviewUtils.ts
+++ b/src/features/contentCreator/webviewUtils.ts
@@ -192,7 +192,7 @@ export function setupMessageHandler(
   const router = new MessageRouter(config, commonState);
 
   const messageHandler = (event: MessageEvent) => {
-    const payload = event.data;
+    const payload: unknown = event.data;
     if (!isRecord(payload)) {
       return;
     }
@@ -293,14 +293,14 @@ export function initializeUI() {
 }
 
 export function clearAllFields(
-  fields: Record<string, Ref>,
-  defaults: Record<string, any> = {},
+  fields: Record<string, Ref<unknown>>,
+  defaults: Record<string, unknown> = {},
 ) {
   Object.keys(fields).forEach((key) => {
     if (defaults[key] !== undefined) {
       fields[key].value = defaults[key];
     } else {
-      const currentValue = fields[key].value;
+      const currentValue: unknown = fields[key].value;
       if (typeof currentValue === "string") {
         fields[key].value = "";
       } else if (typeof currentValue === "boolean") {

--- a/src/features/lightspeed/api.ts
+++ b/src/features/lightspeed/api.ts
@@ -243,7 +243,7 @@ export class LightSpeedAPI {
         JSON.stringify(requestData),
       );
 
-      const data = await response.json();
+      const data: unknown = await response.json();
 
       if (!response.ok) {
         throw new HTTPError(response, response.status, data as object);
@@ -294,7 +294,7 @@ export class LightSpeedAPI {
         JSON.stringify(requestData),
       );
 
-      const data = await response.json();
+      const data: unknown = await response.json();
 
       if (!response.ok) {
         throw new HTTPError(response, response.status, data as object);
@@ -327,7 +327,7 @@ export class LightSpeedAPI {
         JSON.stringify(requestData),
       );
 
-      const data = await response.json();
+      const data: unknown = await response.json();
 
       if (!response.ok) {
         throw new HTTPError(response, response.status, data as object);
@@ -360,7 +360,7 @@ export class LightSpeedAPI {
         JSON.stringify(requestData),
       );
 
-      const data = await response.json();
+      const data: unknown = await response.json();
 
       if (!response.ok) {
         throw new HTTPError(response, response.status, data as object);
@@ -429,7 +429,7 @@ export class LightSpeedAPI {
         JSON.stringify(requestData),
       );
 
-      const data = await response.json();
+      const data: unknown = await response.json();
 
       if (!response.ok) {
         throw new HTTPError(response, response.status, data as object);

--- a/src/features/lightspeed/lightSpeedOAuthProvider.ts
+++ b/src/features/lightspeed/lightSpeedOAuthProvider.ts
@@ -581,7 +581,8 @@ export class LightSpeedAuthenticationProvider
 
     this._logger.trace("[ansible-lightspeed-oauth] Account found");
 
-    const currentAccount: OAuthAccount = JSON.parse(account);
+    const parsedAccount: unknown = JSON.parse(account);
+    const currentAccount = parsedAccount as OAuthAccount;
     let tokenToBeReturned = currentAccount.accessToken;
 
     // check if token needs to be refreshed

--- a/src/features/lightspeed/lightspeedUser.ts
+++ b/src/features/lightspeed/lightspeedUser.ts
@@ -162,17 +162,18 @@ export class LightspeedUser {
       );
 
       if (response.ok) {
-        const userInfo: LoggedInUserInfo = await response.json();
-        if (!userInfo) {
+        const userInfo: unknown = await response.json();
+        if (!userInfo || typeof userInfo !== "object") {
           throw new Error("Unexpected userinfo payload");
         }
-        this._getUserInfoCache.userInfo = userInfo;
+        const parsedUserInfo = userInfo as LoggedInUserInfo;
+        this._getUserInfoCache.userInfo = parsedUserInfo;
 
         this._getUserInfoCache.time = Date.now();
         this._getUserInfoCache.token = token;
         this._getUserInfoCache.locked = false;
 
-        return userInfo;
+        return parsedUserInfo;
       } else {
         this._logger.error(
           `[ansible-lightspeed-user] call to get user info returned non-2xx response. Status: ${response.status}`,

--- a/src/features/lightspeed/utils/explanationUtils.ts
+++ b/src/features/lightspeed/utils/explanationUtils.ts
@@ -24,7 +24,8 @@ export function getObjectKeys(content: string): string[] {
     ) {
       return [];
     }
-    const lastObject = parsedAnsibleDocument[parsedAnsibleDocument.length - 1];
+    const lastObject: unknown =
+      parsedAnsibleDocument[parsedAnsibleDocument.length - 1];
     if (typeof lastObject === "object") {
       return Object.keys(lastObject as object);
     }

--- a/src/features/lightspeed/utils/outlineGenerator.ts
+++ b/src/features/lightspeed/utils/outlineGenerator.ts
@@ -43,7 +43,7 @@ function extractTasksFromPlay(play: Record<string, unknown>): string[] {
  */
 export function generateOutlineFromPlaybook(playbookYaml: string): string {
   try {
-    const parsed = yaml.parse(playbookYaml);
+    const parsed: unknown = yaml.parse(playbookYaml);
 
     if (!parsed || !Array.isArray(parsed)) {
       return "";
@@ -71,7 +71,7 @@ export function generateOutlineFromPlaybook(playbookYaml: string): string {
  */
 export function generateOutlineFromRole(roleYaml: string): string {
   try {
-    const parsed = yaml.parse(roleYaml);
+    const parsed: unknown = yaml.parse(roleYaml);
 
     if (!parsed || !Array.isArray(parsed)) {
       return "";

--- a/src/features/lightspeed/utils/readVarFiles.ts
+++ b/src/features/lightspeed/utils/readVarFiles.ts
@@ -7,7 +7,7 @@ export function readVarFiles(varFile: string): string | undefined {
       return undefined;
     }
     const contents = fs.readFileSync(varFile, "utf8");
-    const parsedAnsibleVars = yaml.parse(contents, {
+    const parsedAnsibleVars: unknown = yaml.parse(contents, {
       keepSourceTokens: true,
     });
     const updatedFileContents = yaml.stringify(parsedAnsibleVars);

--- a/src/features/runner.ts
+++ b/src/features/runner.ts
@@ -131,8 +131,9 @@ export class AnsiblePlaybookRunProvider {
    * Create or reuse a terminal with Python environment activated.
    */
   private async getTerminal(): Promise<vscode.Terminal> {
-    const reuseTerminal =
-      vscode.workspace.getConfiguration("ansible.ansible").reuseTerminal;
+    const reuseTerminal = vscode.workspace
+      .getConfiguration("ansible.ansible")
+      .get<boolean>("reuseTerminal", false);
     const terminalService = TerminalService.getInstance();
 
     const managed = await terminalService.createActivatedTerminal({

--- a/src/features/utils/ansible.ts
+++ b/src/features/utils/ansible.ts
@@ -37,11 +37,12 @@ export function getAnsibleFileType(
   ) {
     return "other";
   }
-  const lastObject = parsedAnsibleDocument[parsedAnsibleDocument.length - 1];
+  const lastObject: unknown =
+    parsedAnsibleDocument[parsedAnsibleDocument.length - 1];
   if (lastObject === null || typeof lastObject !== "object") {
     return "other";
   }
-  const objectKeys = Object.keys(lastObject as Record<string, unknown>);
+  const objectKeys = Object.keys(lastObject);
   for (const keyword of objectKeys) {
     if (PlaybookKeywords.includes(keyword)) {
       return "playbook";

--- a/src/features/utils/applyFileInspectionForKeywords.ts
+++ b/src/features/utils/applyFileInspectionForKeywords.ts
@@ -16,7 +16,7 @@ export async function applyFileInspectionForKeywords(
     }
 
     const fileText = editor.document.getText();
-    const parsedYaml = fileText ? yaml.parse(fileText) : "";
+    const parsedYaml: unknown = fileText ? yaml.parse(fileText) : "";
 
     if (parsedYaml && Array.isArray(parsedYaml)) {
       // Check for all seq

--- a/src/features/utils/applyModelines.ts
+++ b/src/features/utils/applyModelines.ts
@@ -1,4 +1,3 @@
-/* eslint-disable  @typescript-eslint/no-explicit-any */
 import * as vscode from "vscode";
 
 export async function configureModelines(
@@ -95,17 +94,17 @@ export function searchModelines(textDoc: vscode.TextDocument) {
   const vscodeModelineRegex = /^.{0,8}code:(.*)/;
   const vscodeModelineOptsRegex = /(\w+)=([^\s]+)/g;
 
-  const parseOption = (name: string, value: string): any => {
-    const parsedVal = _parseGenericValue(value);
+  const parseOption = (name: string, value: string): Record<string, string> => {
+    const parsedVal: string | number | boolean = _parseGenericValue(value);
     switch (name.toLowerCase()) {
       case "language":
       case "lang":
-        return { language: parsedVal };
+        return { language: String(parsedVal) };
       default:
         return {};
     }
   };
-  let options = {};
+  let options: Record<string, string> = {};
 
   const searchLines = getLinesToSearch(textDoc);
   searchLines.forEach((line) => {
@@ -137,7 +136,7 @@ function getLinesToSearch(document: vscode.TextDocument): string[] {
     .filter((line) => line.length <= MAX_LINE_LENGTH);
 }
 
-function _parseGenericValue(value: string): any {
+function _parseGenericValue(value: string): string | number | boolean {
   if (typeof value != "string") return value;
   value = value.trim();
   if (/^(true|false)$/i.test(value)) {

--- a/src/features/utils/formatAnsibleMetaData.ts
+++ b/src/features/utils/formatAnsibleMetaData.ts
@@ -1,4 +1,3 @@
-/* eslint-disable  @typescript-eslint/no-explicit-any */
 import { MarkdownString, workspace } from "vscode";
 import * as os from "os";
 import * as path from "path";
@@ -7,6 +6,19 @@ const asRecord = (value: unknown): Record<string, unknown> =>
   value !== null && typeof value === "object" && !Array.isArray(value)
     ? (value as Record<string, unknown>)
     : {};
+
+function formatMetadataValue(value: unknown): string {
+  if (value === null || value === undefined) {
+    return "";
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  return JSON.stringify(value);
+}
 
 export interface FormattedAnsibleMetaData {
   metaData: Record<string, unknown>;
@@ -106,16 +118,17 @@ export function formatAnsibleMetaData(
         return;
       }
       mdString += `\n   - ${key}: `;
-      const value = valueObj[key] as any;
+      const value: unknown = valueObj[key];
       if (Array.isArray(value)) {
-        value.forEach((val: any, index: any) => {
+        value.forEach((val: unknown, index: number) => {
           if (val && val !== "None") {
+            const formattedVal = formatMetadataValue(val);
             if (key.includes("path")) {
               mdString += `\n       ${
                 index + 1
-              }. <a href='${val}'>${getTildePath(val as string)}</a>`;
+              }. <a href='${formattedVal}'>${getTildePath(formattedVal)}</a>`;
             } else {
-              mdString += `\n       ${index + 1}. ${getTildePath(val as string)}`;
+              mdString += `\n       ${index + 1}. ${getTildePath(formattedVal)}`;
             }
           }
           if (index === value.length - 1) {
@@ -124,17 +137,18 @@ export function formatAnsibleMetaData(
         });
       } else {
         if (key.includes("path")) {
-          mdString += `<a href='${value}'>${getTildePath(value as string)}</a>`;
+          const pathValue = formatMetadataValue(value);
+          mdString += `<a href='${pathValue}'>${getTildePath(pathValue)}</a>`;
         } else if (key.includes("version")) {
-          const versionInfo = (value as string).split(/\r?\n/); // first part of versionInfo has the version no., the second part has message (if any)
+          const versionInfo = formatMetadataValue(value).split(/\r?\n/);
           mdString += `\`${versionInfo[0]}\`\n`;
           if (versionInfo[1]) {
             mdString += `*<span style="color:${WARNING_COLOR};">${versionInfo[1]}*\n`;
           }
         } else if (key.includes("location")) {
-          mdString += `${getTildePath(value as string)}\n`;
+          mdString += `${getTildePath(formatMetadataValue(value))}\n`;
         } else {
-          mdString += `${value}\n`;
+          mdString += `${formatMetadataValue(value)}\n`;
         }
       }
     });

--- a/src/utils/telemetryUtils.ts
+++ b/src/utils/telemetryUtils.ts
@@ -50,7 +50,7 @@ export async function sendTelemetry(
 
   await telemetryService.send({
     name: eventName,
-    properties: eventData,
+    properties: eventData as Record<string, string | number | boolean>,
   });
 }
 

--- a/webviews/lightspeed/src/components/llmProviderState.ts
+++ b/webviews/lightspeed/src/components/llmProviderState.ts
@@ -24,6 +24,30 @@ export interface ProviderInfo {
 
 type ProviderConfig = Record<string, string>;
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function asString(value: unknown, fallback = ""): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+function asProviderInfoArray(value: unknown): ProviderInfo[] {
+  return Array.isArray(value) ? (value as ProviderInfo[]) : [];
+}
+
+function asConnectionStatuses(value: unknown): Record<string, boolean> {
+  return isRecord(value) ? (value as Record<string, boolean>) : {};
+}
+
+function asProviderConfigs(
+  value: unknown,
+): Record<string, Record<string, unknown>> {
+  return isRecord(value)
+    ? (value as Record<string, Record<string, unknown>>)
+    : {};
+}
+
 export function useProviderSettings() {
   const providers = ref<ProviderInfo[]>([]);
   const activeProvider = ref<string>("wca");
@@ -196,28 +220,35 @@ export function useProviderSettings() {
 
   // Message handler
   const handleMessage = (event: MessageEvent) => {
-    const message = event.data;
+    const message: unknown = event.data;
+    if (!isRecord(message) || typeof message.command !== "string") {
+      return;
+    }
 
     switch (message.command) {
       case "providerSettings": {
-        providers.value = message.providers || [];
-        activeProvider.value = message.currentProvider || "wca";
-        connectionStatuses.value = message.connectionStatuses || {};
+        providers.value = asProviderInfoArray(message.providers);
+        activeProvider.value = asString(message.currentProvider, "wca");
+        connectionStatuses.value = asConnectionStatuses(
+          message.connectionStatuses,
+        );
 
         // Load configs for ALL providers from backend, using configSchema as the field source
-        const backendConfigs = message.providerConfigs || {};
+        const backendConfigs = asProviderConfigs(message.providerConfigs);
 
         providers.value.forEach((provider) => {
-          const backendConfig = backendConfigs[provider.type] || {};
+          const backendConfig = backendConfigs[provider.type] ?? {};
           const config: ProviderConfig = {};
 
           // Initialize each field from configSchema with backend value or default
           provider.configSchema.forEach((field) => {
             if (field.key === "apiEndpoint") {
               config[field.key] =
-                backendConfig[field.key] || provider.defaultEndpoint || "";
+                asString(backendConfig[field.key]) ||
+                provider.defaultEndpoint ||
+                "";
             } else {
-              config[field.key] = backendConfig[field.key] || "";
+              config[field.key] = asString(backendConfig[field.key]);
             }
           });
 
@@ -234,11 +265,11 @@ export function useProviderSettings() {
       case "connectionResult":
         connectingProvider.value = null;
         if (message.connected) {
-          connectionStatuses.value[message.provider] = true;
+          connectionStatuses.value[asString(message.provider)] = true;
         } else {
-          connectionStatuses.value[message.provider] = false;
+          connectionStatuses.value[asString(message.provider)] = false;
           console.error(
-            `Connection failed for ${message.provider}: ${message.error}`,
+            `Connection failed for ${asString(message.provider)}: ${asString(message.error)}`,
           );
         }
         break;


### PR DESCRIPTION
Related: AAP-66052


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Enforce TypeScript's `@typescript-eslint/no-unsafe-assignment` rule by explicitly typing values from external sources (JSON/YAML parsing, API responses) as `unknown` before safe type narrowing and casting, improving type safety throughout the codebase.

- Updated ESLint flat configuration to enforce `@typescript-eslint/no-unsafe-assignment` rule with relaxations for test and WDIO TypeScript test files
- Added explicit `unknown` type annotations for parsed YAML/JSON data in language server providers, services, utilities, and API handlers
- Implemented type guards and safe type narrowing instead of relying on implicit typing from external data sources
- Removed file-level `eslint-disable` directives for `@typescript-eslint/no-explicit-any` and replaced `any` types with specific typed signatures
- Updated function parameters with proper generic type constraints (`Record<string, Ref<unknown>>`, `Record<string, unknown>`)
- Added type-guard helpers in webview components to safely coerce and normalize backend message payloads
- Added `python-downloads = "automatic"` configuration to `pyproject.toml` for UV dependency management

related: AAP-66052

<!-- end of auto-generated comment: release notes by coderabbit.ai -->