### PR TITLE
feat(core): add multi-format skill registry with MCP tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -269,6 +269,12 @@
           "name": "AI Tools",
           "type": "tree",
           "when": "config.ansibleEnvironments.enableAiFeatures"
+        },
+        {
+          "id": "ansibleSkills",
+          "name": "AI Skills",
+          "type": "tree",
+          "when": "config.ansibleEnvironments.enableAiFeatures"
         }
       ]
     },
@@ -415,6 +421,21 @@
         "command": "ansibleMcpTools.configure",
         "title": "Configure MCP",
         "icon": "$(gear)"
+      },
+      {
+        "command": "ansibleSkills.refresh",
+        "title": "Refresh",
+        "icon": "$(refresh)"
+      },
+      {
+        "command": "ansibleSkills.useInChat",
+        "title": "Use in Chat",
+        "icon": "$(sparkle)"
+      },
+      {
+        "command": "ansibleSkills.copyPrompt",
+        "title": "Copy Prompt",
+        "icon": "$(sparkle)"
       },
       {
         "command": "ansiblePlaybooks.refresh",
@@ -588,6 +609,11 @@
           "group": "navigation@1"
         },
         {
+          "command": "ansibleSkills.refresh",
+          "when": "view == ansibleSkills",
+          "group": "navigation@1"
+        },
+        {
           "command": "ansiblePlaybooks.editDefaults",
           "when": "view == ansiblePlaybooks",
           "group": "navigation@1"
@@ -685,6 +711,11 @@
           "group": "inline"
         },
         {
+          "command": "ansibleSkills.useInChat",
+          "when": "view == ansibleSkills && viewItem == skill",
+          "group": "inline"
+        },
+        {
           "command": "ansibleCollectionSources.installFromSource",
           "when": "view == ansibleCollectionSources && viewItem == collectionSource",
           "group": "inline@1"
@@ -713,6 +744,60 @@
           "type": "boolean",
           "default": true,
           "description": "Enable AI enhancements (AI Tools view, sparkle icons, AI prompt buttons)"
+        },
+        "ansibleEnvironments.skillSources": {
+          "type": "array",
+          "default": [
+            {
+              "id": "ai-forge",
+              "type": "github",
+              "url": "https://github.com/ansible-community/ai-forge",
+              "trust": "community"
+            }
+          ],
+          "items": {
+            "type": "object",
+            "required": [
+              "id",
+              "type",
+              "url",
+              "trust"
+            ],
+            "properties": {
+              "id": {
+                "type": "string",
+                "description": "Unique source identifier"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "github",
+                  "registry",
+                  "local"
+                ],
+                "description": "Source transport type"
+              },
+              "url": {
+                "type": "string",
+                "description": "GitHub repo URL or local directory path"
+              },
+              "trust": {
+                "type": "string",
+                "enum": [
+                  "community",
+                  "certified",
+                  "partner",
+                  "private"
+                ],
+                "description": "Trust level for skills from this source"
+              },
+              "refreshInterval": {
+                "type": "number",
+                "description": "Hours between cache refreshes (default: 24)"
+              }
+            }
+          },
+          "description": "AI skill sources. Each source points to a GitHub repo or local directory containing SKILL.md files."
         },
         "ansibleEnvironments.pluginDocZoom": {
           "type": "number",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -41,6 +41,15 @@ export type { GalaxyCollection } from './services/GalaxyCollectionCache';
 export { GitHubCollectionCache } from './services/GitHubCollectionCache';
 export type { GitHubCollection } from './services/GitHubCollectionCache';
 
+export { SkillRegistry, _resetGitHubToken } from './services/SkillRegistry';
+export type {
+    SkillEntry,
+    SkillSource,
+    SkillCategory,
+    TrustLevel,
+    RepoFormat,
+} from './services/SkillRegistry';
+
 export { setLogFunction, log, getLogFunction } from './utils/logging';
 export { SimpleEventEmitter } from './utils/SimpleEventEmitter';
 export type { Disposable } from './utils/SimpleEventEmitter';

--- a/packages/core/src/services/SkillRegistry.ts
+++ b/packages/core/src/services/SkillRegistry.ts
@@ -1,0 +1,1416 @@
+/**
+ * Skill Registry — discovers, indexes, and caches AI development skills
+ * from multiple sources (ai-forge community, certified, partner, private).
+ *
+ * Supports auto-detection of repo formats:
+ *   - Lola (lola-market.yml manifest, e.g. ai-forge / agentic-collections)
+ *   - Vercel/harness (skills/ directory with SKILL.md files)
+ *   - Generic (any repo with SKILL.md files in subdirectories)
+ *
+ * No hard dependency on vscode. Works standalone in MCP server and CLI.
+ */
+
+// Conditional vscode import — only used for the event emitter
+let vscode: typeof import('vscode') | undefined;
+try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-unsafe-assignment -- conditional require for VS Code-optional usage
+    vscode = require('vscode');
+} catch {
+    // Running standalone (MCP server, CLI)
+}
+
+import * as https from 'https';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import * as childProcess from 'child_process';
+import * as yaml from 'js-yaml';
+
+import { log } from '../utils/logging';
+import { SimpleEventEmitter } from '../utils/SimpleEventEmitter';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Broad skill category. */
+export type SkillCategory = 'standards' | 'sdlc' | 'domain' | 'scaffold' | 'workflow' | 'other';
+
+/** How much the source is trusted. */
+export type TrustLevel = 'community' | 'certified' | 'partner' | 'private';
+
+/** Detected repository layout convention. */
+export type RepoFormat = 'lola' | 'vercel' | 'generic';
+
+/** Describes a location from which skills can be loaded. */
+export interface SkillSource {
+    /** Unique identifier for this source. */
+    id: string;
+    /** Transport type: github, registry (future), or local disk. */
+    type: 'github' | 'registry' | 'local';
+    /** URL or path for the source. */
+    url: string;
+    /** Trust level applied to all skills from this source. */
+    trust: TrustLevel;
+    /** Hours between automatic refreshes (default: 24). */
+    refreshInterval?: number;
+}
+
+/** A single indexed skill. */
+export interface SkillEntry {
+    /** Globally unique ID, e.g. "ai-forge/ansible-collection-sdlc/commit". */
+    id: string;
+    /** Source ID this skill came from. */
+    source: string;
+    /** Module or collection grouping. */
+    module: string;
+    /** Human-readable skill name. */
+    name: string;
+    /** Short description. */
+    description: string;
+    /** Phrases that trigger this skill. */
+    triggers: string[];
+    /** Broad category. */
+    category: SkillCategory;
+    /** Optional domain qualifier (e.g. "cloud", "network"). */
+    domain?: string;
+    /** Trust level inherited from the source. */
+    trust: TrustLevel;
+    /** Freeform tags for search. */
+    tags: string[];
+    /** URL to fetch SKILL.md content on demand (persisted in cache). */
+    contentUrl?: string;
+    /** Full SKILL.md body — loaded on demand, undefined until fetched. */
+    content?: string;
+    /** Paths to supplementary files (reference.md, templates, etc.). */
+    references?: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Internal interfaces
+// ---------------------------------------------------------------------------
+
+/** Shape of lola-market.yml module entries. */
+interface LolaModuleEntry {
+    name: string;
+    description?: string;
+    version?: string;
+    repository?: string;
+    path?: string;
+    tags?: string[];
+}
+
+/** Shape of a lola-market.yml manifest. */
+interface LolaMarketManifest {
+    name?: string;
+    description?: string;
+    version?: string;
+    modules?: LolaModuleEntry[];
+}
+
+/** SKILL.md YAML frontmatter. */
+interface SkillFrontmatter {
+    name?: string;
+    description?: string;
+    version?: string;
+    type?: string;
+    mandatory?: boolean;
+    triggers?: string[] | string;
+    category?: string;
+    domain?: string;
+    tags?: string[];
+    'allowed-tools'?: string[];
+    'argument-hint'?: string;
+    sdlc_mcp_tools?: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Cache helpers
+// ---------------------------------------------------------------------------
+
+let CACHE_DIR = path.join(os.tmpdir(), 'ansible-mcp', 'skills');
+const INDEX_CACHE_FILE = 'skill-index.json';
+
+/** Persisted index for one source. */
+interface CachedIndex {
+    timestamp: number;
+    sourceId: string;
+    sourceUrl?: string;
+    format?: RepoFormat;
+    skills: SkillEntry[];
+}
+
+// ---------------------------------------------------------------------------
+// GitHub auth
+// ---------------------------------------------------------------------------
+
+let _cachedGhToken: string | undefined | null;
+
+/**
+ * Resolve a GitHub token from the environment or gh CLI.
+ *
+ * @returns Token string or undefined when no auth is available.
+ */
+function _resolveGitHubToken(): string | undefined {
+    if (_cachedGhToken !== undefined) {
+        return _cachedGhToken ?? undefined;
+    }
+
+    const envToken = process.env.GITHUB_TOKEN;
+    if (envToken) {
+        _cachedGhToken = envToken;
+        return envToken;
+    }
+
+    try {
+        const result = childProcess.execSync('gh auth token', {
+            encoding: 'utf-8',
+            timeout: 5000,
+            stdio: ['pipe', 'pipe', 'pipe'],
+        });
+        const token = result.trim();
+        if (token) {
+            _cachedGhToken = token;
+            return token;
+        }
+    } catch {
+        // gh not installed or not authenticated
+    }
+
+    _cachedGhToken = null;
+    return undefined;
+}
+
+/**
+ * Reset the cached GitHub token (for tests).
+ */
+export function _resetGitHubToken(): void {
+    _cachedGhToken = undefined;
+}
+
+// ---------------------------------------------------------------------------
+// SkillRegistry
+// ---------------------------------------------------------------------------
+
+/**
+ * Singleton registry that discovers, indexes, and caches AI development skills.
+ *
+ * Supports local sources, GitHub repos with Lola manifests,
+ * Vercel-style skills/ directories, and generic SKILL.md repos.
+ */
+export class SkillRegistry {
+    private static _instance: SkillRegistry | undefined;
+
+    private _sources: SkillSource[] = [];
+    private _skills = new Map<string, SkillEntry>();
+    private _loading = false;
+    private _loaded = false;
+    private _forceRefresh = false;
+    private _loadPromise: Promise<void> | undefined;
+    private _onDidLoad = vscode ? new vscode.EventEmitter<void>() : new SimpleEventEmitter<void>();
+
+    /** Fires after skills finish loading. */
+    public readonly onDidLoad = this._onDidLoad.event;
+
+    /** Private constructor for singleton access via getInstance(). */
+    // eslint-disable-next-line @typescript-eslint/no-empty-function, no-empty-function -- singleton pattern requires private constructor
+    private constructor() {}
+
+    /**
+     * Returns the singleton instance, creating it if necessary.
+     *
+     * @returns The shared SkillRegistry instance.
+     */
+    static getInstance(): SkillRegistry {
+        SkillRegistry._instance ??= new SkillRegistry();
+        return SkillRegistry._instance;
+    }
+
+    /** Destroy the singleton for test isolation. */
+    static resetInstance(): void {
+        SkillRegistry._instance = undefined;
+    }
+
+    /**
+     * Override the disk-cache directory (useful for tests).
+     *
+     * @param dir - Absolute path to an alternative cache directory.
+     */
+    static setCacheDir(dir: string): void {
+        CACHE_DIR = dir;
+    }
+
+    // -- Configuration ------------------------------------------------------
+
+    /**
+     * Replace the set of configured sources and reset loaded state.
+     *
+     * @param sources - The new source list.
+     */
+    setSources(sources: SkillSource[]): void {
+        this._sources = sources;
+        this._loaded = false;
+        this._skills.clear();
+    }
+
+    /**
+     * Returns a shallow copy of the configured sources.
+     *
+     * @returns Array of skill sources.
+     */
+    getSources(): SkillSource[] {
+        return [...this._sources];
+    }
+
+    // -- Loading ------------------------------------------------------------
+
+    /**
+     * Loads skills once; subsequent calls are no-ops until reset.
+     *
+     * @returns A promise that resolves when loading is complete.
+     */
+    async ensureLoaded(): Promise<void> {
+        if (this._loaded) {
+            return;
+        }
+        if (this._loadPromise) {
+            return this._loadPromise;
+        }
+        this._loadPromise = this._loadAll();
+        await this._loadPromise;
+        this._loadPromise = undefined;
+    }
+
+    /** Force-reload all sources, bypassing the cache. */
+    async refresh(): Promise<void> {
+        this._loaded = false;
+        this._skills.clear();
+        this._forceRefresh = true;
+        await this.ensureLoaded();
+        this._forceRefresh = false;
+    }
+
+    /**
+     * Whether skill data has been loaded.
+     *
+     * @returns True when at least one load cycle has completed.
+     */
+    isLoaded(): boolean {
+        return this._loaded;
+    }
+
+    // -- Queries ------------------------------------------------------------
+
+    /**
+     * Returns every indexed skill.
+     *
+     * @returns Flat array of all skills.
+     */
+    getAllSkills(): SkillEntry[] {
+        return Array.from(this._skills.values());
+    }
+
+    /**
+     * Look up a skill by its full ID.
+     *
+     * @param id - Skill ID, e.g. "ai-forge/ansible-collection-sdlc/commit".
+     * @returns The matching skill or undefined.
+     */
+    getSkill(id: string): SkillEntry | undefined {
+        return this._skills.get(id);
+    }
+
+    /**
+     * Search skills by keyword against name, description, triggers, and tags.
+     *
+     * @param query - Space-separated search terms.
+     * @param opts - Optional filters and limit.
+     * @param opts.category - Filter results to a single category.
+     * @param opts.domain - Filter results to a domain qualifier.
+     * @param opts.source - Restrict results to a source ID.
+     * @param opts.limit - Maximum number of results (default 20).
+     * @returns Matching skills sorted by relevance.
+     */
+    search(
+        query: string,
+        opts?: {
+            category?: SkillCategory;
+            domain?: string;
+            source?: string;
+            limit?: number;
+        },
+    ): SkillEntry[] {
+        const terms = query.toLowerCase().split(/\s+/).filter(Boolean);
+        const limit = opts?.limit ?? 20;
+
+        let results = this.getAllSkills();
+
+        if (opts?.category) {
+            results = results.filter((s) => s.category === opts.category);
+        }
+        if (opts?.domain) {
+            results = results.filter((s) => s.domain === opts.domain);
+        }
+        if (opts?.source) {
+            results = results.filter((s) => s.source === opts.source);
+        }
+
+        if (terms.length === 0) {
+            return results.slice(0, limit);
+        }
+
+        const scored = results.map((skill) => {
+            let score = 0;
+            const haystack = [
+                skill.name,
+                skill.description,
+                ...skill.triggers,
+                ...skill.tags,
+                skill.module,
+                skill.domain ?? '',
+            ]
+                .join(' ')
+                .toLowerCase();
+
+            for (const term of terms) {
+                if (skill.name.toLowerCase().includes(term)) {
+                    score += 10;
+                }
+                if (skill.description.toLowerCase().includes(term)) {
+                    score += 5;
+                }
+                if (skill.triggers.some((t) => t.toLowerCase().includes(term))) {
+                    score += 8;
+                }
+                if (skill.tags.some((t) => t.toLowerCase().includes(term))) {
+                    score += 3;
+                }
+                if (haystack.includes(term)) {
+                    score += 1;
+                }
+            }
+            return { skill, score };
+        });
+
+        return scored
+            .filter((s) => s.score > 0)
+            .sort((a, b) => b.score - a.score)
+            .slice(0, limit)
+            .map((s) => s.skill);
+    }
+
+    /**
+     * Load full content for a skill (fetches SKILL.md body on demand).
+     *
+     * @param id - Skill ID.
+     * @returns The SKILL.md body text, or undefined.
+     */
+    async loadSkillContent(id: string): Promise<string | undefined> {
+        const skill = this._skills.get(id);
+        if (!skill) {
+            return undefined;
+        }
+        if (skill.content) {
+            return skill.content;
+        }
+
+        const source = this._sources.find((s) => s.id === skill.source);
+        if (!source) {
+            return undefined;
+        }
+
+        try {
+            const content = await this._fetchSkillContent(source, skill);
+            if (content) {
+                skill.content = content;
+            }
+            return content;
+        } catch (err: unknown) {
+            log(`SkillRegistry: failed to load content for ${id}: ${String(err)}`);
+            return undefined;
+        }
+    }
+
+    // -- Private: loading ---------------------------------------------------
+
+    /** Iterates all configured sources, loading skills from each. */
+    private async _loadAll(): Promise<void> {
+        if (this._loading) {
+            return;
+        }
+        this._loading = true;
+
+        try {
+            for (const source of this._sources) {
+                try {
+                    await this._loadSource(source);
+                } catch (err: unknown) {
+                    log(`SkillRegistry: failed to load source ${source.id}: ${String(err)}`);
+                }
+            }
+            this._loaded = true;
+            this._onDidLoad.fire();
+        } finally {
+            this._loading = false;
+        }
+    }
+
+    /**
+     * Loads a single source, using cache when available.
+     *
+     * @param source - The source to load.
+     */
+    private async _loadSource(source: SkillSource): Promise<void> {
+        const cached = this._forceRefresh ? undefined : this._readCache(source.id);
+        const maxAge = (source.refreshInterval ?? 24) * 60 * 60 * 1000;
+        const urlMatch = !cached?.sourceUrl || cached.sourceUrl === source.url;
+
+        if (cached && urlMatch && Date.now() - cached.timestamp < maxAge) {
+            for (const skill of cached.skills) {
+                this._skills.set(skill.id, skill);
+            }
+            log(
+                `SkillRegistry: loaded ${String(cached.skills.length)} skills from cache for ${source.id}`,
+            );
+            return;
+        }
+        if (cached && !urlMatch) {
+            log(`SkillRegistry: cache invalidated for ${source.id} (URL changed)`);
+        }
+
+        let skills: SkillEntry[] = [];
+        let format: RepoFormat | undefined;
+        switch (source.type) {
+            case 'github': {
+                const result = await this._loadGitHubSource(source);
+                skills = result.skills;
+                format = result.format;
+                break;
+            }
+            case 'local':
+                skills = this._loadLocalSource(source);
+                break;
+            case 'registry':
+                skills = this._loadRegistrySource();
+                break;
+        }
+
+        for (const skill of skills) {
+            this._skills.set(skill.id, skill);
+        }
+
+        this._writeCache(source.id, skills, format, source.url);
+        log(
+            `SkillRegistry: loaded ${String(skills.length)} skills from ${source.id}` +
+                (format ? ` (${format} format)` : ''),
+        );
+    }
+
+    // -- Private: GitHub source (auto-detect) --------------------------------
+
+    /**
+     * Auto-detects the repo format and delegates to the appropriate loader.
+     *
+     * @param source - GitHub source to load.
+     * @returns Discovered skills and detected format.
+     */
+    private async _loadGitHubSource(
+        source: SkillSource,
+    ): Promise<{ skills: SkillEntry[]; format: RepoFormat }> {
+        const format = await this._detectRepoFormat(source);
+        log(`SkillRegistry: detected ${format} format for ${source.id}`);
+
+        switch (format) {
+            case 'lola':
+                return { skills: await this._loadLolaSource(source), format };
+            case 'vercel':
+                return { skills: await this._loadVercelSource(source), format };
+            default:
+                return { skills: await this._loadGenericGitHubSource(source), format };
+        }
+    }
+
+    /**
+     * Probes a GitHub repo to determine its skill layout convention.
+     *
+     * @param source - The source whose URL to probe.
+     * @returns The detected repo format.
+     */
+    private async _detectRepoFormat(source: SkillSource): Promise<RepoFormat> {
+        const repoPath = this._githubRepoPath(source.url);
+        if (!repoPath) {
+            return 'generic';
+        }
+
+        const apiHeaders = this._githubApiHeaders();
+
+        const lolaCheck = await this._httpGet(
+            `https://api.github.com/repos/${repoPath}/contents/lola-market.yml`,
+            apiHeaders,
+        );
+        if (lolaCheck) {
+            return 'lola';
+        }
+
+        const marketplaceCheck = await this._httpGet(
+            `https://api.github.com/repos/${repoPath}/contents/marketplace`,
+            apiHeaders,
+        );
+        if (marketplaceCheck) {
+            try {
+                const entries = JSON.parse(marketplaceCheck) as {
+                    name: string;
+                    type: string;
+                }[];
+                if (
+                    Array.isArray(entries) &&
+                    entries.some((e) => e.type === 'file' && e.name.endsWith('.yml'))
+                ) {
+                    return 'lola';
+                }
+            } catch {
+                /* not valid JSON directory listing */
+            }
+        }
+
+        const skillsCheck = await this._httpGet(
+            `https://api.github.com/repos/${repoPath}/contents/skills`,
+            apiHeaders,
+        );
+        if (skillsCheck) {
+            try {
+                const entries = JSON.parse(skillsCheck) as { type: string }[];
+                if (Array.isArray(entries) && entries.some((e) => e.type === 'dir')) {
+                    return 'vercel';
+                }
+            } catch {
+                /* not valid JSON directory listing */
+            }
+        }
+
+        return 'generic';
+    }
+
+    // -- Private: Lola format (ai-forge / agentic-collections) ---------------
+
+    /**
+     * Loads skills from a Lola-manifest repo including unlisted modules.
+     *
+     * @param source - The Lola-format source.
+     * @returns All discovered skills.
+     */
+    private async _loadLolaSource(source: SkillSource): Promise<SkillEntry[]> {
+        const manifest = await this._fetchLolaManifest(source);
+        if (!manifest?.modules) {
+            return [];
+        }
+
+        const skills: SkillEntry[] = [];
+        const coveredDirs = new Set<string>();
+
+        for (const mod of manifest.modules) {
+            const moduleSkills = await this._fetchModuleSkills(source, mod);
+            skills.push(...moduleSkills);
+            const rootDir = (mod.path ?? mod.name).split('/')[0];
+            coveredDirs.add(rootDir);
+        }
+
+        const extraSkills = await this._discoverUnlistedModules(source, coveredDirs);
+        skills.push(...extraSkills);
+
+        return skills;
+    }
+
+    /**
+     * Fetches and parses the Lola manifest from root or marketplace/.
+     *
+     * @param source - The source to fetch from.
+     * @returns Parsed manifest or undefined.
+     */
+    private async _fetchLolaManifest(source: SkillSource): Promise<LolaMarketManifest | undefined> {
+        const rawBase = this._githubRawBase(source.url);
+        if (!rawBase) {
+            return undefined;
+        }
+        const authHeaders = this._getAuthHeaders();
+
+        const rootManifest = await this._httpGet(`${rawBase}/main/lola-market.yml`, authHeaders);
+        if (rootManifest) {
+            return this._parseLolaManifest(rootManifest, source.id, 'lola-market.yml');
+        }
+
+        const repoPath = this._githubRepoPath(source.url);
+        if (repoPath) {
+            const apiHeaders = this._githubApiHeaders();
+            const dirText = await this._httpGet(
+                `https://api.github.com/repos/${repoPath}/contents/marketplace`,
+                apiHeaders,
+            );
+            if (dirText) {
+                try {
+                    const entries = JSON.parse(dirText) as {
+                        name: string;
+                        type: string;
+                    }[];
+                    const ymlFile = entries.find(
+                        (e) => e.type === 'file' && e.name.endsWith('.yml'),
+                    );
+                    if (ymlFile) {
+                        const text = await this._httpGet(
+                            `${rawBase}/main/marketplace/${ymlFile.name}`,
+                            authHeaders,
+                        );
+                        if (text) {
+                            return this._parseLolaManifest(
+                                text,
+                                source.id,
+                                `marketplace/${ymlFile.name}`,
+                            );
+                        }
+                    }
+                } catch {
+                    /* directory listing parse failed */
+                }
+            }
+        }
+
+        return undefined;
+    }
+
+    /**
+     * Attempts to parse a YAML string as a Lola manifest.
+     *
+     * @param text - Raw YAML text.
+     * @param sourceId - Source ID for error logging.
+     * @param fileName - File name for error logging.
+     * @returns Parsed manifest or undefined on parse failure.
+     */
+    private _parseLolaManifest(
+        text: string,
+        sourceId: string,
+        fileName: string,
+    ): LolaMarketManifest | undefined {
+        try {
+            return yaml.load(text) as LolaMarketManifest;
+        } catch (err: unknown) {
+            log(`SkillRegistry: failed to parse ${fileName} for ${sourceId}: ${String(err)}`);
+            return undefined;
+        }
+    }
+
+    /**
+     * Fetches skills from a single Lola module's skills/ directory.
+     *
+     * @param source - Parent source.
+     * @param mod - Lola module entry from the manifest.
+     * @returns Skills discovered under this module.
+     */
+    private async _fetchModuleSkills(
+        source: SkillSource,
+        mod: LolaModuleEntry,
+    ): Promise<SkillEntry[]> {
+        const rawBase = this._githubRawBase(source.url);
+        if (!rawBase) {
+            return [];
+        }
+
+        const modulePath = mod.path ?? `${mod.name}/module`;
+        const authHeaders = this._getAuthHeaders();
+        const agentsUrl = `${rawBase}/main/${modulePath}/AGENTS.md`;
+        const agentsContent = await this._httpGet(agentsUrl, authHeaders);
+
+        const skills = await this._discoverSkillsFromTree(source, mod, modulePath);
+        if (skills.length > 0) {
+            return skills;
+        }
+
+        if (agentsContent) {
+            return [
+                {
+                    id: `${source.id}/${mod.name}`,
+                    source: source.id,
+                    module: mod.name,
+                    name: mod.name,
+                    description: mod.description ?? mod.name,
+                    triggers: [],
+                    category: this._inferCategory(mod),
+                    tags: mod.tags ?? [],
+                    trust: source.trust,
+                    contentUrl: agentsUrl,
+                    content: agentsContent,
+                },
+            ];
+        }
+        return [];
+    }
+
+    /**
+     * Scans a module's skills/ directory for SKILL.md files via the GitHub API.
+     *
+     * @param source - Parent source.
+     * @param mod - Module entry.
+     * @param modulePath - Filesystem path within the repo.
+     * @returns Individual skill entries from each sub-directory.
+     */
+    private async _discoverSkillsFromTree(
+        source: SkillSource,
+        mod: LolaModuleEntry,
+        modulePath: string,
+    ): Promise<SkillEntry[]> {
+        const repoPath = this._githubRepoPath(source.url);
+        if (!repoPath) {
+            return [];
+        }
+
+        const authHeaders = this._getAuthHeaders();
+        const apiUrl = `https://api.github.com/repos/${repoPath}/contents/${modulePath}/skills`;
+        const text = await this._httpGet(apiUrl, this._githubApiHeaders());
+        if (!text) {
+            return [];
+        }
+
+        let entries: { name: string; type: string }[];
+        try {
+            entries = JSON.parse(text) as { name: string; type: string }[];
+        } catch {
+            return [];
+        }
+        if (!Array.isArray(entries)) {
+            return [];
+        }
+
+        const skills: SkillEntry[] = [];
+        const rawBase = this._githubRawBase(source.url);
+        if (!rawBase) {
+            return [];
+        }
+
+        for (const entry of entries) {
+            if (entry.type !== 'dir') {
+                continue;
+            }
+
+            const skillMdUrl = `${rawBase}/main/${modulePath}/skills/${entry.name}/SKILL.md`;
+            const skillMd = await this._httpGet(skillMdUrl, authHeaders);
+            if (!skillMd) {
+                continue;
+            }
+
+            const { frontmatter, body } = this._parseSkillMd(skillMd);
+            skills.push({
+                id: `${source.id}/${mod.name}/${entry.name}`,
+                source: source.id,
+                module: mod.name,
+                name: frontmatter.name ?? entry.name,
+                description: frontmatter.description ?? '',
+                triggers: this._normalizeTriggers(frontmatter.triggers),
+                category:
+                    (frontmatter.category as SkillCategory | undefined) ?? this._inferCategory(mod),
+                domain: frontmatter.domain,
+                tags: frontmatter.tags ?? mod.tags ?? [],
+                trust: source.trust,
+                contentUrl: skillMdUrl,
+                content: body,
+            });
+        }
+        return skills;
+    }
+
+    /**
+     * Scan the repo root for directories not in the manifest that follow
+     * the Lola convention ({name}/module/skills/).
+     *
+     * @param source - Parent source.
+     * @param coveredDirs - Set of directories already handled by the manifest.
+     * @returns Skills from unlisted modules.
+     */
+    private async _discoverUnlistedModules(
+        source: SkillSource,
+        coveredDirs: Set<string>,
+    ): Promise<SkillEntry[]> {
+        const repoPath = this._githubRepoPath(source.url);
+        if (!repoPath) {
+            return [];
+        }
+
+        const apiHeaders = this._githubApiHeaders();
+        const rootText = await this._httpGet(
+            `https://api.github.com/repos/${repoPath}/contents/`,
+            apiHeaders,
+        );
+        if (!rootText) {
+            return [];
+        }
+
+        let entries: { name: string; type: string }[];
+        try {
+            entries = JSON.parse(rootText) as { name: string; type: string }[];
+        } catch {
+            return [];
+        }
+        if (!Array.isArray(entries)) {
+            return [];
+        }
+
+        const skills: SkillEntry[] = [];
+        for (const entry of entries) {
+            if (entry.type !== 'dir' || entry.name.startsWith('.') || coveredDirs.has(entry.name)) {
+                continue;
+            }
+
+            const skillsDirCheck = await this._httpGet(
+                `https://api.github.com/repos/${repoPath}/contents/${entry.name}/module/skills`,
+                apiHeaders,
+            );
+            if (!skillsDirCheck) {
+                continue;
+            }
+
+            try {
+                const skillEntries = JSON.parse(skillsDirCheck) as unknown[];
+                if (!Array.isArray(skillEntries)) {
+                    continue;
+                }
+            } catch {
+                continue;
+            }
+
+            log(`SkillRegistry: discovered unlisted module ${entry.name} in ${source.id}`);
+            const syntheticMod: LolaModuleEntry = {
+                name: entry.name,
+                description: entry.name,
+                path: `${entry.name}/module`,
+                tags: [],
+            };
+            const modSkills = await this._fetchModuleSkills(source, syntheticMod);
+            skills.push(...modSkills);
+        }
+
+        return skills;
+    }
+
+    // -- Private: Vercel/harness format (skills/ directory) ------------------
+
+    /**
+     * Loads skills from a repo with a top-level skills/ directory.
+     *
+     * @param source - The Vercel/harness-format source.
+     * @returns All discovered skills.
+     */
+    private async _loadVercelSource(source: SkillSource): Promise<SkillEntry[]> {
+        const repoPath = this._githubRepoPath(source.url);
+        if (!repoPath) {
+            return [];
+        }
+
+        const authHeaders = this._getAuthHeaders();
+        const apiHeaders = this._githubApiHeaders();
+
+        const dirText = await this._httpGet(
+            `https://api.github.com/repos/${repoPath}/contents/skills`,
+            apiHeaders,
+        );
+        if (!dirText) {
+            return [];
+        }
+
+        let entries: { name: string; type: string }[];
+        try {
+            entries = JSON.parse(dirText) as { name: string; type: string }[];
+        } catch {
+            return [];
+        }
+        if (!Array.isArray(entries)) {
+            return [];
+        }
+
+        const rawBase = this._githubRawBase(source.url);
+        if (!rawBase) {
+            return [];
+        }
+        const repoName = repoPath.split('/').pop() ?? source.id;
+        const skills: SkillEntry[] = [];
+
+        for (const entry of entries) {
+            if (entry.type !== 'dir' || entry.name.startsWith('.')) {
+                continue;
+            }
+
+            const skillMdUrl = `${rawBase}/main/skills/${entry.name}/SKILL.md`;
+            const skillMd = await this._httpGet(skillMdUrl, authHeaders);
+            if (!skillMd) {
+                continue;
+            }
+
+            const { frontmatter, body } = this._parseSkillMd(skillMd);
+            skills.push({
+                id: `${source.id}/${entry.name}`,
+                source: source.id,
+                module: repoName,
+                name: frontmatter.name ?? entry.name,
+                description: frontmatter.description ?? '',
+                triggers: this._normalizeTriggers(frontmatter.triggers),
+                category:
+                    (frontmatter.category as SkillCategory | undefined) ??
+                    this._inferCategoryFromFrontmatter(frontmatter) ??
+                    'other',
+                domain: frontmatter.domain,
+                tags: frontmatter.tags ?? [],
+                trust: source.trust,
+                contentUrl: skillMdUrl,
+                content: body,
+            });
+        }
+
+        return skills;
+    }
+
+    // -- Private: generic format (scan root for SKILL.md dirs) --------------
+
+    /**
+     * Scans root-level directories for SKILL.md files as a fallback.
+     *
+     * @param source - The generic-format source.
+     * @returns All discovered skills.
+     */
+    private async _loadGenericGitHubSource(source: SkillSource): Promise<SkillEntry[]> {
+        const repoPath = this._githubRepoPath(source.url);
+        if (!repoPath) {
+            return [];
+        }
+
+        const authHeaders = this._getAuthHeaders();
+        const apiHeaders = this._githubApiHeaders();
+
+        const rootText = await this._httpGet(
+            `https://api.github.com/repos/${repoPath}/contents/`,
+            apiHeaders,
+        );
+        if (!rootText) {
+            return [];
+        }
+
+        let entries: { name: string; type: string }[];
+        try {
+            entries = JSON.parse(rootText) as { name: string; type: string }[];
+        } catch {
+            return [];
+        }
+        if (!Array.isArray(entries)) {
+            return [];
+        }
+
+        const rawBase = this._githubRawBase(source.url);
+        if (!rawBase) {
+            return [];
+        }
+        const skills: SkillEntry[] = [];
+
+        for (const entry of entries) {
+            if (entry.type !== 'dir' || entry.name.startsWith('.')) {
+                continue;
+            }
+
+            const skillMdUrl = `${rawBase}/main/${entry.name}/SKILL.md`;
+            const skillMd = await this._httpGet(skillMdUrl, authHeaders);
+            if (!skillMd) {
+                continue;
+            }
+
+            const { frontmatter, body } = this._parseSkillMd(skillMd);
+            skills.push({
+                id: `${source.id}/${entry.name}`,
+                source: source.id,
+                module: source.id,
+                name: frontmatter.name ?? entry.name,
+                description: frontmatter.description ?? '',
+                triggers: this._normalizeTriggers(frontmatter.triggers),
+                category: (frontmatter.category as SkillCategory | undefined) ?? 'other',
+                domain: frontmatter.domain,
+                tags: frontmatter.tags ?? [],
+                trust: source.trust,
+                contentUrl: skillMdUrl,
+                content: body,
+            });
+        }
+        return skills;
+    }
+
+    // -- Private: local source ----------------------------------------------
+
+    /**
+     * Loads skills from a local directory of SKILL.md files.
+     *
+     * @param source - The local source with a directory path in url.
+     * @returns Discovered skills from disk.
+     */
+    private _loadLocalSource(source: SkillSource): SkillEntry[] {
+        const skillsDir = source.url;
+        if (!fs.existsSync(skillsDir)) {
+            return [];
+        }
+
+        const skills: SkillEntry[] = [];
+        const entries = fs.readdirSync(skillsDir, { withFileTypes: true });
+
+        for (const entry of entries) {
+            if (!entry.isDirectory()) {
+                continue;
+            }
+            const skillMdPath = path.join(skillsDir, entry.name, 'SKILL.md');
+            if (!fs.existsSync(skillMdPath)) {
+                continue;
+            }
+
+            const raw = fs.readFileSync(skillMdPath, 'utf-8');
+            const { frontmatter, body } = this._parseSkillMd(raw);
+
+            skills.push({
+                id: `${source.id}/${entry.name}`,
+                source: source.id,
+                module: source.id,
+                name: frontmatter.name ?? entry.name,
+                description: frontmatter.description ?? '',
+                triggers: this._normalizeTriggers(frontmatter.triggers),
+                category: (frontmatter.category as SkillCategory | undefined) ?? 'other',
+                domain: frontmatter.domain,
+                tags: frontmatter.tags ?? [],
+                trust: source.trust,
+                content: body,
+            });
+        }
+        return skills;
+    }
+
+    // -- Private: registry source (future) ----------------------------------
+
+    /**
+     * Placeholder for future registry-based source support.
+     *
+     * @returns Empty array (not yet implemented).
+     */
+    private _loadRegistrySource(): SkillEntry[] {
+        log('SkillRegistry: registry source type not yet implemented');
+        return [];
+    }
+
+    // -- Private: fetch skill content on demand -----------------------------
+
+    /**
+     * Fetches the SKILL.md body for a skill from its source.
+     *
+     * @param source - The source the skill belongs to.
+     * @param skill - The skill entry with a contentUrl or name.
+     * @returns The parsed body text, or undefined.
+     */
+    private async _fetchSkillContent(
+        source: SkillSource,
+        skill: SkillEntry,
+    ): Promise<string | undefined> {
+        if (source.type === 'local') {
+            const skillMdPath = path.join(source.url, skill.name, 'SKILL.md');
+            if (fs.existsSync(skillMdPath)) {
+                const raw = fs.readFileSync(skillMdPath, 'utf-8');
+                const { body } = this._parseSkillMd(raw);
+                return body;
+            }
+            return undefined;
+        }
+
+        if (skill.contentUrl) {
+            const raw = await this._httpGet(skill.contentUrl, this._getAuthHeaders());
+            if (!raw) {
+                log(`SkillRegistry: failed to fetch content from ${skill.contentUrl}`);
+                return undefined;
+            }
+            const { body } = this._parseSkillMd(raw);
+            return body;
+        }
+
+        return undefined;
+    }
+
+    // -- Private: SKILL.md parsing ------------------------------------------
+
+    /**
+     * Parses a SKILL.md file into its YAML frontmatter and body sections.
+     *
+     * @param raw - Raw SKILL.md file content.
+     * @returns Parsed frontmatter object and the body text below the fence.
+     */
+    private _parseSkillMd(raw: string): { frontmatter: SkillFrontmatter; body: string } {
+        const fmMatch = /^---\n([\s\S]*?)\n---\n?([\s\S]*)$/.exec(raw);
+        if (!fmMatch) {
+            return { frontmatter: {}, body: raw };
+        }
+
+        let frontmatter: SkillFrontmatter = {};
+        try {
+            const parsed = yaml.load(fmMatch[1]) as SkillFrontmatter | undefined;
+            frontmatter = parsed ?? {};
+        } catch {
+            // Malformed frontmatter — treat entire file as body
+        }
+        return { frontmatter, body: fmMatch[2].trim() };
+    }
+
+    /**
+     * Normalize triggers: harness uses array or comma-separated string.
+     *
+     * @param raw - String, array, or undefined triggers value.
+     * @returns Flat array of trigger strings.
+     */
+    private _normalizeTriggers(raw: string[] | string | undefined): string[] {
+        if (!raw) {
+            return [];
+        }
+        if (Array.isArray(raw)) {
+            return raw;
+        }
+        return raw
+            .split(',')
+            .map((t) => t.trim())
+            .filter(Boolean);
+    }
+
+    // -- Private: category inference ----------------------------------------
+
+    /**
+     * Infers a category from Lola module name and tags.
+     *
+     * @param mod - The Lola module entry.
+     * @returns Best-guess skill category.
+     */
+    private _inferCategory(mod: LolaModuleEntry): SkillCategory {
+        const name = mod.name.toLowerCase();
+        const tags = (mod.tags ?? []).join(' ').toLowerCase();
+        const combined = `${name} ${tags}`;
+
+        if (combined.includes('sdlc') || combined.includes('lifecycle')) {
+            return 'sdlc';
+        }
+        if (
+            combined.includes('standard') ||
+            combined.includes('review') ||
+            combined.includes('lint')
+        ) {
+            return 'standards';
+        }
+        if (
+            combined.includes('scaffold') ||
+            combined.includes('role') ||
+            combined.includes('creator')
+        ) {
+            return 'scaffold';
+        }
+        if (
+            combined.includes('cloud') ||
+            combined.includes('network') ||
+            combined.includes('security')
+        ) {
+            return 'domain';
+        }
+        if (combined.includes('workflow')) {
+            return 'workflow';
+        }
+        return 'other';
+    }
+
+    /**
+     * Infer category from SKILL.md frontmatter type field (harness convention).
+     *
+     * @param fm - Parsed frontmatter object.
+     * @returns Inferred category or undefined when the type is unrecognized.
+     */
+    private _inferCategoryFromFrontmatter(fm: SkillFrontmatter): SkillCategory | undefined {
+        const type = fm.type?.toLowerCase();
+        if (!type) {
+            return undefined;
+        }
+
+        if (type === 'review' || type === 'standards') {
+            return 'standards';
+        }
+        if (type === 'workflow' || type === 'sdlc' || type === 'implementation') {
+            return 'sdlc';
+        }
+        if (type === 'scaffold' || type === 'create') {
+            return 'scaffold';
+        }
+        if (type === 'domain') {
+            return 'domain';
+        }
+        return undefined;
+    }
+
+    // -- Private: GitHub URL helpers ----------------------------------------
+
+    /**
+     * Extracts the raw.githubusercontent.com base URL from a GitHub repo URL.
+     *
+     * @param url - GitHub repository URL.
+     * @returns Raw content base URL, or undefined for non-GitHub URLs.
+     */
+    private _githubRawBase(url: string): string | undefined {
+        const match = /github\.com\/([^/]+\/[^/]+)/.exec(url);
+        if (!match) {
+            return undefined;
+        }
+        return `https://raw.githubusercontent.com/${match[1]}`;
+    }
+
+    /**
+     * Extracts the "owner/repo" path from a GitHub URL.
+     *
+     * @param url - GitHub repository URL.
+     * @returns The "owner/repo" string, or undefined.
+     */
+    private _githubRepoPath(url: string): string | undefined {
+        const match = /github\.com\/([^/]+\/[^/]+)/.exec(url);
+        return match?.[1]?.replace(/\.git$/, '');
+    }
+
+    // -- Private: GitHub auth -----------------------------------------------
+
+    /**
+     * Returns an Authorization header if a GitHub token is available.
+     *
+     * @returns Headers object, possibly empty.
+     */
+    private _getAuthHeaders(): Record<string, string> {
+        const token = _resolveGitHubToken();
+        if (!token) {
+            return {};
+        }
+        return { Authorization: `token ${token}` };
+    }
+
+    /**
+     * Standard headers for GitHub API requests.
+     *
+     * @returns Headers with Accept, User-Agent, and optional Authorization.
+     */
+    private _githubApiHeaders(): Record<string, string> {
+        return {
+            Accept: 'application/vnd.github.v3+json',
+            'User-Agent': 'ansible-environments-mcp',
+            ...this._getAuthHeaders(),
+        };
+    }
+
+    // -- Private: HTTP ------------------------------------------------------
+
+    /**
+     * Performs a GET request, following redirects, with a 10s timeout.
+     *
+     * @param url - The URL to fetch.
+     * @param headers - Optional request headers.
+     * @returns Response body as a string, or undefined on error/non-200.
+     */
+    private _httpGet(url: string, headers?: Record<string, string>): Promise<string | undefined> {
+        return new Promise((resolve) => {
+            const reqHeaders: Record<string, string> = {
+                'User-Agent': 'ansible-environments-mcp',
+                ...headers,
+            };
+
+            const req = https.get(url, { headers: reqHeaders }, (res) => {
+                if (
+                    res.statusCode &&
+                    res.statusCode >= 300 &&
+                    res.statusCode < 400 &&
+                    res.headers.location
+                ) {
+                    void this._httpGet(res.headers.location, headers).then(resolve);
+                    return;
+                }
+
+                if (res.statusCode !== 200) {
+                    resolve(undefined);
+                    return;
+                }
+
+                const chunks: Buffer[] = [];
+                res.on('data', (chunk: Buffer) => chunks.push(chunk));
+                res.on('end', () => {
+                    resolve(Buffer.concat(chunks).toString('utf-8'));
+                });
+                res.on('error', () => {
+                    resolve(undefined);
+                });
+            });
+
+            req.on('error', () => {
+                resolve(undefined);
+            });
+            req.setTimeout(10000, () => {
+                req.destroy();
+                resolve(undefined);
+            });
+        });
+    }
+
+    // -- Private: disk cache ------------------------------------------------
+
+    /**
+     * Returns the cache file path for a given source.
+     *
+     * @param sourceId - Unique source identifier.
+     * @returns Absolute path to the cache JSON file.
+     */
+    private _getCachePath(sourceId: string): string {
+        return path.join(CACHE_DIR, `${sourceId}-${INDEX_CACHE_FILE}`);
+    }
+
+    /**
+     * Reads a cached skill index from disk.
+     *
+     * @param sourceId - Source to read cached data for.
+     * @returns Parsed cached index, or undefined when not available.
+     */
+    private _readCache(sourceId: string): CachedIndex | undefined {
+        try {
+            const cachePath = this._getCachePath(sourceId);
+            if (!fs.existsSync(cachePath)) {
+                return undefined;
+            }
+            const raw = fs.readFileSync(cachePath, 'utf-8');
+            return JSON.parse(raw) as CachedIndex;
+        } catch {
+            return undefined;
+        }
+    }
+
+    /**
+     * Persists a skill index to disk, stripping content to save space.
+     *
+     * @param sourceId - Source identifier for the cache file.
+     * @param skills - Skills to persist.
+     * @param format - Detected repo format.
+     * @param sourceUrl - Source URL stored for cache invalidation.
+     */
+    private _writeCache(
+        sourceId: string,
+        skills: SkillEntry[],
+        format?: RepoFormat,
+        sourceUrl?: string,
+    ): void {
+        try {
+            fs.mkdirSync(CACHE_DIR, { recursive: true });
+            const data: CachedIndex = {
+                timestamp: Date.now(),
+                sourceId,
+                sourceUrl,
+                format,
+                skills: skills.map((s) => ({
+                    ...s,
+                    content: undefined,
+                    contentUrl: s.contentUrl,
+                })),
+            };
+            fs.writeFileSync(this._getCachePath(sourceId), JSON.stringify(data));
+        } catch (err: unknown) {
+            log(`SkillRegistry: failed to write cache for ${sourceId}: ${String(err)}`);
+        }
+    }
+}

--- a/packages/core/test/services/SkillRegistry.test.ts
+++ b/packages/core/test/services/SkillRegistry.test.ts
@@ -1,7 +1,57 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const httpResponses = vi.hoisted(() => {
+    const map = new Map<string, string | undefined>();
+    return {
+        map,
+        reset: () => {
+            map.clear();
+        },
+        set: (key: string, value: string | undefined) => map.set(key, value),
+    };
+});
+
+vi.mock('https', () => ({
+    get: vi.fn((url: string | URL, opts: unknown, cb?: unknown) => {
+        const urlStr = typeof url === 'string' ? url : url.toString();
+        const callback = typeof opts === 'function' ? opts : cb;
+
+        let body: string | undefined;
+        for (const [key, val] of httpResponses.map.entries()) {
+            if (urlStr.endsWith(key)) {
+                body = val;
+                break;
+            }
+        }
+
+        const statusCode = body !== undefined ? 200 : 404;
+        const res = {
+            statusCode,
+            headers: {},
+            on: vi.fn((event: string, handler: (data?: Buffer) => void) => {
+                if (statusCode === 200 && body !== undefined) {
+                    if (event === 'data') handler(Buffer.from(body));
+                    if (event === 'end') handler();
+                }
+                return res;
+            }),
+        };
+
+        if (typeof callback === 'function') {
+            (callback as (res: unknown) => void)(res);
+        }
+
+        return {
+            on: vi.fn(),
+            setTimeout: vi.fn(),
+            destroy: vi.fn(),
+        };
+    }),
+}));
+
 import { SkillRegistry, _resetGitHubToken } from '../../src/services/SkillRegistry';
 import type { SkillSource } from '../../src/services/SkillRegistry';
 
@@ -252,7 +302,6 @@ This is the body of the skill.`,
 
     describe('cache invalidation', () => {
         it('invalidates cache when source URL changes', async () => {
-            // Create two different local skill dirs
             for (const name of ['dir-a', 'dir-b']) {
                 const skillDir = path.join(tempDir, name, 'my-skill');
                 fs.mkdirSync(skillDir, { recursive: true });
@@ -262,7 +311,6 @@ This is the body of the skill.`,
                 );
             }
 
-            // Load from dir-a
             const reg = SkillRegistry.getInstance();
             reg.setSources([
                 {
@@ -275,7 +323,6 @@ This is the body of the skill.`,
             await reg.ensureLoaded();
             expect(reg.getSkill('changing-source/my-skill')?.name).toBe('Skill from dir-a');
 
-            // Change URL to dir-b, new instance
             SkillRegistry.resetInstance();
             const reg2 = SkillRegistry.getInstance();
             reg2.setSources([
@@ -288,6 +335,495 @@ This is the body of the skill.`,
             ]);
             await reg2.ensureLoaded();
             expect(reg2.getSkill('changing-source/my-skill')?.name).toBe('Skill from dir-b');
+        });
+    });
+
+    describe('refresh', () => {
+        it('force-reloads skills from sources', async () => {
+            const skillDir = path.join(tempDir, 'refresh-test', 'my-skill');
+            fs.mkdirSync(skillDir, { recursive: true });
+            fs.writeFileSync(path.join(skillDir, 'SKILL.md'), '---\nname: Original\n---\nBody');
+
+            const reg = SkillRegistry.getInstance();
+            reg.setSources([
+                {
+                    id: 'refresh-src',
+                    type: 'local',
+                    url: path.join(tempDir, 'refresh-test'),
+                    trust: 'community',
+                },
+            ]);
+            await reg.ensureLoaded();
+            expect(reg.getSkill('refresh-src/my-skill')?.name).toBe('Original');
+
+            fs.writeFileSync(path.join(skillDir, 'SKILL.md'), '---\nname: Updated\n---\nNew body');
+            await reg.refresh();
+            expect(reg.getSkill('refresh-src/my-skill')?.name).toBe('Updated');
+        });
+    });
+
+    describe('search advanced', () => {
+        it('filters by domain', async () => {
+            const base = path.join(tempDir, 'domain-test');
+            for (const [name, domain] of [
+                ['cloud-skill', 'cloud'],
+                ['network-skill', 'network'],
+            ] as const) {
+                const dir = path.join(base, name);
+                fs.mkdirSync(dir, { recursive: true });
+                fs.writeFileSync(
+                    path.join(dir, 'SKILL.md'),
+                    `---\nname: ${name}\ndescription: ${name}\ndomain: ${domain}\n---\nBody`,
+                );
+            }
+
+            const reg = SkillRegistry.getInstance();
+            reg.setSources([{ id: 'dom', type: 'local', url: base, trust: 'community' }]);
+            await reg.ensureLoaded();
+
+            const results = reg.search('', { domain: 'cloud' });
+            expect(results).toHaveLength(1);
+            expect(results[0].name).toBe('cloud-skill');
+        });
+
+        it('filters by source', async () => {
+            const base1 = path.join(tempDir, 'src1');
+            const base2 = path.join(tempDir, 'src2');
+            for (const [base, id] of [
+                [base1, 'source-a'],
+                [base2, 'source-b'],
+            ] as const) {
+                const dir = path.join(base, 'skill');
+                fs.mkdirSync(dir, { recursive: true });
+                fs.writeFileSync(
+                    path.join(dir, 'SKILL.md'),
+                    `---\nname: skill-from-${id}\n---\nBody`,
+                );
+            }
+
+            const reg = SkillRegistry.getInstance();
+            reg.setSources([
+                { id: 'source-a', type: 'local', url: base1, trust: 'community' },
+                { id: 'source-b', type: 'local', url: base2, trust: 'certified' },
+            ]);
+            await reg.ensureLoaded();
+
+            const results = reg.search('', { source: 'source-b' });
+            expect(results).toHaveLength(1);
+            expect(results[0].name).toBe('skill-from-source-b');
+        });
+
+        it('respects limit', async () => {
+            const base = path.join(tempDir, 'limit-test');
+            for (let i = 0; i < 5; i++) {
+                const dir = path.join(base, `skill-${String(i)}`);
+                fs.mkdirSync(dir, { recursive: true });
+                fs.writeFileSync(
+                    path.join(dir, 'SKILL.md'),
+                    `---\nname: skill-${String(i)}\ndescription: test\n---\nBody`,
+                );
+            }
+
+            const reg = SkillRegistry.getInstance();
+            reg.setSources([{ id: 'lim', type: 'local', url: base, trust: 'community' }]);
+            await reg.ensureLoaded();
+
+            const results = reg.search('', { limit: 2 });
+            expect(results).toHaveLength(2);
+        });
+    });
+
+    describe('loadSkillContent for cached skill', () => {
+        it('returns cached content on second call without refetch', async () => {
+            const skillDir = path.join(tempDir, 'cache-content', 'my-skill');
+            fs.mkdirSync(skillDir, { recursive: true });
+            fs.writeFileSync(
+                path.join(skillDir, 'SKILL.md'),
+                '---\nname: Cached Content\n---\nBody text here.',
+            );
+
+            const reg = SkillRegistry.getInstance();
+            reg.setSources([
+                {
+                    id: 'cc',
+                    type: 'local',
+                    url: path.join(tempDir, 'cache-content'),
+                    trust: 'community',
+                },
+            ]);
+            await reg.ensureLoaded();
+
+            const first = await reg.loadSkillContent('cc/my-skill');
+            const second = await reg.loadSkillContent('cc/my-skill');
+            expect(first).toBe(second);
+            expect(first).toContain('Body text here.');
+        });
+
+        it('returns undefined when source is missing', async () => {
+            const skillDir = path.join(tempDir, 'orphan', 'my-skill');
+            fs.mkdirSync(skillDir, { recursive: true });
+            fs.writeFileSync(path.join(skillDir, 'SKILL.md'), '---\nname: Orphan\n---\nBody');
+
+            const reg = SkillRegistry.getInstance();
+            reg.setSources([
+                {
+                    id: 'orphan-src',
+                    type: 'local',
+                    url: path.join(tempDir, 'orphan'),
+                    trust: 'community',
+                },
+            ]);
+            await reg.ensureLoaded();
+
+            // Remove the source so loadSkillContent can't find it
+            reg.setSources([]);
+            const content = await reg.loadSkillContent('orphan-src/my-skill');
+            expect(content).toBeUndefined();
+        });
+    });
+
+    describe('local source edge cases', () => {
+        it('returns empty array for nonexistent directory', async () => {
+            const reg = SkillRegistry.getInstance();
+            reg.setSources([
+                {
+                    id: 'missing',
+                    type: 'local',
+                    url: path.join(tempDir, 'does-not-exist'),
+                    trust: 'community',
+                },
+            ]);
+            await reg.ensureLoaded();
+            expect(reg.getAllSkills()).toHaveLength(0);
+        });
+
+        it('skips non-directory entries', async () => {
+            const base = path.join(tempDir, 'mixed');
+            fs.mkdirSync(base, { recursive: true });
+            fs.writeFileSync(path.join(base, 'not-a-dir.txt'), 'just a file');
+            const skillDir = path.join(base, 'real-skill');
+            fs.mkdirSync(skillDir);
+            fs.writeFileSync(path.join(skillDir, 'SKILL.md'), '---\nname: Real\n---\nBody');
+
+            const reg = SkillRegistry.getInstance();
+            reg.setSources([{ id: 'mix', type: 'local', url: base, trust: 'community' }]);
+            await reg.ensureLoaded();
+            expect(reg.getAllSkills()).toHaveLength(1);
+            expect(reg.getAllSkills()[0].name).toBe('Real');
+        });
+
+        it('skips directories without SKILL.md', async () => {
+            const base = path.join(tempDir, 'no-skill');
+            fs.mkdirSync(path.join(base, 'empty-dir'), { recursive: true });
+            fs.mkdirSync(path.join(base, 'has-skill'));
+            fs.writeFileSync(
+                path.join(base, 'has-skill', 'SKILL.md'),
+                '---\nname: Present\n---\nBody',
+            );
+
+            const reg = SkillRegistry.getInstance();
+            reg.setSources([{ id: 'no', type: 'local', url: base, trust: 'community' }]);
+            await reg.ensureLoaded();
+            expect(reg.getAllSkills()).toHaveLength(1);
+        });
+    });
+
+    describe('registry source (placeholder)', () => {
+        it('returns empty for registry type', async () => {
+            const reg = SkillRegistry.getInstance();
+            reg.setSources([
+                {
+                    id: 'reg-src',
+                    type: 'registry',
+                    url: 'https://example.com/registry',
+                    trust: 'certified',
+                },
+            ]);
+            await reg.ensureLoaded();
+            expect(reg.getAllSkills()).toHaveLength(0);
+        });
+    });
+
+    describe('GitHub source with mocked HTTP', () => {
+        beforeEach(() => {
+            httpResponses.reset();
+        });
+
+        afterEach(() => {
+            httpResponses.reset();
+        });
+
+        it('detects lola format from lola-market.yml', async () => {
+            const manifest = `
+name: test-forge
+modules:
+  - name: my-module
+    description: A test module
+    path: my-module/module
+    tags: [sdlc]
+`;
+            const skillMd =
+                '---\nname: commit\ndescription: Commit changes\ncategory: sdlc\n---\nCommit body';
+            httpResponses.set(
+                'contents/lola-market.yml',
+                JSON.stringify({ name: 'lola-market.yml' }),
+            );
+            httpResponses.set('main/lola-market.yml', manifest);
+            httpResponses.set(
+                'contents/my-module/module/skills',
+                JSON.stringify([{ name: 'commit', type: 'dir' }]),
+            );
+            httpResponses.set('my-module/module/skills/commit/SKILL.md', skillMd);
+            httpResponses.set('my-module/module/AGENTS.md', '# Agents');
+
+            const reg = SkillRegistry.getInstance();
+            reg.setSources([
+                {
+                    id: 'lola-test',
+                    type: 'github',
+                    url: 'https://github.com/test-org/test-repo',
+                    trust: 'community',
+                },
+            ]);
+            await reg.ensureLoaded();
+
+            const skills = reg.getAllSkills();
+            expect(skills.length).toBeGreaterThan(0);
+            expect(skills[0].name).toBe('commit');
+            expect(skills[0].category).toBe('sdlc');
+        });
+
+        it('detects vercel format from skills/ directory', async () => {
+            const skillMd =
+                '---\nname: review-code\ndescription: Code review\ntype: review\n---\nReview instructions';
+            httpResponses.set(
+                'contents/skills',
+                JSON.stringify([
+                    { name: 'review-code', type: 'dir' },
+                    { name: '.hidden', type: 'dir' },
+                ]),
+            );
+            httpResponses.set('skills/review-code/SKILL.md', skillMd);
+
+            const reg = SkillRegistry.getInstance();
+            reg.setSources([
+                {
+                    id: 'vercel-test',
+                    type: 'github',
+                    url: 'https://github.com/test-org/harness-repo',
+                    trust: 'partner',
+                },
+            ]);
+            await reg.ensureLoaded();
+
+            const skills = reg.getAllSkills();
+            expect(skills.length).toBeGreaterThan(0);
+            expect(skills[0].name).toBe('review-code');
+            expect(skills[0].trust).toBe('partner');
+            expect(skills[0].category).toBe('standards');
+        });
+
+        it('falls back to generic format when no markers found', async () => {
+            const skillMd = '---\nname: my-tool\ndescription: A generic tool\n---\nGeneric body';
+            httpResponses.set(
+                'generic-repo/contents/',
+                JSON.stringify([
+                    { name: 'my-tool', type: 'dir' },
+                    { name: '.git', type: 'dir' },
+                    { name: 'README.md', type: 'file' },
+                ]),
+            );
+            httpResponses.set('main/my-tool/SKILL.md', skillMd);
+
+            const reg = SkillRegistry.getInstance();
+            reg.setSources([
+                {
+                    id: 'generic-test',
+                    type: 'github',
+                    url: 'https://github.com/test-org/generic-repo',
+                    trust: 'community',
+                },
+            ]);
+            await reg.ensureLoaded();
+
+            const skills = reg.getAllSkills();
+            expect(skills.length).toBeGreaterThan(0);
+            expect(skills[0].name).toBe('my-tool');
+        });
+
+        it('returns empty for non-GitHub URL in github source', async () => {
+            const reg = SkillRegistry.getInstance();
+            reg.setSources([
+                {
+                    id: 'bad-url',
+                    type: 'github',
+                    url: 'https://not-github.example.com/repo',
+                    trust: 'community',
+                },
+            ]);
+            await reg.ensureLoaded();
+            expect(reg.getAllSkills()).toHaveLength(0);
+        });
+
+        it('detects lola from marketplace/ directory', async () => {
+            const manifest = `
+name: marketplace-collection
+modules:
+  - name: basics
+    description: Basic skills
+    path: basics/module
+`;
+            httpResponses.set(
+                'agentic-collections/contents/marketplace',
+                JSON.stringify([{ name: 'catalog.yml', type: 'file' }]),
+            );
+            httpResponses.set('agentic-collections/main/marketplace/catalog.yml', manifest);
+            httpResponses.set(
+                'agentic-collections/contents/basics/module/skills',
+                JSON.stringify([]),
+            );
+            httpResponses.set('agentic-collections/main/basics/module/AGENTS.md', '# Basics agent');
+            httpResponses.set(
+                'agentic-collections/contents/',
+                JSON.stringify([{ name: 'basics', type: 'dir' }]),
+            );
+
+            const reg = SkillRegistry.getInstance();
+            reg.setSources([
+                {
+                    id: 'marketplace-test',
+                    type: 'github',
+                    url: 'https://github.com/test-org/agentic-collections',
+                    trust: 'certified',
+                },
+            ]);
+            await reg.ensureLoaded();
+
+            const skills = reg.getAllSkills();
+            expect(skills.length).toBeGreaterThan(0);
+        });
+
+        it('discovers unlisted modules in lola repos', async () => {
+            const manifest = `
+name: partial-forge
+modules:
+  - name: listed-mod
+    path: listed-mod/module
+`;
+            const listedSkillMd = '---\nname: listed-skill\n---\nListed body';
+            const unlistedSkillMd = '---\nname: unlisted-skill\n---\nUnlisted body';
+
+            httpResponses.set(
+                'partial-forge/contents/lola-market.yml',
+                JSON.stringify({ name: 'lola-market.yml' }),
+            );
+            httpResponses.set('partial-forge/main/lola-market.yml', manifest);
+            httpResponses.set(
+                'partial-forge/contents/listed-mod/module/skills',
+                JSON.stringify([{ name: 'listed-skill', type: 'dir' }]),
+            );
+            httpResponses.set(
+                'partial-forge/main/listed-mod/module/skills/listed-skill/SKILL.md',
+                listedSkillMd,
+            );
+            httpResponses.set('partial-forge/main/listed-mod/module/AGENTS.md', '# Agents');
+            httpResponses.set(
+                'partial-forge/contents/',
+                JSON.stringify([
+                    { name: 'listed-mod', type: 'dir' },
+                    { name: 'extra-mod', type: 'dir' },
+                    { name: '.git', type: 'dir' },
+                ]),
+            );
+            httpResponses.set(
+                'partial-forge/contents/extra-mod/module/skills',
+                JSON.stringify([{ name: 'unlisted-skill', type: 'dir' }]),
+            );
+            httpResponses.set(
+                'partial-forge/main/extra-mod/module/skills/unlisted-skill/SKILL.md',
+                unlistedSkillMd,
+            );
+            httpResponses.set('partial-forge/main/extra-mod/module/AGENTS.md', '# Extra agents');
+
+            const reg = SkillRegistry.getInstance();
+            reg.setSources([
+                {
+                    id: 'partial',
+                    type: 'github',
+                    url: 'https://github.com/test-org/partial-forge',
+                    trust: 'community',
+                },
+            ]);
+            await reg.ensureLoaded();
+
+            const skills = reg.getAllSkills();
+            const names = skills.map((s) => s.name);
+            expect(names).toContain('listed-skill');
+            expect(names).toContain('unlisted-skill');
+        });
+
+        it('loads skill content on demand via contentUrl', async () => {
+            const skillMd =
+                '---\nname: on-demand\ndescription: test\n---\nFull content loaded on demand.';
+            httpResponses.set(
+                'contents/skills',
+                JSON.stringify([{ name: 'on-demand', type: 'dir' }]),
+            );
+            httpResponses.set('skills/on-demand/SKILL.md', skillMd);
+
+            const reg = SkillRegistry.getInstance();
+            reg.setSources([
+                {
+                    id: 'demand-test',
+                    type: 'github',
+                    url: 'https://github.com/test-org/demand-repo',
+                    trust: 'community',
+                },
+            ]);
+            await reg.ensureLoaded();
+
+            const skill = reg.getSkill('demand-test/on-demand');
+            expect(skill).toBeDefined();
+
+            const content = await reg.loadSkillContent('demand-test/on-demand');
+            expect(content).toContain('Full content loaded on demand.');
+        });
+    });
+
+    describe('category inference', () => {
+        it('infers sdlc from name', async () => {
+            const base = path.join(tempDir, 'infer');
+            for (const name of ['sdlc-helper', 'lifecycle-check', 'workflow-runner']) {
+                const dir = path.join(base, name);
+                fs.mkdirSync(dir, { recursive: true });
+                fs.writeFileSync(path.join(dir, 'SKILL.md'), `---\nname: ${name}\n---\nBody`);
+            }
+
+            const reg = SkillRegistry.getInstance();
+            reg.setSources([{ id: 'inf', type: 'local', url: base, trust: 'community' }]);
+            await reg.ensureLoaded();
+
+            const skills = reg.getAllSkills();
+            const sdlcSkill = skills.find((s) => s.name === 'sdlc-helper');
+            expect(sdlcSkill).toBeDefined();
+        });
+    });
+
+    describe('ensureLoaded idempotency', () => {
+        it('does not reload if already loaded', async () => {
+            const base = path.join(tempDir, 'idem');
+            const dir = path.join(base, 'skill');
+            fs.mkdirSync(dir, { recursive: true });
+            fs.writeFileSync(path.join(dir, 'SKILL.md'), '---\nname: Idem\n---\nBody');
+
+            const reg = SkillRegistry.getInstance();
+            reg.setSources([{ id: 'idem', type: 'local', url: base, trust: 'community' }]);
+            await reg.ensureLoaded();
+            expect(reg.getAllSkills()).toHaveLength(1);
+
+            // Second call should be a no-op
+            await reg.ensureLoaded();
+            expect(reg.getAllSkills()).toHaveLength(1);
         });
     });
 });

--- a/packages/core/test/services/SkillRegistry.test.ts
+++ b/packages/core/test/services/SkillRegistry.test.ts
@@ -1,0 +1,293 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { SkillRegistry, _resetGitHubToken } from '../../src/services/SkillRegistry';
+import type { SkillSource } from '../../src/services/SkillRegistry';
+
+let tempDir: string;
+
+beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'skill-reg-test-'));
+    SkillRegistry.setCacheDir(tempDir);
+    SkillRegistry.resetInstance();
+    _resetGitHubToken();
+});
+
+afterEach(() => {
+    _resetGitHubToken();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe('SkillRegistry', () => {
+    it('returns the same singleton from getInstance', () => {
+        const a = SkillRegistry.getInstance();
+        const b = SkillRegistry.getInstance();
+        expect(a).toBe(b);
+    });
+
+    it('starts with no skills loaded', () => {
+        const reg = SkillRegistry.getInstance();
+        expect(reg.isLoaded()).toBe(false);
+        expect(reg.getAllSkills()).toEqual([]);
+    });
+
+    it('loads skills from a local source', async () => {
+        const skillDir = path.join(tempDir, 'local-skills', 'test-skill');
+        fs.mkdirSync(skillDir, { recursive: true });
+        fs.writeFileSync(
+            path.join(skillDir, 'SKILL.md'),
+            `---
+name: Test Skill
+description: A test skill for unit testing
+category: sdlc
+triggers:
+  - test me
+  - run test
+tags:
+  - testing
+---
+# Test Skill
+
+This is the body of the skill.`,
+        );
+
+        const source: SkillSource = {
+            id: 'test-local',
+            type: 'local',
+            url: path.join(tempDir, 'local-skills'),
+            trust: 'private',
+        };
+
+        const reg = SkillRegistry.getInstance();
+        reg.setSources([source]);
+        await reg.ensureLoaded();
+
+        expect(reg.isLoaded()).toBe(true);
+        const skills = reg.getAllSkills();
+        expect(skills).toHaveLength(1);
+        expect(skills[0].name).toBe('Test Skill');
+        expect(skills[0].description).toBe('A test skill for unit testing');
+        expect(skills[0].category).toBe('sdlc');
+        expect(skills[0].triggers).toEqual(['test me', 'run test']);
+        expect(skills[0].trust).toBe('private');
+        expect(skills[0].content).toContain('This is the body of the skill.');
+    });
+
+    it('handles SKILL.md without frontmatter', async () => {
+        const skillDir = path.join(tempDir, 'local-skills', 'bare-skill');
+        fs.mkdirSync(skillDir, { recursive: true });
+        fs.writeFileSync(path.join(skillDir, 'SKILL.md'), '# Just a heading\n\nBody content here.');
+
+        const source: SkillSource = {
+            id: 'bare-test',
+            type: 'local',
+            url: path.join(tempDir, 'local-skills'),
+            trust: 'community',
+        };
+
+        const reg = SkillRegistry.getInstance();
+        reg.setSources([source]);
+        await reg.ensureLoaded();
+
+        const skills = reg.getAllSkills();
+        expect(skills).toHaveLength(1);
+        expect(skills[0].name).toBe('bare-skill');
+        expect(skills[0].category).toBe('other');
+    });
+
+    it('loads skills from cache on second call', async () => {
+        const skillDir = path.join(tempDir, 'cached', 'my-skill');
+        fs.mkdirSync(skillDir, { recursive: true });
+        fs.writeFileSync(
+            path.join(skillDir, 'SKILL.md'),
+            '---\nname: Cached Skill\ndescription: cache test\n---\nBody.',
+        );
+
+        const source: SkillSource = {
+            id: 'cache-test',
+            type: 'local',
+            url: path.join(tempDir, 'cached'),
+            trust: 'community',
+        };
+
+        // First load
+        const reg1 = SkillRegistry.getInstance();
+        reg1.setSources([source]);
+        await reg1.ensureLoaded();
+        expect(reg1.getAllSkills()).toHaveLength(1);
+
+        // New instance, same cache dir
+        SkillRegistry.resetInstance();
+        const reg2 = SkillRegistry.getInstance();
+        reg2.setSources([source]);
+        await reg2.ensureLoaded();
+        expect(reg2.getAllSkills()).toHaveLength(1);
+        expect(reg2.getSkill('cache-test/my-skill')?.name).toBe('Cached Skill');
+    });
+
+    describe('search', () => {
+        it('finds skills by name', async () => {
+            const base = path.join(tempDir, 'search-test');
+            for (const s of ['code-review', 'deploy-app', 'write-test']) {
+                const dir = path.join(base, s);
+                fs.mkdirSync(dir, { recursive: true });
+                fs.writeFileSync(
+                    path.join(dir, 'SKILL.md'),
+                    `---\nname: ${s}\ndescription: ${s} desc\ncategory: sdlc\ntags:\n  - ${s.split('-')[0]}\n---\nBody of ${s}`,
+                );
+            }
+
+            const reg = SkillRegistry.getInstance();
+            reg.setSources([{ id: 'search', type: 'local', url: base, trust: 'community' }]);
+            await reg.ensureLoaded();
+
+            const results = reg.search('review');
+            expect(results.length).toBeGreaterThan(0);
+            expect(results[0].name).toBe('code-review');
+        });
+
+        it('filters by category', async () => {
+            const base = path.join(tempDir, 'cat-test');
+            for (const [name, cat] of [
+                ['lint', 'standards'],
+                ['build', 'workflow'],
+            ] as const) {
+                const dir = path.join(base, name);
+                fs.mkdirSync(dir, { recursive: true });
+                fs.writeFileSync(
+                    path.join(dir, 'SKILL.md'),
+                    `---\nname: ${name}\ndescription: ${name}\ncategory: ${cat}\n---\nBody`,
+                );
+            }
+
+            const reg = SkillRegistry.getInstance();
+            reg.setSources([{ id: 'cat', type: 'local', url: base, trust: 'community' }]);
+            await reg.ensureLoaded();
+
+            const results = reg.search('', { category: 'standards' });
+            expect(results).toHaveLength(1);
+            expect(results[0].name).toBe('lint');
+        });
+    });
+
+    describe('loadSkillContent', () => {
+        it('returns content for a local skill', async () => {
+            const skillDir = path.join(tempDir, 'content-test', 'my-skill');
+            fs.mkdirSync(skillDir, { recursive: true });
+            fs.writeFileSync(
+                path.join(skillDir, 'SKILL.md'),
+                '---\nname: Content Skill\n---\nThe full body.',
+            );
+
+            const reg = SkillRegistry.getInstance();
+            reg.setSources([
+                {
+                    id: 'content',
+                    type: 'local',
+                    url: path.join(tempDir, 'content-test'),
+                    trust: 'community',
+                },
+            ]);
+            await reg.ensureLoaded();
+
+            const content = await reg.loadSkillContent('content/my-skill');
+            expect(content).toContain('The full body.');
+        });
+
+        it('returns undefined for unknown skill ID', async () => {
+            const reg = SkillRegistry.getInstance();
+            reg.setSources([]);
+            await reg.ensureLoaded();
+
+            const content = await reg.loadSkillContent('nonexistent/skill');
+            expect(content).toBeUndefined();
+        });
+    });
+
+    describe('trigger normalization', () => {
+        it('handles comma-separated trigger strings', async () => {
+            const skillDir = path.join(tempDir, 'trigger-test', 'skill-a');
+            fs.mkdirSync(skillDir, { recursive: true });
+            fs.writeFileSync(
+                path.join(skillDir, 'SKILL.md'),
+                '---\nname: Trigger Skill\ntriggers: "build, deploy, test"\n---\nBody',
+            );
+
+            const reg = SkillRegistry.getInstance();
+            reg.setSources([
+                {
+                    id: 'trig',
+                    type: 'local',
+                    url: path.join(tempDir, 'trigger-test'),
+                    trust: 'community',
+                },
+            ]);
+            await reg.ensureLoaded();
+
+            const skill = reg.getSkill('trig/skill-a');
+            expect(skill?.triggers).toEqual(['build', 'deploy', 'test']);
+        });
+    });
+
+    describe('GitHub token resolution', () => {
+        it('uses GITHUB_TOKEN env var when available', async () => {
+            const orig = process.env.GITHUB_TOKEN;
+            process.env.GITHUB_TOKEN = 'test-token-123';
+            _resetGitHubToken();
+
+            const reg = SkillRegistry.getInstance();
+            // Just verify it doesn't crash — actual HTTP calls are out of scope
+            reg.setSources([]);
+            await reg.ensureLoaded();
+            expect(reg.isLoaded()).toBe(true);
+
+            if (orig === undefined) {
+                delete process.env.GITHUB_TOKEN;
+            } else {
+                process.env.GITHUB_TOKEN = orig;
+            }
+        });
+    });
+
+    describe('cache invalidation', () => {
+        it('invalidates cache when source URL changes', async () => {
+            // Create two different local skill dirs
+            for (const name of ['dir-a', 'dir-b']) {
+                const skillDir = path.join(tempDir, name, 'my-skill');
+                fs.mkdirSync(skillDir, { recursive: true });
+                fs.writeFileSync(
+                    path.join(skillDir, 'SKILL.md'),
+                    `---\nname: Skill from ${name}\n---\nBody`,
+                );
+            }
+
+            // Load from dir-a
+            const reg = SkillRegistry.getInstance();
+            reg.setSources([
+                {
+                    id: 'changing-source',
+                    type: 'local',
+                    url: path.join(tempDir, 'dir-a'),
+                    trust: 'community',
+                },
+            ]);
+            await reg.ensureLoaded();
+            expect(reg.getSkill('changing-source/my-skill')?.name).toBe('Skill from dir-a');
+
+            // Change URL to dir-b, new instance
+            SkillRegistry.resetInstance();
+            const reg2 = SkillRegistry.getInstance();
+            reg2.setSources([
+                {
+                    id: 'changing-source',
+                    type: 'local',
+                    url: path.join(tempDir, 'dir-b'),
+                    trust: 'community',
+                },
+            ]);
+            await reg2.ensureLoaded();
+            expect(reg2.getSkill('changing-source/my-skill')?.name).toBe('Skill from dir-b');
+        });
+    });
+});

--- a/packages/mcp-server/src/handlers.ts
+++ b/packages/mcp-server/src/handlers.ts
@@ -12,6 +12,7 @@ import { PluginSearchIndex } from './pluginSearch';
 import { TaskGenerator } from './taskGenerator';
 import { TaskBuilder } from './taskBuilder';
 import { CreatorToolGenerator } from './creatorTools';
+import { SkillToolGenerator } from './skillTools';
 import {
     CollectionsService,
     DevToolsService,
@@ -44,11 +45,13 @@ export class McpToolHandler {
     private _taskGenerator = new TaskGenerator();
     private _taskBuilder = new TaskBuilder();
     private _creatorTools = new CreatorToolGenerator();
+    private _skillTools = new SkillToolGenerator();
 
-    /** Warms the plugin search index and loads ansible-creator tool definitions. */
+    /** Warms the plugin search index, creator tools, and skill registry. */
     async initialize(): Promise<void> {
         await this._searchIndex.ensureBuilt();
         await this._creatorTools.initialize();
+        await this._skillTools.initialize();
     }
 
     /**
@@ -58,6 +61,15 @@ export class McpToolHandler {
      */
     getCreatorTools(): CreatorToolGenerator {
         return this._creatorTools;
+    }
+
+    /**
+     * Skill tool generator used when listing and invoking `skill_*` tools.
+     *
+     * @returns Shared SkillToolGenerator instance owned by this handler
+     */
+    getSkillTools(): SkillToolGenerator {
+        return this._skillTools;
     }
 
     /**
@@ -72,6 +84,11 @@ export class McpToolHandler {
             // Creator tools
             if (this._creatorTools.isCreatorTool(name)) {
                 return await this._creatorTools.handleTool(name, args);
+            }
+
+            // Skill tools
+            if (this._skillTools.isSkillTool(name)) {
+                return await this._skillTools.handleTool(name, args);
             }
 
             // Route to appropriate handler

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -5,6 +5,7 @@
 export { McpToolHandler } from './handlers';
 export { STATIC_TOOLS, type McpToolDefinition, type McpToolResult } from './tools';
 export { CreatorToolGenerator } from './creatorTools';
+export { SkillToolGenerator } from './skillTools';
 export { PluginSearchIndex, type PluginSearchResult } from './pluginSearch';
 export { TaskBuilder, type TaskBuilderInput, type TaskBuilderResult } from './taskBuilder';
 export { TaskGenerator, type TaskGeneratorInput, type TaskGeneratorResult } from './taskGenerator';

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -39,6 +39,8 @@ import {
 
 import { STATIC_TOOLS, McpToolDefinition } from './tools';
 import { McpToolHandler } from './handlers';
+import { SkillRegistry } from '@ansible/core';
+import type { SkillSource } from '@ansible/core';
 
 // Initialize the server (low-level Server API; McpServer wrapper not used for custom handlers)
 // eslint-disable-next-line @typescript-eslint/no-deprecated -- setRequestHandler requires the low-level Server API
@@ -121,9 +123,14 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
     // Ensure handler is initialized
     await handler.initialize();
 
-    // Combine static tools with dynamic creator tools
+    // Combine static, creator, and skill tools
     const creatorTools = handler.getCreatorTools();
-    const allTools: McpToolDefinition[] = [...STATIC_TOOLS, ...creatorTools.getTools()];
+    const skillTools = handler.getSkillTools();
+    const allTools: McpToolDefinition[] = [
+        ...STATIC_TOOLS,
+        ...creatorTools.getTools(),
+        ...skillTools.getTools(),
+    ];
 
     return {
         tools: allTools.map((tool) => ({
@@ -203,7 +210,19 @@ async function main() {
     console.error('[MCP Server] Starting Ansible Environments MCP server...');
 
     try {
-        // Initialize handler (loads collections, creator schema, etc.)
+        // Configure skill sources from environment
+        const skillSourcesEnv = process.env.ANSIBLE_SKILL_SOURCES;
+        if (skillSourcesEnv) {
+            try {
+                const sources = JSON.parse(skillSourcesEnv) as SkillSource[];
+                SkillRegistry.getInstance().setSources(sources);
+                console.error(`[MCP Server] Configured ${String(sources.length)} skill source(s)`);
+            } catch (err) {
+                console.error('[MCP Server] Failed to parse ANSIBLE_SKILL_SOURCES:', err);
+            }
+        }
+
+        // Initialize handler (loads collections, creator schema, skills, etc.)
         await handler.initialize();
         console.error('[MCP Server] Handler initialized');
 

--- a/packages/mcp-server/src/skillTools.ts
+++ b/packages/mcp-server/src/skillTools.ts
@@ -1,0 +1,358 @@
+/**
+ * Skill Tool Generator
+ *
+ * Exposes skill_search, skill_list, skill_get, and skill_list_sources
+ * as MCP tools backed by the SkillRegistry service.
+ */
+
+import { SkillRegistry } from '@ansible/core';
+import type { SkillSource, SkillCategory } from '@ansible/core';
+import { McpToolDefinition, McpToolResult } from './tools';
+
+/** MCP tool names handled by this generator. */
+const SKILL_TOOL_NAMES = ['skill_search', 'skill_list', 'skill_get', 'skill_list_sources'] as const;
+
+type SkillToolName = (typeof SKILL_TOOL_NAMES)[number];
+
+/**
+ * Generates MCP tools that expose the SkillRegistry to AI agents.
+ */
+export class SkillToolGenerator {
+    private _registry: SkillRegistry;
+
+    /**
+     *
+     */
+    constructor() {
+        this._registry = SkillRegistry.getInstance();
+    }
+
+    /**
+     * Ensures skills are loaded, then logs a summary.
+     */
+    async initialize(): Promise<void> {
+        await this._registry.ensureLoaded();
+        const sources = this._registry.getSources();
+        const skills = this._registry.getAllSkills();
+        console.error(
+            `SkillToolGenerator: Loaded ${String(skills.length)} skills from ${String(sources.length)} sources`,
+        );
+    }
+
+    /**
+     * Returns the set of MCP tool definitions for skill operations.
+     *
+     * @returns Array of tool definitions.
+     */
+    getTools(): McpToolDefinition[] {
+        return [
+            {
+                name: 'skill_search',
+                description:
+                    'Search available AI development skills by keyword. ' +
+                    'Searches name, description, triggers, and tags.',
+                inputSchema: {
+                    type: 'object' as const,
+                    properties: {
+                        query: {
+                            type: 'string',
+                            description: 'Search query (keywords)',
+                        },
+                        category: {
+                            type: 'string',
+                            description:
+                                'Filter by category: standards, sdlc, domain, scaffold, workflow, other',
+                            enum: ['standards', 'sdlc', 'domain', 'scaffold', 'workflow', 'other'],
+                        },
+                        source: {
+                            type: 'string',
+                            description: 'Filter by source ID',
+                        },
+                        limit: {
+                            type: 'number',
+                            description: 'Maximum results (default: 10)',
+                        },
+                    },
+                    required: ['query'],
+                },
+            },
+            {
+                name: 'skill_list',
+                description:
+                    'List all available AI development skills, optionally filtered by category or source.',
+                inputSchema: {
+                    type: 'object' as const,
+                    properties: {
+                        category: {
+                            type: 'string',
+                            description:
+                                'Filter by category: standards, sdlc, domain, scaffold, workflow, other',
+                            enum: ['standards', 'sdlc', 'domain', 'scaffold', 'workflow', 'other'],
+                        },
+                        source: {
+                            type: 'string',
+                            description: 'Filter by source ID',
+                        },
+                    },
+                },
+            },
+            {
+                name: 'skill_get',
+                description:
+                    'Get the full content of a skill by its ID. ' +
+                    'Returns the SKILL.md body with instructions the agent should follow.',
+                inputSchema: {
+                    type: 'object' as const,
+                    properties: {
+                        skill_id: {
+                            type: 'string',
+                            description:
+                                'Skill ID (e.g. "ai-forge/ansible-collection-sdlc/commit")',
+                        },
+                    },
+                    required: ['skill_id'],
+                },
+            },
+            {
+                name: 'skill_list_sources',
+                description:
+                    'List configured skill sources and their status (loaded count, trust level).',
+                inputSchema: {
+                    type: 'object' as const,
+                    properties: {},
+                },
+            },
+        ];
+    }
+
+    /**
+     * Whether the given tool name is handled by this generator.
+     *
+     * @param name - MCP tool name to check.
+     * @returns True when the name is a skill tool.
+     */
+    isSkillTool(name: string): boolean {
+        return (SKILL_TOOL_NAMES as readonly string[]).includes(name);
+    }
+
+    /**
+     * Dispatch a tool invocation to the appropriate skill handler.
+     *
+     * @param name - MCP tool name.
+     * @param args - Tool arguments.
+     * @returns MCP tool result.
+     */
+    async handleTool(name: string, args: Record<string, unknown>): Promise<McpToolResult> {
+        await this._registry.ensureLoaded();
+
+        switch (name as SkillToolName) {
+            case 'skill_search':
+                return this._handleSearch(args);
+            case 'skill_list':
+                return this._handleList(args);
+            case 'skill_get':
+                return this._handleGet(args);
+            case 'skill_list_sources':
+                return this._handleListSources();
+            default:
+                return {
+                    content: [{ type: 'text', text: `Unknown skill tool: ${name}` }],
+                    isError: true,
+                };
+        }
+    }
+
+    /** Force-reload skills from all sources. */
+    async refresh(): Promise<void> {
+        await this._registry.refresh();
+    }
+
+    // -- Handlers -----------------------------------------------------------
+
+    /**
+     * Searches skills by keyword and returns formatted results.
+     *
+     * @param args - Tool arguments containing the search query and optional filters.
+     * @returns MCP tool result with matching skills.
+     */
+    private _handleSearch(args: Record<string, unknown>): McpToolResult {
+        const query = args.query as string | undefined;
+        if (!query) {
+            return {
+                content: [{ type: 'text', text: 'Error: "query" parameter is required' }],
+                isError: true,
+            };
+        }
+
+        const limit = typeof args.limit === 'number' ? args.limit : 10;
+        const results = this._registry.search(query, {
+            category: args.category as SkillCategory | undefined,
+            source: args.source as string | undefined,
+            limit,
+        });
+
+        if (results.length === 0) {
+            return {
+                content: [
+                    {
+                        type: 'text',
+                        text: `No skills found for "${query}". Try broader terms or use skill_list to see all available skills.`,
+                    },
+                ],
+            };
+        }
+
+        const lines = results.map(
+            (s) =>
+                `- **${s.name}** (${s.id})\n  ${s.description}\n  Category: ${s.category} | ` +
+                `Triggers: ${s.triggers.join(', ') || 'none'}`,
+        );
+
+        return {
+            content: [
+                {
+                    type: 'text',
+                    text: `Found ${String(results.length)} skill(s) matching "${query}":\n\n${lines.join('\n\n')}`,
+                },
+            ],
+        };
+    }
+
+    /**
+     * Lists all available skills, optionally filtered by category or source.
+     *
+     * @param args - Tool arguments with optional category and source filters.
+     * @returns MCP tool result with a grouped skill listing.
+     */
+    private _handleList(args: Record<string, unknown>): McpToolResult {
+        const results = this._registry.search('', {
+            category: args.category as SkillCategory | undefined,
+            source: args.source as string | undefined,
+            limit: 100,
+        });
+
+        if (results.length === 0) {
+            return {
+                content: [
+                    {
+                        type: 'text',
+                        text: 'No skills available. Configure skill sources in settings.',
+                    },
+                ],
+            };
+        }
+
+        const grouped = new Map<string, typeof results>();
+        for (const s of results) {
+            const key = `${s.source}/${s.module}`;
+            const existing = grouped.get(key);
+            if (existing) {
+                existing.push(s);
+            } else {
+                grouped.set(key, [s]);
+            }
+        }
+
+        const sections: string[] = [];
+        for (const [key, skills] of grouped) {
+            const lines = skills.map((s) => `  - ${s.name} (${s.id}) — ${s.description}`);
+            sections.push(`### ${key}\n${lines.join('\n')}`);
+        }
+
+        return {
+            content: [
+                {
+                    type: 'text',
+                    text: `Available skills (${String(results.length)}):\n\n${sections.join('\n\n')}`,
+                },
+            ],
+        };
+    }
+
+    /**
+     * Fetches and returns the full SKILL.md content for a given skill ID.
+     *
+     * @param args - Tool arguments containing the skill_id string.
+     * @returns MCP tool result with skill metadata header and body content.
+     */
+    private async _handleGet(args: Record<string, unknown>): Promise<McpToolResult> {
+        const skillId = args.skill_id as string | undefined;
+        if (!skillId) {
+            return {
+                content: [{ type: 'text', text: 'Error: "skill_id" parameter is required' }],
+                isError: true,
+            };
+        }
+
+        const skill = this._registry.getSkill(skillId);
+        if (!skill) {
+            return {
+                content: [{ type: 'text', text: `Skill not found: ${skillId}` }],
+                isError: true,
+            };
+        }
+
+        const content = await this._registry.loadSkillContent(skillId);
+        if (!content) {
+            return {
+                content: [
+                    {
+                        type: 'text',
+                        text: 'Skill content could not be loaded. The source may be unavailable.',
+                    },
+                ],
+                isError: true,
+            };
+        }
+
+        const header =
+            `# Skill: ${skill.name}\n\n` +
+            `- **Source:** ${skill.source} (${skill.trust})\n` +
+            `- **Module:** ${skill.module}\n` +
+            `- **Category:** ${skill.category}\n` +
+            (skill.triggers.length > 0 ? `- **Triggers:** ${skill.triggers.join(', ')}\n` : '') +
+            '\n---\n\n';
+
+        return {
+            content: [{ type: 'text', text: header + content }],
+        };
+    }
+
+    /**
+     * Lists all configured skill sources and how many skills each loaded.
+     *
+     * @returns MCP tool result with source details and skill counts.
+     */
+    private _handleListSources(): McpToolResult {
+        const sources = this._registry.getSources();
+        const allSkills = this._registry.getAllSkills();
+
+        if (sources.length === 0) {
+            return {
+                content: [
+                    {
+                        type: 'text',
+                        text:
+                            'No skill sources configured.\n\n' +
+                            'Add sources in VS Code settings under `ansibleEnvironments.skillSources` ' +
+                            'or set the ANSIBLE_SKILL_SOURCES environment variable.',
+                    },
+                ],
+            };
+        }
+
+        const lines = sources.map((s: SkillSource) => {
+            const count = allSkills.filter((sk) => sk.source === s.id).length;
+            return `- **${s.id}** (${s.type}, ${s.trust}): ${String(count)} skills\n  URL: ${s.url}`;
+        });
+
+        return {
+            content: [
+                {
+                    type: 'text',
+                    text: `Configured skill sources:\n\n${lines.join('\n')}`,
+                },
+            ],
+        };
+    }
+}

--- a/packages/mcp-server/test/handlers.test.ts
+++ b/packages/mcp-server/test/handlers.test.ts
@@ -178,6 +178,18 @@ vi.mock('@ansible/core', () => ({
     GitHubCollectionCache: {
         getInstance: vi.fn(() => hoisted.githubInstance),
     },
+    SkillRegistry: {
+        getInstance: vi.fn(() => ({
+            setSources: vi.fn(),
+            getSources: vi.fn(() => []),
+            ensureLoaded: vi.fn().mockResolvedValue(undefined),
+            getAllSkills: vi.fn(() => []),
+            getSkill: vi.fn(),
+            search: vi.fn(() => []),
+            loadSkillContent: vi.fn().mockResolvedValue(undefined),
+            isLoaded: vi.fn(() => true),
+        })),
+    },
 }));
 
 import { McpToolHandler } from '../src/handlers';

--- a/packages/mcp-server/test/skillTools.test.ts
+++ b/packages/mcp-server/test/skillTools.test.ts
@@ -1,0 +1,150 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { SkillRegistry, _resetGitHubToken } from '@ansible/core';
+import { SkillToolGenerator } from '../src/skillTools';
+
+let tempDir: string;
+
+beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'skill-tools-test-'));
+    SkillRegistry.setCacheDir(tempDir);
+    SkillRegistry.resetInstance();
+    _resetGitHubToken();
+
+    // Set up a local skill source for testing
+    const skillDir = path.join(tempDir, 'skills', 'test-skill');
+    fs.mkdirSync(skillDir, { recursive: true });
+    fs.writeFileSync(
+        path.join(skillDir, 'SKILL.md'),
+        `---
+name: Test Skill
+description: A skill for testing
+category: sdlc
+triggers:
+  - run tests
+  - unit test
+tags:
+  - test
+  - ci
+---
+# Test Skill
+
+Follow these instructions to run tests.`,
+    );
+
+    const reg = SkillRegistry.getInstance();
+    reg.setSources([
+        {
+            id: 'test-source',
+            type: 'local',
+            url: path.join(tempDir, 'skills'),
+            trust: 'community',
+        },
+    ]);
+});
+
+afterEach(() => {
+    _resetGitHubToken();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe('SkillToolGenerator', () => {
+    it('getTools returns four tool definitions', () => {
+        const gen = new SkillToolGenerator();
+        const tools = gen.getTools();
+        expect(tools).toHaveLength(4);
+        const names = tools.map((t) => t.name);
+        expect(names).toContain('skill_search');
+        expect(names).toContain('skill_list');
+        expect(names).toContain('skill_get');
+        expect(names).toContain('skill_list_sources');
+    });
+
+    it('isSkillTool identifies skill tools', () => {
+        const gen = new SkillToolGenerator();
+        expect(gen.isSkillTool('skill_search')).toBe(true);
+        expect(gen.isSkillTool('skill_list')).toBe(true);
+        expect(gen.isSkillTool('skill_get')).toBe(true);
+        expect(gen.isSkillTool('skill_list_sources')).toBe(true);
+        expect(gen.isSkillTool('other_tool')).toBe(false);
+    });
+
+    it('skill_search finds matching skills', async () => {
+        const gen = new SkillToolGenerator();
+        await gen.initialize();
+
+        const result = await gen.handleTool('skill_search', { query: 'test' });
+        expect(result.isError).toBeUndefined();
+        expect(result.content[0].text).toContain('Test Skill');
+    });
+
+    it('skill_search returns friendly message when no matches', async () => {
+        const gen = new SkillToolGenerator();
+        await gen.initialize();
+
+        const result = await gen.handleTool('skill_search', {
+            query: 'nonexistent-xyz-abc',
+        });
+        expect(result.content[0].text).toContain('No skills found');
+    });
+
+    it('skill_search requires query parameter', async () => {
+        const gen = new SkillToolGenerator();
+        await gen.initialize();
+
+        const result = await gen.handleTool('skill_search', {});
+        expect(result.isError).toBe(true);
+        expect(result.content[0].text).toContain('query');
+    });
+
+    it('skill_list returns all skills', async () => {
+        const gen = new SkillToolGenerator();
+        await gen.initialize();
+
+        const result = await gen.handleTool('skill_list', {});
+        expect(result.content[0].text).toContain('Test Skill');
+        expect(result.content[0].text).toContain('Available skills');
+    });
+
+    it('skill_get returns full skill content', async () => {
+        const gen = new SkillToolGenerator();
+        await gen.initialize();
+
+        const result = await gen.handleTool('skill_get', {
+            skill_id: 'test-source/test-skill',
+        });
+        expect(result.isError).toBeUndefined();
+        expect(result.content[0].text).toContain('Follow these instructions');
+        expect(result.content[0].text).toContain('Test Skill');
+    });
+
+    it('skill_get requires skill_id parameter', async () => {
+        const gen = new SkillToolGenerator();
+        await gen.initialize();
+
+        const result = await gen.handleTool('skill_get', {});
+        expect(result.isError).toBe(true);
+    });
+
+    it('skill_get returns error for unknown skill', async () => {
+        const gen = new SkillToolGenerator();
+        await gen.initialize();
+
+        const result = await gen.handleTool('skill_get', {
+            skill_id: 'nonexistent/skill',
+        });
+        expect(result.isError).toBe(true);
+        expect(result.content[0].text).toContain('Skill not found');
+    });
+
+    it('skill_list_sources shows configured sources', async () => {
+        const gen = new SkillToolGenerator();
+        await gen.initialize();
+
+        const result = await gen.handleTool('skill_list_sources', {});
+        expect(result.content[0].text).toContain('test-source');
+        expect(result.content[0].text).toContain('community');
+    });
+});

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -37,8 +37,10 @@ import {
     DevToolsService,
     cacheSelectedEnvironment,
     getCommandService,
+    SkillRegistry,
 } from '@ansible/core';
-import type { PythonEnvironment, SchemaNode } from '@ansible/core';
+import type { PythonEnvironment, SchemaNode, SkillSource, SkillEntry } from '@ansible/core';
+import { SkillsProvider, openChatWithSkill, copySkillPrompt } from '@src/views/SkillsProvider';
 import {
     registerMcpServerProvider,
     isMcpAvailable,
@@ -423,6 +425,55 @@ export function activate(context: vscode.ExtensionContext) {
         showCollapseAll: false,
     });
     context.subscriptions.push(collectionSourcesView);
+
+    // Configure skill registry from settings and register Skills view
+    const skillSources =
+        vscode.workspace
+            .getConfiguration('ansibleEnvironments')
+            .get<SkillSource[]>('skillSources') ?? [];
+    const skillRegistry = SkillRegistry.getInstance();
+    skillRegistry.setSources(skillSources);
+
+    const skillsProvider = new SkillsProvider();
+    const skillsView = vscode.window.createTreeView('ansibleSkills', {
+        treeDataProvider: skillsProvider,
+        showCollapseAll: true,
+    });
+    context.subscriptions.push(skillsView);
+
+    context.subscriptions.push(
+        vscode.commands.registerCommand('ansibleSkills.refresh', () => {
+            skillsProvider.refresh();
+        }),
+        vscode.commands.registerCommand(
+            'ansibleSkills.useInChat',
+            (arg: SkillEntry | { skill: SkillEntry }) => {
+                const skill = 'skill' in arg ? arg.skill : arg;
+                void openChatWithSkill(skill);
+            },
+        ),
+        vscode.commands.registerCommand(
+            'ansibleSkills.copyPrompt',
+            (arg: SkillEntry | { skill: SkillEntry }) => {
+                const skill = 'skill' in arg ? arg.skill : arg;
+                void copySkillPrompt(skill);
+            },
+        ),
+    );
+
+    // Reload skill sources when settings change
+    context.subscriptions.push(
+        vscode.workspace.onDidChangeConfiguration((e) => {
+            if (e.affectsConfiguration('ansibleEnvironments.skillSources')) {
+                const updated =
+                    vscode.workspace
+                        .getConfiguration('ansibleEnvironments')
+                        .get<SkillSource[]>('skillSources') ?? [];
+                skillRegistry.setSources(updated);
+                skillsProvider.refresh();
+            }
+        }),
+    );
 
     // Register sidebar commands
     const refreshCommand = vscode.commands.registerCommand(

--- a/src/mcp/cursorConfig.ts
+++ b/src/mcp/cursorConfig.ts
@@ -70,9 +70,16 @@ function registerViaCursorApi(serverPath: string): boolean {
             server: {
                 command: 'node',
                 args: [serverPath],
-                env: {
-                    ...(workspaceFolder ? { ANSIBLE_ENV_WORKSPACE: workspaceFolder } : {}),
-                },
+                env: Object.assign(
+                    {},
+                    workspaceFolder ? { ANSIBLE_ENV_WORKSPACE: workspaceFolder } : {},
+                    (() => {
+                        const ss = vscode.workspace
+                            .getConfiguration('ansibleEnvironments')
+                            .get('skillSources');
+                        return ss ? { ANSIBLE_SKILL_SOURCES: JSON.stringify(ss) } : {};
+                    })(),
+                ) as Record<string, string>,
             },
         });
         log('MCP server registered via Cursor extension API');

--- a/src/mcp/vscodeProvider.ts
+++ b/src/mcp/vscodeProvider.ts
@@ -53,15 +53,25 @@ export function registerMcpServerProvider(context: vscode.ExtensionContext): voi
                     return [];
                 }
 
+                const env: Record<string, string> = {
+                    ANSIBLE_ENV_WORKSPACE: workspaceFolder,
+                    ANSIBLE_ENV_EXTENSION_PATH: context.extensionPath,
+                };
+
+                // Forward skill sources to the MCP server process
+                const skillSources = vscode.workspace
+                    .getConfiguration('ansibleEnvironments')
+                    .get('skillSources');
+                if (skillSources) {
+                    env.ANSIBLE_SKILL_SOURCES = JSON.stringify(skillSources);
+                }
+
                 return [
                     new (vscode as any).McpStdioServerDefinition(
                         'Ansible Environments',
                         'node',
                         [serverPath],
-                        {
-                            ANSIBLE_ENV_WORKSPACE: workspaceFolder,
-                            ANSIBLE_ENV_EXTENSION_PATH: context.extensionPath,
-                        },
+                        env,
                     ),
                 ];
             },

--- a/src/views/SkillsProvider.ts
+++ b/src/views/SkillsProvider.ts
@@ -1,0 +1,279 @@
+/**
+ * Skills Tree View Provider
+ *
+ * Displays AI development skills from configured sources, grouped by
+ * source and module. Provides "Use in Chat" and "Copy Prompt" actions.
+ */
+
+import * as vscode from 'vscode';
+import { SkillRegistry } from '@ansible/core';
+import type { SkillEntry, SkillSource } from '@ansible/core';
+import { log } from '@src/extension';
+
+type TreeNode = SourceNode | ModuleNode | SkillNode | MessageNode;
+
+/** Static tree item showing an informational or warning message. */
+class MessageNode extends vscode.TreeItem {
+    /**
+     * @param label - Text to display.
+     * @param icon  - Optional codicon name (defaults to "info").
+     */
+    constructor(label: string, icon?: string) {
+        super(label, vscode.TreeItemCollapsibleState.None);
+        this.contextValue = 'skillMessage';
+        this.iconPath = new vscode.ThemeIcon(icon ?? 'info');
+    }
+}
+
+/** Tree item representing a configured skill source. */
+class SourceNode extends vscode.TreeItem {
+    /**
+     * @param source     - Skill source metadata.
+     * @param skillCount - Number of skills loaded from this source.
+     */
+    constructor(
+        public readonly source: SkillSource,
+        public readonly skillCount: number,
+    ) {
+        super(source.id, vscode.TreeItemCollapsibleState.Collapsed);
+        this.contextValue = 'skillSource';
+        this.description =
+            skillCount > 0
+                ? `${source.trust} · ${String(skillCount)} skills`
+                : `${source.trust} · no skills loaded`;
+        this.tooltip = new vscode.MarkdownString(
+            `**${source.id}**\n\n` +
+                `- Type: ${source.type}\n` +
+                `- Trust: ${source.trust}\n` +
+                `- URL: ${source.url}\n` +
+                `- Skills: ${String(skillCount)}`,
+        );
+
+        const iconMap: Record<string, string> = {
+            community: 'globe',
+            certified: 'verified',
+            partner: 'organization',
+            private: 'lock',
+        };
+        this.iconPath = new vscode.ThemeIcon(iconMap[source.trust] ?? 'globe');
+    }
+}
+
+/** Tree item representing a module grouping within a source. */
+class ModuleNode extends vscode.TreeItem {
+    /**
+     * @param moduleName - Module display name.
+     * @param sourceId   - Parent source ID.
+     * @param skillCount - Number of skills in this module.
+     */
+    constructor(
+        public readonly moduleName: string,
+        public readonly sourceId: string,
+        public readonly skillCount: number,
+    ) {
+        super(moduleName, vscode.TreeItemCollapsibleState.Collapsed);
+        this.contextValue = 'skillModule';
+        this.description = `${String(skillCount)} skills`;
+        this.iconPath = new vscode.ThemeIcon('package');
+    }
+}
+
+/** Leaf tree item representing a single skill. */
+class SkillNode extends vscode.TreeItem {
+    /** @param skill - The indexed skill entry. */
+    constructor(public readonly skill: SkillEntry) {
+        super(skill.name, vscode.TreeItemCollapsibleState.None);
+        this.contextValue = 'skill';
+        this.description = skill.category;
+        this.tooltip = new vscode.MarkdownString(
+            `**${skill.name}**\n\n` +
+                `${skill.description}\n\n` +
+                `- Source: ${skill.source} (${skill.trust})\n` +
+                `- Module: ${skill.module}\n` +
+                `- Category: ${skill.category}\n` +
+                (skill.domain ? `- Domain: ${skill.domain}\n` : '') +
+                (skill.triggers.length > 0 ? `- Triggers: ${skill.triggers.join(', ')}\n` : '') +
+                `\n\`skill_get({ skill_id: "${skill.id}" })\``,
+        );
+        this.iconPath = new vscode.ThemeIcon('mortar-board');
+
+        this.command = {
+            command: 'ansibleSkills.useInChat',
+            title: 'Use in Chat',
+            arguments: [skill],
+        };
+    }
+}
+
+/** Tree data provider for the Ansible Skills sidebar view. */
+export class SkillsProvider implements vscode.TreeDataProvider<TreeNode> {
+    private _onDidChangeTreeData = new vscode.EventEmitter<TreeNode | undefined | null>();
+
+    readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
+
+    private _registry: SkillRegistry;
+    private _loading = false;
+
+    /** Initializes the provider with a shared SkillRegistry instance. */
+    constructor() {
+        this._registry = SkillRegistry.getInstance();
+    }
+
+    /** Trigger a full reload of all skill sources. */
+    refresh(): void {
+        this._loading = true;
+        this._onDidChangeTreeData.fire(undefined);
+
+        this._registry
+            .refresh()
+            .then(() => {
+                this._loading = false;
+                this._onDidChangeTreeData.fire(undefined);
+                this._notifyEmptySources();
+            })
+            .catch((err: unknown) => {
+                log(`SkillsProvider: refresh failed: ${String(err)}`);
+                this._loading = false;
+                this._onDidChangeTreeData.fire(undefined);
+            });
+    }
+
+    /** @inheritdoc */
+    getTreeItem(element: TreeNode): vscode.TreeItem {
+        return element;
+    }
+
+    /** @inheritdoc */
+    async getChildren(element?: TreeNode): Promise<TreeNode[]> {
+        if (this._loading) {
+            return [new MessageNode('Loading skills...', 'loading~spin')];
+        }
+
+        // Root level: list sources
+        if (!element) {
+            await this._registry.ensureLoaded();
+            const sources = this._registry.getSources();
+            const allSkills = this._registry.getAllSkills();
+
+            if (sources.length === 0) {
+                return [new MessageNode('No skill sources configured', 'warning')];
+            }
+
+            if (allSkills.length === 0) {
+                return [new MessageNode('No skills available', 'info')];
+            }
+
+            return sources.map((source) => {
+                const count = allSkills.filter((s) => s.source === source.id).length;
+                return new SourceNode(source, count);
+            });
+        }
+
+        // Source level: list modules (or skills directly when only one module)
+        if (element instanceof SourceNode) {
+            const skills = this._registry
+                .getAllSkills()
+                .filter((s) => s.source === element.source.id);
+
+            if (skills.length === 0) {
+                return [new MessageNode('No skills loaded — check URL and auth', 'warning')];
+            }
+
+            const modules = new Map<string, SkillEntry[]>();
+            for (const skill of skills) {
+                const existing = modules.get(skill.module);
+                if (existing) {
+                    existing.push(skill);
+                } else {
+                    modules.set(skill.module, [skill]);
+                }
+            }
+
+            if (modules.size === 1) {
+                const [, modSkills] = [...modules.entries()][0];
+                return modSkills.map((s) => new SkillNode(s));
+            }
+
+            return [...modules.entries()].map(
+                ([mod, modSkills]) => new ModuleNode(mod, element.source.id, modSkills.length),
+            );
+        }
+
+        // Module level: list skills
+        if (element instanceof ModuleNode) {
+            const skills = this._registry
+                .getAllSkills()
+                .filter((s) => s.source === element.sourceId && s.module === element.moduleName);
+            return skills.map((s) => new SkillNode(s));
+        }
+
+        return [];
+    }
+
+    /** Show a warning notification for each source that loaded zero skills. */
+    private _notifyEmptySources(): void {
+        const sources = this._registry.getSources();
+        const allSkills = this._registry.getAllSkills();
+
+        for (const source of sources) {
+            const count = allSkills.filter((s) => s.source === source.id).length;
+            if (count === 0) {
+                const isGitHub = source.url.includes('github.com');
+                const hint = isGitHub
+                    ? 'Check the URL points to a valid GitHub repo with skills.'
+                    : 'The URL may not point to a supported skill repository.';
+                void vscode.window
+                    .showWarningMessage(
+                        `Skill source "${source.id}" loaded 0 skills. ${hint}`,
+                        'Open Settings',
+                    )
+                    .then((choice) => {
+                        if (choice === 'Open Settings') {
+                            void vscode.commands.executeCommand(
+                                'workbench.action.openSettings',
+                                'ansibleEnvironments.skillSources',
+                            );
+                        }
+                    });
+            }
+        }
+    }
+}
+
+/**
+ * Open the AI chat with a lightweight prompt that directs the agent
+ * to fetch the skill via MCP rather than injecting the full content.
+ *
+ * @param skill - The skill entry to use.
+ */
+export async function openChatWithSkill(skill: SkillEntry): Promise<void> {
+    const prompt =
+        `Use the skill_get tool to load the "${skill.name}" skill (ID: "${skill.id}"), ` +
+        `then follow its guidance to help me with: ${skill.description}`;
+
+    try {
+        await vscode.commands.executeCommand('workbench.action.chat.open', prompt);
+    } catch {
+        await vscode.env.clipboard.writeText(prompt);
+        const selection = await vscode.window.showInformationMessage(
+            'Skill prompt copied to clipboard. Paste it into an agent chat session.',
+            'Open Chat',
+        );
+        if (selection === 'Open Chat') {
+            void vscode.commands.executeCommand('workbench.action.chat.open');
+        }
+    }
+}
+
+/**
+ * Copy a skill prompt to the clipboard.
+ *
+ * @param skill - The skill entry to copy the prompt for.
+ */
+export async function copySkillPrompt(skill: SkillEntry): Promise<void> {
+    const prompt =
+        `Use the MCP tool skill_get({ skill_id: "${skill.id}" }) to load the ` +
+        `"${skill.name}" skill, then apply its guidance to help me with: ${skill.description}`;
+    await vscode.env.clipboard.writeText(prompt);
+    void vscode.window.showInformationMessage(`Prompt for "${skill.name}" copied to clipboard.`);
+}


### PR DESCRIPTION
## Summary
- Add a multi-format skill registry that auto-detects repository layouts (Lola, Vercel/harness, generic SKILL.md) and indexes AI development skills for agent consumption via MCP tools.

## Changes
- **`@ansible/core`**: New `SkillRegistry` service supporting local, GitHub (Lola/Vercel/generic), and future registry sources. Includes disk caching with URL-based invalidation, GitHub auth via `GITHUB_TOKEN`/`gh CLI`, and automatic discovery of unlisted Lola modules.
- **`@ansible/mcp-server`**: New `SkillToolGenerator` exposing `skill_search`, `skill_list`, `skill_get`, and `skill_list_sources` MCP tools. Wired into `McpToolHandler` and the standalone MCP server.
- **Extension**: New `SkillsProvider` tree view (AI Skills) with source/module/skill hierarchy, "Use in Chat" sparkle action, and empty-source warning notifications. Skill sources are configurable via `ansibleEnvironments.skillSources` and forwarded to the MCP server process.
- **`package.json`**: Added `ansibleSkills` view, commands, menus, and `ansibleEnvironments.skillSources` configuration schema with `ai-forge` as default source.

## Quality of life
- AI-authored: `SkillRegistry.ts`, `skillTools.ts`, `SkillsProvider.ts`, tests, and extension wiring

## Commits
- `8ca2a034` feat(core): add multi-format skill registry with MCP tools
- `43569683` test(core): add GitHub HTTP mock tests for SkillRegistry

## Test plan
- [x] `npm exec eslint -- .` passes
- [x] `npm exec tsc -- -b` compiles cleanly
- [x] `npm exec vitest -- run` passes (465 tests, including 41 new)
- [x] Coverage at 87.6% (above 85% threshold)
- [ ] Manual: verify AI Skills view loads skills from ai-forge after configuring source