### PR TITLE
fix: complete incomplete test assertions in ALS tests

### DIFF
--- a/packages/ansible-language-server/test/providers/hoverProvider.test.ts
+++ b/packages/ansible-language-server/test/providers/hoverProvider.test.ts
@@ -283,7 +283,7 @@ describe("doHover()", function () {
 
   const textDoc = getDoc(fixtureFilePath);
   const docSettings = context?.documentSettings.get(textDoc.uri);
-  expect(docSettings !== undefined);
+  expect(docSettings).toBeDefined();
 
   describe("Play keywords hover", function () {
     describe("@ee", function () {

--- a/packages/ansible-language-server/test/providers/settingsManager.test.ts
+++ b/packages/ansible-language-server/test/providers/settingsManager.test.ts
@@ -35,7 +35,7 @@ describe("get()", function () {
       });
 
       it("should return default value for all settings", function () {
-        expect(typeof context !== "undefined");
+        expect(context).toBeDefined();
         if (typeof context !== "undefined") {
           expect(mergedSettings).toEqual(
             context.documentSettings.globalSettings,

--- a/packages/ansible-language-server/test/services/schemaService.test.ts
+++ b/packages/ansible-language-server/test/services/schemaService.test.ts
@@ -71,14 +71,28 @@ describe("SchemaCache", () => {
     expect(result).toBeUndefined();
   });
 
-  it("invalidates specific URL", () => {
+  it("invalidates specific URL", async () => {
+    const mockSchema = { type: "object", properties: {} };
+    fetchStub.resolves({ ok: true, json: async () => mockSchema });
+    await cache.getSchema("http://test.com/schema.json");
+
     cache.invalidate("http://test.com/schema.json");
-    // No error should be thrown
+
+    fetchStub.resolves({ ok: true, json: async () => mockSchema });
+    await cache.getSchema("http://test.com/schema.json");
+    expect(fetchStub.calledTwice).toBe(true);
   });
 
-  it("invalidates all cache", () => {
+  it("invalidates all cache", async () => {
+    const mockSchema = { type: "object", properties: {} };
+    fetchStub.resolves({ ok: true, json: async () => mockSchema });
+    await cache.getSchema("http://test.com/schema.json");
+
     cache.invalidate();
-    // No error should be thrown
+
+    fetchStub.resolves({ ok: true, json: async () => mockSchema });
+    await cache.getSchema("http://test.com/schema.json");
+    expect(fetchStub.calledTwice).toBe(true);
   });
 });
 

--- a/packages/ansible-language-server/test/utils/getAnsibleMetaData.test.ts
+++ b/packages/ansible-language-server/test/utils/getAnsibleMetaData.test.ts
@@ -243,7 +243,7 @@ describe("getAnsibleMetaData()", function () {
 
     describe("Verify ansible-lint details", function () {
       it("should contain all the keys for ansible-lint information", function () {
-        expect(actualAnsibleMetaData["ansible-lint information"]);
+        expect(actualAnsibleMetaData["ansible-lint information"]).toBeDefined();
         if (actualAnsibleMetaData["ansible-lint information"]) {
           const expectedKeys = Object.keys(ansibleLintInfoForTest);
           const actualKeys = Object.keys(

--- a/packages/ansible-language-server/test/utils/withInterpreter.test.ts
+++ b/packages/ansible-language-server/test/utils/withInterpreter.test.ts
@@ -81,7 +81,7 @@ describe("withInterpreter", function () {
 
           expectedKeys.forEach((key) => {
             expect(actualCommand.env).to.haveOwnProperty(key);
-            expect(typeof actualCommand.env === "object");
+            expect(typeof actualCommand.env).toBe("object");
             if (!actualCommand.env || typeof expectedEnv === "string") {
               expect(false).toBe(true);
             } else {


### PR DESCRIPTION
Fixes incomplete `expect()` calls that were missing assertion chains — these tests were passing without actually checking anything.

- hoverProvider.test.ts
- settingsManager.test.ts
- schemaService.test.ts
- getAnsibleMetaData.test.ts
- withInterpreter.test.ts

Ref: AAP-78608

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR fixes incomplete test assertions across five test files in the Ansible Language Server test suite. Tests were using incomplete `expect()` calls that weren't actually verifying any assertions, allowing potential bugs to go undetected. The fix ensures all test cases include proper assertion chains with complete Jest/Vitest syntax.

- hoverProvider.test.ts: Updated docSettings assertion to use `expect(docSettings).toBeDefined()`
- settingsManager.test.ts: Updated context assertion to use `expect(context).toBeDefined()`
- schemaService.test.ts: Added proper assertions to verify fetch is called twice after cache invalidation
- getAnsibleMetaData.test.ts: Updated ansible-lint information assertion to use `expect(...).toBeDefined()`
- withInterpreter.test.ts: Corrected env type assertion to use `expect(typeof actualCommand.env).toBe("object")`

related: AAP-78608

<!-- end of auto-generated comment: release notes by coderabbit.ai -->