### PR TITLE
fix(core): fix system_packages type, add accessor, and share EE loading promise

### DIFF
--- a/packages/core/src/services/ExecutionEnvService.ts
+++ b/packages/core/src/services/ExecutionEnvService.ts
@@ -504,7 +504,11 @@ export class ExecutionEnvService {
         return details.system_packages.details
             .map((pkg) => ({
                 name: pkg.name,
-                version: pkg.version ? `${pkg.version}-${pkg.release}` : '',
+                version: pkg.version
+                    ? pkg.release
+                        ? `${pkg.version}-${pkg.release}`
+                        : pkg.version
+                    : '',
             }))
             .filter((pkg) => pkg.name !== '')
             .sort((a, b) => a.name.localeCompare(b.name));

--- a/packages/core/src/services/ExecutionEnvService.ts
+++ b/packages/core/src/services/ExecutionEnvService.ts
@@ -495,9 +495,7 @@ export class ExecutionEnvService {
      * @param fullName - Full image name to inspect.
      * @returns Sorted system package name and version pairs from EE details.
      */
-    public async getSystemPackages(
-        fullName: string,
-    ): Promise<{ name: string; version: string }[]> {
+    public async getSystemPackages(fullName: string): Promise<{ name: string; version: string }[]> {
         const details = await this.loadDetails(fullName);
         if (!details?.system_packages?.details) {
             return [];
@@ -505,8 +503,8 @@ export class ExecutionEnvService {
 
         return details.system_packages.details
             .map((pkg) => ({
-                name: pkg.name ?? '',
-                version: pkg.version ? `${pkg.version}-${pkg.release ?? ''}` : '',
+                name: pkg.name,
+                version: pkg.version ? `${pkg.version}-${pkg.release}` : '',
             }))
             .filter((pkg) => pkg.name !== '')
             .sort((a, b) => a.name.localeCompare(b.name));

--- a/packages/core/src/services/ExecutionEnvService.ts
+++ b/packages/core/src/services/ExecutionEnvService.ts
@@ -39,7 +39,7 @@ export interface EEDetails {
         details: string;
     };
     system_packages?: {
-        details: Record<string, string>;
+        details: Record<string, string>[];
     };
     python_packages?: {
         details: {
@@ -77,6 +77,7 @@ export class ExecutionEnvService {
     private _engine: ContainerEngine | null = null;
     private _scriptCacheDir: string | null = null;
     private _loading = false;
+    private _loadingPromise: Promise<ExecutionEnvironment[]> | null = null;
     private _loaded = false;
     private _onDidChange: SimpleEventEmitter<void> | { fire: () => void; event: unknown };
     public readonly onDidChange: unknown;
@@ -282,8 +283,8 @@ export class ExecutionEnvService {
      * @returns Filtered list of images marked as execution environments.
      */
     public async loadExecutionEnvironments(): Promise<ExecutionEnvironment[]> {
-        if (this._loading) {
-            return this._executionEnvironments;
+        if (this._loadingPromise) {
+            return this._loadingPromise;
         }
 
         if (this._loaded && this._executionEnvironments.length > 0) {
@@ -293,6 +294,20 @@ export class ExecutionEnvService {
         this._loading = true;
         (this._onDidChange as { fire: () => void }).fire();
 
+        this._loadingPromise = this._doLoadExecutionEnvironments();
+        try {
+            return await this._loadingPromise;
+        } finally {
+            this._loadingPromise = null;
+        }
+    }
+
+    /**
+     * Internal implementation of EE loading.
+     *
+     * @returns Filtered list of images marked as execution environments.
+     */
+    private async _doLoadExecutionEnvironments(): Promise<ExecutionEnvironment[]> {
         try {
             const engine = await this._ensureEngine();
             const images = await ContainerRuntime.listImages(engine);
@@ -472,6 +487,29 @@ export class ExecutionEnvService {
         }
 
         return [...details.python_packages.details].sort((a, b) => a.name.localeCompare(b.name));
+    }
+
+    /**
+     * Get system packages installed in an execution environment.
+     *
+     * @param fullName - Full image name to inspect.
+     * @returns Sorted system package name and version pairs from EE details.
+     */
+    public async getSystemPackages(
+        fullName: string,
+    ): Promise<{ name: string; version: string }[]> {
+        const details = await this.loadDetails(fullName);
+        if (!details?.system_packages?.details) {
+            return [];
+        }
+
+        return details.system_packages.details
+            .map((pkg) => ({
+                name: pkg.name ?? '',
+                version: pkg.version ? `${pkg.version}-${pkg.release ?? ''}` : '',
+            }))
+            .filter((pkg) => pkg.name !== '')
+            .sort((a, b) => a.name.localeCompare(b.name));
     }
 
     /**

--- a/packages/core/test/services/ExecutionEnvService.test.ts
+++ b/packages/core/test/services/ExecutionEnvService.test.ts
@@ -114,7 +114,10 @@ const INTROSPECTION_JSON = JSON.stringify({
         errors: [],
     },
     system_packages: {
-        details: { bash: '5.2.26', openssl: '3.2.1' },
+        details: [
+            { name: 'bash', version: '5.2.26', release: '1.el9' },
+            { name: 'openssl', version: '3.2.1', release: '2.el9' },
+        ],
         errors: [],
     },
     redhat_release: { details: 'Red Hat Enterprise Linux release 9.4', errors: [] },
@@ -256,10 +259,10 @@ describe('ExecutionEnvService', () => {
             expect(details?.ansible_collections?.details['ansible.builtin']).toBe('2.19.0');
             expect(details?.os_release?.details[0]['pretty-name']).toBe('RHEL 9.4');
             expect(details?.python_packages?.details).toHaveLength(2);
-            expect(details?.system_packages?.details).toEqual({
-                bash: '5.2.26',
-                openssl: '3.2.1',
-            });
+            expect(details?.system_packages?.details).toEqual([
+                { name: 'bash', version: '5.2.26', release: '1.el9' },
+                { name: 'openssl', version: '3.2.1', release: '2.el9' },
+            ]);
             expect(details?.redhat_release?.details).toBe('Red Hat Enterprise Linux release 9.4');
             expect(details?.image_name).toBe('quay.io/ansible/ee-supported:latest');
         });
@@ -328,6 +331,70 @@ describe('ExecutionEnvService', () => {
                 { name: 'ansible-core', version: '2.19.0', summary: 'Ansible' },
                 { name: 'jinja2', version: '3.1.4' },
             ]);
+        });
+    });
+
+    describe('getSystemPackages', () => {
+        it('extracts and sorts packages with version-release', async () => {
+            setupDefaultMocks();
+            containerMocks.runInContainer.mockResolvedValue(INTROSPECTION_JSON);
+
+            const svc = ExecutionEnvService.getInstance();
+            await svc.loadExecutionEnvironments();
+            const pkgs = await svc.getSystemPackages('quay.io/ansible/ee-supported:latest');
+            expect(pkgs).toEqual([
+                { name: 'bash', version: '5.2.26-1.el9' },
+                { name: 'openssl', version: '3.2.1-2.el9' },
+            ]);
+        });
+
+        it('returns version without release suffix when release is empty', async () => {
+            setupDefaultMocks();
+            containerMocks.runInContainer.mockResolvedValue(
+                JSON.stringify({
+                    errors: [],
+                    system_packages: {
+                        details: [{ name: 'zlib', version: '1.2.13', release: '' }],
+                    },
+                }),
+            );
+
+            const svc = ExecutionEnvService.getInstance();
+            await svc.loadExecutionEnvironments();
+            const pkgs = await svc.getSystemPackages('quay.io/ansible/ee-supported:latest');
+            expect(pkgs).toEqual([{ name: 'zlib', version: '1.2.13' }]);
+        });
+
+        it('filters out entries with empty name', async () => {
+            setupDefaultMocks();
+            containerMocks.runInContainer.mockResolvedValue(
+                JSON.stringify({
+                    errors: [],
+                    system_packages: {
+                        details: [
+                            { name: 'bash', version: '5.0', release: '1' },
+                            { name: '', version: '0.0', release: '' },
+                        ],
+                    },
+                }),
+            );
+
+            const svc = ExecutionEnvService.getInstance();
+            await svc.loadExecutionEnvironments();
+            const pkgs = await svc.getSystemPackages('quay.io/ansible/ee-supported:latest');
+            expect(pkgs).toEqual([{ name: 'bash', version: '5.0-1' }]);
+        });
+
+        it('returns empty when details lack system_packages', async () => {
+            setupDefaultMocks();
+            containerMocks.runInContainer.mockResolvedValue(
+                JSON.stringify({ errors: [], image_name: 'x' }),
+            );
+
+            const svc = ExecutionEnvService.getInstance();
+            await svc.loadExecutionEnvironments();
+            const pkgs = await svc.getSystemPackages('quay.io/ansible/ee-supported:latest');
+            expect(pkgs).toEqual([]);
         });
     });
 

--- a/packages/core/test/services/ExecutionEnvService.test.ts
+++ b/packages/core/test/services/ExecutionEnvService.test.ts
@@ -225,8 +225,8 @@ describe('ExecutionEnvService', () => {
             const [r1, r2] = await Promise.all([p1, p2]);
             expect(containerMocks.listImages).toHaveBeenCalledTimes(1);
             expect(r1).toHaveLength(1);
-            // p2 returned early (loading guard)
-            expect(r2).toEqual([]);
+            // p2 shares the same in-flight promise
+            expect(r2).toEqual(r1);
         });
 
         it('returns cached list when already loaded with data', async () => {

--- a/packages/mcp-server/src/handlers.ts
+++ b/packages/mcp-server/src/handlers.ts
@@ -1036,7 +1036,18 @@ export class McpToolHandler {
                     .filter((pkg) => pkg.name)
                     .sort((a, b) => a.name.localeCompare(b.name));
                 sections.push(`## System Packages (${String(sysPkgs.length)})\n`);
-                sections.push(sysPkgs.map((pkg) => `• ${pkg.name}: ${pkg.version}`).join('\n'));
+                sections.push(
+                    sysPkgs
+                        .map((pkg) => {
+                            const ver = pkg.version
+                                ? pkg.release
+                                    ? `${pkg.version}-${pkg.release}`
+                                    : pkg.version
+                                : '';
+                            return `• ${pkg.name}: ${ver}`;
+                        })
+                        .join('\n'),
+                );
             }
 
             return {

--- a/packages/mcp-server/src/handlers.ts
+++ b/packages/mcp-server/src/handlers.ts
@@ -1032,11 +1032,11 @@ export class McpToolHandler {
 
             // System packages if available
             if (details.system_packages?.details) {
-                const sysPkgs = Object.entries(details.system_packages.details).sort(([a], [b]) =>
-                    a.localeCompare(b),
-                );
+                const sysPkgs = [...details.system_packages.details]
+                    .filter((pkg) => pkg.name)
+                    .sort((a, b) => a.name.localeCompare(b.name));
                 sections.push(`## System Packages (${String(sysPkgs.length)})\n`);
-                sections.push(sysPkgs.map(([name, version]) => `• ${name}: ${version}`).join('\n'));
+                sections.push(sysPkgs.map((pkg) => `• ${pkg.name}: ${pkg.version}`).join('\n'));
             }
 
             return {

--- a/packages/mcp-server/test/handlers.test.ts
+++ b/packages/mcp-server/test/handlers.test.ts
@@ -708,7 +708,10 @@ describe('McpToolHandler', () => {
                     ],
                 },
                 system_packages: {
-                    details: { bash: '5.2', curl: '8.0' },
+                    details: [
+                        { name: 'bash', version: '5.2', release: '1.fc40' },
+                        { name: 'curl', version: '8.0', release: '2.fc40' },
+                    ],
                 },
             });
 

--- a/src/views/ExecutionEnvironmentsProvider.ts
+++ b/src/views/ExecutionEnvironmentsProvider.ts
@@ -311,22 +311,16 @@ export class ExecutionEnvironmentsProvider implements vscode.TreeDataProvider<Tr
                 const systemItems: EEDetailItemNode[] = [];
                 const systemPkgs = [...details.system_packages.details]
                     .filter((pkg) => pkg.name)
-                    .sort((a, b) => (a.name ?? '').localeCompare(b.name ?? ''));
+                    .sort((a, b) => a.name.localeCompare(b.name));
 
                 for (const pkg of systemPkgs) {
-                    const version = pkg.version
-                        ? `${pkg.version}-${pkg.release ?? ''}`
-                        : '';
+                    const version = pkg.version ? `${pkg.version}-${pkg.release}` : '';
                     systemItems.push(new EEDetailItemNode(pkg.name, version));
                 }
 
                 if (systemItems.length > 0) {
                     categories.push(
-                        new EEDetailCategoryNode(
-                            'System Packages',
-                            systemItems,
-                            ee.full_name,
-                        ),
+                        new EEDetailCategoryNode('System Packages', systemItems, ee.full_name),
                     );
                 }
             }

--- a/src/views/ExecutionEnvironmentsProvider.ts
+++ b/src/views/ExecutionEnvironmentsProvider.ts
@@ -44,7 +44,7 @@ class MessageNode extends vscode.TreeItem {
 class EENode extends vscode.TreeItem {
     /**
      * Create a tree node for an execution environment summary.
-     * @param ee - Execution environment metadata returned by ansible-navigator
+     * @param ee - Execution environment metadata from the container runtime
      */
     constructor(public readonly ee: ExecutionEnvironment) {
         super(ee.full_name, vscode.TreeItemCollapsibleState.Collapsed);
@@ -83,6 +83,9 @@ class EEDetailCategoryNode extends vscode.TreeItem {
             case 'Python Packages':
                 this.iconPath = new vscode.ThemeIcon('symbol-package');
                 break;
+            case 'System Packages':
+                this.iconPath = new vscode.ThemeIcon('archive');
+                break;
             case 'Info':
                 this.iconPath = new vscode.ThemeIcon('info');
                 break;
@@ -120,7 +123,7 @@ export class ExecutionEnvironmentsProvider implements vscode.TreeDataProvider<Tr
     private _service: ExecutionEnvService;
     private _serviceListener: vscode.Disposable | undefined;
 
-    /** Create the provider and load execution environments from ansible-navigator. */
+    /** Create the provider and begin loading execution environments. */
     constructor() {
         this._service = ExecutionEnvService.getInstance();
         this._service.setLogFunction(log);
@@ -299,6 +302,31 @@ export class ExecutionEnvironmentsProvider implements vscode.TreeDataProvider<Tr
                 if (packageItems.length > 0) {
                     categories.push(
                         new EEDetailCategoryNode('Python Packages', packageItems, ee.full_name),
+                    );
+                }
+            }
+
+            // System Packages category
+            if (details.system_packages?.details) {
+                const systemItems: EEDetailItemNode[] = [];
+                const systemPkgs = [...details.system_packages.details]
+                    .filter((pkg) => pkg.name)
+                    .sort((a, b) => (a.name ?? '').localeCompare(b.name ?? ''));
+
+                for (const pkg of systemPkgs) {
+                    const version = pkg.version
+                        ? `${pkg.version}-${pkg.release ?? ''}`
+                        : '';
+                    systemItems.push(new EEDetailItemNode(pkg.name, version));
+                }
+
+                if (systemItems.length > 0) {
+                    categories.push(
+                        new EEDetailCategoryNode(
+                            'System Packages',
+                            systemItems,
+                            ee.full_name,
+                        ),
                     );
                 }
             }

--- a/src/views/ExecutionEnvironmentsProvider.ts
+++ b/src/views/ExecutionEnvironmentsProvider.ts
@@ -307,22 +307,14 @@ export class ExecutionEnvironmentsProvider implements vscode.TreeDataProvider<Tr
             }
 
             // System Packages category
-            if (details.system_packages?.details) {
-                const systemItems: EEDetailItemNode[] = [];
-                const systemPkgs = [...details.system_packages.details]
-                    .filter((pkg) => pkg.name)
-                    .sort((a, b) => a.name.localeCompare(b.name));
-
-                for (const pkg of systemPkgs) {
-                    const version = pkg.version ? `${pkg.version}-${pkg.release}` : '';
-                    systemItems.push(new EEDetailItemNode(pkg.name, version));
-                }
-
-                if (systemItems.length > 0) {
-                    categories.push(
-                        new EEDetailCategoryNode('System Packages', systemItems, ee.full_name),
-                    );
-                }
+            const systemPkgs = await this._service.getSystemPackages(ee.full_name);
+            if (systemPkgs.length > 0) {
+                const systemItems = systemPkgs.map(
+                    (pkg) => new EEDetailItemNode(pkg.name, pkg.version),
+                );
+                categories.push(
+                    new EEDetailCategoryNode('System Packages', systemItems, ee.full_name),
+                );
             }
 
             return categories;


### PR DESCRIPTION
## Summary

- **Type correction**: `system_packages.details` is typed as `Record<string, string>[]` (array of RPM info dicts) instead of `Record<string, string>`. The old type caused `Object.entries()` to yield array indices as package "names" in the UI.
- **New accessor**: Added `getSystemPackages()` method that correctly parses name/version/release from each package dict, matching the existing `getCollections()` / `getPythonPackages()` pattern. Version-release formatting only appends `-<release>` when release is non-empty.
- **Concurrent loading fix**: `loadExecutionEnvironments()` now stores and shares a single in-flight `_loadingPromise`. Concurrent callers await the real result instead of receiving `[]` when a load is already in progress, eliminating the premature "No EE images found" state.
- **Extension tree view**: Added a System Packages category to the EE detail tree using the `getSystemPackages()` accessor. Previously only Info, Ansible Collections, and Python Packages were rendered. Also cleaned up stale `ansible-navigator` references in JSDoc comments.
- **MCP handler**: Updated `get_ee_details` handler to iterate the array-shaped `system_packages.details` with proper version-release formatting.
- **Tests**: Added `getSystemPackages()` unit tests (version-release, empty release fallback, empty-name filtering, missing section). Updated MCP and core test fixtures to use array-shaped `system_packages`.

## Commits

1. `e50ec5e6` — fix(core): fix system_packages type, add accessor, and share loading promise
2. `53152403` — fix(ext): add System Packages category to EE detail tree
3. `6b1eba36` — fix: resolve lint errors in system packages handling
4. `295139c5` — fix(mcp): update handlers test mock to use array-shaped system_packages
5. `c949190a` — fix: address Copilot review feedback on system packages

## Test plan

- [x] `ExecutionEnvService.test.ts` — 21 tests pass (concurrent loading, getSystemPackages with version-release, empty release, empty name, missing section)
- [x] `handlers.test.ts` — 49 tests pass (mock updated to array shape)
- [x] Lint — `npm run lint` passes clean
- [ ] Manual: open EE list view — verify system packages show real names, not numbers
- [ ] Manual: expand an EE node — verify System Packages category appears alongside Info, Collections, and Python Packages
- [ ] Manual: navigate away and back while EEs are loading — verify list populates correctly without showing empty state