### PR TITLE
feat(core): replace ansible-navigator with native EE discovery

### DIFF
--- a/packages/core/src/data/NOTICE
+++ b/packages/core/src/data/NOTICE
@@ -1,0 +1,25 @@
+Vendored Scripts from ansible-navigator
+========================================
+
+The files image_introspect.py and python_latest.sh in this directory are
+vendored from the ansible-navigator project:
+
+  https://github.com/ansible/ansible-navigator
+
+Original location:
+  src/ansible_navigator/data/image_introspect.py
+  src/ansible_navigator/data/python_latest.sh
+
+Copyright Red Hat
+
+These files are licensed under the Apache License, Version 2.0.
+You may obtain a copy of the License at:
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+They are included here to allow @ansible/core to perform Execution
+Environment introspection without requiring a Python-based
+ansible-navigator installation on the host.
+
+These scripts run exclusively inside EE containers (which always have
+Python available) and are never executed on the host.

--- a/packages/core/src/data/image_introspect.py
+++ b/packages/core/src/data/image_introspect.py
@@ -1,0 +1,521 @@
+# Vendored from ansible-navigator (https://github.com/ansible/ansible-navigator)
+# Original: src/ansible_navigator/data/image_introspect.py
+#
+# Copyright Red Hat
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# This script runs INSIDE an Execution Environment container to collect
+# metadata about installed Ansible collections, Python/system packages,
+# OS release, and Ansible version. It outputs JSON to stdout.
+
+"""Introspect an execution environment image."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import threading
+
+from queue import Queue
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import TypeAlias
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+# https://github.com/python/typing/issues/182#issuecomment-1320974824
+JSONTypes: TypeAlias = dict[str, "JSONTypes"] | list["JSONTypes"] | str | int | float | bool | None
+
+
+class Command(SimpleNamespace):
+    """Abstraction for a details about a shell command."""
+
+    id_: str
+    command: str
+    parse: Callable[..., Any]
+    stdout: str = ""
+    stderr: str = ""
+    details: list[str] | dict[Any, Any] | list[dict[Any, Any]] | str = ""
+    errors: list[str] = []
+
+
+def run_command(command: Command) -> None:
+    """Run a command using subprocess.
+
+    Args:
+        command: Details of the command to run
+    """
+    try:
+        proc_out = subprocess.run(
+            command.command,
+            capture_output=True,
+            check=True,
+            text=True,
+            shell=True,
+        )
+        command.stdout = proc_out.stdout
+    except subprocess.CalledProcessError as exc:
+        command.stderr = str(exc.stderr)
+        command.errors = [str(exc.stderr)]
+
+
+def worker(pending_queue: Queue[Any], completed_queue: Queue[Any]) -> None:
+    """Run a command from pending, parse, and place in completed.
+
+    Args:
+        pending_queue: A queue with plugins to process
+        completed_queue: The queue in which extracted documentation will
+            be placed
+    """
+    while True:
+        command = pending_queue.get()
+        if command is None:
+            break
+        run_command(command)
+        try:
+            command.parse(command)
+        except Exception as exc:  # noqa: BLE001
+            command.errors = command.errors + [str(exc)]
+        completed_queue.put(command)
+
+
+class CommandRunner:
+    """A command runner.
+
+    Run commands using single or multiple processes.
+    """
+
+    def __init__(self) -> None:
+        """Initialize the command runner."""
+        self._completed_queue: Queue[Any] | None = None
+        self._pending_queue: Queue[Any] | None = None
+
+    def run_multi_thread(self, command_classes: list[CmdParser]) -> list[CmdParser]:
+        """Run commands with multiple threads.
+
+        Workers are started to read from pending queue.
+        Exit when the number of results is equal to the number
+        of commands needing to be run.
+
+        Args:
+            command_classes: All command classes to be run
+
+        Returns:
+            The results from running all commands
+        """
+        if self._completed_queue is None:
+            self._completed_queue = Queue()
+        if self._pending_queue is None:
+            self._pending_queue = Queue()
+        all_commands = tuple(
+            command for command_class in command_classes for command in command_class.commands
+        )
+        self.start_workers(all_commands)
+        results: list[CmdParser] = []
+        while len(results) != len(all_commands):
+            results.append(self._completed_queue.get())
+        return results
+
+    def start_workers(self, jobs: tuple[Command, ...]) -> None:
+        """Start workers and submit jobs to pending queue.
+
+        Args:
+            jobs: The jobs to be run
+
+        Raises:
+            RuntimeError: if there is a runtime error
+        """
+        worker_count = len(jobs)
+        processes = []
+        for _proc in range(worker_count):
+            proc = threading.Thread(
+                target=worker,
+                args=(self._pending_queue, self._completed_queue),
+            )
+            processes.append(proc)
+            proc.start()
+        if not self._pending_queue:
+            raise RuntimeError
+        for job in jobs:
+            self._pending_queue.put(job)
+        for _proc in range(worker_count):
+            self._pending_queue.put(None)
+        for proc in processes:
+            proc.join()
+
+
+class CmdParser:
+    """A base class for command parsers with common parsing functions."""
+
+    @property
+    def commands(self) -> list[Command]:
+        """List of commands to be executed."""
+        return []
+
+    @staticmethod
+    def _strip(value: str) -> str:
+        """Remove quotes, leading and trailing whitespace.
+
+        Args:
+            value: The string to act on
+
+        Returns:
+            The string after removing quotes, leading and trailing
+            whitespace
+        """
+        return value.strip('"').strip("'").strip()
+
+    @staticmethod
+    def re_partition(content: Any, separator: str) -> Any:
+        """Partition a string using a regular expression.
+
+        Args:
+            content: The content to partition
+            separator: The separator to use for the partitioning
+
+        Returns:
+            The first partition, separator, and final partition
+        """
+        separator_match = re.search(separator, content)
+        if not separator_match or content.startswith(" "):
+            return "", "", content
+        delim = separator_match.group(0)
+        key, content = re.split(delim, content, maxsplit=1)
+        return key, delim, content
+
+    def splitter(
+        self,
+        lines: list[str],
+        line_split: str,
+        section_delim: str | None = None,
+    ) -> list[dict[str, Any]] | dict[str, Any]:
+        """Split lines given a delimiter.
+
+        Args:
+            lines: The lines to split
+            line_split: The delimiter use for splitting each line
+            section_delim: The separator between different packages
+
+        Returns:
+            All lines split on the delimiter
+        """
+        results: list[dict[str, Any]] = []
+        result: dict[str, Any] = {}
+        current_key: str = ""
+        while lines:
+            line = lines.pop(0)
+            key, delim, content = self.re_partition(line, line_split)
+            content = self._strip(content)
+            if section_delim and line == section_delim:
+                results.append(result)
+                result = {}
+                continue
+            if not delim and current_key:
+                result[current_key] += f" {content}"
+                continue
+            current_key = key.lower().replace("_", "-").strip()
+            # system_packages description field needs special handling
+            if current_key == "description":
+                description = []
+                while lines:
+                    line = lines.pop(0)
+                    if line == section_delim:
+                        break
+                    description.append(line)
+                if description:
+                    result[current_key] = " ".join(description)
+                else:
+                    result[current_key] = "No description available"
+                results.append(result)
+                return result
+            result[current_key] = content
+
+        if result:
+            results.append(result)
+        return results
+
+
+class AnsibleCollections(CmdParser):
+    """Available ansible collections collector."""
+
+    @property
+    def commands(self) -> list[Command]:
+        """Define the ansible-galaxy command to list ansible collections.
+
+        Returns:
+            The defined command
+        """
+        command = "ansible-galaxy collection list"
+        return [
+            Command(
+                id_="ansible_collections",
+                command=command,
+                parse=self.parse,
+            ),
+        ]
+
+    @staticmethod
+    def parse(command: Command) -> None:
+        """Parse the output of the ansible-galaxy command.
+
+        Args:
+            command: The result of running the command
+        """
+        if "invalid choice: 'list'" in command.stderr:
+            command.details = "This command is not supported with ansible 2.9."
+            return
+        collections = {}
+        for line in command.stdout.splitlines():
+            parts = line.split()
+            if len(parts) == 2 and parts[1][0].isdigit():
+                collections[parts[0].strip()] = parts[1].strip()
+        command.details = collections
+
+
+class AnsibleVersion(CmdParser):
+    """Ansible version collector."""
+
+    @property
+    def commands(self) -> list[Command]:
+        """Define the ansible command to get the version.
+
+        Returns:
+            The defined command
+        """
+        return [Command(id_="ansible_version", command="ansible --version", parse=self.parse)]
+
+    @staticmethod
+    def parse(command: Command) -> None:
+        """Parse the output of the ansible command.
+
+        Args:
+            command: The result of running the command
+        """
+        version = command.stdout.splitlines()[0]
+        command.details = version
+
+
+class OsRelease(CmdParser):
+    """OS release information collector."""
+
+    @property
+    def commands(self) -> list[Command]:
+        """Define the command to collect os release information.
+
+        Returns:
+            The defined command
+        """
+        return [Command(id_="os_release", command="cat /etc/os-release", parse=self.parse)]
+
+    def parse(self, command: Command) -> None:
+        """Parse the output of the cat command.
+
+        Args:
+            command: The result of running the command
+        """
+        parsed = self.splitter(command.stdout.splitlines(), "=")
+        command.details = parsed
+
+
+class PythonPackages(CmdParser):
+    """Python package collector."""
+
+    @property
+    def commands(self) -> list[Command]:
+        """Define the pip command to list installed pip packages.
+
+        Returns:
+            The defined command
+        """
+        pre = Command(
+            id_="pip_freeze",
+            command=f"{sys.executable} -m pip freeze",
+            parse=self.parse_freeze,
+        )
+        run_command(pre)
+        pre.parse(pre)
+        pkgs = " ".join(pkg for pkg in pre.details[0]) if pre.details else ""
+        return [
+            Command(
+                id_="python_packages",
+                command=f"{sys.executable} -m pip show {pkgs}",
+                parse=self.parse,
+            ),
+        ]
+
+    def parse(self, command: Command) -> None:
+        """Parse the output of the pip command.
+
+        Args:
+            command: The result of running the command
+        """
+        parsed = self.splitter(command.stdout.splitlines(), line_split=":", section_delim="---")
+        if isinstance(parsed, dict):
+            parsed = [parsed]
+        for pkg in parsed:
+            for entry in ["required-by", "requires"]:
+                if pkg[entry]:
+                    pkg[entry] = [p.strip() for p in pkg[entry].split(",")]
+                else:
+                    pkg[entry] = []
+        command.details = parsed
+
+    def parse_freeze(self, command: Command) -> None:
+        """Parse the output of the pip freeze command, skipping editables.
+
+        Args:
+            command: The result of running the command
+        """
+        lines = [line for line in command.stdout.splitlines() if not line.startswith("-e")]
+        parsed = self.splitter(lines, "(==|@)")
+        command.details = parsed
+
+
+class RedhatRelease(CmdParser):
+    """Red Hat release collector."""
+
+    @property
+    def commands(self) -> list[Command]:
+        """Define the command to get the redhat release information.
+
+        Returns:
+            The defined command
+        """
+        return [Command(id_="redhat_release", command="cat /etc/redhat-release", parse=self.parse)]
+
+    @staticmethod
+    def parse(command: Command) -> None:
+        """Parse the output of the cat redhat release command.
+
+        Args:
+            command: The result of running the command
+        """
+        parsed = command.stdout
+        command.details = parsed
+
+
+class SystemPackages(CmdParser):
+    """System packages collector."""
+
+    @property
+    def commands(self) -> list[Command]:
+        """Define the command to list system packages.
+
+        Returns:
+            The defined command
+        """
+        return [Command(id_="system_packages", command="rpm -qai", parse=self.parse)]
+
+    def parse(self, command: Command) -> None:
+        """Parse the output of the rpm command.
+
+        Args:
+            command: The result of running the command
+        """
+        packages = []
+        package: list[str] = []
+        for line in command.stdout.splitlines():
+            if re.match(r"^Name\s{2,}:", line) and package:
+                packages.append(package)
+                package = [line]
+            else:
+                package.append(line)
+        if package:
+            packages.append(package)
+
+        parsed: list[Any] = []
+        for package in packages:
+            result = self.splitter(package, line_split=":")
+            parsed.append(result)
+
+        command.details = parsed
+
+
+ALL_COLLECTORS: dict[str, type[CmdParser]] = {
+    "ansible_collections": AnsibleCollections,
+    "ansible_version": AnsibleVersion,
+    "os_release": OsRelease,
+    "redhat_release": RedhatRelease,
+    "python_packages": PythonPackages,
+    "system_packages": SystemPackages,
+}
+
+
+def main(
+    serialize: bool = True,
+    sections: list[str] | None = None,
+) -> dict[str, JSONTypes] | None:
+    """Enter the image introspection process.
+
+    Args:
+        serialize: Whether to serialize the results
+        sections: Optional list of section IDs to collect. When ``None`` or
+            when ``"everything"`` is present, all collectors run.
+
+    Returns:
+        The collected data or none if serialize is False
+    """
+    response: dict[str, Any] = {"errors": []}
+    response["python_version"] = {"details": {"version": " ".join(sys.version.splitlines())}}
+    response["environment_variables"] = {"details": dict(os.environ)}
+    try:
+        command_runner = CommandRunner()
+
+        if sections and "everything" not in sections:
+            commands: list[CmdParser] = [
+                ALL_COLLECTORS[s]() for s in sections if s in ALL_COLLECTORS
+            ]
+        else:
+            commands = [cls() for cls in ALL_COLLECTORS.values()]
+
+        results = command_runner.run_multi_thread(commands)
+        for result in results:
+            result_as_dict = vars(result)
+            result_as_dict.pop("parse")
+            for key in list(result_as_dict.keys()):
+                if key not in ["details", "errors"]:
+                    result_as_dict[f"__{key}"] = result_as_dict[key]
+                    result_as_dict.pop(key)
+            response[result_as_dict["__id_"]] = result_as_dict
+    except Exception as exc:  # noqa: BLE001
+        response["errors"].append(str(exc))
+    if serialize:
+        print(json.dumps(response))
+        return None
+    return response
+
+
+ALWAYS_COLLECTED = ("python_version", "environment_variables")
+
+
+def _parse_args() -> list[str] | None:
+    """Parse command-line arguments for section filtering.
+
+    Returns:
+        The list of requested sections, or None for all sections.
+    """
+    parser = argparse.ArgumentParser(description="Introspect an execution environment image.")
+    parser.add_argument(
+        "--sections",
+        nargs="*",
+        default=None,
+        choices=[*ALL_COLLECTORS, *ALWAYS_COLLECTED, "everything"],
+        help="Sections to collect. Omit for all sections.",
+    )
+    args = parser.parse_args()
+    return args.sections
+
+
+if __name__ == "__main__":  # pragma: no cover
+    requested_sections = _parse_args()
+    main(sections=requested_sections)

--- a/packages/core/src/data/python_latest.sh
+++ b/packages/core/src/data/python_latest.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Vendored from ansible-navigator (https://github.com/ansible/ansible-navigator)
+# Original: src/ansible_navigator/data/python_latest.sh
+#
+# Copyright Red Hat
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Finds the highest-version python on PATH inside a container and
+# executes the given script with it.
+
+# Find the latest Python version installed
+find_latest_python() {
+    # Get all python executables in the PATH and sort them
+    PYTHON_EXECUTABLE=$(compgen -c python | grep -E '^python[0-9]+(\.[0-9]+)?$' | sort -V | tail -n 1)
+
+    # Check if any Python executable was found
+    if [[ -z "$PYTHON_EXECUTABLE" ]]; then
+        echo "No Python executable found on the system."
+        return 1
+    fi
+
+    return 0
+}
+
+# Use the latest Python executable
+run_with_latest_python() {
+    find_latest_python
+    if [[ $? -ne 0 ]]; then
+        exit 1
+    fi
+
+    # Run a Python script or use the Python shell
+    "$PYTHON_EXECUTABLE" "$@"
+}
+
+# Pass arguments to the script
+run_with_latest_python "$@"

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -35,6 +35,20 @@ export type { CachedEnvironment } from './services/EnvironmentCache';
 export { ExecutionEnvService } from './services/ExecutionEnvService';
 export type { ExecutionEnvironment, EEDetails } from './services/ExecutionEnvService';
 
+export { EECache } from './services/EECache';
+export type { CacheIndex, CacheIndexEntry } from './services/EECache';
+
+export {
+    detectEngine,
+    listImages,
+    inspectImage,
+    classifyEE,
+    runInContainer,
+    deployScripts,
+    getScriptCacheDir,
+} from './services/ContainerRuntime';
+export type { ContainerEngine, ContainerImage, InspectedImage } from './services/ContainerRuntime';
+
 export { GalaxyCollectionCache } from './services/GalaxyCollectionCache';
 export type { GalaxyCollection } from './services/GalaxyCollectionCache';
 

--- a/packages/core/src/services/CommandService.ts
+++ b/packages/core/src/services/CommandService.ts
@@ -27,6 +27,7 @@ import { getCachedBinDir, getCachedToolPath, findExecutableWithCache } from './E
 import { log } from '../utils/logging';
 
 const execAsync = promisify(cp.exec);
+const execFileAsync = promisify(cp.execFile);
 
 export type BinDirResolver = (workspaceUri?: unknown) => Promise<string | null>;
 
@@ -213,6 +214,55 @@ export class CommandService {
                 maxBuffer,
                 timeout: options.timeout,
                 env: env,
+            });
+            return {
+                stdout: stdout.trim(),
+                stderr: stderr.trim(),
+                exitCode: 0,
+            };
+        } catch (error) {
+            const execError = error as cp.ExecException & { stdout?: string; stderr?: string };
+            return {
+                stdout: execError.stdout?.trim() ?? '',
+                stderr: execError.stderr?.trim() ?? execError.message,
+                exitCode: execError.code ?? 1,
+            };
+        }
+    }
+
+    /**
+     * Run a command with an explicit args array, bypassing the shell.
+     * Prevents shell injection when arguments come from user input.
+     *
+     * @param file - Executable path or name.
+     * @param args - Arguments passed directly to the process (no shell interpolation).
+     * @param options - Execution options such as cwd, env, and timeout.
+     * @returns Captured stdout, stderr, and exit code from the subprocess.
+     */
+    public async runCommandArgs(
+        file: string,
+        args: string[],
+        options: CommandOptions = {},
+    ): Promise<ExecResult> {
+        const cwd = options.cwd ?? this.getWorkspaceRoot() ?? process.cwd();
+        const maxBuffer = options.maxBuffer ?? 10 * 1024 * 1024;
+
+        const binDir = await this.getBinDir();
+        const processPath = process.env.PATH ?? '';
+        const envPath = binDir ? `${binDir}${path.delimiter}${processPath}` : processPath;
+
+        const env: Record<string, string | undefined> = {
+            ...process.env,
+            PATH: envPath,
+            ...options.env,
+        };
+
+        try {
+            const { stdout, stderr } = await execFileAsync(file, args, {
+                cwd,
+                maxBuffer,
+                timeout: options.timeout,
+                env,
             });
             return {
                 stdout: stdout.trim(),

--- a/packages/core/src/services/ContainerRuntime.ts
+++ b/packages/core/src/services/ContainerRuntime.ts
@@ -1,0 +1,353 @@
+/**
+ * Container Runtime
+ *
+ * Host-side TypeScript replacement for ansible-navigator's image discovery.
+ * Detects podman/docker, lists and inspects images, classifies EEs,
+ * and runs the vendored introspection script inside containers.
+ *
+ * Zero Python required on the host -- the introspection script runs
+ * exclusively inside EE containers using the container's own Python.
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { getCommandService } from './CommandService';
+import type { ExecResult } from './CommandService';
+import { log } from '../utils/logging';
+
+export type ContainerEngine = 'podman' | 'docker';
+
+/** Normalized image record from `{engine} images --format json`. */
+export interface ContainerImage {
+    id: string;
+    repository: string;
+    tag: string;
+    created: string;
+    size: string;
+    names: string[];
+}
+
+/** Result of `{engine} inspect` with EE classification. */
+export interface InspectedImage extends ContainerImage {
+    executionEnvironment: boolean;
+    inspect: {
+        config: {
+            labels: Record<string, string>;
+            workingDir: string;
+        };
+        architecture?: string;
+        os?: string;
+    };
+}
+
+// ── Raw JSON shapes from podman / docker ────────────────────────────
+
+interface PodmanImageJson {
+    Id: string;
+    Names: string[] | null;
+    Created?: string;
+    CreatedAt?: string;
+    Size?: number;
+}
+
+interface DockerImageJson {
+    ID: string;
+    Repository: string;
+    Tag: string;
+    CreatedAt: string;
+    Size: string;
+}
+
+interface InspectJson {
+    Id?: string;
+    Config?: {
+        Labels?: Record<string, string>;
+        WorkingDir?: string;
+    };
+    Architecture?: string;
+    Os?: string;
+    [key: string]: unknown;
+}
+
+// ── Public API ──────────────────────────────────────────────────────
+
+/**
+ * Detect which container engine is available (prefers podman).
+ *
+ * @returns The detected engine name, or null if neither is found.
+ */
+export async function detectEngine(): Promise<ContainerEngine | null> {
+    const cmd = getCommandService();
+    for (const engine of ['podman', 'docker'] as const) {
+        const result = await cmd.runCommand(`${engine} --version`);
+        if (result.exitCode === 0) {
+            log(`ContainerRuntime: detected ${engine}`);
+            return engine;
+        }
+    }
+    log('ContainerRuntime: no container engine found');
+    return null;
+}
+
+/**
+ * List all local container images.
+ * Uses `--format json` for both podman and docker (no tabular parsing).
+ *
+ * @param engine - Container engine to invoke.
+ * @returns Normalized image records.
+ */
+export async function listImages(engine: ContainerEngine): Promise<ContainerImage[]> {
+    const cmd = getCommandService();
+    let result: ExecResult;
+
+    if (engine === 'podman') {
+        result = await cmd.runCommand(`${engine} images --format json`);
+    } else {
+        result = await cmd.runCommand(`${engine} images --format "{{json .}}" --no-trunc`);
+    }
+
+    if (result.exitCode !== 0 || !result.stdout) {
+        log(`ContainerRuntime: ${engine} images failed: ${result.stderr}`);
+        return [];
+    }
+
+    return engine === 'podman'
+        ? parsePodmanImages(result.stdout)
+        : parseDockerImages(result.stdout);
+}
+
+/**
+ * Run `{engine} inspect` on a single image and classify whether it's an EE.
+ *
+ * @param engine - Container engine to invoke.
+ * @param image - Image to inspect.
+ * @returns The image with EE classification and inspect metadata.
+ */
+export async function inspectImage(
+    engine: ContainerEngine,
+    image: ContainerImage,
+): Promise<InspectedImage> {
+    const cmd = getCommandService();
+    const result = await cmd.runCommand(`${engine} inspect ${image.id}`);
+
+    let inspectData: InspectJson = {};
+    if (result.exitCode === 0 && result.stdout) {
+        try {
+            const parsed: unknown = JSON.parse(result.stdout);
+            const arr = Array.isArray(parsed) ? parsed : [parsed];
+            inspectData = (arr[0] as InspectJson | undefined) ?? {};
+        } catch {
+            log(`ContainerRuntime: failed to parse inspect JSON for ${image.id}`);
+        }
+    }
+
+    const config = inspectData.Config ?? {};
+    const labels = config.Labels ?? {};
+    const workingDir = config.WorkingDir ?? '';
+
+    return {
+        ...image,
+        executionEnvironment: classifyEE(labels, workingDir),
+        inspect: {
+            config: { labels, workingDir },
+            architecture: inspectData.Architecture,
+            os: inspectData.Os,
+        },
+    };
+}
+
+/**
+ * Determine if an image is an Ansible Execution Environment.
+ * Matches navigator's three-way check:
+ *   1. Label `ansible-execution-environment` = "true" (root level)
+ *   2. Label in Config.Labels
+ *   3. Legacy: WorkingDir = "/runner"
+ * @param labels - Image labels from container inspect.
+ * @param workingDir - Container working directory from inspect.
+ * @returns True when the image qualifies as an EE.
+ */
+export function classifyEE(labels: Record<string, string>, workingDir: string): boolean {
+    const labelCheck = labels['ansible-execution-environment'] === 'true';
+    const legacyCheck = workingDir === '/runner';
+    return labelCheck || legacyCheck;
+}
+
+/**
+ * Run the vendored introspection script inside a container.
+ * @param engine - Container engine to use.
+ * @param imageName - Full image name (repository:tag).
+ * @param cacheDir - Directory where the vendored scripts are deployed.
+ * @param sections - Optional list of sections to collect.
+ * @returns Raw JSON string from the introspection script.
+ */
+export async function runInContainer(
+    engine: ContainerEngine,
+    imageName: string,
+    cacheDir: string,
+    sections?: string[],
+): Promise<string> {
+    const cmd = getCommandService();
+
+    const scriptPath = path.join(cacheDir, 'image_introspect.py');
+    const pythonWrapper = path.join(cacheDir, 'python_latest.sh');
+
+    const containerArgs = [engine, 'run', '--rm', '-v', `${cacheDir}:${cacheDir}:Z`];
+
+    // podman needs --user=root for introspection to access all packages
+    if (engine === 'podman') {
+        containerArgs.push('--user=root');
+    }
+
+    containerArgs.push(imageName, pythonWrapper, scriptPath);
+
+    if (sections?.length) {
+        containerArgs.push('--sections', ...sections);
+    }
+
+    const command = containerArgs.map((a) => (a.includes(' ') ? `"${a}"` : a)).join(' ');
+    log(`ContainerRuntime: introspecting ${imageName}`);
+
+    const result = await cmd.runCommand(command, { timeout: 120_000 });
+
+    if (result.exitCode !== 0) {
+        log(`ContainerRuntime: introspection failed for ${imageName}: ${result.stderr}`);
+        throw new Error(`Introspection failed for ${imageName}: ${result.stderr}`);
+    }
+
+    return result.stdout;
+}
+
+/**
+ * Get the XDG-compliant cache directory for vendored scripts.
+ *
+ * @returns Absolute path to the cache directory.
+ */
+export function getScriptCacheDir(): string {
+    const xdgCache = process.env.XDG_CACHE_HOME ?? path.join(os.homedir(), '.cache');
+    return path.join(xdgCache, 'ansible-tools');
+}
+
+/**
+ * Deploy the vendored scripts to the cache directory so they can be
+ * volume-mounted into containers.
+ *
+ * @param dataDir - The directory containing the vendored .py and .sh source files.
+ * @returns The cache directory path where scripts were deployed.
+ */
+export function deployScripts(dataDir: string): string {
+    const cacheDir = getScriptCacheDir();
+    fs.mkdirSync(cacheDir, { recursive: true });
+
+    for (const file of ['image_introspect.py', 'python_latest.sh']) {
+        const src = path.join(dataDir, file);
+        const dst = path.join(cacheDir, file);
+
+        // Only copy if source is newer or destination doesn't exist
+        const srcStat = fs.statSync(src);
+        let needsCopy = true;
+        try {
+            const dstStat = fs.statSync(dst);
+            needsCopy = srcStat.mtimeMs > dstStat.mtimeMs;
+        } catch {
+            // destination doesn't exist
+        }
+
+        if (needsCopy) {
+            fs.copyFileSync(src, dst);
+            // Ensure scripts are executable
+            fs.chmodSync(dst, 0o755);
+            log(`ContainerRuntime: deployed ${file} to ${cacheDir}`);
+        }
+    }
+
+    return cacheDir;
+}
+
+// ── Parsers (engine-specific JSON normalization) ────────────────────
+
+/**
+ * Parse podman's `--format json` array output into normalized images.
+ *
+ * @param stdout - Raw JSON stdout from `podman images --format json`.
+ * @returns Normalized image records.
+ */
+function parsePodmanImages(stdout: string): ContainerImage[] {
+    let raw: PodmanImageJson[];
+    try {
+        raw = JSON.parse(stdout) as PodmanImageJson[];
+    } catch {
+        log('ContainerRuntime: failed to parse podman images JSON');
+        return [];
+    }
+
+    const images: ContainerImage[] = [];
+    for (const entry of raw) {
+        const names = entry.Names ?? [];
+        if (names.length === 0) continue;
+
+        // Each name is "repository:tag" -- one entry per name
+        for (const fullName of names) {
+            const lastColon = fullName.lastIndexOf(':');
+            const repo = lastColon > 0 ? fullName.substring(0, lastColon) : fullName;
+            const tag = lastColon > 0 ? fullName.substring(lastColon + 1) : 'latest';
+            if (tag === '<none>') continue;
+
+            images.push({
+                id: entry.Id,
+                repository: repo,
+                tag,
+                created: entry.CreatedAt ?? entry.Created ?? '',
+                size: entry.Size != null ? formatBytes(entry.Size) : '',
+                names: [fullName],
+            });
+        }
+    }
+    return images;
+}
+
+/**
+ * Parse docker's line-delimited `{{json .}}` output into normalized images.
+ *
+ * @param stdout - Raw per-line JSON stdout from `docker images`.
+ * @returns Normalized image records.
+ */
+function parseDockerImages(stdout: string): ContainerImage[] {
+    // Docker with `--format "{{json .}}"` outputs one JSON object per line
+    const images: ContainerImage[] = [];
+    for (const line of stdout.split('\n')) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+        try {
+            const entry = JSON.parse(trimmed) as DockerImageJson;
+            if (entry.Tag === '<none>' || entry.Repository === '<none>') continue;
+            const fullName = `${entry.Repository}:${entry.Tag}`;
+            images.push({
+                id: entry.ID,
+                repository: entry.Repository,
+                tag: entry.Tag,
+                created: entry.CreatedAt,
+                size: entry.Size,
+                names: [fullName],
+            });
+        } catch {
+            // skip malformed lines
+        }
+    }
+    return images;
+}
+
+/**
+ * Format a byte count into a human-readable string.
+ *
+ * @param bytes - Number of bytes.
+ * @returns Formatted string like "1.2 GB".
+ */
+function formatBytes(bytes: number): string {
+    if (bytes === 0) return '0 B';
+    const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+    const i = Math.floor(Math.log(bytes) / Math.log(1024));
+    const val = bytes / Math.pow(1024, i);
+    return `${val.toFixed(1)} ${units[i]}`;
+}

--- a/packages/core/src/services/ContainerRuntime.ts
+++ b/packages/core/src/services/ContainerRuntime.ts
@@ -176,6 +176,8 @@ export function classifyEE(labels: Record<string, string>, workingDir: string): 
 
 /**
  * Run the vendored introspection script inside a container.
+ * Uses execFile (no shell) to prevent injection via imageName.
+ *
  * @param engine - Container engine to use.
  * @param imageName - Full image name (repository:tag).
  * @param cacheDir - Directory where the vendored scripts are deployed.
@@ -193,23 +195,21 @@ export async function runInContainer(
     const scriptPath = path.join(cacheDir, 'image_introspect.py');
     const pythonWrapper = path.join(cacheDir, 'python_latest.sh');
 
-    const containerArgs = [engine, 'run', '--rm', '-v', `${cacheDir}:${cacheDir}:Z`];
+    const args = ['run', '--rm', '--pull=never', '-v', `${cacheDir}:${cacheDir}:Z`];
 
-    // podman needs --user=root for introspection to access all packages
     if (engine === 'podman') {
-        containerArgs.push('--user=root');
+        args.push('--user=root');
     }
 
-    containerArgs.push(imageName, pythonWrapper, scriptPath);
+    args.push(imageName, pythonWrapper, scriptPath);
 
     if (sections?.length) {
-        containerArgs.push('--sections', ...sections);
+        args.push('--sections', ...sections);
     }
 
-    const command = containerArgs.map((a) => (a.includes(' ') ? `"${a}"` : a)).join(' ');
     log(`ContainerRuntime: introspecting ${imageName}`);
 
-    const result = await cmd.runCommand(command, { timeout: 120_000 });
+    const result = await cmd.runCommandArgs(engine, args, { timeout: 120_000 });
 
     if (result.exitCode !== 0) {
         log(`ContainerRuntime: introspection failed for ${imageName}: ${result.stderr}`);

--- a/packages/core/src/services/EECache.ts
+++ b/packages/core/src/services/EECache.ts
@@ -1,0 +1,232 @@
+/**
+ * EE Image Cache
+ *
+ * SHA-keyed file-based cache for Execution Environment introspection data.
+ * Cache key is the container image's content digest (SHA) which guarantees:
+ *   - Natural invalidation: new image content = new SHA = cache miss
+ *   - Deduplication: multiple tags pointing to the same SHA share one entry
+ *   - Persistence across process restarts
+ *
+ * Cache location: $XDG_CACHE_HOME/ansible-tools/ee-cache/
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import type { EEDetails } from './ExecutionEnvService';
+import { log } from '../utils/logging';
+
+/** Metadata stored in the cache index for each image SHA. */
+export interface CacheIndexEntry {
+    fullName: string;
+    tag: string;
+    introspectedAt: string;
+}
+
+/** Maps image SHA to its cache index entry. */
+export type CacheIndex = Record<string, CacheIndexEntry>;
+
+/** File-based cache for EE introspection data, keyed by image SHA. */
+export class EECache {
+    private _cacheDir: string;
+    private _index: CacheIndex = {};
+
+    /**
+     * @param cacheDir - Override cache directory (defaults to XDG_CACHE_HOME).
+     */
+    constructor(cacheDir?: string) {
+        const xdgCache = process.env.XDG_CACHE_HOME ?? path.join(os.homedir(), '.cache');
+        this._cacheDir = cacheDir ?? path.join(xdgCache, 'ansible-tools', 'ee-cache');
+        this._ensureDir();
+        this._loadIndex();
+    }
+
+    /**
+     * Shortened SHA used as cache file name (first 12 hex chars).
+     *
+     * @param sha - Full image SHA.
+     * @returns First 12 hex characters with the `sha256:` prefix stripped.
+     */
+    private _shortSha(sha: string): string {
+        return sha.replace(/^sha256:/, '').substring(0, 12);
+    }
+
+    /**
+     * @returns Absolute path to the index.json file.
+     */
+    private _indexPath(): string {
+        return path.join(this._cacheDir, 'index.json');
+    }
+
+    /**
+     * @param sha - Image SHA to resolve.
+     * @returns Absolute path to the per-image detail JSON file.
+     */
+    private _detailPath(sha: string): string {
+        return path.join(this._cacheDir, `${this._shortSha(sha)}.json`);
+    }
+
+    /** Create the cache directory if it does not exist. */
+    private _ensureDir(): void {
+        fs.mkdirSync(this._cacheDir, { recursive: true });
+    }
+
+    /** Read the index from disk, or start with an empty index. */
+    private _loadIndex(): void {
+        try {
+            const raw = fs.readFileSync(this._indexPath(), 'utf-8');
+            this._index = JSON.parse(raw) as CacheIndex;
+        } catch {
+            this._index = {};
+        }
+    }
+
+    /** Persist the current index to disk. */
+    private _saveIndex(): void {
+        try {
+            fs.writeFileSync(this._indexPath(), JSON.stringify(this._index, null, 2));
+        } catch (err) {
+            log(
+                `EECache: failed to write index: ${err instanceof Error ? err.message : String(err)}`,
+            );
+        }
+    }
+
+    /**
+     * Check if introspection data exists for a given image SHA.
+     *
+     * @param sha - Image content digest.
+     * @returns True when both the index entry and detail file exist.
+     */
+    has(sha: string): boolean {
+        if (!(sha in this._index)) return false;
+        try {
+            fs.accessSync(this._detailPath(sha), fs.constants.R_OK);
+            return true;
+        } catch {
+            return false;
+        }
+    }
+
+    /**
+     * Read cached EEDetails for a SHA.
+     *
+     * @param sha - Image content digest.
+     * @returns Cached details, or null if not cached.
+     */
+    get(sha: string): EEDetails | null {
+        if (!this.has(sha)) return null;
+        try {
+            const raw = fs.readFileSync(this._detailPath(sha), 'utf-8');
+            return JSON.parse(raw) as EEDetails;
+        } catch {
+            return null;
+        }
+    }
+
+    /**
+     * Store EEDetails for an image SHA.
+     *
+     * @param sha - Image content digest.
+     * @param fullName - Full image name (repository:tag).
+     * @param details - Introspection payload to cache.
+     */
+    set(sha: string, fullName: string, details: EEDetails): void {
+        const parts = fullName.split(':');
+        const tag = parts.length > 1 ? (parts.at(-1) ?? 'latest') : 'latest';
+        this._index[sha] = {
+            fullName,
+            tag,
+            introspectedAt: new Date().toISOString(),
+        };
+        try {
+            fs.writeFileSync(this._detailPath(sha), JSON.stringify(details, null, 2));
+        } catch (err) {
+            log(
+                `EECache: failed to write detail for ${sha}: ${err instanceof Error ? err.message : String(err)}`,
+            );
+        }
+        this._saveIndex();
+    }
+
+    /**
+     * Remove a specific SHA from the cache.
+     *
+     * @param sha - Image content digest to remove.
+     */
+    remove(sha: string): void {
+        this._index = Object.fromEntries(
+            Object.entries(this._index).filter(([key]) => key !== sha),
+        );
+        try {
+            fs.unlinkSync(this._detailPath(sha));
+        } catch {
+            // already gone
+        }
+        this._saveIndex();
+    }
+
+    /**
+     * Prune entries whose SHAs are no longer present in the given set
+     * of current image IDs (i.e. the image was removed or replaced).
+     *
+     * @param currentShas - Set of image SHAs currently present locally.
+     * @returns Number of entries removed.
+     */
+    prune(currentShas: Set<string>): number {
+        let removed = 0;
+        for (const sha of Object.keys(this._index)) {
+            if (!currentShas.has(sha)) {
+                this.remove(sha);
+                removed++;
+            }
+        }
+        if (removed > 0) {
+            log(`EECache: pruned ${String(removed)} stale entries`);
+        }
+        return removed;
+    }
+
+    /** Clear the entire cache. */
+    clear(): void {
+        for (const sha of Object.keys(this._index)) {
+            try {
+                fs.unlinkSync(this._detailPath(sha));
+            } catch {
+                // already gone
+            }
+        }
+        this._index = {};
+        this._saveIndex();
+        log('EECache: cleared all entries');
+    }
+
+    /**
+     * Get the index entry for a SHA (metadata only, no details).
+     *
+     * @param sha - Image content digest.
+     * @returns Index metadata, or undefined if not cached.
+     */
+    getEntry(sha: string): CacheIndexEntry | undefined {
+        return this._index[sha];
+    }
+
+    /**
+     * Get all indexed SHAs.
+     *
+     * @returns Array of cached image SHAs.
+     */
+    keys(): string[] {
+        return Object.keys(this._index);
+    }
+
+    /**
+     * Number of cached entries.
+     *
+     * @returns Count of entries in the index.
+     */
+    get size(): number {
+        return Object.keys(this._index).length;
+    }
+}

--- a/packages/core/src/services/EECache.ts
+++ b/packages/core/src/services/EECache.ts
@@ -43,13 +43,13 @@ export class EECache {
     }
 
     /**
-     * Shortened SHA used as cache file name (first 12 hex chars).
+     * Normalize SHA for use as a cache file name by stripping the algo prefix.
      *
-     * @param sha - Full image SHA.
-     * @returns First 12 hex characters with the `sha256:` prefix stripped.
+     * @param sha - Full image SHA (e.g. "sha256:abc123...").
+     * @returns Full hex digest with the `sha256:` prefix stripped.
      */
-    private _shortSha(sha: string): string {
-        return sha.replace(/^sha256:/, '').substring(0, 12);
+    private _normalizedSha(sha: string): string {
+        return sha.replace(/^sha256:/, '');
     }
 
     /**
@@ -64,7 +64,7 @@ export class EECache {
      * @returns Absolute path to the per-image detail JSON file.
      */
     private _detailPath(sha: string): string {
-        return path.join(this._cacheDir, `${this._shortSha(sha)}.json`);
+        return path.join(this._cacheDir, `${this._normalizedSha(sha)}.json`);
     }
 
     /** Create the cache directory if it does not exist. */
@@ -170,22 +170,32 @@ export class EECache {
     /**
      * Prune entries whose SHAs are no longer present in the given set
      * of current image IDs (i.e. the image was removed or replaced).
+     * Writes the index once at the end instead of per-entry.
      *
      * @param currentShas - Set of image SHAs currently present locally.
      * @returns Number of entries removed.
      */
     prune(currentShas: Set<string>): number {
-        let removed = 0;
-        for (const sha of Object.keys(this._index)) {
-            if (!currentShas.has(sha)) {
-                this.remove(sha);
-                removed++;
+        const stale = Object.keys(this._index).filter((sha) => !currentShas.has(sha));
+        if (stale.length === 0) {
+            return 0;
+        }
+
+        for (const sha of stale) {
+            try {
+                fs.unlinkSync(this._detailPath(sha));
+            } catch {
+                // already gone
             }
         }
-        if (removed > 0) {
-            log(`EECache: pruned ${String(removed)} stale entries`);
-        }
-        return removed;
+
+        this._index = Object.fromEntries(
+            Object.entries(this._index).filter(([key]) => currentShas.has(key)),
+        );
+        this._saveIndex();
+
+        log(`EECache: pruned ${String(stale.length)} stale entries`);
+        return stale.length;
     }
 
     /** Clear the entire cache. */

--- a/packages/core/src/services/ExecutionEnvService.ts
+++ b/packages/core/src/services/ExecutionEnvService.ts
@@ -7,10 +7,16 @@ try {
     // Running standalone (not in VS Code)
 }
 
+import * as fs from 'fs';
+import * as path from 'path';
+
 import { SimpleEventEmitter } from '../utils/SimpleEventEmitter';
+import { EECache } from './EECache';
+import * as ContainerRuntime from './ContainerRuntime';
+import type { ContainerEngine, InspectedImage } from './ContainerRuntime';
 
 /**
- * Information about an execution environment container image
+ * Information about an execution environment container image.
  */
 export interface ExecutionEnvironment {
     created: string;
@@ -20,7 +26,7 @@ export interface ExecutionEnvironment {
 }
 
 /**
- * Detailed information about an execution environment
+ * Detailed information about an execution environment.
  */
 export interface EEDetails {
     ansible_collections?: {
@@ -54,23 +60,32 @@ export interface EEDetails {
 
 /**
  * Service for managing Ansible Execution Environments.
- * This service works both in VS Code and standalone (for MCP server).
+ *
+ * Uses ContainerRuntime (TypeScript) for host-side image discovery and
+ * a vendored Python script for in-container introspection. No Python
+ * or ansible-navigator needed on the host.
+ *
+ * Introspection results are cached on disk keyed by image SHA for
+ * instant subsequent lookups, even across process restarts.
  */
 export class ExecutionEnvService {
     private static _instance: ExecutionEnvService | undefined;
     private _executionEnvironments: ExecutionEnvironment[] = [];
-    private _detailsCache = new Map<string, EEDetails>();
+    private _inspectedImages = new Map<string, InspectedImage>();
+    private _memoryCache = new Map<string, EEDetails>();
+    private _fileCache: EECache;
+    private _engine: ContainerEngine | null = null;
+    private _scriptCacheDir: string | null = null;
     private _loading = false;
     private _loaded = false;
     private _onDidChange: SimpleEventEmitter<void> | { fire: () => void; event: unknown };
     public readonly onDidChange: unknown;
     private _logFn: (message: string) => void = console.error;
 
-    /**
-     * Initializes change notifications using VS Code or a standalone event emitter.
-     */
+    /** Create the singleton service, initializing the file cache and event emitters. */
     private constructor() {
-        // Use VS Code EventEmitter if available, otherwise use simple implementation
+        this._fileCache = new EECache();
+
         if (vscode) {
             const emitter = new vscode.EventEmitter<void>();
             this._onDidChange = emitter;
@@ -83,9 +98,9 @@ export class ExecutionEnvService {
     }
 
     /**
-     * Returns the shared ExecutionEnvService instance.
+     * Get the singleton instance.
      *
-     * @returns Singleton service for execution environment discovery.
+     * @returns The shared ExecutionEnvService instance.
      */
     public static getInstance(): ExecutionEnvService {
         ExecutionEnvService._instance ??= new ExecutionEnvService();
@@ -111,9 +126,7 @@ export class ExecutionEnvService {
     }
 
     /**
-     * Writes a prefixed diagnostic message through the configured log function.
-     *
-     * @param message - Log text without the ExecutionEnvService prefix.
+     * @param message - Diagnostic message to emit.
      */
     private _log(message: string): void {
         this._logFn(`ExecutionEnvService: ${message}`);
@@ -122,7 +135,7 @@ export class ExecutionEnvService {
     /**
      * Check if the service is currently loading data.
      *
-     * @returns True while ansible-navigator discovery is in progress.
+     * @returns True while container image discovery is in progress.
      */
     public isLoading(): boolean {
         return this._loading;
@@ -149,7 +162,7 @@ export class ExecutionEnvService {
     /**
      * Get a specific execution environment by name.
      *
-     * @param fullName - Full image name reported by ansible-navigator.
+     * @param fullName - Full image name (repository:tag).
      * @returns Matching environment metadata, or undefined when not loaded.
      */
     public getExecutionEnvironment(fullName: string): ExecutionEnvironment | undefined {
@@ -163,7 +176,7 @@ export class ExecutionEnvService {
      * @returns Cached inspection details, or undefined when not yet loaded.
      */
     public getCachedDetails(fullName: string): EEDetails | undefined {
-        return this._detailsCache.get(fullName);
+        return this._memoryCache.get(fullName);
     }
 
     /**
@@ -173,14 +186,74 @@ export class ExecutionEnvService {
      */
     public refresh(): Promise<void> {
         this._executionEnvironments = [];
-        this._detailsCache.clear();
+        this._inspectedImages.clear();
+        this._memoryCache.clear();
         this._loaded = false;
         (this._onDidChange as { fire: () => void }).fire();
         return Promise.resolve();
     }
 
     /**
-     * Load execution environments from ansible-navigator.
+     * Force refresh details for a specific image (or all).
+     * Clears both file and memory caches for the given image.
+     *
+     * @param fullName - Image to refresh, or omit for all.
+     */
+    public forceRefresh(fullName?: string): void {
+        if (fullName) {
+            this._memoryCache.delete(fullName);
+            const ee = this._executionEnvironments.find((e) => e.full_name === fullName);
+            if (ee) {
+                this._fileCache.remove(ee.image_id);
+            }
+        } else {
+            this._memoryCache.clear();
+            this._fileCache.clear();
+        }
+        this._executionEnvironments = [];
+        this._inspectedImages.clear();
+        this._loaded = false;
+        (this._onDidChange as { fire: () => void }).fire();
+    }
+
+    /**
+     * Ensure we have a container engine detected.
+     *
+     * @returns The detected container engine.
+     */
+    private async _ensureEngine(): Promise<ContainerEngine> {
+        this._engine ??= await ContainerRuntime.detectEngine();
+        if (!this._engine) {
+            throw new Error(
+                'No container engine found. Install podman or docker to use Execution Environments.',
+            );
+        }
+        return this._engine;
+    }
+
+    /**
+     * Ensure vendored scripts are deployed to the cache directory.
+     *
+     * @returns Path to the cache directory containing deployed scripts.
+     */
+    private _ensureScripts(): string {
+        if (!this._scriptCacheDir) {
+            // __dirname at runtime points to the compiled JS output directory.
+            // The data/ directory with vendored scripts is at the package root.
+            let dataDir = path.resolve(__dirname, '..', 'data');
+            if (!existsSync(path.join(dataDir, 'image_introspect.py'))) {
+                dataDir = path.resolve(__dirname, '..', 'src', 'data');
+            }
+            if (!existsSync(path.join(dataDir, 'image_introspect.py'))) {
+                throw new Error(`Vendored introspection scripts not found. Looked in: ${dataDir}`);
+            }
+            this._scriptCacheDir = ContainerRuntime.deployScripts(dataDir);
+        }
+        return this._scriptCacheDir;
+    }
+
+    /**
+     * Load execution environments by querying the local container engine.
      *
      * @returns Filtered list of images marked as execution environments.
      */
@@ -197,35 +270,32 @@ export class ExecutionEnvService {
         (this._onDidChange as { fire: () => void }).fire();
 
         try {
-            const { getCommandService } = await import('./CommandService');
-            const commandService = getCommandService();
+            const engine = await this._ensureEngine();
+            const images = await ContainerRuntime.listImages(engine);
 
-            // Run ansible-navigator images command using CommandService
-            const result = await commandService.runTool('ansible-navigator', [
-                'images',
-                '--mode',
-                'stdout',
-                '--pull-policy',
-                'never',
-                '--format',
-                'json',
-            ]);
+            const inspected = await Promise.all(
+                images.map((img) => ContainerRuntime.inspectImage(engine, img)),
+            );
 
-            const output = result.stdout || null;
-
-            if (!output) {
-                this._executionEnvironments = [];
-                this._loaded = true;
-                return [];
+            const ees: ExecutionEnvironment[] = [];
+            for (const img of inspected) {
+                this._inspectedImages.set(`${img.repository}:${img.tag}`, img);
+                if (img.executionEnvironment) {
+                    ees.push({
+                        created: img.created,
+                        execution_environment: true,
+                        full_name: `${img.repository}:${img.tag}`,
+                        image_id: img.id,
+                    });
+                }
             }
 
-            const ees = JSON.parse(output) as ExecutionEnvironment[];
-            // Filter to only execution environments
-            this._executionEnvironments = ees.filter((ee) => ee.execution_environment);
+            this._executionEnvironments = ees;
             this._loaded = true;
-            this._log(
-                `Loaded ${String(this._executionEnvironments.length)} execution environments`,
-            );
+            this._log(`Loaded ${String(ees.length)} execution environments`);
+
+            const currentShas = new Set(inspected.map((img) => img.id));
+            this._fileCache.prune(currentShas);
 
             return this._executionEnvironments;
         } catch (error) {
@@ -241,40 +311,47 @@ export class ExecutionEnvService {
 
     /**
      * Load detailed information for a specific execution environment.
+     * Checks: memory cache -> file cache (by SHA) -> live introspection.
      *
-     * @param fullName - Full image name to inspect with ansible-navigator.
-     * @returns Parsed inspection details, or null when the command yields no output.
+     * @param fullName - Full image name to inspect.
+     * @returns Parsed inspection details, or null when introspection yields no output.
      */
     public async loadDetails(fullName: string): Promise<EEDetails | null> {
-        // Check cache first
-        const cached = this._detailsCache.get(fullName);
-        if (cached) {
-            return cached;
+        const memCached = this._memoryCache.get(fullName);
+        if (memCached) {
+            return memCached;
+        }
+
+        const ee = this._executionEnvironments.find((e) => e.full_name === fullName);
+        const sha = ee?.image_id;
+
+        if (sha) {
+            const fileCached = this._fileCache.get(sha);
+            if (fileCached) {
+                this._memoryCache.set(fullName, fileCached);
+                this._log(`Cache hit (file) for ${fullName} [${sha.substring(0, 12)}]`);
+                return fileCached;
+            }
         }
 
         try {
-            const { getCommandService } = await import('./CommandService');
-            const commandService = getCommandService();
+            const engine = await this._ensureEngine();
+            const cacheDir = this._ensureScripts();
+            const stdout = await ContainerRuntime.runInContainer(engine, fullName, cacheDir);
 
-            // Run ansible-navigator images with --details using CommandService
-            const result = await commandService.runTool('ansible-navigator', [
-                'images',
-                fullName,
-                '--mode',
-                'stdout',
-                '--pull-policy',
-                'never',
-                '--details',
-                '--format',
-                'json',
-            ]);
-
-            if (!result.stdout) {
+            if (!stdout) {
                 return null;
             }
 
-            const details = JSON.parse(result.stdout) as EEDetails;
-            this._detailsCache.set(fullName, details);
+            const rawDetails = JSON.parse(stdout) as Record<string, unknown>;
+            const details = this._normalizeIntrospectionOutput(rawDetails, fullName);
+
+            this._memoryCache.set(fullName, details);
+            if (sha) {
+                this._fileCache.set(sha, fullName, details);
+                this._log(`Cached introspection for ${fullName} [${sha.substring(0, 12)}]`);
+            }
+
             return details;
         } catch (error) {
             this._log(
@@ -282,6 +359,39 @@ export class ExecutionEnvService {
             );
             throw error;
         }
+    }
+
+    /**
+     * Normalize the raw introspection script output into the EEDetails shape
+     * expected by consumers (extension, MCP server, Studio).
+     *
+     * @param raw - Raw JSON output from the vendored introspection script.
+     * @param imageName - Full image name to attach to the result.
+     * @returns Normalized EEDetails with only the `details` payload per section.
+     */
+    private _normalizeIntrospectionOutput(
+        raw: Record<string, unknown>,
+        imageName: string,
+    ): EEDetails {
+        const details: EEDetails = { image_name: imageName };
+
+        const sections = [
+            'ansible_collections',
+            'ansible_version',
+            'os_release',
+            'redhat_release',
+            'python_packages',
+            'system_packages',
+        ];
+
+        for (const key of sections) {
+            const section = raw[key] as Record<string, unknown> | undefined;
+            if (section?.details !== undefined) {
+                (details as Record<string, unknown>)[key] = { details: section.details };
+            }
+        }
+
+        return details;
     }
 
     /**
@@ -339,8 +449,8 @@ export class ExecutionEnvService {
         }
 
         if (details.os_release?.details[0]) {
-            const os = details.os_release.details[0];
-            info.os = os['pretty-name'] ?? os.name ?? 'Unknown';
+            const osInfo = details.os_release.details[0];
+            info.os = osInfo['pretty-name'] ?? osInfo.name ?? 'Unknown';
         }
 
         if (details.image_name) {
@@ -349,31 +459,19 @@ export class ExecutionEnvService {
 
         return info;
     }
+}
 
-    /**
-     * Executes a raw shell command and returns stdout when available.
-     *
-     * @param command - Full shell command to run via CommandService.
-     * @returns Captured stdout, or null when the command fails.
-     */
-    private async _runCommand(command: string): Promise<string | null> {
-        try {
-            const { getCommandService } = await import('./CommandService');
-            const commandService = getCommandService();
-
-            this._log(`Running command: ${command}`);
-
-            const result = await commandService.runCommand(command);
-
-            // Exit code 1 is normal for ansible-navigator when returning JSON
-            if (result.exitCode !== 0 && result.exitCode !== 1) {
-                this._log(`Command error (exit ${String(result.exitCode)}): ${result.stderr}`);
-            }
-
-            return result.stdout || null;
-        } catch (error) {
-            this._log(`Command error: ${error instanceof Error ? error.message : String(error)}`);
-            return null;
-        }
+/**
+ * Check whether a filesystem path exists synchronously.
+ *
+ * @param p - Path to check.
+ * @returns True when the path is accessible.
+ */
+function existsSync(p: string): boolean {
+    try {
+        fs.accessSync(p);
+        return true;
+    } catch {
+        return false;
     }
 }

--- a/packages/core/src/services/ExecutionEnvService.ts
+++ b/packages/core/src/services/ExecutionEnvService.ts
@@ -322,8 +322,30 @@ export class ExecutionEnvService {
             return memCached;
         }
 
+        // Ensure we have the EE list so we can resolve the image SHA for
+        // disk-cache lookup. Without this, direct callers (e.g. MCP handler)
+        // would bypass the file cache entirely.
+        if (!this._loaded) {
+            await this.loadExecutionEnvironments();
+        }
+
         const ee = this._executionEnvironments.find((e) => e.full_name === fullName);
-        const sha = ee?.image_id;
+        let sha = ee?.image_id;
+
+        // If the image isn't in the EE list (e.g. user passed an arbitrary
+        // name), try to resolve its SHA via a single inspect call.
+        if (!sha) {
+            try {
+                const engine = await this._ensureEngine();
+                const images = await ContainerRuntime.listImages(engine);
+                const match = images.find((img) => `${img.repository}:${img.tag}` === fullName);
+                if (match) {
+                    sha = match.id;
+                }
+            } catch {
+                this._log(`Could not resolve SHA for ${fullName}, skipping disk cache`);
+            }
+        }
 
         if (sha) {
             const fileCached = this._fileCache.get(sha);

--- a/packages/core/test/services/CommandService.test.ts
+++ b/packages/core/test/services/CommandService.test.ts
@@ -46,8 +46,44 @@ const execExport = vi.hoisted(() => {
     });
 });
 
+const execFileImpl = vi.hoisted(() =>
+    vi.fn(
+        (
+            file: string,
+            args: string[],
+            opts: Record<string, unknown>,
+            cb: (err: Error | null, stdout?: string, stderr?: string) => void,
+        ) => {
+            cb(null, 'out\n', '');
+        },
+    ),
+);
+
+const execFileExport = vi.hoisted(() => {
+    const customPromisify = Symbol.for('nodejs.util.promisify.custom');
+    return Object.assign(execFileImpl, {
+        [customPromisify](file: string, args: string[], options?: Record<string, unknown>) {
+            return new Promise<{ stdout: string; stderr: string }>((resolve, reject) => {
+                execFileImpl(
+                    file,
+                    args,
+                    options ?? {},
+                    (err: Error | null, stdout?: string, stderr?: string) => {
+                        if (err) {
+                            reject(err);
+                        } else {
+                            resolve({ stdout: stdout ?? '', stderr: stderr ?? '' });
+                        }
+                    },
+                );
+            });
+        },
+    });
+});
+
 vi.mock('child_process', () => ({
     exec: execExport,
+    execFile: execFileExport,
 }));
 
 describe('CommandService', () => {

--- a/packages/core/test/services/ContainerRuntime.test.ts
+++ b/packages/core/test/services/ContainerRuntime.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+    const mockRunCommand = vi.fn();
+    return {
+        mockRunCommand,
+        getCommandService: vi.fn(() => ({
+            runCommand: mockRunCommand,
+        })),
+    };
+});
+
+vi.mock('../../src/services/CommandService', () => ({
+    getCommandService: mocks.getCommandService,
+}));
+
+import {
+    detectEngine,
+    listImages,
+    inspectImage,
+    classifyEE,
+} from '../../src/services/ContainerRuntime';
+
+// ── Sample data ─────────────────────────────────────────────────────
+
+const PODMAN_IMAGES_JSON = JSON.stringify([
+    {
+        Id: 'sha256:aaa111',
+        Names: ['quay.io/ansible/ee-supported:latest'],
+        CreatedAt: '2026-06-01T10:00:00Z',
+        Size: 1073741824,
+    },
+    {
+        Id: 'sha256:bbb222',
+        Names: ['quay.io/ansible/ee-minimal:2.19', 'quay.io/ansible/ee-minimal:latest'],
+        CreatedAt: '2026-05-15T08:00:00Z',
+        Size: 536870912,
+    },
+    {
+        Id: 'sha256:ccc333',
+        Names: null,
+    },
+]);
+
+const DOCKER_IMAGES_LINES = [
+    '{"ID":"sha256:aaa111","Repository":"quay.io/ansible/ee-supported","Tag":"latest","CreatedAt":"2026-06-01T10:00:00Z","Size":"1.2GB"}',
+    '{"ID":"sha256:bbb222","Repository":"quay.io/ansible/ee-minimal","Tag":"2.19","CreatedAt":"2026-05-15T08:00:00Z","Size":"512MB"}',
+    '{"ID":"sha256:ddd444","Repository":"<none>","Tag":"<none>","CreatedAt":"2026-01-01T00:00:00Z","Size":"0B"}',
+].join('\n');
+
+const INSPECT_EE_JSON = JSON.stringify([
+    {
+        Id: 'sha256:aaa111',
+        Config: {
+            Labels: { 'ansible-execution-environment': 'true' },
+            WorkingDir: '/runner',
+        },
+        Architecture: 'amd64',
+        Os: 'linux',
+    },
+]);
+
+const INSPECT_NON_EE_JSON = JSON.stringify([
+    {
+        Id: 'sha256:eee555',
+        Config: {
+            Labels: {},
+            WorkingDir: '/app',
+        },
+    },
+]);
+
+// ── Tests ───────────────────────────────────────────────────────────
+
+describe('ContainerRuntime', () => {
+    beforeEach(() => {
+        mocks.mockRunCommand.mockReset();
+    });
+
+    describe('detectEngine', () => {
+        it('returns podman when available', async () => {
+            mocks.mockRunCommand.mockResolvedValue({
+                exitCode: 0,
+                stdout: 'podman 5.0',
+                stderr: '',
+            });
+            const engine = await detectEngine();
+            expect(engine).toBe('podman');
+            expect(mocks.mockRunCommand).toHaveBeenCalledWith('podman --version');
+        });
+
+        it('falls back to docker when podman is not found', async () => {
+            mocks.mockRunCommand
+                .mockResolvedValueOnce({ exitCode: 127, stdout: '', stderr: 'not found' })
+                .mockResolvedValueOnce({ exitCode: 0, stdout: 'Docker version 24.0', stderr: '' });
+            const engine = await detectEngine();
+            expect(engine).toBe('docker');
+        });
+
+        it('returns null when neither is found', async () => {
+            mocks.mockRunCommand.mockResolvedValue({
+                exitCode: 127,
+                stdout: '',
+                stderr: 'not found',
+            });
+            const engine = await detectEngine();
+            expect(engine).toBeNull();
+        });
+    });
+
+    describe('listImages (podman)', () => {
+        it('parses podman JSON format', async () => {
+            mocks.mockRunCommand.mockResolvedValue({
+                exitCode: 0,
+                stdout: PODMAN_IMAGES_JSON,
+                stderr: '',
+            });
+            const images = await listImages('podman');
+
+            // 3 images: ee-supported:latest, ee-minimal:2.19, ee-minimal:latest
+            // The null-Names entry is skipped
+            expect(images).toHaveLength(3);
+            expect(images[0]).toMatchObject({
+                id: 'sha256:aaa111',
+                repository: 'quay.io/ansible/ee-supported',
+                tag: 'latest',
+            });
+            expect(images[1]).toMatchObject({
+                id: 'sha256:bbb222',
+                repository: 'quay.io/ansible/ee-minimal',
+                tag: '2.19',
+            });
+            expect(images[2]).toMatchObject({
+                id: 'sha256:bbb222',
+                repository: 'quay.io/ansible/ee-minimal',
+                tag: 'latest',
+            });
+        });
+
+        it('returns empty array on failure', async () => {
+            mocks.mockRunCommand.mockResolvedValue({
+                exitCode: 1,
+                stdout: '',
+                stderr: 'error',
+            });
+            const images = await listImages('podman');
+            expect(images).toEqual([]);
+        });
+    });
+
+    describe('listImages (docker)', () => {
+        it('parses docker line-delimited JSON format', async () => {
+            mocks.mockRunCommand.mockResolvedValue({
+                exitCode: 0,
+                stdout: DOCKER_IMAGES_LINES,
+                stderr: '',
+            });
+            const images = await listImages('docker');
+
+            // 2 valid images (<none> is filtered)
+            expect(images).toHaveLength(2);
+            expect(images[0]).toMatchObject({
+                id: 'sha256:aaa111',
+                repository: 'quay.io/ansible/ee-supported',
+                tag: 'latest',
+            });
+        });
+    });
+
+    describe('inspectImage', () => {
+        it('classifies EE image correctly', async () => {
+            mocks.mockRunCommand.mockResolvedValue({
+                exitCode: 0,
+                stdout: INSPECT_EE_JSON,
+                stderr: '',
+            });
+            const image = {
+                id: 'sha256:aaa111',
+                repository: 'quay.io/ansible/ee-supported',
+                tag: 'latest',
+                created: '2026-06-01',
+                size: '1.2 GB',
+                names: ['quay.io/ansible/ee-supported:latest'],
+            };
+            const result = await inspectImage('podman', image);
+            expect(result.executionEnvironment).toBe(true);
+            expect(result.inspect.config.labels['ansible-execution-environment']).toBe('true');
+        });
+
+        it('classifies non-EE image correctly', async () => {
+            mocks.mockRunCommand.mockResolvedValue({
+                exitCode: 0,
+                stdout: INSPECT_NON_EE_JSON,
+                stderr: '',
+            });
+            const image = {
+                id: 'sha256:eee555',
+                repository: 'python',
+                tag: '3.11',
+                created: '2026-01-01',
+                size: '200 MB',
+                names: ['python:3.11'],
+            };
+            const result = await inspectImage('podman', image);
+            expect(result.executionEnvironment).toBe(false);
+        });
+    });
+
+    describe('classifyEE', () => {
+        it('returns true for ansible-execution-environment label', () => {
+            expect(classifyEE({ 'ansible-execution-environment': 'true' }, '/app')).toBe(true);
+        });
+
+        it('returns true for legacy /runner working dir', () => {
+            expect(classifyEE({}, '/runner')).toBe(true);
+        });
+
+        it('returns false for non-EE image', () => {
+            expect(classifyEE({}, '/app')).toBe(false);
+        });
+
+        it('returns false when label is not "true"', () => {
+            expect(classifyEE({ 'ansible-execution-environment': 'false' }, '/app')).toBe(false);
+        });
+    });
+});

--- a/packages/core/test/services/EECache.test.ts
+++ b/packages/core/test/services/EECache.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { EECache } from '../../src/services/EECache';
+import type { EEDetails } from '../../src/services/ExecutionEnvService';
+
+const SAMPLE_DETAILS: EEDetails = {
+    ansible_collections: {
+        details: { 'ansible.builtin': '2.19.0', 'community.general': '10.2.0' },
+    },
+    ansible_version: { details: 'ansible [core 2.19.0]' },
+    os_release: {
+        details: [{ 'pretty-name': 'Fedora Linux 43', name: 'Fedora', version: '43' }],
+    },
+    python_packages: {
+        details: [
+            { name: 'ansible-core', version: '2.19.0' },
+            { name: 'jinja2', version: '3.1.4' },
+        ],
+    },
+    image_name: 'quay.io/ansible/ee-supported:latest',
+};
+
+describe('EECache', () => {
+    let tmpDir: string;
+    let cache: EECache;
+
+    beforeEach(() => {
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ee-cache-test-'));
+        cache = new EECache(tmpDir);
+    });
+
+    afterEach(() => {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('starts empty', () => {
+        expect(cache.size).toBe(0);
+        expect(cache.has('sha256:abc123')).toBe(false);
+        expect(cache.get('sha256:abc123')).toBeNull();
+    });
+
+    it('set and get round-trip', () => {
+        const sha = 'sha256:aabbccddee11';
+        cache.set(sha, 'quay.io/ansible/ee-supported:latest', SAMPLE_DETAILS);
+
+        expect(cache.has(sha)).toBe(true);
+        expect(cache.size).toBe(1);
+
+        const retrieved = cache.get(sha);
+        expect(retrieved).toEqual(SAMPLE_DETAILS);
+    });
+
+    it('persists to disk and survives new instance', () => {
+        const sha = 'sha256:persistent1234';
+        cache.set(sha, 'img:latest', SAMPLE_DETAILS);
+
+        const cache2 = new EECache(tmpDir);
+        expect(cache2.has(sha)).toBe(true);
+        expect(cache2.get(sha)).toEqual(SAMPLE_DETAILS);
+    });
+
+    it('index entry stores metadata', () => {
+        const sha = 'sha256:metadata5678';
+        cache.set(sha, 'quay.io/ansible/ee-minimal:2.19', SAMPLE_DETAILS);
+
+        const entry = cache.getEntry(sha);
+        expect(entry).toBeDefined();
+        expect(entry?.fullName).toBe('quay.io/ansible/ee-minimal:2.19');
+        expect(entry?.tag).toBe('2.19');
+        expect(entry?.introspectedAt).toBeDefined();
+    });
+
+    it('delete removes entry', () => {
+        const sha = 'sha256:deleteme1234';
+        cache.set(sha, 'img:tag', SAMPLE_DETAILS);
+        expect(cache.has(sha)).toBe(true);
+
+        cache.remove(sha);
+        expect(cache.has(sha)).toBe(false);
+        expect(cache.get(sha)).toBeNull();
+        expect(cache.size).toBe(0);
+    });
+
+    it('prune removes stale entries', () => {
+        cache.set('sha256:keep1111', 'img1:latest', SAMPLE_DETAILS);
+        cache.set('sha256:keep2222', 'img2:latest', SAMPLE_DETAILS);
+        cache.set('sha256:stale3333', 'img3:old', SAMPLE_DETAILS);
+
+        const currentShas = new Set(['sha256:keep1111', 'sha256:keep2222']);
+        const removed = cache.prune(currentShas);
+
+        expect(removed).toBe(1);
+        expect(cache.has('sha256:keep1111')).toBe(true);
+        expect(cache.has('sha256:keep2222')).toBe(true);
+        expect(cache.has('sha256:stale3333')).toBe(false);
+        expect(cache.size).toBe(2);
+    });
+
+    it('clear removes everything', () => {
+        cache.set('sha256:one1111', 'img1:latest', SAMPLE_DETAILS);
+        cache.set('sha256:two2222', 'img2:latest', SAMPLE_DETAILS);
+        expect(cache.size).toBe(2);
+
+        cache.clear();
+        expect(cache.size).toBe(0);
+        expect(cache.keys()).toEqual([]);
+    });
+
+    it('has returns false if index entry exists but file is missing', () => {
+        const sha = 'sha256:orphan1234';
+        cache.set(sha, 'img:tag', SAMPLE_DETAILS);
+
+        // Manually delete the detail file to simulate corruption
+        const files = fs
+            .readdirSync(tmpDir)
+            .filter((f) => f.endsWith('.json') && f !== 'index.json');
+        for (const f of files) {
+            fs.unlinkSync(path.join(tmpDir, f));
+        }
+
+        expect(cache.has(sha)).toBe(false);
+    });
+
+    it('multiple tags pointing to same SHA share one entry', () => {
+        const sha = 'sha256:shared1234';
+        cache.set(sha, 'img:latest', SAMPLE_DETAILS);
+        cache.set(sha, 'img:v2.0', SAMPLE_DETAILS);
+
+        expect(cache.size).toBe(1);
+        const entry = cache.getEntry(sha);
+        expect(entry?.fullName).toBe('img:v2.0');
+    });
+});

--- a/packages/core/test/services/ExecutionEnvService.test.ts
+++ b/packages/core/test/services/ExecutionEnvService.test.ts
@@ -1,79 +1,160 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 
-const EE_LIST = [
-    {
-        created: '2024-01-01',
-        execution_environment: true,
-        full_name: 'quay.io/ansible/ee-supported:latest',
-        image_id: 'abc123',
-    },
-    {
-        created: '2024-01-01',
-        execution_environment: false,
-        full_name: 'python:3.11',
-        image_id: 'def456',
-    },
-    {
-        created: '2024-01-01',
-        execution_environment: true,
-        full_name: 'quay.io/ansible/ee-minimal:latest',
-        image_id: 'ghi789',
-    },
-];
+// ── Mock ContainerRuntime ───────────────────────────────────────────
 
-const EE_DETAILS = {
-    ansible_collections: {
-        details: { 'ansible.builtin': '2.15.0', 'community.general': '7.0.0' },
-    },
-    ansible_version: { details: 'ansible [core 2.15.0]' },
-    os_release: {
-        details: [
-            {
-                'pretty-name': 'Red Hat Enterprise Linux 9.2',
-                name: 'RHEL',
-                version: '9.2',
-            },
-        ],
-    },
-    python_packages: {
-        details: [
-            { name: 'ansible-core', version: '2.15.0' },
-            { name: 'jinja2', version: '3.1.2' },
-        ],
-    },
-    image_name: 'quay.io/ansible/ee-supported:latest',
-};
+const containerMocks = vi.hoisted(() => ({
+    detectEngine: vi.fn(),
+    listImages: vi.fn(),
+    inspectImage: vi.fn(),
+    runInContainer: vi.fn(),
+    deployScripts: vi.fn(),
+    getScriptCacheDir: vi.fn(),
+}));
 
-const mocks = vi.hoisted(() => {
-    const mockRunTool = vi.fn();
+vi.mock('../../src/services/ContainerRuntime', () => containerMocks);
+
+// ── Mock EECache (use real implementation with temp dir) ────────────
+
+let tmpCacheDir: string;
+
+vi.mock('../../src/services/EECache', async () => {
+    const actual = await vi.importActual<typeof import('../../src/services/EECache')>(
+        '../../src/services/EECache',
+    );
     return {
-        mockRunTool,
-        getCommandService: vi.fn(() => ({
-            runTool: mockRunTool,
-        })),
+        EECache: class extends actual.EECache {
+            /** Create a test cache in a temp directory. */
+            constructor() {
+                tmpCacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ee-svc-test-'));
+                super(tmpCacheDir);
+            }
+        },
     };
 });
 
-vi.mock('../../src/services/CommandService', () => ({
-    getCommandService: mocks.getCommandService,
-}));
-
 import { ExecutionEnvService } from '../../src/services/ExecutionEnvService';
+import type { ContainerImage, InspectedImage } from '../../src/services/ContainerRuntime';
 
-/** Clears the ExecutionEnvService singleton so each test starts with a fresh instance. */
-function resetExecutionEnvSingleton(): void {
+// ── Sample data ─────────────────────────────────────────────────────
+
+const IMG_SUPPORTED: ContainerImage = {
+    id: 'sha256:aaa111',
+    repository: 'quay.io/ansible/ee-supported',
+    tag: 'latest',
+    created: '2026-06-01',
+    size: '1.2 GB',
+    names: ['quay.io/ansible/ee-supported:latest'],
+};
+
+const IMG_MINIMAL: ContainerImage = {
+    id: 'sha256:bbb222',
+    repository: 'quay.io/ansible/ee-minimal',
+    tag: 'latest',
+    created: '2026-05-15',
+    size: '512 MB',
+    names: ['quay.io/ansible/ee-minimal:latest'],
+};
+
+const IMG_PYTHON: ContainerImage = {
+    id: 'sha256:ccc333',
+    repository: 'python',
+    tag: '3.11',
+    created: '2026-01-01',
+    size: '200 MB',
+    names: ['python:3.11'],
+};
+
+const INSPECTED_SUPPORTED: InspectedImage = {
+    ...IMG_SUPPORTED,
+    executionEnvironment: true,
+    inspect: {
+        config: { labels: { 'ansible-execution-environment': 'true' }, workingDir: '/runner' },
+        architecture: 'amd64',
+        os: 'linux',
+    },
+};
+
+const INSPECTED_MINIMAL: InspectedImage = {
+    ...IMG_MINIMAL,
+    executionEnvironment: true,
+    inspect: {
+        config: { labels: { 'ansible-execution-environment': 'true' }, workingDir: '/runner' },
+    },
+};
+
+const INSPECTED_PYTHON: InspectedImage = {
+    ...IMG_PYTHON,
+    executionEnvironment: false,
+    inspect: {
+        config: { labels: {}, workingDir: '/app' },
+    },
+};
+
+const INTROSPECTION_JSON = JSON.stringify({
+    errors: [],
+    python_version: { details: { version: '3.11.7' } },
+    environment_variables: { details: {} },
+    ansible_collections: {
+        details: { 'ansible.builtin': '2.19.0', 'community.general': '10.2.0' },
+        errors: [],
+    },
+    ansible_version: { details: 'ansible [core 2.19.0]', errors: [] },
+    os_release: {
+        details: [{ 'pretty-name': 'RHEL 9.4', name: 'RHEL', version: '9.4' }],
+        errors: [],
+    },
+    python_packages: {
+        details: [
+            { name: 'ansible-core', version: '2.19.0', summary: 'Ansible' },
+            { name: 'jinja2', version: '3.1.4' },
+        ],
+        errors: [],
+    },
+    system_packages: {
+        details: { bash: '5.2.26', openssl: '3.2.1' },
+        errors: [],
+    },
+    redhat_release: { details: 'Red Hat Enterprise Linux release 9.4', errors: [] },
+});
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+/** Clears the ExecutionEnvService singleton so each test starts fresh. */
+function resetSingleton(): void {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (ExecutionEnvService as any)._instance = undefined;
 }
 
+/** Wire up ContainerRuntime mocks with standard test data. */
+function setupDefaultMocks(): void {
+    containerMocks.detectEngine.mockResolvedValue('podman');
+    containerMocks.listImages.mockResolvedValue([IMG_SUPPORTED, IMG_MINIMAL, IMG_PYTHON]);
+    containerMocks.inspectImage
+        .mockResolvedValueOnce(INSPECTED_SUPPORTED)
+        .mockResolvedValueOnce(INSPECTED_MINIMAL)
+        .mockResolvedValueOnce(INSPECTED_PYTHON);
+    containerMocks.deployScripts.mockReturnValue('/tmp/scripts');
+}
+
+// ── Tests ───────────────────────────────────────────────────────────
+
 describe('ExecutionEnvService', () => {
     beforeEach(() => {
-        resetExecutionEnvSingleton();
-        mocks.mockRunTool.mockReset();
-        mocks.getCommandService.mockClear();
-        mocks.getCommandService.mockImplementation(() => ({
-            runTool: mocks.mockRunTool,
-        }));
+        resetSingleton();
+        vi.clearAllMocks();
+    });
+
+    afterEach(() => {
+        if (tmpCacheDir) {
+            try {
+                fs.rmSync(tmpCacheDir, { recursive: true, force: true });
+            } catch {
+                /* */
+            }
+        }
     });
 
     it('getInstance returns the same singleton', () => {
@@ -82,271 +163,224 @@ describe('ExecutionEnvService', () => {
         expect(a).toBe(b);
     });
 
-    it('loadExecutionEnvironments parses navigator JSON and filters EEs', async () => {
-        mocks.mockRunTool.mockResolvedValue({
-            exitCode: 0,
-            stdout: JSON.stringify(EE_LIST),
-            stderr: '',
-        });
-        const svc = ExecutionEnvService.getInstance();
-        const list = await svc.loadExecutionEnvironments();
-        expect(mocks.mockRunTool).toHaveBeenCalledWith('ansible-navigator', [
-            'images',
-            '--mode',
-            'stdout',
-            '--pull-policy',
-            'never',
-            '--format',
-            'json',
-        ]);
-        expect(list).toHaveLength(2);
-        expect(list.map((e) => e.full_name).sort()).toEqual(
-            ['quay.io/ansible/ee-minimal:latest', 'quay.io/ansible/ee-supported:latest'].sort(),
-        );
-        expect(svc.isLoaded()).toBe(true);
-    });
-
-    it('loadExecutionEnvironments handles empty output', async () => {
-        mocks.mockRunTool.mockResolvedValue({
-            exitCode: 0,
-            stdout: '',
-            stderr: '',
-        });
-        const svc = ExecutionEnvService.getInstance();
-        const list = await svc.loadExecutionEnvironments();
-        expect(list).toEqual([]);
-        expect(svc.getExecutionEnvironments()).toEqual([]);
-        expect(svc.isLoaded()).toBe(true);
-    });
-
-    it('loadExecutionEnvironments concurrent call protection', async () => {
-        let release!: () => void;
-        const gate = new Promise<void>((r) => {
-            release = r;
-        });
-        let notifyEntered!: () => void;
-        const enteredRunTool = new Promise<void>((r) => {
-            notifyEntered = r;
-        });
-        mocks.mockRunTool.mockImplementation(async () => {
-            notifyEntered();
-            await gate;
-            return { exitCode: 0, stdout: JSON.stringify(EE_LIST), stderr: '' };
-        });
-        const svc = ExecutionEnvService.getInstance();
-        const p1 = svc.loadExecutionEnvironments();
-        await enteredRunTool;
-        const p2 = svc.loadExecutionEnvironments();
-        await p2;
-        expect(mocks.mockRunTool).toHaveBeenCalledTimes(1);
-        release();
-        await p1;
-        expect(svc.getExecutionEnvironments()).toHaveLength(2);
-        expect(mocks.mockRunTool).toHaveBeenCalledTimes(1);
-    });
-
-    it('loadDetails fetches and caches details', async () => {
-        mocks.mockRunTool.mockResolvedValue({
-            exitCode: 0,
-            stdout: JSON.stringify(EE_DETAILS),
-            stderr: '',
-        });
-        const svc = ExecutionEnvService.getInstance();
-        const name = 'quay.io/ansible/ee-supported:latest';
-        const d = await svc.loadDetails(name);
-        expect(d).toEqual(EE_DETAILS);
-        expect(mocks.mockRunTool).toHaveBeenCalledWith('ansible-navigator', [
-            'images',
-            name,
-            '--mode',
-            'stdout',
-            '--pull-policy',
-            'never',
-            '--details',
-            '--format',
-            'json',
-        ]);
-        expect(svc.getCachedDetails(name)).toEqual(EE_DETAILS);
-    });
-
-    it('loadDetails returns cached details on second call', async () => {
-        mocks.mockRunTool.mockResolvedValue({
-            exitCode: 0,
-            stdout: JSON.stringify(EE_DETAILS),
-            stderr: '',
-        });
-        const svc = ExecutionEnvService.getInstance();
-        const name = 'quay.io/ansible/ee-supported:latest';
-        await svc.loadDetails(name);
-        mocks.mockRunTool.mockClear();
-        const again = await svc.loadDetails(name);
-        expect(again).toEqual(EE_DETAILS);
-        expect(mocks.mockRunTool).not.toHaveBeenCalled();
-    });
-
-    it('getCollections extracts and sorts collections from details', async () => {
-        mocks.mockRunTool.mockResolvedValue({
-            exitCode: 0,
-            stdout: JSON.stringify(EE_DETAILS),
-            stderr: '',
-        });
-        const svc = ExecutionEnvService.getInstance();
-        const cols = await svc.getCollections('quay.io/ansible/ee-supported:latest');
-        expect(cols).toEqual([
-            { name: 'ansible.builtin', version: '2.15.0' },
-            { name: 'community.general', version: '7.0.0' },
-        ]);
-    });
-
-    it('getPythonPackages extracts and sorts packages from details', async () => {
-        mocks.mockRunTool.mockResolvedValue({
-            exitCode: 0,
-            stdout: JSON.stringify(EE_DETAILS),
-            stderr: '',
-        });
-        const svc = ExecutionEnvService.getInstance();
-        const pkgs = await svc.getPythonPackages('quay.io/ansible/ee-supported:latest');
-        expect(pkgs).toEqual([
-            { name: 'ansible-core', version: '2.15.0' },
-            { name: 'jinja2', version: '3.1.2' },
-        ]);
-    });
-
-    it('getInfo extracts ansible version, OS, and image name', async () => {
-        mocks.mockRunTool.mockResolvedValue({
-            exitCode: 0,
-            stdout: JSON.stringify(EE_DETAILS),
-            stderr: '',
-        });
-        const svc = ExecutionEnvService.getInstance();
-        const info = await svc.getInfo('quay.io/ansible/ee-supported:latest');
-        expect(info.ansible).toBe('ansible [core 2.15.0]');
-        expect(info.os).toBe('Red Hat Enterprise Linux 9.2');
-        expect(info.image).toBe('quay.io/ansible/ee-supported:latest');
-    });
-
     it('isInVSCode is false in test environment', () => {
         expect(ExecutionEnvService.getInstance().isInVSCode()).toBe(false);
     });
 
-    it('setLogFunction receives load errors', async () => {
-        const log = vi.fn();
-        mocks.mockRunTool.mockResolvedValue({
-            exitCode: 0,
-            stdout: 'not-json-array',
-            stderr: '',
+    describe('loadExecutionEnvironments', () => {
+        it('discovers EEs via ContainerRuntime and filters non-EEs', async () => {
+            setupDefaultMocks();
+            const svc = ExecutionEnvService.getInstance();
+            const list = await svc.loadExecutionEnvironments();
+
+            expect(containerMocks.detectEngine).toHaveBeenCalled();
+            expect(containerMocks.listImages).toHaveBeenCalledWith('podman');
+            expect(containerMocks.inspectImage).toHaveBeenCalledTimes(3);
+
+            expect(list).toHaveLength(2);
+            expect(list.map((e) => e.full_name).sort()).toEqual([
+                'quay.io/ansible/ee-minimal:latest',
+                'quay.io/ansible/ee-supported:latest',
+            ]);
+            expect(svc.isLoaded()).toBe(true);
         });
-        const svc = ExecutionEnvService.getInstance();
-        svc.setLogFunction(log);
-        await expect(svc.loadExecutionEnvironments()).rejects.toThrow();
-        expect(log).toHaveBeenCalledWith(
-            expect.stringContaining('Error loading execution environments'),
-        );
+
+        it('handles empty image list', async () => {
+            containerMocks.detectEngine.mockResolvedValue('podman');
+            containerMocks.listImages.mockResolvedValue([]);
+
+            const svc = ExecutionEnvService.getInstance();
+            const list = await svc.loadExecutionEnvironments();
+            expect(list).toEqual([]);
+            expect(svc.isLoaded()).toBe(true);
+        });
+
+        it('throws when no container engine is found', async () => {
+            containerMocks.detectEngine.mockResolvedValue(null);
+
+            const svc = ExecutionEnvService.getInstance();
+            await expect(svc.loadExecutionEnvironments()).rejects.toThrow(
+                /No container engine found/,
+            );
+        });
+
+        it('concurrent call protection', async () => {
+            let release!: () => void;
+            const gate = new Promise<void>((r) => {
+                release = r;
+            });
+
+            containerMocks.detectEngine.mockResolvedValue('podman');
+            containerMocks.listImages.mockImplementation(async () => {
+                await gate;
+                return [IMG_SUPPORTED];
+            });
+            containerMocks.inspectImage.mockResolvedValue(INSPECTED_SUPPORTED);
+
+            const svc = ExecutionEnvService.getInstance();
+            const p1 = svc.loadExecutionEnvironments();
+            const p2 = svc.loadExecutionEnvironments();
+            release();
+
+            const [r1, r2] = await Promise.all([p1, p2]);
+            expect(containerMocks.listImages).toHaveBeenCalledTimes(1);
+            expect(r1).toHaveLength(1);
+            // p2 returned early (loading guard)
+            expect(r2).toEqual([]);
+        });
+
+        it('returns cached list when already loaded with data', async () => {
+            setupDefaultMocks();
+            const svc = ExecutionEnvService.getInstance();
+            const first = await svc.loadExecutionEnvironments();
+
+            vi.clearAllMocks();
+            const second = await svc.loadExecutionEnvironments();
+            expect(second).toEqual(first);
+            expect(containerMocks.listImages).not.toHaveBeenCalled();
+        });
     });
 
-    it('loadExecutionEnvironments returns cached list when already loaded with data', async () => {
-        mocks.mockRunTool.mockResolvedValue({
-            exitCode: 0,
-            stdout: JSON.stringify(EE_LIST),
-            stderr: '',
+    describe('loadDetails', () => {
+        it('runs introspection and caches result', async () => {
+            setupDefaultMocks();
+            containerMocks.runInContainer.mockResolvedValue(INTROSPECTION_JSON);
+
+            const svc = ExecutionEnvService.getInstance();
+            await svc.loadExecutionEnvironments();
+
+            const details = await svc.loadDetails('quay.io/ansible/ee-supported:latest');
+
+            expect(details).toBeDefined();
+            expect(details?.ansible_version?.details).toBe('ansible [core 2.19.0]');
+            expect(details?.ansible_collections?.details['ansible.builtin']).toBe('2.19.0');
+            expect(details?.os_release?.details[0]['pretty-name']).toBe('RHEL 9.4');
+            expect(details?.python_packages?.details).toHaveLength(2);
+            expect(details?.system_packages?.details).toEqual({
+                bash: '5.2.26',
+                openssl: '3.2.1',
+            });
+            expect(details?.redhat_release?.details).toBe('Red Hat Enterprise Linux release 9.4');
+            expect(details?.image_name).toBe('quay.io/ansible/ee-supported:latest');
         });
-        const svc = ExecutionEnvService.getInstance();
-        const first = await svc.loadExecutionEnvironments();
-        mocks.mockRunTool.mockClear();
-        const second = await svc.loadExecutionEnvironments();
-        expect(second).toEqual(first);
-        expect(mocks.mockRunTool).not.toHaveBeenCalled();
+
+        it('returns memory-cached details on second call', async () => {
+            setupDefaultMocks();
+            containerMocks.runInContainer.mockResolvedValue(INTROSPECTION_JSON);
+
+            const svc = ExecutionEnvService.getInstance();
+            await svc.loadExecutionEnvironments();
+            await svc.loadDetails('quay.io/ansible/ee-supported:latest');
+
+            containerMocks.runInContainer.mockClear();
+            const again = await svc.loadDetails('quay.io/ansible/ee-supported:latest');
+            expect(again).toBeDefined();
+            expect(containerMocks.runInContainer).not.toHaveBeenCalled();
+        });
+
+        it('returns null when introspection returns empty stdout', async () => {
+            setupDefaultMocks();
+            containerMocks.runInContainer.mockResolvedValue('');
+
+            const svc = ExecutionEnvService.getInstance();
+            await svc.loadExecutionEnvironments();
+            const details = await svc.loadDetails('quay.io/ansible/ee-supported:latest');
+            expect(details).toBeNull();
+        });
     });
 
-    it('getExecutionEnvironment finds by full_name', async () => {
-        mocks.mockRunTool.mockResolvedValue({
-            exitCode: 0,
-            stdout: JSON.stringify(EE_LIST),
-            stderr: '',
+    describe('getCollections', () => {
+        it('extracts and sorts collections from details', async () => {
+            setupDefaultMocks();
+            containerMocks.runInContainer.mockResolvedValue(INTROSPECTION_JSON);
+
+            const svc = ExecutionEnvService.getInstance();
+            await svc.loadExecutionEnvironments();
+            const cols = await svc.getCollections('quay.io/ansible/ee-supported:latest');
+            expect(cols).toEqual([
+                { name: 'ansible.builtin', version: '2.19.0' },
+                { name: 'community.general', version: '10.2.0' },
+            ]);
         });
-        const svc = ExecutionEnvService.getInstance();
-        await svc.loadExecutionEnvironments();
-        const ee = svc.getExecutionEnvironment('quay.io/ansible/ee-supported:latest');
-        expect(ee?.image_id).toBe('abc123');
+
+        it('returns empty when details lack ansible_collections', async () => {
+            setupDefaultMocks();
+            containerMocks.runInContainer.mockResolvedValue(
+                JSON.stringify({ errors: [], image_name: 'x' }),
+            );
+
+            const svc = ExecutionEnvService.getInstance();
+            await svc.loadExecutionEnvironments();
+            const cols = await svc.getCollections('quay.io/ansible/ee-supported:latest');
+            expect(cols).toEqual([]);
+        });
     });
 
-    it('loadDetails returns null when stdout is empty', async () => {
-        mocks.mockRunTool.mockResolvedValue({
-            exitCode: 0,
-            stdout: '',
-            stderr: '',
+    describe('getPythonPackages', () => {
+        it('extracts and sorts packages from details', async () => {
+            setupDefaultMocks();
+            containerMocks.runInContainer.mockResolvedValue(INTROSPECTION_JSON);
+
+            const svc = ExecutionEnvService.getInstance();
+            await svc.loadExecutionEnvironments();
+            const pkgs = await svc.getPythonPackages('quay.io/ansible/ee-supported:latest');
+            expect(pkgs).toEqual([
+                { name: 'ansible-core', version: '2.19.0', summary: 'Ansible' },
+                { name: 'jinja2', version: '3.1.4' },
+            ]);
         });
-        const svc = ExecutionEnvService.getInstance();
-        await expect(svc.loadDetails('some:img')).resolves.toBeNull();
     });
 
-    it('getCollections returns empty when details lack ansible_collections', async () => {
-        mocks.mockRunTool.mockResolvedValue({
-            exitCode: 0,
-            stdout: JSON.stringify({ image_name: 'x' }),
-            stderr: '',
+    describe('getInfo', () => {
+        it('extracts ansible version, OS, and image name', async () => {
+            setupDefaultMocks();
+            containerMocks.runInContainer.mockResolvedValue(INTROSPECTION_JSON);
+
+            const svc = ExecutionEnvService.getInstance();
+            await svc.loadExecutionEnvironments();
+            const info = await svc.getInfo('quay.io/ansible/ee-supported:latest');
+            expect(info.ansible).toBe('ansible [core 2.19.0]');
+            expect(info.os).toBe('RHEL 9.4');
+            expect(info.image).toBe('quay.io/ansible/ee-supported:latest');
         });
-        const svc = ExecutionEnvService.getInstance();
-        const cols = await svc.getCollections('some:img');
-        expect(cols).toEqual([]);
+
+        it('returns only image name when details have no sections', async () => {
+            setupDefaultMocks();
+            containerMocks.runInContainer.mockResolvedValue(JSON.stringify({ errors: [] }));
+
+            const svc = ExecutionEnvService.getInstance();
+            await svc.loadExecutionEnvironments();
+            const info = await svc.getInfo('quay.io/ansible/ee-supported:latest');
+            expect(info).toEqual({ image: 'quay.io/ansible/ee-supported:latest' });
+        });
     });
 
-    it('getPythonPackages returns empty when details lack python_packages', async () => {
-        mocks.mockRunTool.mockResolvedValue({
-            exitCode: 0,
-            stdout: JSON.stringify({ image_name: 'x' }),
-            stderr: '',
+    describe('getExecutionEnvironment', () => {
+        it('finds by full_name', async () => {
+            setupDefaultMocks();
+            const svc = ExecutionEnvService.getInstance();
+            await svc.loadExecutionEnvironments();
+            const ee = svc.getExecutionEnvironment('quay.io/ansible/ee-supported:latest');
+            expect(ee?.image_id).toBe('sha256:aaa111');
         });
-        const svc = ExecutionEnvService.getInstance();
-        const pkgs = await svc.getPythonPackages('some:img');
-        expect(pkgs).toEqual([]);
     });
 
-    it('getInfo returns empty object when details are missing', async () => {
-        mocks.mockRunTool.mockResolvedValue({
-            exitCode: 0,
-            stdout: JSON.stringify({}),
-            stderr: '',
-        });
-        const svc = ExecutionEnvService.getInstance();
-        await expect(svc.getInfo('nope:tag')).resolves.toEqual({});
-    });
+    describe('refresh', () => {
+        it('clears environments and caches', async () => {
+            setupDefaultMocks();
+            containerMocks.runInContainer.mockResolvedValue(INTROSPECTION_JSON);
 
-    it('getInfo uses os name when pretty-name is absent', async () => {
-        const details = {
-            ansible_version: { details: 'ansible 1' },
-            os_release: { details: [{ name: 'Linux', version: '1' }] },
-            image_name: 'img',
-        };
-        mocks.mockRunTool.mockResolvedValue({
-            exitCode: 0,
-            stdout: JSON.stringify(details),
-            stderr: '',
-        });
-        const svc = ExecutionEnvService.getInstance();
-        const info = await svc.getInfo('img');
-        expect(info.os).toBe('Linux');
-    });
+            const svc = ExecutionEnvService.getInstance();
+            await svc.loadExecutionEnvironments();
+            await svc.loadDetails('quay.io/ansible/ee-supported:latest');
 
-    it('refresh clears environments and details cache', async () => {
-        mocks.mockRunTool.mockResolvedValue({
-            exitCode: 0,
-            stdout: JSON.stringify(EE_LIST),
-            stderr: '',
+            expect(svc.getExecutionEnvironments().length).toBeGreaterThan(0);
+            expect(svc.getCachedDetails('quay.io/ansible/ee-supported:latest')).toBeDefined();
+
+            await svc.refresh();
+            expect(svc.getExecutionEnvironments()).toEqual([]);
+            expect(svc.getCachedDetails('quay.io/ansible/ee-supported:latest')).toBeUndefined();
+            expect(svc.isLoaded()).toBe(false);
         });
-        const svc = ExecutionEnvService.getInstance();
-        await svc.loadExecutionEnvironments();
-        mocks.mockRunTool.mockResolvedValue({
-            exitCode: 0,
-            stdout: JSON.stringify(EE_DETAILS),
-            stderr: '',
-        });
-        await svc.loadDetails('quay.io/ansible/ee-supported:latest');
-        expect(svc.getExecutionEnvironments().length).toBeGreaterThan(0);
-        expect(svc.getCachedDetails('quay.io/ansible/ee-supported:latest')).toBeDefined();
-        await svc.refresh();
-        expect(svc.getExecutionEnvironments()).toEqual([]);
-        expect(svc.getCachedDetails('quay.io/ansible/ee-supported:latest')).toBeUndefined();
-        expect(svc.isLoaded()).toBe(false);
     });
 });

--- a/packages/mcp-server/src/handlers.ts
+++ b/packages/mcp-server/src/handlers.ts
@@ -925,7 +925,7 @@ export class McpToolHandler {
                     content: [
                         {
                             type: 'text',
-                            text: 'No execution environments found.\n\nMake sure ansible-navigator and a container runtime (Podman/Docker) are installed.',
+                            text: 'No execution environments found.\n\nMake sure a container runtime (Podman or Docker) is installed and EE images are pulled locally.',
                         },
                     ],
                 };


### PR DESCRIPTION
## Summary
- Replace `ansible-navigator` Python dependency with native TypeScript EE discovery
- Add SHA-keyed file cache for instant introspection lookups across restarts
- Vendor navigator's in-container introspection script (Apache 2.0)

## Changes
- **ContainerRuntime.ts**: New module with `detectEngine()`, `listImages()`, `inspectImage()`, `classifyEE()`, `runInContainer()`, and `deployScripts()`. Handles both podman and docker JSON output formats natively. Uses `execFile` (no shell) to prevent injection via image names. Passes `--pull=never` to avoid unintended network pulls.
- **EECache.ts**: File-based cache at `$XDG_CACHE_HOME/ansible-tools/ee-cache/` keyed by image SHA. Uses full SHA digest for filenames (no truncation). Provides natural invalidation (new image = new SHA = cache miss), deduplication (multiple tags share one entry), and batched stale pruning (single index write).
- **ExecutionEnvService.ts**: Rewritten `loadExecutionEnvironments()` and `loadDetails()` to use `ContainerRuntime` + `EECache` instead of shelling out to `ansible-navigator`. `loadDetails()` auto-loads the EE list when needed so direct callers (e.g. MCP handler) always benefit from disk caching. Same public API surface -- no consumer changes required.
- **CommandService.ts**: Added `runCommandArgs()` method for shell-free subprocess execution via `execFile` with an args array.
- **Vendored scripts**: `image_introspect.py` and `python_latest.sh` copied from ansible-navigator with Apache 2.0 attribution. These run exclusively inside EE containers (which always have Python); zero Python needed on the host.
- **MCP handler**: Updated error message to remove ansible-navigator mention.
- **Tests**: 38 new tests across `ContainerRuntime.test.ts` (12), `EECache.test.ts` (9), and rewritten `ExecutionEnvService.test.ts` (17). Updated `CommandService.test.ts` mock for `execFile`.

## Copilot review feedback (6cebaeed)
- Added `--pull=never` to prevent unintended image pulls
- Switched to `execFile` args array to prevent shell injection
- Use full SHA digest for cache filenames (no 12-char truncation)
- Batch `prune()` to write index.json once instead of per-entry
- Auto-load EE list in `loadDetails()` so disk cache is always used

## Quality of life
- AI-authored additions: ContainerRuntime module, EECache module, vendored script attribution (NOTICE file)

## Test plan
- [x] `npm exec eslint -- .` passes
- [x] `npm exec tsc -- -b` compiles cleanly
- [x] `npm exec vitest -- run` passes (228 tests in core, 11 files)
- [x] CI: lint, build-and-test (Node 20 + 22), integration, package, Windows, WSL all green
- [ ] sonar: pre-existing config issue (missing `sonar.projectKey`)
- [ ] docs/readthedocs: unrelated to this PR