### PR TITLE
fix(core): widen vendored script search path for EE discovery

### DIFF
--- a/packages/core/src/services/CommandService.ts
+++ b/packages/core/src/services/CommandService.ts
@@ -93,7 +93,6 @@ export class CommandService {
             try {
                 const binDir = await this._binDirResolver(workspaceUri);
                 if (binDir) {
-                    log(`CommandService: binDirResolver -> ${binDir}`);
                     return binDir;
                 }
                 log('CommandService: binDirResolver returned null');
@@ -102,13 +101,12 @@ export class CommandService {
                     `CommandService: binDirResolver failed: ${error instanceof Error ? error.message : String(error)}`,
                 );
             }
-        } else {
-            log('CommandService: no binDirResolver set');
         }
 
         const cached = getCachedBinDir();
-        log(`CommandService: falling back to cached binDir -> ${cached ?? 'null'}`);
-        return cached;
+        if (cached) return cached;
+        log('CommandService: no binDir available');
+        return null;
     }
 
     /**

--- a/packages/core/src/services/ExecutionEnvService.ts
+++ b/packages/core/src/services/ExecutionEnvService.ts
@@ -238,14 +238,27 @@ export class ExecutionEnvService {
      */
     private _ensureScripts(): string {
         if (!this._scriptCacheDir) {
-            // __dirname at runtime points to the compiled JS output directory.
-            // The data/ directory with vendored scripts is at the package root.
-            let dataDir = path.resolve(__dirname, '..', 'data');
-            if (!existsSync(path.join(dataDir, 'image_introspect.py'))) {
-                dataDir = path.resolve(__dirname, '..', 'src', 'data');
-            }
-            if (!existsSync(path.join(dataDir, 'image_introspect.py'))) {
-                throw new Error(`Vendored introspection scripts not found. Looked in: ${dataDir}`);
+            // __dirname varies by context: tsc output, esbuild bundle, Electron
+            // asar, etc. Try multiple candidate paths relative to __dirname and
+            // process.cwd() to cover all layouts.
+            const candidates = [
+                path.resolve(__dirname, '..', 'data'),
+                path.resolve(__dirname, '..', 'src', 'data'),
+                path.resolve(__dirname, '..', '..', 'data'),
+                path.resolve(__dirname, '..', '..', 'src', 'data'),
+                path.resolve(__dirname, '..', '..', 'packages', 'core', 'src', 'data'),
+                path.resolve(__dirname, '..', '..', 'packages', 'core', 'data'),
+                path.resolve(process.cwd(), 'packages', 'core', 'src', 'data'),
+                path.resolve(process.cwd(), 'packages', 'core', 'data'),
+            ];
+
+            const target = 'image_introspect.py';
+            const dataDir = candidates.find((dir) => existsSync(path.join(dir, target)));
+
+            if (!dataDir) {
+                throw new Error(
+                    `Vendored introspection scripts not found. Searched:\n${candidates.join('\n')}`,
+                );
             }
             this._scriptCacheDir = ContainerRuntime.deployScripts(dataDir);
         }

--- a/packages/core/src/services/ExecutionEnvService.ts
+++ b/packages/core/src/services/ExecutionEnvService.ts
@@ -238,21 +238,32 @@ export class ExecutionEnvService {
      */
     private _ensureScripts(): string {
         if (!this._scriptCacheDir) {
-            // __dirname varies by context: tsc output, esbuild bundle, Electron
-            // asar, etc. Try multiple candidate paths relative to __dirname and
-            // process.cwd() to cover all layouts.
+            const target = 'image_introspect.py';
+
+            // Fast path: scripts already deployed to XDG cache from a prior run.
+            const cacheDir = ContainerRuntime.getScriptCacheDir();
+            if (cacheDir && existsSync(path.join(cacheDir, target))) {
+                this._scriptCacheDir = cacheDir;
+                return this._scriptCacheDir;
+            }
+
+            // __dirname varies by context: tsc output (packages/core/out/services),
+            // esbuild bundle (dist/), Electron asar, etc.  Try multiple candidate
+            // paths to locate the vendored source files for initial deployment.
             const candidates = [
+                // tsc: __dirname = packages/core/out/services
                 path.resolve(__dirname, '..', 'data'),
                 path.resolve(__dirname, '..', 'src', 'data'),
-                path.resolve(__dirname, '..', '..', 'data'),
-                path.resolve(__dirname, '..', '..', 'src', 'data'),
+                // esbuild: __dirname = dist/  (one level below repo root)
+                path.resolve(__dirname, '..', 'packages', 'core', 'src', 'data'),
+                path.resolve(__dirname, '..', 'packages', 'core', 'data'),
+                // deeper nesting (Electron asar, etc.)
                 path.resolve(__dirname, '..', '..', 'packages', 'core', 'src', 'data'),
                 path.resolve(__dirname, '..', '..', 'packages', 'core', 'data'),
-                path.resolve(process.cwd(), 'packages', 'core', 'src', 'data'),
-                path.resolve(process.cwd(), 'packages', 'core', 'data'),
+                path.resolve(__dirname, '..', '..', 'data'),
+                path.resolve(__dirname, '..', '..', 'src', 'data'),
             ];
 
-            const target = 'image_introspect.py';
             const dataDir = candidates.find((dir) => existsSync(path.join(dir, target)));
 
             if (!dataDir) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -285,12 +285,16 @@ export function activate(context: vscode.ExtensionContext) {
     // Inject bin dir resolver into CommandService BEFORE any providers are
     // constructed so that early refresh() calls resolve the venv, not ~/.local/bin.
     const commandService = getCommandService();
+    let binDirLogged = false;
     commandService.setBinDirResolver(async (workspaceUri) => {
         await pythonEnvService.initialize();
         const env = await pythonEnvService.getEnvironment(workspaceUri as vscode.Uri | undefined);
         if (env?.execInfo.run.executable) {
             const binDir = path.dirname(env.execInfo.run.executable);
-            log(`binDirResolver: env=${env.displayName}, binDir=${binDir}`);
+            if (!binDirLogged) {
+                log(`binDirResolver: env=${env.displayName}, binDir=${binDir}`);
+                binDirLogged = true;
+            }
             return binDir;
         }
         log('binDirResolver: no environment or executable found');


### PR DESCRIPTION
## Summary
- `_ensureScripts()` now checks the XDG cache (`$XDG_CACHE_HOME/ansible-tools/`) first — once scripts are deployed, the source tree search is skipped entirely
- Adds correct esbuild candidate path (`__dirname/../packages/core/src/data`) so vendored scripts are found when `__dirname` resolves to `dist/`
- Quiets `CommandService.getBinDir()` logging that produced ~60 redundant log lines per EE operation
- Quiets the VS Code extension's `binDirResolver` callback to log only on first resolution

## Test plan
- [x] `vitest` — `ExecutionEnvService.test.ts` and `CommandService.test.ts` pass (29/29)
- [x] Launch VS Code Extension Development Host and confirm EE discovery loads 2 EEs via native `ContainerRuntime`
- [x] Verify `ansible-navigator` is no longer called in a polling loop
- [ ] Verify terminal/output panel is no longer flooded with `binDirResolver` lines