### PR TITLE
feat(panels): add per-package detail views for EE browsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -370,6 +370,10 @@
         "title": "Show Execution Environment Details"
       },
       {
+        "command": "ansibleExecutionEnvironments.showPackageDetail",
+        "title": "Show Package Details"
+      },
+      {
         "command": "ansibleExecutionEnvironments.aiSummary",
         "title": "AI Summary",
         "icon": "$(sparkle)"

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -33,7 +33,12 @@ export {
 export type { CachedEnvironment } from './services/EnvironmentCache';
 
 export { ExecutionEnvService } from './services/ExecutionEnvService';
-export type { ExecutionEnvironment, EEDetails } from './services/ExecutionEnvService';
+export type {
+    ExecutionEnvironment,
+    EEDetails,
+    PythonPackageDetail,
+    SystemPackageDetail,
+} from './services/ExecutionEnvService';
 
 export { EECache } from './services/EECache';
 export type { CacheIndex, CacheIndexEntry } from './services/EECache';

--- a/packages/core/src/services/ExecutionEnvService.ts
+++ b/packages/core/src/services/ExecutionEnvService.ts
@@ -39,13 +39,30 @@ export interface EEDetails {
         details: string;
     };
     system_packages?: {
-        details: Record<string, string>[];
+        details: {
+            name: string;
+            version: string;
+            release?: string;
+            architecture?: string;
+            description?: string;
+            size?: string;
+            license?: string;
+            url?: string;
+            [key: string]: string | undefined;
+        }[];
     };
     python_packages?: {
         details: {
             name: string;
             version: string;
             summary?: string;
+            'home-page'?: string;
+            author?: string;
+            'author-email'?: string;
+            license?: string;
+            location?: string;
+            requires?: string[];
+            'required-by'?: string[];
         }[];
     };
     os_release?: {
@@ -545,6 +562,102 @@ export class ExecutionEnvService {
 
         return info;
     }
+
+    /**
+     * Get detailed metadata for a single Python package in an EE.
+     *
+     * @param fullName - Full image name to inspect.
+     * @param packageName - Python package name (case-insensitive match).
+     * @returns Detailed package metadata or undefined if not found.
+     */
+    public async getPythonPackageDetail(
+        fullName: string,
+        packageName: string,
+    ): Promise<PythonPackageDetail | undefined> {
+        const details = await this.loadDetails(fullName);
+        if (!details?.python_packages?.details) {
+            return undefined;
+        }
+
+        const lower = packageName.toLowerCase();
+        const pkg = details.python_packages.details.find((p) => p.name.toLowerCase() === lower);
+        if (!pkg) return undefined;
+
+        return {
+            name: pkg.name,
+            version: pkg.version,
+            summary: pkg.summary ?? '',
+            license: pkg.license ?? '',
+            homepage: pkg['home-page'] ?? '',
+            author: pkg.author ?? '',
+            authorEmail: pkg['author-email'] ?? '',
+            location: pkg.location ?? '',
+            requires: pkg.requires ?? [],
+            requiredBy: pkg['required-by'] ?? [],
+        };
+    }
+
+    /**
+     * Get detailed metadata for a single system package in an EE.
+     *
+     * @param fullName - Full image name to inspect.
+     * @param packageName - System package name (case-insensitive match).
+     * @returns Detailed package metadata or undefined if not found.
+     */
+    public async getSystemPackageDetail(
+        fullName: string,
+        packageName: string,
+    ): Promise<SystemPackageDetail | undefined> {
+        const details = await this.loadDetails(fullName);
+        if (!details?.system_packages?.details) {
+            return undefined;
+        }
+
+        const lower = packageName.toLowerCase();
+        const pkg = details.system_packages.details.find((p) => p.name.toLowerCase() === lower);
+        if (!pkg) return undefined;
+
+        return {
+            name: pkg.name,
+            version: pkg.version,
+            release: pkg.release ?? '',
+            arch: pkg.architecture ?? '',
+            description: pkg.description ?? '',
+            size: pkg.size ?? '',
+            license: pkg.license ?? '',
+            url: pkg.url ?? '',
+        };
+    }
+}
+
+/**
+ * Detailed metadata for a single Python package inside an EE.
+ */
+export interface PythonPackageDetail {
+    name: string;
+    version: string;
+    summary: string;
+    license: string;
+    homepage: string;
+    author: string;
+    authorEmail: string;
+    location: string;
+    requires: string[];
+    requiredBy: string[];
+}
+
+/**
+ * Detailed metadata for a single system package inside an EE.
+ */
+export interface SystemPackageDetail {
+    name: string;
+    version: string;
+    release: string;
+    arch: string;
+    description: string;
+    size: string;
+    license: string;
+    url: string;
 }
 
 /**

--- a/packages/core/test/services/ExecutionEnvService.test.ts
+++ b/packages/core/test/services/ExecutionEnvService.test.ts
@@ -108,15 +108,46 @@ const INTROSPECTION_JSON = JSON.stringify({
     },
     python_packages: {
         details: [
-            { name: 'ansible-core', version: '2.19.0', summary: 'Ansible' },
-            { name: 'jinja2', version: '3.1.4' },
+            {
+                name: 'ansible-core',
+                version: '2.19.0',
+                summary: 'Ansible',
+                license: 'GPL-3.0',
+                'home-page': 'https://ansible.com',
+                author: 'Ansible',
+                'author-email': 'info@ansible.com',
+                location: '/usr/lib/python3.11/site-packages',
+                requires: ['jinja2', 'PyYAML'],
+                'required-by': [],
+            },
+            {
+                name: 'jinja2',
+                version: '3.1.4',
+                summary: 'Template engine',
+                requires: ['MarkupSafe'],
+                'required-by': ['ansible-core'],
+            },
         ],
         errors: [],
     },
     system_packages: {
         details: [
-            { name: 'bash', version: '5.2.26', release: '1.el9' },
-            { name: 'openssl', version: '3.2.1', release: '2.el9' },
+            {
+                name: 'bash',
+                version: '5.2.26',
+                release: '1.el9',
+                architecture: 'x86_64',
+                description: 'GNU Bourne Again shell',
+                size: '7.5M',
+                license: 'GPLv3+',
+                url: 'https://www.gnu.org/software/bash',
+            },
+            {
+                name: 'openssl',
+                version: '3.2.1',
+                release: '2.el9',
+                architecture: 'x86_64',
+            },
         ],
         errors: [],
     },
@@ -259,7 +290,7 @@ describe('ExecutionEnvService', () => {
             expect(details?.ansible_collections?.details['ansible.builtin']).toBe('2.19.0');
             expect(details?.os_release?.details[0]['pretty-name']).toBe('RHEL 9.4');
             expect(details?.python_packages?.details).toHaveLength(2);
-            expect(details?.system_packages?.details).toEqual([
+            expect(details?.system_packages?.details).toMatchObject([
                 { name: 'bash', version: '5.2.26', release: '1.el9' },
                 { name: 'openssl', version: '3.2.1', release: '2.el9' },
             ]);
@@ -327,7 +358,7 @@ describe('ExecutionEnvService', () => {
             const svc = ExecutionEnvService.getInstance();
             await svc.loadExecutionEnvironments();
             const pkgs = await svc.getPythonPackages('quay.io/ansible/ee-supported:latest');
-            expect(pkgs).toEqual([
+            expect(pkgs).toMatchObject([
                 { name: 'ansible-core', version: '2.19.0', summary: 'Ansible' },
                 { name: 'jinja2', version: '3.1.4' },
             ]);
@@ -429,6 +460,153 @@ describe('ExecutionEnvService', () => {
             await svc.loadExecutionEnvironments();
             const ee = svc.getExecutionEnvironment('quay.io/ansible/ee-supported:latest');
             expect(ee?.image_id).toBe('sha256:aaa111');
+        });
+    });
+
+    describe('getPythonPackageDetail', () => {
+        it('returns full metadata for a known package (case-insensitive)', async () => {
+            setupDefaultMocks();
+            containerMocks.runInContainer.mockResolvedValue(INTROSPECTION_JSON);
+
+            const svc = ExecutionEnvService.getInstance();
+            await svc.loadExecutionEnvironments();
+            const detail = await svc.getPythonPackageDetail(
+                'quay.io/ansible/ee-supported:latest',
+                'Ansible-Core',
+            );
+
+            expect(detail).toMatchObject({
+                name: 'ansible-core',
+                version: '2.19.0',
+                summary: 'Ansible',
+                license: 'GPL-3.0',
+                homepage: 'https://ansible.com',
+                author: 'Ansible',
+                requires: ['jinja2', 'PyYAML'],
+                requiredBy: [],
+                location: '/usr/lib/python3.11/site-packages',
+            });
+        });
+
+        it('returns undefined for an unknown package', async () => {
+            setupDefaultMocks();
+            containerMocks.runInContainer.mockResolvedValue(INTROSPECTION_JSON);
+
+            const svc = ExecutionEnvService.getInstance();
+            await svc.loadExecutionEnvironments();
+            const detail = await svc.getPythonPackageDetail(
+                'quay.io/ansible/ee-supported:latest',
+                'nonexistent-pkg',
+            );
+            expect(detail).toBeUndefined();
+        });
+
+        it('returns undefined when python_packages section is missing', async () => {
+            setupDefaultMocks();
+            containerMocks.runInContainer.mockResolvedValue(
+                JSON.stringify({ errors: [], image_name: 'x' }),
+            );
+
+            const svc = ExecutionEnvService.getInstance();
+            await svc.loadExecutionEnvironments();
+            const detail = await svc.getPythonPackageDetail(
+                'quay.io/ansible/ee-supported:latest',
+                'ansible-core',
+            );
+            expect(detail).toBeUndefined();
+        });
+
+        it('defaults optional fields to empty strings/arrays', async () => {
+            setupDefaultMocks();
+            containerMocks.runInContainer.mockResolvedValue(INTROSPECTION_JSON);
+
+            const svc = ExecutionEnvService.getInstance();
+            await svc.loadExecutionEnvironments();
+            const detail = await svc.getPythonPackageDetail(
+                'quay.io/ansible/ee-supported:latest',
+                'jinja2',
+            );
+
+            expect(detail).toMatchObject({
+                name: 'jinja2',
+                license: '',
+                homepage: '',
+                author: '',
+                location: '',
+            });
+        });
+    });
+
+    describe('getSystemPackageDetail', () => {
+        it('returns full metadata for a known package (case-insensitive)', async () => {
+            setupDefaultMocks();
+            containerMocks.runInContainer.mockResolvedValue(INTROSPECTION_JSON);
+
+            const svc = ExecutionEnvService.getInstance();
+            await svc.loadExecutionEnvironments();
+            const detail = await svc.getSystemPackageDetail(
+                'quay.io/ansible/ee-supported:latest',
+                'BASH',
+            );
+
+            expect(detail).toMatchObject({
+                name: 'bash',
+                version: '5.2.26',
+                release: '1.el9',
+                arch: 'x86_64',
+                description: 'GNU Bourne Again shell',
+                size: '7.5M',
+                license: 'GPLv3+',
+                url: 'https://www.gnu.org/software/bash',
+            });
+        });
+
+        it('returns undefined for an unknown package', async () => {
+            setupDefaultMocks();
+            containerMocks.runInContainer.mockResolvedValue(INTROSPECTION_JSON);
+
+            const svc = ExecutionEnvService.getInstance();
+            await svc.loadExecutionEnvironments();
+            const detail = await svc.getSystemPackageDetail(
+                'quay.io/ansible/ee-supported:latest',
+                'nonexistent-pkg',
+            );
+            expect(detail).toBeUndefined();
+        });
+
+        it('returns undefined when system_packages section is missing', async () => {
+            setupDefaultMocks();
+            containerMocks.runInContainer.mockResolvedValue(
+                JSON.stringify({ errors: [], image_name: 'x' }),
+            );
+
+            const svc = ExecutionEnvService.getInstance();
+            await svc.loadExecutionEnvironments();
+            const detail = await svc.getSystemPackageDetail(
+                'quay.io/ansible/ee-supported:latest',
+                'bash',
+            );
+            expect(detail).toBeUndefined();
+        });
+
+        it('defaults optional fields to empty strings', async () => {
+            setupDefaultMocks();
+            containerMocks.runInContainer.mockResolvedValue(INTROSPECTION_JSON);
+
+            const svc = ExecutionEnvService.getInstance();
+            await svc.loadExecutionEnvironments();
+            const detail = await svc.getSystemPackageDetail(
+                'quay.io/ansible/ee-supported:latest',
+                'openssl',
+            );
+
+            expect(detail).toMatchObject({
+                name: 'openssl',
+                description: '',
+                size: '',
+                license: '',
+                url: '',
+            });
         });
     });
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -10,8 +10,7 @@
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
     },
-    "./styles/tokens.css": "./dist/styles/tokens.css",
-    "./styles/vscode-host.css": "./dist/styles/vscode-host.css"
+    "./styles/*": "./src/styles/*"
   },
   "license": "MIT",
   "engines": {

--- a/packages/ui/src/bridge/ee.ts
+++ b/packages/ui/src/bridge/ee.ts
@@ -22,6 +22,30 @@ export interface EEInfo {
     image?: string;
 }
 
+export interface PythonPackageDetail {
+    name: string;
+    version: string;
+    summary: string;
+    license: string;
+    homepage: string;
+    author: string;
+    authorEmail: string;
+    location: string;
+    requires: string[];
+    requiredBy: string[];
+}
+
+export interface SystemPackageDetail {
+    name: string;
+    version: string;
+    release: string;
+    arch: string;
+    description: string;
+    size: string;
+    license: string;
+    url: string;
+}
+
 /**
  * Bridge contract for execution environment detail views.
  * Host implementations fetch data from @ansible/core services
@@ -32,4 +56,13 @@ export interface EEBridge extends HostBridgeCore {
     getCollections(eeName: string): Promise<EECollection[]>;
     getPythonPackages(eeName: string): Promise<EEPythonPackage[]>;
     getSystemPackages(eeName: string): Promise<EEPackage[]>;
+    getPythonPackageDetail(
+        eeName: string,
+        packageName: string,
+    ): Promise<PythonPackageDetail | undefined>;
+    getSystemPackageDetail(
+        eeName: string,
+        packageName: string,
+    ): Promise<SystemPackageDetail | undefined>;
+    openPackageDetail(eeName: string, packageName: string, packageType: 'python' | 'system'): void;
 }

--- a/packages/ui/src/components/PackageList.tsx
+++ b/packages/ui/src/components/PackageList.tsx
@@ -11,6 +11,7 @@ interface PackageListProps {
     packages: PackageItem[];
     title: string;
     icon?: string;
+    onSelect?: (packageName: string) => void;
 }
 
 const styles: Record<string, CSSProperties> = {
@@ -40,6 +41,9 @@ const styles: Record<string, CSSProperties> = {
         alignItems: 'baseline',
         padding: '4px 12px',
         borderBottom: '1px solid var(--ui-border)',
+    },
+    rowClickable: {
+        cursor: 'pointer',
     },
     rowAlt: {
         background: 'var(--ui-bg-surface)',
@@ -81,9 +85,10 @@ const styles: Record<string, CSSProperties> = {
  * @param root0 - Component props.
  * @param root0.packages - Array of package items to display.
  * @param root0.title - Heading label for the list (e.g. "System Packages").
+ * @param root0.onSelect - Optional callback when a package row is clicked.
  * @returns The rendered package list.
  */
-export function PackageList({ packages, title }: PackageListProps) {
+export function PackageList({ packages, title, onSelect }: PackageListProps) {
     const [filter, setFilter] = useState('');
 
     const filtered = useMemo(() => {
@@ -122,7 +127,30 @@ export function PackageList({ packages, title }: PackageListProps) {
                 filtered.map((pkg, i) => (
                     <div
                         key={pkg.name}
-                        style={{ ...styles.row, ...(i % 2 === 1 ? styles.rowAlt : {}) }}
+                        role={onSelect ? 'button' : undefined}
+                        tabIndex={onSelect ? 0 : undefined}
+                        style={{
+                            ...styles.row,
+                            ...(i % 2 === 1 ? styles.rowAlt : {}),
+                            ...(onSelect ? styles.rowClickable : {}),
+                        }}
+                        onClick={
+                            onSelect
+                                ? () => {
+                                      onSelect(pkg.name);
+                                  }
+                                : undefined
+                        }
+                        onKeyDown={
+                            onSelect
+                                ? (e) => {
+                                      if (e.key === 'Enter' || e.key === ' ') {
+                                          e.preventDefault();
+                                          onSelect(pkg.name);
+                                      }
+                                  }
+                                : undefined
+                        }
                     >
                         <div>
                             <span style={styles.name}>{pkg.name}</span>

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,8 +1,18 @@
 export { BridgeProvider, useBridge } from './bridge/context';
 export type { HostBridgeCore, Disposable } from './bridge/core';
-export type { EEBridge, EEPackage, EEPythonPackage, EECollection, EEInfo } from './bridge/ee';
+export type {
+    EEBridge,
+    EEPackage,
+    EEPythonPackage,
+    EECollection,
+    EEInfo,
+    PythonPackageDetail,
+    SystemPackageDetail,
+} from './bridge/ee';
 
 export { EEDetailView } from './views/EEDetailView';
+export { PythonPackageDetailView } from './views/PythonPackageDetailView';
+export { SystemPackageDetailView } from './views/SystemPackageDetailView';
 export { PackageList } from './components/PackageList';
 export type { PackageItem } from './components/PackageList';
 export { TabBar } from './components/TabBar';

--- a/packages/ui/src/views/EEDetailView.tsx
+++ b/packages/ui/src/views/EEDetailView.tsx
@@ -125,10 +125,22 @@ export function EEDetailView({ eeName }: EEDetailViewProps) {
                     <PackageList packages={data.collections} title="Ansible Collections" />
                 )}
                 {activeTab === 'python' && (
-                    <PackageList packages={data.pythonPackages} title="Python Packages" />
+                    <PackageList
+                        packages={data.pythonPackages}
+                        title="Python Packages"
+                        onSelect={(name) => {
+                            bridge.openPackageDetail(eeName, name, 'python');
+                        }}
+                    />
                 )}
                 {activeTab === 'system' && (
-                    <PackageList packages={data.systemPackages} title="System Packages" />
+                    <PackageList
+                        packages={data.systemPackages}
+                        title="System Packages"
+                        onSelect={(name) => {
+                            bridge.openPackageDetail(eeName, name, 'system');
+                        }}
+                    />
                 )}
             </TabBar>
         </div>

--- a/packages/ui/src/views/PythonPackageDetailView.tsx
+++ b/packages/ui/src/views/PythonPackageDetailView.tsx
@@ -1,0 +1,247 @@
+import { useState, useEffect, useCallback } from 'react';
+import type { CSSProperties } from 'react';
+import { useBridge } from '../bridge/context';
+import type { EEBridge, PythonPackageDetail } from '../bridge/ee';
+import { InfoList } from '../components/InfoList';
+import type { InfoItem } from '../components/InfoList';
+
+interface PythonPackageDetailViewProps {
+    eeName: string;
+    packageName: string;
+}
+
+const styles: Record<string, CSSProperties> = {
+    container: {
+        display: 'flex',
+        flexDirection: 'column',
+        height: '100%',
+        background: 'var(--ui-bg-primary)',
+        overflow: 'auto',
+    },
+    header: {
+        padding: '16px',
+        borderBottom: '1px solid var(--ui-border)',
+    },
+    title: {
+        fontSize: '16px',
+        fontWeight: 600,
+        fontFamily: 'var(--ui-font-mono)',
+        color: 'var(--ui-text-primary)',
+        margin: 0,
+    },
+    badge: {
+        display: 'inline-block',
+        marginLeft: 8,
+        padding: '2px 8px',
+        fontSize: '12px',
+        fontFamily: 'var(--ui-font-mono)',
+        color: 'var(--ui-text-secondary)',
+        background: 'var(--ui-bg-surface)',
+        border: '1px solid var(--ui-border)',
+        borderRadius: 3,
+    },
+    summary: {
+        marginTop: 8,
+        fontSize: '13px',
+        color: 'var(--ui-text-secondary)',
+        lineHeight: 1.5,
+    },
+    section: {
+        padding: '12px 16px',
+        borderBottom: '1px solid var(--ui-border)',
+    },
+    sectionTitle: {
+        fontSize: '12px',
+        fontWeight: 600,
+        color: 'var(--ui-text-secondary)',
+        textTransform: 'uppercase' as const,
+        letterSpacing: '0.5px',
+        marginBottom: 8,
+    },
+    depList: {
+        display: 'flex',
+        flexWrap: 'wrap',
+        gap: 6,
+        padding: 0,
+        margin: 0,
+        listStyle: 'none',
+    },
+    depItem: {
+        padding: '2px 8px',
+        fontSize: '12px',
+        fontFamily: 'var(--ui-font-mono)',
+        color: 'var(--ui-text-primary)',
+        background: 'var(--ui-bg-surface)',
+        border: '1px solid var(--ui-border)',
+        borderRadius: 3,
+        cursor: 'pointer',
+    },
+    link: {
+        color: 'var(--ui-text-link)',
+        textDecoration: 'none',
+        fontSize: '12px',
+        fontFamily: 'var(--ui-font-mono)',
+    },
+    loading: {
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: '48px 16px',
+        color: 'var(--ui-text-secondary)',
+        fontSize: '13px',
+    },
+    error: {
+        padding: '16px',
+        color: 'var(--ui-error)',
+        fontSize: '13px',
+    },
+    emptyDeps: {
+        fontSize: '12px',
+        color: 'var(--ui-text-muted)',
+        fontStyle: 'italic',
+    },
+};
+
+/**
+ * Detail view for a single Python package inside an execution environment.
+ * @param root0 - Component props.
+ * @param root0.eeName - Full image name of the execution environment.
+ * @param root0.packageName - Name of the Python package to display.
+ * @returns The rendered Python package detail view.
+ */
+export function PythonPackageDetailView({ eeName, packageName }: PythonPackageDetailViewProps) {
+    const bridge = useBridge() as EEBridge;
+    const [data, setData] = useState<PythonPackageDetail | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+
+    const loadData = useCallback(async () => {
+        setLoading(true);
+        setError(null);
+        try {
+            const detail = await bridge.getPythonPackageDetail(eeName, packageName);
+            if (!detail) {
+                setError(`Package "${packageName}" not found`);
+            } else {
+                setData(detail);
+            }
+        } catch (err) {
+            setError(err instanceof Error ? err.message : String(err));
+        } finally {
+            setLoading(false);
+        }
+    }, [bridge, eeName, packageName]);
+
+    useEffect(() => {
+        void loadData();
+    }, [loadData]);
+
+    if (loading) {
+        return <div style={styles.loading}>Loading package details…</div>;
+    }
+
+    if (error) {
+        return <div style={styles.error}>Error: {error}</div>;
+    }
+
+    if (!data) {
+        return <div style={styles.loading}>No data available</div>;
+    }
+
+    const metadata: InfoItem[] = [];
+    if (data.author) metadata.push({ label: 'Author', value: data.author });
+    if (data.license) metadata.push({ label: 'License', value: data.license });
+    if (data.location) metadata.push({ label: 'Location', value: data.location });
+
+    return (
+        <div style={styles.container} className="ansible-ui">
+            <div style={styles.header}>
+                <h2 style={styles.title}>
+                    {data.name}
+                    <span style={styles.badge}>{data.version}</span>
+                </h2>
+                {data.summary && <div style={styles.summary}>{data.summary}</div>}
+            </div>
+
+            {(metadata.length > 0 || data.homepage) && (
+                <div style={styles.section}>
+                    <div style={styles.sectionTitle}>Metadata</div>
+                    <InfoList items={metadata} />
+                    {data.homepage && (
+                        <div style={{ padding: '6px 12px' }}>
+                            <a
+                                href={data.homepage}
+                                style={styles.link}
+                                title={data.homepage}
+                                target="_blank"
+                                rel="noreferrer"
+                            >
+                                {data.homepage}
+                            </a>
+                        </div>
+                    )}
+                </div>
+            )}
+
+            <div style={styles.section}>
+                <div style={styles.sectionTitle}>Dependencies ({String(data.requires.length)})</div>
+                {data.requires.length > 0 ? (
+                    <ul style={styles.depList}>
+                        {data.requires.map((dep) => (
+                            <li
+                                key={dep}
+                                style={styles.depItem}
+                                role="button"
+                                tabIndex={0}
+                                onClick={() => {
+                                    bridge.openPackageDetail(eeName, dep, 'python');
+                                }}
+                                onKeyDown={(e) => {
+                                    if (e.key === 'Enter' || e.key === ' ') {
+                                        e.preventDefault();
+                                        bridge.openPackageDetail(eeName, dep, 'python');
+                                    }
+                                }}
+                            >
+                                {dep}
+                            </li>
+                        ))}
+                    </ul>
+                ) : (
+                    <span style={styles.emptyDeps}>No dependencies</span>
+                )}
+            </div>
+
+            <div style={styles.section}>
+                <div style={styles.sectionTitle}>
+                    Required By ({String(data.requiredBy.length)})
+                </div>
+                {data.requiredBy.length > 0 ? (
+                    <ul style={styles.depList}>
+                        {data.requiredBy.map((dep) => (
+                            <li
+                                key={dep}
+                                style={styles.depItem}
+                                role="button"
+                                tabIndex={0}
+                                onClick={() => {
+                                    bridge.openPackageDetail(eeName, dep, 'python');
+                                }}
+                                onKeyDown={(e) => {
+                                    if (e.key === 'Enter' || e.key === ' ') {
+                                        e.preventDefault();
+                                        bridge.openPackageDetail(eeName, dep, 'python');
+                                    }
+                                }}
+                            >
+                                {dep}
+                            </li>
+                        ))}
+                    </ul>
+                ) : (
+                    <span style={styles.emptyDeps}>No reverse dependencies</span>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/packages/ui/src/views/SystemPackageDetailView.tsx
+++ b/packages/ui/src/views/SystemPackageDetailView.tsx
@@ -1,0 +1,167 @@
+import { useState, useEffect, useCallback } from 'react';
+import type { CSSProperties } from 'react';
+import { useBridge } from '../bridge/context';
+import type { EEBridge, SystemPackageDetail } from '../bridge/ee';
+import { InfoList } from '../components/InfoList';
+import type { InfoItem } from '../components/InfoList';
+
+interface SystemPackageDetailViewProps {
+    eeName: string;
+    packageName: string;
+}
+
+const styles: Record<string, CSSProperties> = {
+    container: {
+        display: 'flex',
+        flexDirection: 'column',
+        height: '100%',
+        background: 'var(--ui-bg-primary)',
+        overflow: 'auto',
+    },
+    header: {
+        padding: '16px',
+        borderBottom: '1px solid var(--ui-border)',
+    },
+    title: {
+        fontSize: '16px',
+        fontWeight: 600,
+        fontFamily: 'var(--ui-font-mono)',
+        color: 'var(--ui-text-primary)',
+        margin: 0,
+    },
+    badge: {
+        display: 'inline-block',
+        marginLeft: 8,
+        padding: '2px 8px',
+        fontSize: '12px',
+        fontFamily: 'var(--ui-font-mono)',
+        color: 'var(--ui-text-secondary)',
+        background: 'var(--ui-bg-surface)',
+        border: '1px solid var(--ui-border)',
+        borderRadius: 3,
+    },
+    description: {
+        marginTop: 12,
+        fontSize: '13px',
+        color: 'var(--ui-text-primary)',
+        lineHeight: 1.6,
+        whiteSpace: 'pre-wrap',
+    },
+    section: {
+        padding: '12px 16px',
+        borderBottom: '1px solid var(--ui-border)',
+    },
+    sectionTitle: {
+        fontSize: '12px',
+        fontWeight: 600,
+        color: 'var(--ui-text-secondary)',
+        textTransform: 'uppercase' as const,
+        letterSpacing: '0.5px',
+        marginBottom: 8,
+    },
+    link: {
+        color: 'var(--ui-text-link)',
+        textDecoration: 'none',
+        fontSize: '12px',
+        fontFamily: 'var(--ui-font-mono)',
+    },
+    loading: {
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: '48px 16px',
+        color: 'var(--ui-text-secondary)',
+        fontSize: '13px',
+    },
+    error: {
+        padding: '16px',
+        color: 'var(--ui-error)',
+        fontSize: '13px',
+    },
+};
+
+/**
+ * Detail view for a single system package inside an execution environment.
+ * @param root0 - Component props.
+ * @param root0.eeName - Full image name of the execution environment.
+ * @param root0.packageName - Name of the system package to display.
+ * @returns The rendered system package detail view.
+ */
+export function SystemPackageDetailView({ eeName, packageName }: SystemPackageDetailViewProps) {
+    const bridge = useBridge() as EEBridge;
+    const [data, setData] = useState<SystemPackageDetail | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+
+    const loadData = useCallback(async () => {
+        setLoading(true);
+        setError(null);
+        try {
+            const detail = await bridge.getSystemPackageDetail(eeName, packageName);
+            if (!detail) {
+                setError(`Package "${packageName}" not found`);
+            } else {
+                setData(detail);
+            }
+        } catch (err) {
+            setError(err instanceof Error ? err.message : String(err));
+        } finally {
+            setLoading(false);
+        }
+    }, [bridge, eeName, packageName]);
+
+    useEffect(() => {
+        void loadData();
+    }, [loadData]);
+
+    if (loading) {
+        return <div style={styles.loading}>Loading package details…</div>;
+    }
+
+    if (error) {
+        return <div style={styles.error}>Error: {error}</div>;
+    }
+
+    if (!data) {
+        return <div style={styles.loading}>No data available</div>;
+    }
+
+    const metadata: InfoItem[] = [];
+    if (data.arch) metadata.push({ label: 'Architecture', value: data.arch });
+    if (data.license) metadata.push({ label: 'License', value: data.license });
+    if (data.size) metadata.push({ label: 'Size', value: data.size });
+    if (data.release) metadata.push({ label: 'Release', value: data.release });
+
+    return (
+        <div style={styles.container} className="ansible-ui">
+            <div style={styles.header}>
+                <h2 style={styles.title}>
+                    {data.name}
+                    <span style={styles.badge}>{data.version}</span>
+                    {data.arch && <span style={styles.badge}>{data.arch}</span>}
+                </h2>
+                {data.description && <div style={styles.description}>{data.description}</div>}
+            </div>
+
+            {(metadata.length > 0 || data.url) && (
+                <div style={styles.section}>
+                    <div style={styles.sectionTitle}>Metadata</div>
+                    <InfoList items={metadata} />
+                    {data.url && (
+                        <div style={{ padding: '6px 12px' }}>
+                            <a
+                                href={data.url}
+                                style={styles.link}
+                                title={data.url}
+                                target="_blank"
+                                rel="noreferrer"
+                            >
+                                {data.url}
+                            </a>
+                        </div>
+                    )}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,6 +18,7 @@ import { PlaybooksProvider } from '@src/views/PlaybooksProvider';
 import { PlaybookConfigPanel } from '@src/panels/PlaybookConfigPanel';
 import { PlaybookProgressPanel } from '@src/panels/PlaybookProgressPanel';
 import { EEDetailPanel } from '@src/panels/EEDetailPanel';
+import { PackageDetailPanel } from '@src/panels/PackageDetailPanel';
 import { PlaybooksService, PlaybookInfo, PlaybookPlay } from '@src/services/PlaybooksService';
 import { TerminalService } from '@src/services/TerminalService';
 import { PythonEnvironmentService } from '@src/services/PythonEnvironmentService';
@@ -700,6 +701,15 @@ export function activate(context: vscode.ExtensionContext) {
         },
     );
     context.subscriptions.push(eeDetailCommand);
+
+    // Open package detail panel
+    const packageDetailCommand = vscode.commands.registerCommand(
+        'ansibleExecutionEnvironments.showPackageDetail',
+        (eeName: string, packageName: string, packageType: 'python' | 'system') => {
+            PackageDetailPanel.show(context.extensionUri, eeName, packageName, packageType);
+        },
+    );
+    context.subscriptions.push(packageDetailCommand);
 
     // AI Summary Commands - Collections
     const collectionsAiSummaryCommand = vscode.commands.registerCommand(

--- a/src/panels/PackageDetailPanel.ts
+++ b/src/panels/PackageDetailPanel.ts
@@ -1,28 +1,32 @@
 import * as vscode from 'vscode';
 import { ExecutionEnvService } from '@ansible/core';
 import { log } from '@src/extension';
-import { PackageDetailPanel } from '@src/panels/PackageDetailPanel';
+
+type PackageType = 'python' | 'system';
 
 /**
- * Webview panel that renders shared EE detail React components.
+ * Webview panel that renders Python or system package detail views.
  *
- * The panel provides a minimal HTML shell that loads the bundled
- * webview.js entry point. All rendering is handled by @ansible/ui
- * components; this class only handles panel lifecycle and bridges
- * postMessage RPC to @ansible/core services.
+ * Reuses the shared webview.js bundle, selecting the appropriate
+ * view via the data-view attribute. Each unique eeName+packageName
+ * combination gets its own panel.
  */
-export class EEDetailPanel {
-    private static _panels = new Map<string, EEDetailPanel>();
+export class PackageDetailPanel {
+    private static _panels = new Map<string, PackageDetailPanel>();
     private _disposables: vscode.Disposable[] = [];
 
     /**
      * @param _panel - The VS Code webview panel instance.
      * @param _eeName - Execution environment image name.
+     * @param _packageName - Package name for detail lookup.
+     * @param _packageType - Whether this is a python or system package.
      * @param _extensionUri - Extension root URI for opening child panels.
      */
     private constructor(
         private readonly _panel: vscode.WebviewPanel,
         private readonly _eeName: string,
+        private readonly _packageName: string,
+        private readonly _packageType: PackageType,
         private readonly _extensionUri: vscode.Uri,
     ) {
         this._panel.onDidDispose(
@@ -42,48 +46,80 @@ export class EEDetailPanel {
     }
 
     /**
-     * Show the EE detail panel for a given image name.
-     * Reuses an existing panel if one is already open for the same image.
+     * Show the package detail panel. Reuses an existing panel for the same package.
      * @param extensionUri - Extension root URI for webview resource resolution.
      * @param eeName - Full image name of the execution environment.
+     * @param packageName - Package name to display.
+     * @param packageType - Whether this is a python or system package.
      */
-    static show(extensionUri: vscode.Uri, eeName: string): void {
-        const existing = EEDetailPanel._panels.get(eeName);
+    static show(
+        extensionUri: vscode.Uri,
+        eeName: string,
+        packageName: string,
+        packageType: PackageType,
+    ): void {
+        const key = `${packageType}:${eeName}:${packageName}`;
+        const existing = PackageDetailPanel._panels.get(key);
         if (existing) {
             existing._panel.reveal();
             return;
         }
 
-        const panel = vscode.window.createWebviewPanel('eeDetail', eeName, vscode.ViewColumn.One, {
-            enableScripts: true,
-            localResourceRoots: [vscode.Uri.joinPath(extensionUri, 'dist')],
-            retainContextWhenHidden: true,
-        });
+        const viewType =
+            packageType === 'python' ? 'python-package-detail' : 'system-package-detail';
+        const icon = packageType === 'python' ? 'symbol-package' : 'archive';
 
-        panel.iconPath = new vscode.ThemeIcon('package');
-        panel.webview.html = EEDetailPanel._getHtml(panel.webview, extensionUri, eeName);
+        const panel = vscode.window.createWebviewPanel(
+            viewType,
+            packageName,
+            vscode.ViewColumn.One,
+            {
+                enableScripts: true,
+                localResourceRoots: [vscode.Uri.joinPath(extensionUri, 'dist')],
+                retainContextWhenHidden: true,
+            },
+        );
 
-        const instance = new EEDetailPanel(panel, eeName, extensionUri);
-        EEDetailPanel._panels.set(eeName, instance);
+        panel.iconPath = new vscode.ThemeIcon(icon);
+        panel.webview.html = PackageDetailPanel._getHtml(
+            panel.webview,
+            extensionUri,
+            eeName,
+            packageName,
+            viewType,
+        );
+
+        const instance = new PackageDetailPanel(
+            panel,
+            eeName,
+            packageName,
+            packageType,
+            extensionUri,
+        );
+        PackageDetailPanel._panels.set(key, instance);
     }
 
     /**
      * Generate the HTML content for the webview panel.
      * @param webview - Webview instance for URI resolution.
      * @param extensionUri - Extension root URI.
-     * @param eeName - EE image name passed as props to the React app.
+     * @param eeName - EE image name.
+     * @param packageName - Package name.
+     * @param viewType - View identifier for the React router.
      * @returns Complete HTML document string.
      */
     private static _getHtml(
         webview: vscode.Webview,
         extensionUri: vscode.Uri,
         eeName: string,
+        packageName: string,
+        viewType: string,
     ): string {
         const scriptUri = webview.asWebviewUri(
             vscode.Uri.joinPath(extensionUri, 'dist', 'webview.js'),
         );
         const nonce = getNonce();
-        const props = JSON.stringify({ eeName });
+        const props = JSON.stringify({ eeName, packageName });
 
         return `<!DOCTYPE html>
 <html lang="en">
@@ -92,7 +128,7 @@ export class EEDetailPanel {
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="Content-Security-Policy"
           content="default-src 'none'; script-src 'nonce-${nonce}'; style-src 'unsafe-inline';">
-    <title>${escapeHtml(eeName)}</title>
+    <title>${escapeHtml(packageName)}</title>
     <style>
         :root {
             --host-bg-primary: var(--vscode-editor-background);
@@ -125,7 +161,7 @@ export class EEDetailPanel {
 </head>
 <body>
     <div id="root"
-         data-view="ee-detail"
+         data-view="${viewType}"
          data-props="${escapeAttr(props)}"></div>
     <script nonce="${nonce}" src="${String(scriptUri)}"></script>
 </body>
@@ -146,6 +182,16 @@ export class EEDetailPanel {
     }): Promise<void> {
         const { id, method, params } = msg;
 
+        if (method === 'showToast') {
+            const text = params?.message;
+            const safeText =
+                typeof text === 'string' ? text : text != null ? JSON.stringify(text) : '';
+            if (safeText) {
+                void vscode.window.showInformationMessage(safeText);
+            }
+            return;
+        }
+
         if (method === 'openPackageDetail') {
             const pkgName = typeof params?.packageName === 'string' ? params.packageName : '';
             const pkgType = params?.packageType === 'system' ? 'system' : 'python';
@@ -160,16 +206,6 @@ export class EEDetailPanel {
             return;
         }
 
-        if (method === 'showToast') {
-            const text = params?.message;
-            const safeText =
-                typeof text === 'string' ? text : text != null ? JSON.stringify(text) : '';
-            if (safeText) {
-                void vscode.window.showInformationMessage(safeText);
-            }
-            return;
-        }
-
         if (id === undefined) return;
 
         try {
@@ -177,7 +213,7 @@ export class EEDetailPanel {
             void this._panel.webview.postMessage({ id, result });
         } catch (err) {
             const errMessage = err instanceof Error ? err.message : String(err);
-            log(`EEDetailPanel: ${method} failed: ${errMessage}`);
+            log(`PackageDetailPanel: ${method} failed: ${errMessage}`);
             void this._panel.webview.postMessage({ id, error: errMessage });
         }
     }
@@ -191,16 +227,14 @@ export class EEDetailPanel {
     private async _dispatch(method: string, params: Record<string, unknown>): Promise<unknown> {
         const svc = ExecutionEnvService.getInstance();
         const eeName = typeof params.eeName === 'string' ? params.eeName : this._eeName;
+        const pkgName =
+            typeof params.packageName === 'string' ? params.packageName : this._packageName;
 
         switch (method) {
-            case 'getInfo':
-                return svc.getInfo(eeName);
-            case 'getCollections':
-                return svc.getCollections(eeName);
-            case 'getPythonPackages':
-                return svc.getPythonPackages(eeName);
-            case 'getSystemPackages':
-                return svc.getSystemPackages(eeName);
+            case 'getPythonPackageDetail':
+                return svc.getPythonPackageDetail(eeName, pkgName);
+            case 'getSystemPackageDetail':
+                return svc.getSystemPackageDetail(eeName, pkgName);
             case 'openFile': {
                 if (typeof params.path !== 'string') {
                     throw new Error('openFile requires a string path parameter');
@@ -219,7 +253,8 @@ export class EEDetailPanel {
      * Clean up panel resources when the webview is closed.
      */
     private _dispose(): void {
-        EEDetailPanel._panels.delete(this._eeName);
+        const key = `${this._packageType}:${this._eeName}:${this._packageName}`;
+        PackageDetailPanel._panels.delete(key);
         for (const d of this._disposables) d.dispose();
         this._disposables.length = 0;
     }

--- a/src/panels/bridges/VsCodeBridge.ts
+++ b/src/panels/bridges/VsCodeBridge.ts
@@ -1,4 +1,12 @@
-import type { EEBridge, EEInfo, EECollection, EEPythonPackage, EEPackage } from '@ansible/ui';
+import type {
+    EEBridge,
+    EEInfo,
+    EECollection,
+    EEPythonPackage,
+    EEPackage,
+    PythonPackageDetail,
+    SystemPackageDetail,
+} from '@ansible/ui';
 
 type VsCodeApi = {
     postMessage(message: unknown): void;
@@ -13,15 +21,22 @@ type VsCodeApi = {
  * The extension host panel class handles the other side of the
  * message channel.
  */
+/** Timeout for RPC requests in milliseconds. */
+const RPC_TIMEOUT_MS = 30_000;
+
 export class VsCodeBridge implements EEBridge {
     private _nextId = 1;
-    private _pending = new Map<number, { resolve: (v: unknown) => void; reject: (e: Error) => void }>();
+    private _pending = new Map<
+        number,
+        { resolve: (v: unknown) => void; reject: (e: Error) => void; timer: ReturnType<typeof setTimeout> }
+    >();
 
     constructor(private _vscode: VsCodeApi) {
         window.addEventListener('message', (event: MessageEvent) => {
             const msg = event.data as { id?: number; result?: unknown; error?: string };
             if (msg.id !== undefined && this._pending.has(msg.id)) {
                 const handler = this._pending.get(msg.id)!;
+                clearTimeout(handler.timer);
                 this._pending.delete(msg.id);
                 if (msg.error) {
                     handler.reject(new Error(msg.error));
@@ -35,9 +50,15 @@ export class VsCodeBridge implements EEBridge {
     private _request<T>(method: string, params?: Record<string, unknown>): Promise<T> {
         const id = this._nextId++;
         return new Promise<T>((resolve, reject) => {
+            const timer = setTimeout(() => {
+                this._pending.delete(id);
+                reject(new Error(`RPC timeout: ${method} (${String(RPC_TIMEOUT_MS)}ms)`));
+            }, RPC_TIMEOUT_MS);
+
             this._pending.set(id, {
                 resolve: resolve as (v: unknown) => void,
                 reject,
+                timer,
             });
             this._vscode.postMessage({ id, method, params });
         });
@@ -74,5 +95,26 @@ export class VsCodeBridge implements EEBridge {
 
     async getSystemPackages(eeName: string): Promise<EEPackage[]> {
         return this._request('getSystemPackages', { eeName });
+    }
+
+    async getPythonPackageDetail(
+        eeName: string,
+        packageName: string,
+    ): Promise<PythonPackageDetail | undefined> {
+        return this._request('getPythonPackageDetail', { eeName, packageName });
+    }
+
+    async getSystemPackageDetail(
+        eeName: string,
+        packageName: string,
+    ): Promise<SystemPackageDetail | undefined> {
+        return this._request('getSystemPackageDetail', { eeName, packageName });
+    }
+
+    openPackageDetail(eeName: string, packageName: string, packageType: 'python' | 'system'): void {
+        this._vscode.postMessage({
+            method: 'openPackageDetail',
+            params: { eeName, packageName, packageType },
+        });
     }
 }

--- a/src/panels/tsconfig.json
+++ b/src/panels/tsconfig.json
@@ -11,6 +11,7 @@
     "forceConsistentCasingInFileNames": true,
     "paths": {
       "@ansible/ui": ["../../packages/ui/src"],
+      "@ansible/ui/*": ["../../packages/ui/src/*"],
       "@src/*": ["../*"]
     },
     "types": [],

--- a/src/panels/webview-entry.tsx
+++ b/src/panels/webview-entry.tsx
@@ -7,8 +7,19 @@
  * implementation, and mounts the app.
  */
 import { createRoot } from 'react-dom/client';
-import { BridgeProvider, EEDetailView } from '@ansible/ui';
+import {
+    BridgeProvider,
+    EEDetailView,
+    PythonPackageDetailView,
+    SystemPackageDetailView,
+} from '@ansible/ui';
 import { VsCodeBridge } from './bridges/VsCodeBridge';
+// esbuild imports CSS as text via loader config; inject at runtime
+import tokensCss from '@ansible/ui/styles/tokens.css';
+
+const style = document.createElement('style');
+style.textContent = tokensCss;
+document.head.appendChild(style);
 
 const vscode = acquireVsCodeApi();
 const bridge = new VsCodeBridge(vscode);
@@ -20,16 +31,30 @@ const viewName = root.dataset.view;
 const props = JSON.parse(root.dataset.props ?? '{}') as Record<string, unknown>;
 
 function App() {
-    switch (viewName) {
-        case 'ee-detail':
-            return (
-                <BridgeProvider value={bridge}>
-                    <EEDetailView eeName={props.eeName as string} />
-                </BridgeProvider>
-            );
-        default:
-            return <div>Unknown view: {viewName}</div>;
-    }
+    const content = (() => {
+        switch (viewName) {
+            case 'ee-detail':
+                return <EEDetailView eeName={props.eeName as string} />;
+            case 'python-package-detail':
+                return (
+                    <PythonPackageDetailView
+                        eeName={props.eeName as string}
+                        packageName={props.packageName as string}
+                    />
+                );
+            case 'system-package-detail':
+                return (
+                    <SystemPackageDetailView
+                        eeName={props.eeName as string}
+                        packageName={props.packageName as string}
+                    />
+                );
+            default:
+                return <div>Unknown view: {viewName}</div>;
+        }
+    })();
+
+    return <BridgeProvider value={bridge}>{content}</BridgeProvider>;
 }
 
 createRoot(root).render(<App />);

--- a/src/panels/webview.d.ts
+++ b/src/panels/webview.d.ts
@@ -7,3 +7,14 @@ declare function acquireVsCodeApi(): {
     getState(): unknown;
     setState(state: unknown): void;
 };
+
+/** CSS files imported as text strings via esbuild loader config. */
+declare module '*.css' {
+    const content: string;
+    export default content;
+}
+
+declare module '@ansible/ui/styles/tokens.css' {
+    const content: string;
+    export default content;
+}

--- a/src/views/ExecutionEnvironmentsProvider.ts
+++ b/src/views/ExecutionEnvironmentsProvider.ts
@@ -105,16 +105,35 @@ class EEDetailItemNode extends vscode.TreeItem {
     /**
      * Create a detail item with optional description and tooltip text.
      * @param label - Primary label shown in the tree
-     * @param description - Optional secondary text shown inline
-     * @param tooltip - Optional hover text with additional detail
+     * @param options - Optional item configuration
+     * @param options.description - Secondary text shown inline
+     * @param options.tooltip - Hover text with additional detail
+     * @param options.eeName - EE image name for opening package detail
+     * @param options.packageType - Package category for opening detail views
      */
-    constructor(label: string, description?: string, tooltip?: string) {
+    constructor(
+        label: string,
+        options?: {
+            description?: string;
+            tooltip?: string;
+            eeName?: string;
+            packageType?: 'python' | 'system';
+        },
+    ) {
         super(label, vscode.TreeItemCollapsibleState.None);
-        this.description = description;
-        if (tooltip) {
-            this.tooltip = tooltip;
+        this.description = options?.description;
+        if (options?.tooltip) {
+            this.tooltip = options.tooltip;
         }
         this.contextValue = 'eeDetailItem';
+
+        if (options?.eeName && options.packageType) {
+            this.command = {
+                command: 'ansibleExecutionEnvironments.showPackageDetail',
+                title: 'Show Package Details',
+                arguments: [options.eeName, label, options.packageType],
+            };
+        }
     }
 }
 
@@ -254,16 +273,20 @@ export class ExecutionEnvironmentsProvider implements vscode.TreeDataProvider<Tr
             // Info category
             const infoItems: EEDetailItemNode[] = [];
             if (details.ansible_version?.details) {
-                infoItems.push(new EEDetailItemNode('Ansible', details.ansible_version.details));
+                infoItems.push(
+                    new EEDetailItemNode('Ansible', {
+                        description: details.ansible_version.details,
+                    }),
+                );
             }
             const osDetails = details.os_release?.details;
             if (osDetails?.[0]) {
                 const os = osDetails[0];
                 const osName = os['pretty-name'] ?? os.name ?? 'Unknown';
-                infoItems.push(new EEDetailItemNode('OS', osName));
+                infoItems.push(new EEDetailItemNode('OS', { description: osName }));
             }
             if (details.image_name) {
-                infoItems.push(new EEDetailItemNode('Image', details.image_name));
+                infoItems.push(new EEDetailItemNode('Image', { description: details.image_name }));
             }
             if (infoItems.length > 0) {
                 categories.push(new EEDetailCategoryNode('Info', infoItems, ee.full_name));
@@ -277,7 +300,7 @@ export class ExecutionEnvironmentsProvider implements vscode.TreeDataProvider<Tr
                 );
 
                 for (const [name, version] of collections) {
-                    collectionItems.push(new EEDetailItemNode(name, version));
+                    collectionItems.push(new EEDetailItemNode(name, { description: version }));
                 }
 
                 if (collectionItems.length > 0) {
@@ -300,7 +323,12 @@ export class ExecutionEnvironmentsProvider implements vscode.TreeDataProvider<Tr
 
                 for (const pkg of packages) {
                     packageItems.push(
-                        new EEDetailItemNode(pkg.name, pkg.version, pkg.summary ?? undefined),
+                        new EEDetailItemNode(pkg.name, {
+                            description: pkg.version,
+                            tooltip: pkg.summary ?? undefined,
+                            eeName: ee.full_name,
+                            packageType: 'python',
+                        }),
                     );
                 }
 
@@ -315,7 +343,12 @@ export class ExecutionEnvironmentsProvider implements vscode.TreeDataProvider<Tr
             const systemPkgs = await this._service.getSystemPackages(ee.full_name);
             if (systemPkgs.length > 0) {
                 const systemItems = systemPkgs.map(
-                    (pkg) => new EEDetailItemNode(pkg.name, pkg.version),
+                    (pkg) =>
+                        new EEDetailItemNode(pkg.name, {
+                            description: pkg.version,
+                            eeName: ee.full_name,
+                            packageType: 'system',
+                        }),
                 );
                 categories.push(
                     new EEDetailCategoryNode('System Packages', systemItems, ee.full_name),
@@ -327,7 +360,11 @@ export class ExecutionEnvironmentsProvider implements vscode.TreeDataProvider<Tr
             log(
                 `ExecutionEnvironmentsProvider: Failed to load EE details: ${error instanceof Error ? error.message : String(error)}`,
             );
-            return [new EEDetailItemNode('Error loading details', '', String(error))];
+            return [
+                new EEDetailItemNode('Error loading details', {
+                    tooltip: String(error),
+                }),
+            ];
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add dedicated webview panels for Python and system package details, accessible from both the EE detail view and the tree view sidebar
- Extend the shared UI bridge and core service layer with per-package introspection methods
- Harden webview communication with CSS token injection, RPC timeouts, and untrusted parameter validation

## Changes
- **`packages/core`**: Add `PythonPackageDetail` and `SystemPackageDetail` types; add `getPythonPackageDetail()` and `getSystemPackageDetail()` accessors to `ExecutionEnvService` that extract details from cached introspection data
- **`packages/core/test`**: Add 8 unit tests for `getPythonPackageDetail` and `getSystemPackageDetail` (case-insensitive lookup, not-found, missing section, optional field defaults); enrich test fixture with full metadata fields
- **`packages/ui`**: Add `PythonPackageDetailView` and `SystemPackageDetailView` shared React components; extend `EEBridge` with `getPythonPackageDetail`, `getSystemPackageDetail`, and `openPackageDetail` methods; make `PackageList` rows clickable via `onSelect` prop; wire `EEDetailView` to navigate to package details
- **`src/panels/PackageDetailPanel.ts`**: New host panel for individual package detail webviews with RPC dispatch to `ExecutionEnvService`
- **`src/panels/EEDetailPanel.ts`**: Handle `openPackageDetail` messages to launch `PackageDetailPanel`; validate untrusted webview params; guard `showToast` against undefined messages
- **`src/panels/bridges/VsCodeBridge.ts`**: Implement new bridge methods; add 30s RPC timeout with cleanup on dispose
- **`src/panels/webview-entry.tsx`**: Route `python-package-detail` and `system-package-detail` view names; inject `tokens.css` into webview `<head>`
- **`src/panels/webview.d.ts`**: Add CSS module declarations for TypeScript
- **`src/panels/tsconfig.json`**: Rename from `tsconfig.webview.json` for IDE auto-discovery; add `@ansible/ui/*` wildcard path
- **`src/views/ExecutionEnvironmentsProvider.ts`**: Attach `showPackageDetail` command to package tree nodes
- **`src/extension.ts`**: Register `ansibleExecutionEnvironments.showPackageDetail` command
- **`package.json`**: Declare new command contribution

### Copilot review fixes (922ec6cc)
- Fix `SystemPackageDetail.version` returning version-release (caused duplication with separate release field)
- Add Space key activation with `preventDefault()` for all `role="button"` elements (package rows, dependency pills)
- Add `target="_blank" rel="noreferrer"` to all webview links (Python homepage, system URL)
- Add 8 unit tests for new `ExecutionEnvService` accessors

## Quality of life
- AI-authored additions: `PythonPackageDetailView.tsx`, `SystemPackageDetailView.tsx`, `PackageDetailPanel.ts` -- new shared UI components and extension host panel for package detail browsing

## Test plan
- [x] `npm exec eslint -- .` passes
- [x] `npm exec tsc -- -b` compiles cleanly
- [x] `npm exec vitest -- run` passes (496/496)
- [ ] `npm run test:ui` passes (manual verification)
- [ ] Click a Python package in EE detail webview → opens package detail panel
- [ ] Click a system package in EE detail webview → opens package detail panel
- [ ] Click a package node in tree view sidebar → opens package detail panel