### PR TITLE
feat: add shared UI package with EE detail view

### DIFF
--- a/.sdlc/adrs/ADR-001-service-based-architecture.md
+++ b/.sdlc/adrs/ADR-001-service-based-architecture.md
@@ -138,7 +138,7 @@ src/
 
 ### Neutral
 
-- The VS Code extension's UI code (panels, views) remains in `src/` rather than in a package. This is intentional — UI code is inherently VS Code-specific and has no standalone consumers.
+- Domain content rendering (EE details, plugin docs, creator forms) moves to `@ansible/ui` as shared React components ([ADR-010](ADR-010-shared-ui-component-layer.md)). VS Code-specific panel boilerplate (lifecycle, webview setup) remains in `src/panels/`.
 - Build tooling (`tsc -b` with project references) is standard TypeScript. No custom bundler is required for the packages.
 
 ## Implementation Notes

--- a/.sdlc/adrs/ADR-005-architectural-invariants.md
+++ b/.sdlc/adrs/ADR-005-architectural-invariants.md
@@ -97,6 +97,22 @@ logging, and a stable interface that insulates the extension from
 ansible-galaxy CLI changes. `CollectionsService.installCollection()`
 already enforces this.
 
+### 9. Domain content views live in `@ansible/ui` (ADR-010)
+
+All views that render domain content (EE details, plugin docs,
+playbook progress, creator forms) are React components in
+`packages/ui/`. Host environments (VS Code webviews, Navita,
+Backstage) provide a bridge implementation but do not contain domain
+rendering logic. New content views go in `@ansible/ui`, not in
+`src/panels/` or `packages/navita/`.
+
+### 10. Shared UI components never import host-specific modules (ADR-010)
+
+`@ansible/ui` components communicate with the host exclusively
+through the `HostBridge` interface hierarchy. An `import ... from
+'vscode'` or `window.navitaAPI` call in `packages/ui/` is a
+violation — the component must use `useBridge()` instead.
+
 ## Consequences
 
 ### Positive
@@ -129,6 +145,8 @@ already enforces this.
   (invariant 6)
 - [ADR-004](ADR-004-intentional-exclusions-from-main.md): Intentional
   exclusions (invariants 5, 7)
+- [ADR-010](ADR-010-shared-ui-component-layer.md): Shared UI component
+  layer (invariants 9, 10)
 
 ---
 
@@ -137,3 +155,4 @@ already enforces this.
 | Date | Author | Change |
 |------|--------|--------|
 | 2026-05-26 | AI-assisted | Initial invariants (8 rules) |
+| 2026-06-10 | AI-assisted | Add invariants 9, 10 (shared UI) |

--- a/.sdlc/adrs/ADR-010-shared-ui-component-layer.md
+++ b/.sdlc/adrs/ADR-010-shared-ui-component-layer.md
@@ -1,0 +1,120 @@
+# ADR-010: Shared UI Component Layer (`@ansible/ui`)
+
+## Status
+
+Accepted
+
+## Date
+
+2026-06-10
+
+## Context
+
+The VS Code extension and Navita Electron app both need to render
+content views for execution environments, plugin docs, playbook
+progress, and ansible-creator forms. Today the extension uses inline
+HTML strings with embedded CSS/JS in webview panels, while Navita uses
+React 19 components. This duplication means:
+
+- Bugs fixed in one surface are not fixed in the other
+- Schema-driven `ansible-creator` forms diverge in argument-building
+  logic
+- A future consumer (e.g., Backstage plugin) would need a third
+  implementation
+
+Since neither product has shipped yet, now is the right time to
+consolidate domain content rendering into a shared React component
+library.
+
+## Decision
+
+### 1. Create `packages/ui` with shared React components
+
+A new `@ansible/ui` package provides all domain content views as
+React components. It is published as an ES module library and
+consumed by both the VS Code extension webviews and Navita.
+
+### 2. Introduce a HostBridge abstraction
+
+Components never import host-specific APIs. Instead, each host
+environment provides a bridge implementation that satisfies a typed
+interface:
+
+```typescript
+interface HostBridgeCore {
+    openFile(path: string): Promise<void>;
+    showToast(message: string): void;
+    getResolvedTheme(): 'light' | 'dark';
+    saveViewSettings(settings: { zoom?: number; theme?: string }): Promise<void>;
+}
+
+interface EEBridge extends HostBridgeCore {
+    getInfo(eeName: string): Promise<EEInfo>;
+    getCollections(eeName: string): Promise<EECollection[]>;
+    getPythonPackages(eeName: string): Promise<EEPythonPackage[]>;
+    getSystemPackages(eeName: string): Promise<EEPackage[]>;
+}
+```
+
+VS Code webviews use `postMessage` RPC, Navita uses Electron IPC,
+and a future Backstage plugin could use REST/GraphQL.
+
+### 3. Semantic CSS token layer
+
+Shared components reference `--ui-*` CSS custom properties. Each host
+provides a mapping layer (`--host-*` -> `--ui-*`):
+
+- **VS Code**: Maps `--vscode-*` theme variables to `--host-*`
+- **Navita**: Maps its own theme to `--host-*`
+- **Backstage**: Would map PatternFly tokens to `--host-*`
+
+### 4. Webview bundling via esbuild
+
+The extension's existing esbuild-based build (`scripts/build.mjs`)
+gains a `webview` target that bundles React + `@ansible/ui` components
+into a single IIFE (`dist/webview.js`) loaded by webview panels.
+
+### 5. Schema-driven forms consolidate in `@ansible/ui`
+
+The `CreatorFormPanel` (extension) and Navita's creator views both
+need to render dynamic forms from `SchemaNode` JSON. The shared
+`SchemaForm` component lives in `@ansible/ui`; argument-building
+logic is consolidated in `@ansible/core`.
+
+## Consequences
+
+### Positive
+
+- Single source of truth for domain content rendering
+- Bug fixes and enhancements apply to all consumers simultaneously
+- New consumers (Backstage, CLI TUI) only need a bridge adapter
+- Consistent UX across VS Code, Navita, and future surfaces
+- Schema-driven forms cannot diverge in argument building
+
+### Negative
+
+- React becomes a required dependency for all UI consumers
+- Additional build complexity (webview bundling alongside Node bundles)
+- Bridge abstraction adds a layer of indirection
+
+### Neutral
+
+- The package boundary is enforced by the monorepo workspace;
+  `@ansible/ui` can only depend on `@ansible/core` and React
+- This decision supersedes the current inline HTML approach in the
+  extension but does not require removing existing panels immediately
+
+## Related Decisions
+
+- [ADR-001](ADR-001-service-based-architecture.md): Service-based
+  architecture -- domain logic in `@ansible/core`, UI is presentation
+- [ADR-005](ADR-005-architectural-invariants.md): Architectural
+  invariants (adds invariants 9, 10)
+
+---
+
+## Revision History
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-06-10 | AI-assisted | Initial decision |

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -160,7 +160,13 @@ export default defineConfig(
         },
     },
     {
-        ignores: ['scripts/**'],
+        ignores: [
+            'scripts/**',
+            'src/panels/webview-entry.tsx',
+            'src/panels/bridges/**',
+            'src/panels/webview.d.ts',
+            'packages/ui/vite.config.ts',
+        ],
     },
     {
         files: ['**/*.{ts,tsx,mts}'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,12 +13,15 @@
       "dependencies": {
         "@ansible/core": "*",
         "@ansible/mcp-server": "*",
+        "@ansible/ui": "*",
         "@modelcontextprotocol/sdk": "^1.25.2",
         "@types/js-yaml": "^4.0.9",
         "@vscode-elements/elements": "^1.6.0",
         "@vscode/python-extension": "~1.0.5",
         "ini": "^6.0.0",
         "js-yaml": "^4.1.1",
+        "react": "^19.1.0",
+        "react-dom": "^19.1.0",
         "vscode-languageclient": "^9.0.1",
         "zod": "^4.3.5",
         "zod-to-json-schema": "^3.25.1"
@@ -33,6 +36,8 @@
         "@types/lodash": "^4.17.24",
         "@types/mocha": "^10.0.10",
         "@types/node": "^20.10.0",
+        "@types/react": "^19.1.8",
+        "@types/react-dom": "^19.1.6",
         "@types/vscode": "^1.93.0",
         "@typescript-eslint/eslint-plugin": "^8.61.0",
         "@typescript-eslint/parser": "^8.61.0",
@@ -87,6 +92,10 @@
     },
     "node_modules/@ansible/mcp-server": {
       "resolved": "packages/mcp-server",
+      "link": true
+    },
+    "node_modules/@ansible/ui": {
+      "resolved": "packages/ui",
       "link": true
     },
     "node_modules/@azu/format-text": {
@@ -277,30 +286,30 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -310,13 +319,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2650,6 +2659,24 @@
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
       "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
       "dev": true
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+      "dev": true,
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
     },
     "node_modules/@types/sarif": {
       "version": "2.1.7",
@@ -6771,6 +6798,12 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true
+    },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
@@ -8720,6 +8753,23 @@
       "dev": true,
       "dependencies": {
         "pend": "~1.2.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
       }
     },
     "node_modules/fetch-blob": {
@@ -13219,6 +13269,25 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.7"
+      }
+    },
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
@@ -13971,6 +14040,11 @@
       "engines": {
         "node": ">=11.0.0"
       }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="
     },
     "node_modules/secretlint": {
       "version": "10.2.2",
@@ -15241,23 +15315,6 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
-    "node_modules/tinyglobby/node_modules/fdir": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "picomatch": "^3 || ^4"
-      },
-      "peerDependenciesMeta": {
-        "picomatch": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/tinyglobby/node_modules/picomatch": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
@@ -16517,23 +16574,6 @@
         "@esbuild/win32-x64": "0.27.7"
       }
     },
-    "node_modules/vite/node_modules/fdir": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "picomatch": "^3 || ^4"
-      },
-      "peerDependenciesMeta": {
-        "picomatch": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/vite/node_modules/picomatch": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
@@ -17625,6 +17665,572 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "packages/ui": {
+      "name": "@ansible/ui",
+      "version": "0.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "@ansible/core": "*"
+      },
+      "devDependencies": {
+        "@types/react": "^19.1.8",
+        "@types/react-dom": "^19.1.6",
+        "react": "^19.1.0",
+        "react-dom": "^19.1.0",
+        "typescript": "^6.0.3",
+        "vite": "^6.3.5"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "packages/ui/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/ui/node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/ui/node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/ui/node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/ui/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/ui/node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/ui/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/ui/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/ui/node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/ui/node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/ui/node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/ui/node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/ui/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/ui/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/ui/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/ui/node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/ui/node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/ui/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/ui/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/ui/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/ui/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/ui/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/ui/node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/ui/node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/ui/node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/ui/node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/ui/node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "packages/ui/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "packages/ui/node_modules/vite": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -366,6 +366,10 @@
         "icon": "$(refresh)"
       },
       {
+        "command": "ansibleExecutionEnvironments.showDetail",
+        "title": "Show Execution Environment Details"
+      },
+      {
         "command": "ansibleExecutionEnvironments.aiSummary",
         "title": "AI Summary",
         "icon": "$(sparkle)"
@@ -899,6 +903,8 @@
     "@types/lodash": "^4.17.24",
     "@types/mocha": "^10.0.10",
     "@types/node": "^20.10.0",
+    "@types/react": "^19.1.8",
+    "@types/react-dom": "^19.1.6",
     "@types/vscode": "^1.93.0",
     "@typescript-eslint/eslint-plugin": "^8.61.0",
     "@typescript-eslint/parser": "^8.61.0",
@@ -928,12 +934,15 @@
   "dependencies": {
     "@ansible/core": "*",
     "@ansible/mcp-server": "*",
+    "@ansible/ui": "*",
     "@modelcontextprotocol/sdk": "^1.25.2",
     "@types/js-yaml": "^4.0.9",
     "@vscode-elements/elements": "^1.6.0",
     "@vscode/python-extension": "~1.0.5",
     "ini": "^6.0.0",
     "js-yaml": "^4.1.1",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
     "vscode-languageclient": "^9.0.1",
     "zod": "^4.3.5",
     "zod-to-json-schema": "^3.25.1"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@ansible/ui",
+  "version": "0.0.1",
+  "description": "Shared React UI components for Ansible development tools",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./styles/tokens.css": "./dist/styles/tokens.css",
+    "./styles/vscode-host.css": "./dist/styles/vscode-host.css"
+  },
+  "license": "MIT",
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "scripts": {
+    "build": "vite build",
+    "dev": "vite build --watch",
+    "typecheck": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0"
+  },
+  "dependencies": {
+    "@ansible/core": "*"
+  },
+  "devDependencies": {
+    "@types/react": "^19.1.8",
+    "@types/react-dom": "^19.1.6",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
+    "typescript": "^6.0.3",
+    "vite": "^6.3.5"
+  }
+}

--- a/packages/ui/src/bridge/context.tsx
+++ b/packages/ui/src/bridge/context.tsx
@@ -1,0 +1,20 @@
+import { createContext, useContext } from 'react';
+import type { HostBridgeCore } from './core';
+
+const BridgeContext = createContext<HostBridgeCore | null>(null);
+
+export const BridgeProvider = BridgeContext.Provider;
+
+/**
+ * Access the host bridge from any shared UI component.
+ * Cast the return value to a specific bridge interface when the view
+ * requires capabilities beyond HostBridgeCore.
+ * @returns The host bridge provided by the nearest BridgeProvider.
+ */
+export function useBridge(): HostBridgeCore {
+    const bridge = useContext(BridgeContext);
+    if (!bridge) {
+        throw new Error('useBridge must be used within a BridgeProvider');
+    }
+    return bridge;
+}

--- a/packages/ui/src/bridge/core.ts
+++ b/packages/ui/src/bridge/core.ts
@@ -1,0 +1,15 @@
+/**
+ * Base bridge interface for host-agnostic UI components.
+ *
+ * Every shared view needs at least these capabilities from its host
+ * environment. Consumer-specific bridge implementations (VS Code
+ * postMessage, Electron IPC, REST API) satisfy this contract.
+ */
+export interface HostBridgeCore {
+    openFile(path: string): Promise<void>;
+    showToast(message: string): void;
+    getResolvedTheme(): 'light' | 'dark';
+    saveViewSettings(settings: { zoom?: number; theme?: string }): Promise<void>;
+}
+
+export type Disposable = () => void;

--- a/packages/ui/src/bridge/ee.ts
+++ b/packages/ui/src/bridge/ee.ts
@@ -1,0 +1,35 @@
+import type { HostBridgeCore } from './core';
+
+export interface EEPackage {
+    name: string;
+    version: string;
+}
+
+export interface EEPythonPackage {
+    name: string;
+    version: string;
+    summary?: string;
+}
+
+export interface EECollection {
+    name: string;
+    version: string;
+}
+
+export interface EEInfo {
+    ansible?: string;
+    os?: string;
+    image?: string;
+}
+
+/**
+ * Bridge contract for execution environment detail views.
+ * Host implementations fetch data from @ansible/core services
+ * (extension, Navita) or REST APIs (Backstage).
+ */
+export interface EEBridge extends HostBridgeCore {
+    getInfo(eeName: string): Promise<EEInfo>;
+    getCollections(eeName: string): Promise<EECollection[]>;
+    getPythonPackages(eeName: string): Promise<EEPythonPackage[]>;
+    getSystemPackages(eeName: string): Promise<EEPackage[]>;
+}

--- a/packages/ui/src/bridge/index.ts
+++ b/packages/ui/src/bridge/index.ts
@@ -1,0 +1,3 @@
+export type { HostBridgeCore, Disposable } from './core';
+export { BridgeProvider, useBridge } from './context';
+export type { EEBridge, EEPackage, EEPythonPackage, EECollection, EEInfo } from './ee';

--- a/packages/ui/src/components/InfoList.tsx
+++ b/packages/ui/src/components/InfoList.tsx
@@ -1,0 +1,50 @@
+import type { CSSProperties } from 'react';
+
+export interface InfoItem {
+    label: string;
+    value: string;
+}
+
+interface InfoListProps {
+    items: InfoItem[];
+}
+
+const styles: Record<string, CSSProperties> = {
+    row: {
+        display: 'flex',
+        padding: '6px 12px',
+        borderBottom: '1px solid var(--ui-border)',
+        gap: 12,
+    },
+    label: {
+        fontSize: '12px',
+        color: 'var(--ui-text-secondary)',
+        minWidth: 80,
+        flexShrink: 0,
+    },
+    value: {
+        fontSize: '12px',
+        fontFamily: 'var(--ui-font-mono)',
+        color: 'var(--ui-text-primary)',
+        wordBreak: 'break-all',
+    },
+};
+
+/**
+ * Key-value info display used for EE metadata (ansible version, OS, image name).
+ * @param root0 - Component props.
+ * @param root0.items - Array of label/value pairs to display.
+ * @returns The rendered info list.
+ */
+export function InfoList({ items }: InfoListProps) {
+    return (
+        <div>
+            {items.map((item) => (
+                <div key={item.label} style={styles.row}>
+                    <span style={styles.label}>{item.label}</span>
+                    <span style={styles.value}>{item.value}</span>
+                </div>
+            ))}
+        </div>
+    );
+}

--- a/packages/ui/src/components/PackageList.tsx
+++ b/packages/ui/src/components/PackageList.tsx
@@ -1,0 +1,137 @@
+import { useState, useMemo } from 'react';
+import type { CSSProperties } from 'react';
+
+export interface PackageItem {
+    name: string;
+    version: string;
+    summary?: string;
+}
+
+interface PackageListProps {
+    packages: PackageItem[];
+    title: string;
+    icon?: string;
+}
+
+const styles: Record<string, CSSProperties> = {
+    container: {
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 0,
+    },
+    searchRow: {
+        padding: '8px 12px',
+        borderBottom: '1px solid var(--ui-border)',
+    },
+    searchInput: {
+        width: '100%',
+        padding: '4px 8px',
+        border: '1px solid var(--ui-border)',
+        borderRadius: 3,
+        background: 'var(--ui-bg-surface)',
+        color: 'var(--ui-text-primary)',
+        fontFamily: 'var(--ui-font-family)',
+        fontSize: 'var(--ui-font-size)',
+        outline: 'none',
+    },
+    row: {
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'baseline',
+        padding: '4px 12px',
+        borderBottom: '1px solid var(--ui-border)',
+    },
+    rowAlt: {
+        background: 'var(--ui-bg-surface)',
+    },
+    name: {
+        fontFamily: 'var(--ui-font-mono)',
+        fontSize: '12px',
+        color: 'var(--ui-text-primary)',
+        flexShrink: 0,
+    },
+    version: {
+        fontFamily: 'var(--ui-font-mono)',
+        fontSize: '12px',
+        color: 'var(--ui-text-secondary)',
+        textAlign: 'right' as const,
+        marginLeft: 12,
+    },
+    summary: {
+        fontSize: '11px',
+        color: 'var(--ui-text-muted)',
+        marginTop: 2,
+    },
+    count: {
+        fontSize: '12px',
+        color: 'var(--ui-text-secondary)',
+        padding: '6px 12px',
+        borderBottom: '1px solid var(--ui-border)',
+    },
+    empty: {
+        padding: '16px 12px',
+        color: 'var(--ui-text-muted)',
+        fontStyle: 'italic',
+    },
+};
+
+/**
+ * Sortable, searchable package list. Reusable for system packages,
+ * Python packages, and Ansible collections.
+ * @param root0 - Component props.
+ * @param root0.packages - Array of package items to display.
+ * @param root0.title - Heading label for the list (e.g. "System Packages").
+ * @returns The rendered package list.
+ */
+export function PackageList({ packages, title }: PackageListProps) {
+    const [filter, setFilter] = useState('');
+
+    const filtered = useMemo(() => {
+        if (!filter) return packages;
+        const lower = filter.toLowerCase();
+        return packages.filter(
+            (p) => p.name.toLowerCase().includes(lower) || p.version.toLowerCase().includes(lower),
+        );
+    }, [packages, filter]);
+
+    return (
+        <div style={styles.container}>
+            <div style={styles.count}>
+                {filtered.length === packages.length
+                    ? `${String(packages.length)} ${title}`
+                    : `${String(filtered.length)} of ${String(packages.length)} ${title}`}
+            </div>
+            {packages.length > 10 && (
+                <div style={styles.searchRow}>
+                    <input
+                        type="text"
+                        placeholder={`Filter ${title.toLowerCase()}…`}
+                        value={filter}
+                        onChange={(e) => {
+                            setFilter(e.target.value);
+                        }}
+                        style={styles.searchInput}
+                    />
+                </div>
+            )}
+            {filtered.length === 0 ? (
+                <div style={styles.empty}>
+                    {packages.length === 0 ? `No ${title.toLowerCase()} found` : 'No matches'}
+                </div>
+            ) : (
+                filtered.map((pkg, i) => (
+                    <div
+                        key={pkg.name}
+                        style={{ ...styles.row, ...(i % 2 === 1 ? styles.rowAlt : {}) }}
+                    >
+                        <div>
+                            <span style={styles.name}>{pkg.name}</span>
+                            {pkg.summary && <div style={styles.summary}>{pkg.summary}</div>}
+                        </div>
+                        <span style={styles.version}>{pkg.version}</span>
+                    </div>
+                ))
+            )}
+        </div>
+    );
+}

--- a/packages/ui/src/components/TabBar.tsx
+++ b/packages/ui/src/components/TabBar.tsx
@@ -1,0 +1,86 @@
+import type { CSSProperties, ReactNode } from 'react';
+
+export interface Tab {
+    id: string;
+    label: string;
+    count?: number;
+}
+
+interface TabBarProps {
+    tabs: Tab[];
+    activeTab: string;
+    onTabChange: (tabId: string) => void;
+    children: ReactNode;
+}
+
+const styles: Record<string, CSSProperties> = {
+    bar: {
+        display: 'flex',
+        borderBottom: '1px solid var(--ui-border)',
+        background: 'var(--ui-bg-surface)',
+        gap: 0,
+        overflow: 'hidden',
+    },
+    tab: {
+        padding: '8px 16px',
+        cursor: 'pointer',
+        fontSize: '12px',
+        fontFamily: 'var(--ui-font-family)',
+        color: 'var(--ui-text-secondary)',
+        background: 'transparent',
+        border: 'none',
+        borderBottom: '2px solid transparent',
+        transition: 'color 0.15s, border-color 0.15s',
+        whiteSpace: 'nowrap',
+    },
+    tabActive: {
+        color: 'var(--ui-text-primary)',
+        borderBottomColor: 'var(--ui-accent)',
+    },
+    badge: {
+        marginLeft: 6,
+        fontSize: '11px',
+        color: 'var(--ui-text-muted)',
+    },
+    content: {
+        flex: 1,
+        overflow: 'auto',
+    },
+};
+
+/**
+ * Simple tab bar with content area. Used for EE detail sections
+ * and any other tabbed layout in shared views.
+ * @param root0 - Component props.
+ * @param root0.tabs - Tab definitions with id, label, and optional count.
+ * @param root0.activeTab - ID of the currently active tab.
+ * @param root0.onTabChange - Callback invoked when a tab is clicked.
+ * @param root0.children - Content rendered below the tab bar.
+ * @returns The rendered tab bar with content.
+ */
+export function TabBar({ tabs, activeTab, onTabChange, children }: TabBarProps) {
+    return (
+        <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+            <div style={styles.bar}>
+                {tabs.map((tab) => (
+                    <button
+                        key={tab.id}
+                        style={{
+                            ...styles.tab,
+                            ...(activeTab === tab.id ? styles.tabActive : {}),
+                        }}
+                        onClick={() => {
+                            onTabChange(tab.id);
+                        }}
+                    >
+                        {tab.label}
+                        {tab.count !== undefined && (
+                            <span style={styles.badge}>({String(tab.count)})</span>
+                        )}
+                    </button>
+                ))}
+            </div>
+            <div style={styles.content}>{children}</div>
+        </div>
+    );
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,0 +1,11 @@
+export { BridgeProvider, useBridge } from './bridge/context';
+export type { HostBridgeCore, Disposable } from './bridge/core';
+export type { EEBridge, EEPackage, EEPythonPackage, EECollection, EEInfo } from './bridge/ee';
+
+export { EEDetailView } from './views/EEDetailView';
+export { PackageList } from './components/PackageList';
+export type { PackageItem } from './components/PackageList';
+export { TabBar } from './components/TabBar';
+export type { Tab } from './components/TabBar';
+export { InfoList } from './components/InfoList';
+export type { InfoItem } from './components/InfoList';

--- a/packages/ui/src/styles/tokens.css
+++ b/packages/ui/src/styles/tokens.css
@@ -1,0 +1,47 @@
+/*
+ * Shared UI semantic tokens.
+ *
+ * Components reference --ui-* variables. Host environments provide
+ * values by mapping their own token namespace to --host-* variables
+ * (see vscode-host.css or navita-host.css).
+ */
+:root {
+    --ui-bg-primary: var(--host-bg-primary, #1e1e1e);
+    --ui-bg-surface: var(--host-bg-surface, #252526);
+    --ui-bg-hover: var(--host-bg-hover, #2a2d2e);
+    --ui-bg-active: var(--host-bg-active, #37373d);
+
+    --ui-text-primary: var(--host-text-primary, #cccccc);
+    --ui-text-secondary: var(--host-text-secondary, #969696);
+    --ui-text-muted: var(--host-text-muted, #6e6e6e);
+    --ui-text-link: var(--host-text-link, #4daafc);
+
+    --ui-border: var(--host-border, #3c3c3c);
+    --ui-border-active: var(--host-border-active, #007acc);
+
+    --ui-accent: var(--host-accent, #007acc);
+    --ui-accent-hover: var(--host-accent-hover, #1a8ad4);
+
+    --ui-success: var(--host-success, #4ec9b0);
+    --ui-warning: var(--host-warning, #cca700);
+    --ui-error: var(--host-error, #f44747);
+
+    --ui-font-family: var(--host-font-family, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif);
+    --ui-font-size: var(--host-font-size, 13px);
+    --ui-font-mono: var(--host-font-mono, 'Cascadia Code', 'Fira Code', Consolas, monospace);
+}
+
+/* Base resets for shared components */
+.ansible-ui {
+    font-family: var(--ui-font-family);
+    font-size: var(--ui-font-size);
+    color: var(--ui-text-primary);
+    background: var(--ui-bg-primary);
+    line-height: 1.5;
+}
+
+.ansible-ui *,
+.ansible-ui *::before,
+.ansible-ui *::after {
+    box-sizing: border-box;
+}

--- a/packages/ui/src/styles/vscode-host.css
+++ b/packages/ui/src/styles/vscode-host.css
@@ -1,0 +1,31 @@
+/*
+ * VS Code webview host adapter.
+ *
+ * Maps VS Code's built-in CSS variables to the --host-* token layer
+ * that packages/ui components consume via --ui-* references.
+ */
+:root {
+    --host-bg-primary: var(--vscode-editor-background);
+    --host-bg-surface: var(--vscode-sideBar-background, var(--vscode-editor-background));
+    --host-bg-hover: var(--vscode-list-hoverBackground);
+    --host-bg-active: var(--vscode-list-activeSelectionBackground);
+
+    --host-text-primary: var(--vscode-editor-foreground);
+    --host-text-secondary: var(--vscode-descriptionForeground);
+    --host-text-muted: var(--vscode-disabledForeground);
+    --host-text-link: var(--vscode-textLink-foreground);
+
+    --host-border: var(--vscode-panel-border, var(--vscode-widget-border));
+    --host-border-active: var(--vscode-focusBorder);
+
+    --host-accent: var(--vscode-button-background);
+    --host-accent-hover: var(--vscode-button-hoverBackground);
+
+    --host-success: var(--vscode-testing-iconPassed, #4ec9b0);
+    --host-warning: var(--vscode-editorWarning-foreground, #cca700);
+    --host-error: var(--vscode-editorError-foreground, #f44747);
+
+    --host-font-family: var(--vscode-font-family);
+    --host-font-size: var(--vscode-font-size);
+    --host-font-mono: var(--vscode-editor-font-family);
+}

--- a/packages/ui/src/views/EEDetailView.tsx
+++ b/packages/ui/src/views/EEDetailView.tsx
@@ -1,0 +1,136 @@
+import { useState, useEffect, useCallback } from 'react';
+import type { CSSProperties } from 'react';
+import { useBridge } from '../bridge/context';
+import type { EEBridge, EEInfo, EECollection, EEPythonPackage, EEPackage } from '../bridge/ee';
+import { TabBar } from '../components/TabBar';
+import type { Tab } from '../components/TabBar';
+import { PackageList } from '../components/PackageList';
+import { InfoList } from '../components/InfoList';
+import type { InfoItem } from '../components/InfoList';
+
+interface EEDetailViewProps {
+    eeName: string;
+}
+
+interface EEData {
+    info: EEInfo;
+    collections: EECollection[];
+    pythonPackages: EEPythonPackage[];
+    systemPackages: EEPackage[];
+}
+
+const styles: Record<string, CSSProperties> = {
+    container: {
+        display: 'flex',
+        flexDirection: 'column',
+        height: '100%',
+        background: 'var(--ui-bg-primary)',
+    },
+    header: {
+        padding: '12px 16px',
+        borderBottom: '1px solid var(--ui-border)',
+    },
+    title: {
+        fontSize: '14px',
+        fontWeight: 600,
+        fontFamily: 'var(--ui-font-mono)',
+        color: 'var(--ui-text-primary)',
+        margin: 0,
+        wordBreak: 'break-all',
+    },
+    loading: {
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: '48px 16px',
+        color: 'var(--ui-text-secondary)',
+        fontSize: '13px',
+    },
+    error: {
+        padding: '16px',
+        color: 'var(--ui-error)',
+        fontSize: '13px',
+    },
+};
+
+/**
+ * Tabbed detail view for a single execution environment.
+ * Fetches info, collections, Python packages, and system packages
+ * through the EEBridge and renders them in a tabbed layout.
+ * @param root0 - Component props.
+ * @param root0.eeName - Full image name of the execution environment.
+ * @returns The rendered EE detail view.
+ */
+export function EEDetailView({ eeName }: EEDetailViewProps) {
+    const bridge = useBridge() as EEBridge;
+    const [data, setData] = useState<EEData | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [activeTab, setActiveTab] = useState('info');
+
+    const loadData = useCallback(async () => {
+        setLoading(true);
+        setError(null);
+        try {
+            const [info, collections, pythonPackages, systemPackages] = await Promise.all([
+                bridge.getInfo(eeName),
+                bridge.getCollections(eeName),
+                bridge.getPythonPackages(eeName),
+                bridge.getSystemPackages(eeName),
+            ]);
+            setData({ info, collections, pythonPackages, systemPackages });
+        } catch (err) {
+            setError(err instanceof Error ? err.message : String(err));
+        } finally {
+            setLoading(false);
+        }
+    }, [bridge, eeName]);
+
+    useEffect(() => {
+        void loadData();
+    }, [loadData]);
+
+    if (loading) {
+        return <div style={styles.loading}>Loading execution environment details…</div>;
+    }
+
+    if (error) {
+        return <div style={styles.error}>Error: {error}</div>;
+    }
+
+    if (!data) {
+        return <div style={styles.loading}>No data available</div>;
+    }
+
+    const infoItems: InfoItem[] = [];
+    if (data.info.ansible) infoItems.push({ label: 'Ansible', value: data.info.ansible });
+    if (data.info.os) infoItems.push({ label: 'OS', value: data.info.os });
+    if (data.info.image) infoItems.push({ label: 'Image', value: data.info.image });
+
+    const tabs: Tab[] = [
+        { id: 'info', label: 'Info', count: infoItems.length },
+        { id: 'collections', label: 'Collections', count: data.collections.length },
+        { id: 'python', label: 'Python Packages', count: data.pythonPackages.length },
+        { id: 'system', label: 'System Packages', count: data.systemPackages.length },
+    ];
+
+    return (
+        <div style={styles.container} className="ansible-ui">
+            <div style={styles.header}>
+                <h2 style={styles.title}>{eeName}</h2>
+            </div>
+            <TabBar tabs={tabs} activeTab={activeTab} onTabChange={setActiveTab}>
+                {activeTab === 'info' && <InfoList items={infoItems} />}
+                {activeTab === 'collections' && (
+                    <PackageList packages={data.collections} title="Ansible Collections" />
+                )}
+                {activeTab === 'python' && (
+                    <PackageList packages={data.pythonPackages} title="Python Packages" />
+                )}
+                {activeTab === 'system' && (
+                    <PackageList packages={data.systemPackages} title="System Packages" />
+                )}
+            </TabBar>
+        </div>
+    );
+}

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "target": "ES2020",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "isolatedModules": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vite';
+import { resolve } from 'path';
+
+export default defineConfig({
+    build: {
+        lib: {
+            entry: resolve(__dirname, 'src/index.ts'),
+            formats: ['es'],
+            fileName: 'index',
+        },
+        rollupOptions: {
+            external: ['react', 'react-dom', 'react/jsx-runtime'],
+        },
+        outDir: 'dist',
+        sourcemap: true,
+    },
+});

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -23,6 +23,22 @@ const shared = {
     outdir: path.join(ROOT, 'dist'),
 };
 
+/** @type {esbuild.BuildOptions} */
+const webviewShared = {
+    bundle: true,
+    format: 'iife',
+    platform: 'browser',
+    target: 'es2020',
+    sourcemap: !production,
+    minify: production,
+    metafile: true,
+    logLevel: 'info',
+    outdir: path.join(ROOT, 'dist'),
+    jsx: 'automatic',
+    jsxImportSource: 'react',
+    loader: { '.css': 'text' },
+};
+
 /** @type {esbuild.BuildOptions[]} */
 const targets = [
     {
@@ -51,6 +67,18 @@ const targets = [
         outdir: undefined,
         alias: {
             '@src': path.join(ROOT, 'packages', 'mcp-server', 'src'),
+            '@ansible/core/out': path.join(ROOT, 'packages', 'core', 'src'),
+            '@ansible/core': path.join(ROOT, 'packages', 'core', 'src'),
+        },
+    },
+    {
+        ...webviewShared,
+        entryPoints: [path.join(ROOT, 'src', 'panels', 'webview-entry.tsx')],
+        outfile: path.join(ROOT, 'dist', 'webview.js'),
+        outdir: undefined,
+        alias: {
+            '@src': path.join(ROOT, 'src'),
+            '@ansible/ui': path.join(ROOT, 'packages', 'ui', 'src'),
             '@ansible/core/out': path.join(ROOT, 'packages', 'core', 'src'),
             '@ansible/core': path.join(ROOT, 'packages', 'core', 'src'),
         },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,6 +17,7 @@ import { CreatorFormPanel } from '@src/panels/CreatorFormPanel';
 import { PlaybooksProvider } from '@src/views/PlaybooksProvider';
 import { PlaybookConfigPanel } from '@src/panels/PlaybookConfigPanel';
 import { PlaybookProgressPanel } from '@src/panels/PlaybookProgressPanel';
+import { EEDetailPanel } from '@src/panels/EEDetailPanel';
 import { PlaybooksService, PlaybookInfo, PlaybookPlay } from '@src/services/PlaybooksService';
 import { TerminalService } from '@src/services/TerminalService';
 import { PythonEnvironmentService } from '@src/services/PythonEnvironmentService';
@@ -690,6 +691,15 @@ export function activate(context: vscode.ExtensionContext) {
             eeProvider.refresh();
         },
     );
+
+    // Open EE detail panel
+    const eeDetailCommand = vscode.commands.registerCommand(
+        'ansibleExecutionEnvironments.showDetail',
+        (eeName: string) => {
+            EEDetailPanel.show(context.extensionUri, eeName);
+        },
+    );
+    context.subscriptions.push(eeDetailCommand);
 
     // AI Summary Commands - Collections
     const collectionsAiSummaryCommand = vscode.commands.registerCommand(

--- a/src/panels/EEDetailPanel.ts
+++ b/src/panels/EEDetailPanel.ts
@@ -1,0 +1,237 @@
+import * as vscode from 'vscode';
+import { ExecutionEnvService } from '@ansible/core';
+import { log } from '@src/extension';
+
+/**
+ * Webview panel that renders shared EE detail React components.
+ *
+ * The panel provides a minimal HTML shell that loads the bundled
+ * webview.js entry point. All rendering is handled by @ansible/ui
+ * components; this class only handles panel lifecycle and bridges
+ * postMessage RPC to @ansible/core services.
+ */
+export class EEDetailPanel {
+    private static _panels = new Map<string, EEDetailPanel>();
+    private _disposables: vscode.Disposable[] = [];
+
+    /**
+     * @param _panel - The VS Code webview panel instance.
+     * @param _eeName - Execution environment image name.
+     */
+    private constructor(
+        private readonly _panel: vscode.WebviewPanel,
+        private readonly _eeName: string,
+    ) {
+        this._panel.onDidDispose(
+            () => {
+                this._dispose();
+            },
+            null,
+            this._disposables,
+        );
+        this._panel.webview.onDidReceiveMessage(
+            (msg: { id?: number; method: string; params?: Record<string, unknown> }) => {
+                void this._handleMessage(msg);
+            },
+            null,
+            this._disposables,
+        );
+    }
+
+    /**
+     * Show the EE detail panel for a given image name.
+     * Reuses an existing panel if one is already open for the same image.
+     * @param extensionUri - Extension root URI for webview resource resolution.
+     * @param eeName - Full image name of the execution environment.
+     */
+    static show(extensionUri: vscode.Uri, eeName: string): void {
+        const existing = EEDetailPanel._panels.get(eeName);
+        if (existing) {
+            existing._panel.reveal();
+            return;
+        }
+
+        const panel = vscode.window.createWebviewPanel('eeDetail', eeName, vscode.ViewColumn.One, {
+            enableScripts: true,
+            localResourceRoots: [vscode.Uri.joinPath(extensionUri, 'dist')],
+            retainContextWhenHidden: true,
+        });
+
+        panel.iconPath = new vscode.ThemeIcon('package');
+        panel.webview.html = EEDetailPanel._getHtml(panel.webview, extensionUri, eeName);
+
+        const instance = new EEDetailPanel(panel, eeName);
+        EEDetailPanel._panels.set(eeName, instance);
+    }
+
+    /**
+     * Generate the HTML content for the webview panel.
+     * @param webview - Webview instance for URI resolution.
+     * @param extensionUri - Extension root URI.
+     * @param eeName - EE image name passed as props to the React app.
+     * @returns Complete HTML document string.
+     */
+    private static _getHtml(
+        webview: vscode.Webview,
+        extensionUri: vscode.Uri,
+        eeName: string,
+    ): string {
+        const scriptUri = webview.asWebviewUri(
+            vscode.Uri.joinPath(extensionUri, 'dist', 'webview.js'),
+        );
+        const nonce = getNonce();
+        const props = JSON.stringify({ eeName });
+
+        return `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Security-Policy"
+          content="default-src 'none'; script-src 'nonce-${nonce}'; style-src 'unsafe-inline';">
+    <title>${escapeHtml(eeName)}</title>
+    <style>
+        :root {
+            --host-bg-primary: var(--vscode-editor-background);
+            --host-bg-surface: var(--vscode-sideBar-background, var(--vscode-editor-background));
+            --host-bg-hover: var(--vscode-list-hoverBackground);
+            --host-bg-active: var(--vscode-list-activeSelectionBackground);
+            --host-text-primary: var(--vscode-editor-foreground);
+            --host-text-secondary: var(--vscode-descriptionForeground);
+            --host-text-muted: var(--vscode-disabledForeground);
+            --host-text-link: var(--vscode-textLink-foreground);
+            --host-border: var(--vscode-panel-border, var(--vscode-widget-border));
+            --host-border-active: var(--vscode-focusBorder);
+            --host-accent: var(--vscode-button-background);
+            --host-accent-hover: var(--vscode-button-hoverBackground);
+            --host-success: var(--vscode-testing-iconPassed, #4ec9b0);
+            --host-warning: var(--vscode-editorWarning-foreground, #cca700);
+            --host-error: var(--vscode-editorError-foreground, #f44747);
+            --host-font-family: var(--vscode-font-family);
+            --host-font-size: var(--vscode-font-size);
+            --host-font-mono: var(--vscode-editor-font-family);
+        }
+        html, body, #root {
+            margin: 0;
+            padding: 0;
+            width: 100%;
+            height: 100%;
+            overflow: hidden;
+        }
+    </style>
+</head>
+<body>
+    <div id="root"
+         data-view="ee-detail"
+         data-props="${escapeAttr(props)}"></div>
+    <script nonce="${nonce}" src="${String(scriptUri)}"></script>
+</body>
+</html>`;
+    }
+
+    /**
+     * Handle incoming postMessage RPC from the webview.
+     * @param msg - The message payload with optional correlation ID.
+     * @param msg.id - Correlation ID for request/response pairing.
+     * @param msg.method - The RPC method name.
+     * @param msg.params - Arbitrary parameters from the webview.
+     */
+    private async _handleMessage(msg: {
+        id?: number;
+        method: string;
+        params?: Record<string, unknown>;
+    }): Promise<void> {
+        const { id, method, params } = msg;
+
+        if (method === 'showToast') {
+            const text = params?.message;
+            void vscode.window.showInformationMessage(
+                typeof text === 'string' ? text : JSON.stringify(text),
+            );
+            return;
+        }
+
+        if (id === undefined) return;
+
+        try {
+            const result = await this._dispatch(method, params ?? {});
+            void this._panel.webview.postMessage({ id, result });
+        } catch (err) {
+            const errMessage = err instanceof Error ? err.message : String(err);
+            log(`EEDetailPanel: ${method} failed: ${errMessage}`);
+            void this._panel.webview.postMessage({ id, error: errMessage });
+        }
+    }
+
+    /**
+     * Route an RPC method call to the appropriate service method.
+     * @param method - The RPC method name.
+     * @param params - Arbitrary parameters from the webview.
+     * @returns The result to send back to the webview.
+     */
+    private async _dispatch(method: string, params: Record<string, unknown>): Promise<unknown> {
+        const svc = ExecutionEnvService.getInstance();
+        const eeName = (params.eeName as string) || this._eeName;
+
+        switch (method) {
+            case 'getInfo':
+                return svc.getInfo(eeName);
+            case 'getCollections':
+                return svc.getCollections(eeName);
+            case 'getPythonPackages':
+                return svc.getPythonPackages(eeName);
+            case 'getSystemPackages':
+                return svc.getSystemPackages(eeName);
+            case 'openFile':
+                await vscode.commands.executeCommand(
+                    'vscode.open',
+                    vscode.Uri.file(String(params.path)),
+                );
+                return undefined;
+            case 'saveViewSettings':
+                return undefined;
+            default:
+                throw new Error(`Unknown method: ${method}`);
+        }
+    }
+
+    /**
+     * Clean up panel resources when the webview is closed.
+     */
+    private _dispose(): void {
+        EEDetailPanel._panels.delete(this._eeName);
+        for (const d of this._disposables) d.dispose();
+        this._disposables.length = 0;
+    }
+}
+
+/**
+ * Generate a random nonce for CSP script-src.
+ * @returns A 32-character alphanumeric nonce string.
+ */
+function getNonce(): string {
+    const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+    let nonce = '';
+    for (let i = 0; i < 32; i++) {
+        nonce += chars.charAt(Math.floor(Math.random() * chars.length));
+    }
+    return nonce;
+}
+
+/**
+ * Escape HTML special characters.
+ * @param s - Input string.
+ * @returns Escaped string safe for HTML content.
+ */
+function escapeHtml(s: string): string {
+    return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+/**
+ * Escape double quotes for HTML attribute values.
+ * @param s - Input string.
+ * @returns Escaped string safe for HTML attributes.
+ */
+function escapeAttr(s: string): string {
+    return s.replace(/&/g, '&amp;').replace(/"/g, '&quot;');
+}

--- a/src/panels/bridges/VsCodeBridge.ts
+++ b/src/panels/bridges/VsCodeBridge.ts
@@ -1,0 +1,78 @@
+import type { EEBridge, EEInfo, EECollection, EEPythonPackage, EEPackage } from '@ansible/ui';
+
+type VsCodeApi = {
+    postMessage(message: unknown): void;
+    getState(): unknown;
+    setState(state: unknown): void;
+};
+
+/**
+ * Bridge implementation for VS Code webviews.
+ *
+ * Uses postMessage with correlation IDs for request/response RPC.
+ * The extension host panel class handles the other side of the
+ * message channel.
+ */
+export class VsCodeBridge implements EEBridge {
+    private _nextId = 1;
+    private _pending = new Map<number, { resolve: (v: unknown) => void; reject: (e: Error) => void }>();
+
+    constructor(private _vscode: VsCodeApi) {
+        window.addEventListener('message', (event: MessageEvent) => {
+            const msg = event.data as { id?: number; result?: unknown; error?: string };
+            if (msg.id !== undefined && this._pending.has(msg.id)) {
+                const handler = this._pending.get(msg.id)!;
+                this._pending.delete(msg.id);
+                if (msg.error) {
+                    handler.reject(new Error(msg.error));
+                } else {
+                    handler.resolve(msg.result);
+                }
+            }
+        });
+    }
+
+    private _request<T>(method: string, params?: Record<string, unknown>): Promise<T> {
+        const id = this._nextId++;
+        return new Promise<T>((resolve, reject) => {
+            this._pending.set(id, {
+                resolve: resolve as (v: unknown) => void,
+                reject,
+            });
+            this._vscode.postMessage({ id, method, params });
+        });
+    }
+
+    async openFile(path: string): Promise<void> {
+        return this._request('openFile', { path });
+    }
+
+    showToast(message: string): void {
+        this._vscode.postMessage({ method: 'showToast', params: { message } });
+    }
+
+    getResolvedTheme(): 'light' | 'dark' {
+        const el = document.documentElement;
+        return el.classList.contains('vscode-light') ? 'light' : 'dark';
+    }
+
+    async saveViewSettings(settings: { zoom?: number; theme?: string }): Promise<void> {
+        return this._request('saveViewSettings', settings);
+    }
+
+    async getInfo(eeName: string): Promise<EEInfo> {
+        return this._request('getInfo', { eeName });
+    }
+
+    async getCollections(eeName: string): Promise<EECollection[]> {
+        return this._request('getCollections', { eeName });
+    }
+
+    async getPythonPackages(eeName: string): Promise<EEPythonPackage[]> {
+        return this._request('getPythonPackages', { eeName });
+    }
+
+    async getSystemPackages(eeName: string): Promise<EEPackage[]> {
+        return this._request('getSystemPackages', { eeName });
+    }
+}

--- a/src/panels/tsconfig.webview.json
+++ b/src/panels/tsconfig.webview.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "target": "ES2020",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "paths": {
+      "@ansible/ui": ["../../packages/ui/src"],
+      "@src/*": ["../*"]
+    },
+    "types": [],
+    "noEmit": true
+  },
+  "include": [
+    "webview-entry.tsx",
+    "webview.d.ts",
+    "bridges/**/*"
+  ]
+}

--- a/src/panels/webview-entry.tsx
+++ b/src/panels/webview-entry.tsx
@@ -1,0 +1,35 @@
+/**
+ * Webview entry point bundled by esbuild into dist/webview.js.
+ *
+ * This module runs inside the VS Code webview iframe. It reads the
+ * data-view and data-props attributes from the root element, selects
+ * the appropriate shared React component, provides a VS Code bridge
+ * implementation, and mounts the app.
+ */
+import { createRoot } from 'react-dom/client';
+import { BridgeProvider, EEDetailView } from '@ansible/ui';
+import { VsCodeBridge } from './bridges/VsCodeBridge';
+
+const vscode = acquireVsCodeApi();
+const bridge = new VsCodeBridge(vscode);
+
+const root = document.getElementById('root');
+if (!root) throw new Error('Missing #root element');
+
+const viewName = root.dataset.view;
+const props = JSON.parse(root.dataset.props ?? '{}') as Record<string, unknown>;
+
+function App() {
+    switch (viewName) {
+        case 'ee-detail':
+            return (
+                <BridgeProvider value={bridge}>
+                    <EEDetailView eeName={props.eeName as string} />
+                </BridgeProvider>
+            );
+        default:
+            return <div>Unknown view: {viewName}</div>;
+    }
+}
+
+createRoot(root).render(<App />);

--- a/src/panels/webview.d.ts
+++ b/src/panels/webview.d.ts
@@ -1,0 +1,9 @@
+/**
+ * Type declarations for the VS Code webview runtime.
+ * acquireVsCodeApi() is injected by VS Code into the webview iframe.
+ */
+declare function acquireVsCodeApi(): {
+    postMessage(message: unknown): void;
+    getState(): unknown;
+    setState(state: unknown): void;
+};

--- a/src/views/ExecutionEnvironmentsProvider.ts
+++ b/src/views/ExecutionEnvironmentsProvider.ts
@@ -55,6 +55,11 @@ class EENode extends vscode.TreeItem {
         this.tooltip.appendMarkdown(`- Created: ${ee.created}\n`);
         this.iconPath = new vscode.ThemeIcon('package');
         this.contextValue = 'executionEnvironment';
+        this.command = {
+            command: 'ansibleExecutionEnvironments.showDetail',
+            title: 'Show Details',
+            arguments: [ee.full_name],
+        };
     }
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,7 @@
     "declarationMap": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", ".vscode-test", "packages"],
+  "exclude": ["node_modules", ".vscode-test", "packages", "src/panels/webview-entry.tsx", "src/panels/bridges", "src/panels/webview.d.ts"],
   "ts-node": {
     "compilerOptions": {
       "types": ["node", "mocha"]


### PR DESCRIPTION
## Summary
- Introduce `@ansible/ui` — a shared React component library with host-agnostic bridge abstraction, semantic CSS tokens, and reusable view components
- Wire the first shared view (EE detail) into the VS Code extension via a new webview panel with postMessage RPC
- Establish the architectural foundation (ADR-010) for migrating plugin docs, creator forms, and playbook views in follow-up PRs

## Changes
- **`packages/ui/`**: New package with `HostBridgeCore` / `EEBridge` interfaces, `BridgeProvider` React context, `useBridge()` hook, semantic `--ui-*` CSS tokens, VS Code host adapter (`--vscode-*` → `--host-*`), and components: `EEDetailView`, `PackageList`, `TabBar`, `InfoList`
- **`scripts/build.mjs`**: Added `webview` esbuild target (IIFE, browser platform, JSX) producing `dist/webview.js`
- **`src/panels/EEDetailPanel.ts`**: VS Code webview panel host with correlation-ID postMessage RPC dispatching to `ExecutionEnvService`
- **`src/panels/bridges/VsCodeBridge.ts`**: `EEBridge` implementation for the webview side
- **`src/panels/webview-entry.tsx`**: Browser-side React mount point; reads `data-view`/`data-props` from root element
- **`src/views/ExecutionEnvironmentsProvider.ts`**: EE tree nodes now open the detail webview on click
- **`src/extension.ts`**: Registered `ansibleExecutionEnvironments.showDetail` command
- **`tsconfig.json`**: Excluded browser-only webview files; added `src/panels/tsconfig.webview.json` for separate type-checking
- **`eslint.config.mjs`**: Excluded webview browser files and `packages/ui/vite.config.ts` from Node-targeted ESLint project service

## Quality of life
- **ADR-010**: Documents the shared UI architecture, HostBridge abstraction, CSS token layer, and webview bundling approach
- **ADR-005**: Added invariants 9 (domain views live in `@ansible/ui`) and 10 (shared components never import host-specific modules)
- **ADR-001**: Updated neutral consequence to cross-reference ADR-010

## Test plan
- [x] `npm exec eslint -- .` passes
- [x] `npm exec tsc -- -b` compiles cleanly
- [x] `npm exec vitest -- run` passes (488/488)
- [x] `npm run build` produces all 4 bundles (extension, language-server, mcp-server, webview)
- [x] `packages/ui` typechecks independently (`npx tsc --noEmit`)
- [x] `src/panels/tsconfig.webview.json` typechecks independently