### PR TITLE
chore: upgrade TypeScript to v6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
         "globals": "^17.6.0",
         "prettier": "^3.8.4",
         "ts-node": "^10.9.2",
-        "typescript": "^5.3.0",
+        "typescript": "^6.0.3",
         "typescript-eslint": "^8.61.0",
         "vitest": "^3.1.1",
         "wdio-vscode-service": "^6.1.4"
@@ -15623,11 +15623,10 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
-      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -920,7 +920,7 @@
     "globals": "^17.6.0",
     "prettier": "^3.8.4",
     "ts-node": "^10.9.2",
-    "typescript": "^5.3.0",
+    "typescript": "^6.0.3",
     "typescript-eslint": "^8.61.0",
     "vitest": "^3.1.1",
     "wdio-vscode-service": "^6.1.4"

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -5,6 +5,7 @@
     "lib": ["ES2020"],
     "outDir": "out",
     "rootDir": "src",
+    "types": ["node"],
     "sourceMap": true,
     "strict": true,
     "esModuleInterop": true,

--- a/packages/language-server/tsconfig.json
+++ b/packages/language-server/tsconfig.json
@@ -5,6 +5,7 @@
     "lib": ["ES2022"],
     "outDir": "out",
     "rootDir": "src",
+    "types": ["node"],
     "sourceMap": true,
     "strict": true,
     "esModuleInterop": true,

--- a/packages/mcp-server/tsconfig.json
+++ b/packages/mcp-server/tsconfig.json
@@ -5,6 +5,7 @@
     "lib": ["ES2020"],
     "outDir": "out",
     "rootDir": "src",
+    "types": ["node"],
     "sourceMap": true,
     "strict": true,
     "esModuleInterop": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,10 +5,10 @@
     "lib": ["ES2020"],
     "outDir": "out",
     "rootDir": "src",
-    "baseUrl": ".",
     "paths": {
-      "@src/*": ["src/*"]
+      "@src/*": ["./src/*"]
     },
+    "types": ["node"],
     "sourceMap": true,
     "strict": true,
     "esModuleInterop": true,
@@ -21,6 +21,11 @@
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", ".vscode-test", "packages"],
+  "ts-node": {
+    "compilerOptions": {
+      "types": ["node", "mocha"]
+    }
+  },
   "references": [
     { "path": "packages/core" },
     { "path": "packages/language-server" },


### PR DESCRIPTION
## Summary
- Upgrade TypeScript from ^5.3.0 to ^6.0.3 on the `next` branch, addressing TS6 deprecations
- Parallel to #2866 which does the same for `main`, but adapted for `next`'s different toolchain (npm workspaces, esbuild, `@ansible/core` package structure)

## Changes
- **`package.json`**: Bump `typescript` from `^5.3.0` to `^6.0.3`
- **`tsconfig.json`**: Remove deprecated `baseUrl: "."`, update `paths` to use explicit relative prefix (`"./src/*"`), add `ts-node` section with `types: ["node", "mocha"]` for WDIO test compatibility
- **`packages/core/tsconfig.json`**: Add `types: ["node"]`
- **`packages/language-server/tsconfig.json`**: Add `types: ["node"]`
- **`packages/mcp-server/tsconfig.json`**: Add `types: ["node"]`
- **`package-lock.json`**: Regenerated for TypeScript 6.0.3

### TS6 deprecations addressed
1. **`baseUrl` removed** -- TS6 deprecates `baseUrl` as a module lookup root. Since it was `"."` at repo root, removing it and prefixing paths with `./` preserves identical resolution.
2. **`types: ["node"]` added to package tsconfigs** -- TS6 defaults `types` to `[]` instead of auto-including all `@types/*`. Three package production tsconfigs needed explicit `types`.
3. **`ts-node` types section in root tsconfig** -- TS6's `types` default change also breaks `ts-node` in WDIO worker processes (which pick up the root tsconfig). A `ts-node` section in `tsconfig.json` provides the needed types (`node`, `mocha`) for ts-node specifically, without affecting `tsc -b` (which ignores the section).
4. **`moduleResolution` default change** -- TS6 changes the implicit default from `node10` to `bundler` for `module: "commonjs"`. Verified transparent since esbuild handles actual runtime resolution.

### What is NOT needed (vs PR #2866 on `main`)
- No tsup `ignoreDeprecations` (no tsup on `next`)
- No pnpm / mise.toml changes (`next` uses npm workspaces)
- No electron / semver / prettier bumps (not applicable or already current)

## Test plan
- [x] `npm exec tsc -- -b` compiles cleanly (clean build, zero errors, zero deprecation warnings)
- [x] `npm run build` (esbuild) produces all 3 bundles successfully
- [ ] CI: `npm exec eslint -- .` passes
- [ ] CI: `npm exec vitest -- run` passes
- [ ] CI: WDIO UI tests pass (ts-node types resolved via root tsconfig `ts-node` section)
- [ ] CI: Windows / WSL WDIO tests pass

related: AAP-66052