### PR TITLE
chore: disable coderabbit docstring coverage check

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -14,6 +14,9 @@ reviews:
   in_progress_fortune: false
   request_changes_workflow: true
   review_status: false
+  pre_merge_checks:
+    docstrings:
+      mode: "off"  # not particularly useful, we will enable an eslint plugin for this
   tools:
     github-checks:
       enabled: true


### PR DESCRIPTION
Disable docstring coverage because the feature is not useful for use
due to its opaque implementation. We will later require docstrings
by using an eslint plugin.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Disabled CodeRabbit's docstring coverage check by configuring the `docstrings` pre-merge check to run in "off" mode in `.coderabbit.yaml`. This feature was disabled due to its opaque implementation, making it not useful in the current workflow. Docstring enforcement will be handled through an eslint plugin in the future.

- Disabled the `docstrings` pre-merge check in `.coderabbit.yaml` by setting it to "off" mode

related: `#AAP-66052`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->