### PR TITLE
feat(panels): migrate PluginDocPanel to shared React components

### DIFF
--- a/packages/ui/src/bridge/plugin-doc.ts
+++ b/packages/ui/src/bridge/plugin-doc.ts
@@ -1,0 +1,71 @@
+import type { HostBridgeCore } from './core';
+
+export interface PluginOption {
+    description?: string | string[];
+    type?: string;
+    default?: unknown;
+    choices?: string[];
+    required?: boolean;
+    elements?: string;
+    aliases?: string[];
+    suboptions?: Record<string, PluginOption>;
+    version_added?: string;
+}
+
+export interface PluginDoc {
+    author?: string | string[];
+    short_description?: string;
+    description?: string | string[];
+    version_added?: string;
+    notes?: string | string[];
+    options?: Record<string, PluginOption>;
+    requirements?: string | string[];
+    seealso?: { module?: string; description?: string; link?: string; name?: string }[];
+}
+
+export type PluginReturn = Record<
+    string,
+    {
+        description?: string | string[];
+        returned?: string;
+        type?: string;
+        sample?: unknown;
+        contains?: Record<string, unknown>;
+    }
+>;
+
+export interface PluginData {
+    doc?: PluginDoc;
+    examples?: string;
+    return?: PluginReturn;
+}
+
+/**
+ * Bridge contract for plugin documentation views.
+ * Host implementations fetch documentation from CollectionsService
+ * and provide clipboard/chat integration.
+ */
+export interface PluginDocBridge extends HostBridgeCore {
+    /**
+     * Fetch plugin documentation for the given FQCN and plugin type.
+     * @param fqcn - Fully qualified collection name of the plugin
+     * @param pluginType - Ansible plugin type (e.g. module, lookup, callback)
+     * @returns Plugin documentation payload, or null when unavailable
+     */
+    getPluginDoc(fqcn: string, pluginType: string): Promise<PluginData | null>;
+
+    /**
+     * Copy text to the host clipboard.
+     * @param text - Text to copy
+     */
+    copyToClipboard(text: string): Promise<void>;
+
+    /**
+     * Open the host chat interface with an optional pre-filled prompt.
+     * @param prompt - Optional initial prompt text
+     */
+    openChat(prompt?: string): Promise<void>;
+
+    /** Whether AI-assisted features are enabled in the host environment. */
+    enableAiFeatures: boolean;
+}

--- a/packages/ui/src/components/ExamplesView.tsx
+++ b/packages/ui/src/components/ExamplesView.tsx
@@ -1,0 +1,166 @@
+import { useMemo, useState } from 'react';
+import type { CSSProperties } from 'react';
+import { parseExamples } from '../utils/example-parser';
+import { YamlBlock } from './YamlBlock';
+
+interface ExamplesViewProps {
+    examples: string;
+    onCopy?: (text: string) => void;
+}
+
+type ViewMode = 'formatted' | 'raw';
+
+const styles: Record<string, CSSProperties> = {
+    toolbar: {
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        marginBottom: 12,
+    },
+    toggle: {
+        display: 'flex',
+        background: 'var(--ui-bg-surface)',
+        border: '1px solid var(--ui-border)',
+        borderRadius: 4,
+        overflow: 'hidden',
+    },
+    toggleBtn: {
+        background: 'transparent',
+        border: 'none',
+        color: 'var(--ui-text-muted)',
+        padding: '6px 12px',
+        fontSize: '11px',
+        fontFamily: 'var(--ui-font-family)',
+        cursor: 'pointer',
+    },
+    toggleBtnActive: {
+        background: 'var(--ui-bg-active)',
+        color: 'var(--ui-text-primary)',
+    },
+    section: {
+        marginBottom: 16,
+    },
+    header: {
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        background: 'var(--ui-bg-surface)',
+        border: '1px solid var(--ui-border)',
+        borderBottom: 'none',
+        borderRadius: '4px 4px 0 0',
+        padding: '8px 12px',
+    },
+    title: {
+        fontSize: '12px',
+        fontWeight: 600,
+        color: 'var(--ui-text-primary)',
+    },
+    context: {
+        background: 'var(--ui-bg-surface)',
+        border: '1px solid var(--ui-border)',
+        borderTop: 'none',
+        padding: '8px 12px',
+        fontFamily: 'var(--ui-font-mono)',
+        fontSize: '11px',
+        color: 'var(--ui-text-muted)',
+        whiteSpace: 'pre-wrap',
+        lineHeight: 1.5,
+    },
+    contextLabel: {
+        fontSize: '10px',
+        fontWeight: 600,
+        textTransform: 'uppercase' as const,
+        letterSpacing: '0.5px',
+        marginBottom: 4,
+        color: 'var(--ui-text-secondary)',
+    },
+    codeWrapper: {
+        overflow: 'hidden',
+    },
+};
+
+/**
+ * Render plugin examples with formatted section parsing or raw YAML view.
+ * @param root0 - Component props.
+ * @param root0.examples - Raw examples text from plugin documentation.
+ * @param root0.onCopy - Optional callback invoked when example YAML is copied.
+ * @returns The rendered examples view.
+ */
+export function ExamplesView({ examples, onCopy }: ExamplesViewProps) {
+    const sections = useMemo(() => parseExamples(examples), [examples]);
+    const [viewMode, setViewMode] = useState<ViewMode>('formatted');
+
+    if (sections.length === 0) {
+        return <YamlBlock yaml={examples} copyable onCopy={onCopy} />;
+    }
+
+    return (
+        <div>
+            <div style={styles.toolbar}>
+                <div style={styles.toggle}>
+                    <button
+                        type="button"
+                        style={{
+                            ...styles.toggleBtn,
+                            ...(viewMode === 'formatted' ? styles.toggleBtnActive : {}),
+                        }}
+                        onClick={() => {
+                            setViewMode('formatted');
+                        }}
+                    >
+                        Formatted
+                    </button>
+                    <button
+                        type="button"
+                        style={{
+                            ...styles.toggleBtn,
+                            ...(viewMode === 'raw' ? styles.toggleBtnActive : {}),
+                        }}
+                        onClick={() => {
+                            setViewMode('raw');
+                        }}
+                    >
+                        Raw
+                    </button>
+                </div>
+            </div>
+
+            {viewMode === 'raw' ? (
+                <YamlBlock yaml={examples} copyable onCopy={onCopy} />
+            ) : (
+                sections.map((section, index) => (
+                    <div key={index} style={styles.section}>
+                        <div style={styles.header}>
+                            <span style={styles.title}>{section.title}</span>
+                        </div>
+
+                        {section.beforeState && (
+                            <div style={styles.context}>
+                                <div style={styles.contextLabel}>Before state:</div>
+                                {section.beforeState}
+                            </div>
+                        )}
+
+                        <div style={styles.codeWrapper}>
+                            <YamlBlock yaml={section.task} copyable onCopy={onCopy} />
+                        </div>
+
+                        {section.taskOutput && (
+                            <div style={styles.context}>
+                                <div style={styles.contextLabel}>Task Output:</div>
+                                {section.taskOutput}
+                            </div>
+                        )}
+
+                        {section.afterState && (
+                            <div style={styles.context}>
+                                <div style={styles.contextLabel}>After state:</div>
+                                {section.afterState}
+                            </div>
+                        )}
+                    </div>
+                ))
+            )}
+        </div>
+    );
+}

--- a/packages/ui/src/components/ParameterTree.tsx
+++ b/packages/ui/src/components/ParameterTree.tsx
@@ -1,0 +1,228 @@
+import { useState } from 'react';
+import type { CSSProperties, KeyboardEvent } from 'react';
+import type { PluginOption } from '../bridge/plugin-doc';
+import { formatAnsibleMarkup, toArray } from '../utils/ansible-markup';
+import { formatYamlValue } from '../utils/sample-task';
+
+interface ParameterTreeProps {
+    options: Record<string, PluginOption>;
+}
+
+interface ParamItemProps {
+    name: string;
+    opt: PluginOption;
+    depth?: number;
+}
+
+const styles: Record<string, CSSProperties> = {
+    tree: {
+        fontSize: '12px',
+    },
+    item: {
+        borderBottom: '1px solid var(--ui-border)',
+        padding: '8px 0',
+    },
+    header: {
+        display: 'flex',
+        alignItems: 'flex-start',
+        gap: 8,
+        cursor: 'pointer',
+        userSelect: 'none',
+    },
+    headerStatic: {
+        cursor: 'default',
+    },
+    toggle: {
+        width: 14,
+        height: 14,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        fontSize: '10px',
+        color: 'var(--ui-text-muted)',
+        flexShrink: 0,
+        marginTop: 2,
+    },
+    name: {
+        fontFamily: 'var(--ui-font-mono)',
+        fontWeight: 600,
+        color: 'var(--ui-text-primary)',
+    },
+    type: {
+        fontSize: '11px',
+        color: 'var(--ui-text-secondary)',
+        fontFamily: 'var(--ui-font-mono)',
+    },
+    required: {
+        fontSize: '10px',
+        fontWeight: 600,
+        color: 'var(--ui-text-primary)',
+        background: 'var(--ui-error)',
+        padding: '1px 6px',
+        borderRadius: 10,
+        marginLeft: 4,
+    },
+    choices: {
+        marginTop: 4,
+        marginLeft: 22,
+    },
+    choice: {
+        display: 'inline-block',
+        background: 'var(--ui-bg-surface)',
+        border: '1px solid var(--ui-border)',
+        padding: '1px 6px',
+        borderRadius: 3,
+        fontFamily: 'var(--ui-font-mono)',
+        fontSize: '11px',
+        marginRight: 4,
+        marginBottom: 2,
+        color: 'var(--ui-text-primary)',
+    },
+    choiceDefault: {
+        borderColor: 'var(--ui-accent)',
+    },
+    defaultValue: {
+        fontSize: '11px',
+        color: 'var(--ui-text-secondary)',
+        marginTop: 4,
+        marginLeft: 22,
+    },
+    desc: {
+        color: 'var(--ui-text-primary)',
+        marginTop: 4,
+        marginLeft: 22,
+        fontSize: '12px',
+    },
+    descParagraph: {
+        margin: '0 0 4px 0',
+    },
+    suboptions: {
+        marginLeft: 22,
+        marginTop: 8,
+        paddingLeft: 12,
+        borderLeft: '1px solid var(--ui-border)',
+    },
+    empty: {
+        color: 'var(--ui-text-muted)',
+        fontStyle: 'italic',
+        fontSize: '12px',
+    },
+};
+
+/**
+ * Render a single parameter row with collapsible suboptions.
+ * @param root0 - Component props.
+ * @param root0.name - Parameter name.
+ * @param root0.opt - Parameter schema metadata.
+ * @param root0.depth - Nesting depth for suboption indentation.
+ * @returns The rendered parameter item.
+ */
+function ParamItem({ name, opt, depth = 0 }: ParamItemProps) {
+    const [expanded, setExpanded] = useState(false);
+    const hasSuboptions = Boolean(opt.suboptions && Object.keys(opt.suboptions).length > 0);
+
+    const typeStr = opt.type ?? 'str';
+    const elementsStr = opt.elements ? `/${opt.elements}` : '';
+    const indentOffset = depth > 0 ? 0 : 22;
+
+    const toggleExpanded = () => {
+        if (hasSuboptions) {
+            setExpanded((prev) => !prev);
+        }
+    };
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+        if (hasSuboptions && (e.key === 'Enter' || e.key === ' ')) {
+            e.preventDefault();
+            toggleExpanded();
+        }
+    };
+
+    return (
+        <div style={styles.item}>
+            <div
+                style={{
+                    ...styles.header,
+                    ...(!hasSuboptions ? styles.headerStatic : {}),
+                }}
+                role={hasSuboptions ? 'button' : undefined}
+                tabIndex={hasSuboptions ? 0 : undefined}
+                onClick={toggleExpanded}
+                onKeyDown={handleKeyDown}
+            >
+                <span style={styles.toggle}>{hasSuboptions ? (expanded ? '▼' : '▶') : ''}</span>
+                <span style={styles.name}>{name}</span>
+                <span style={styles.type}>
+                    ({typeStr}
+                    {elementsStr})
+                </span>
+                {opt.required && <span style={styles.required}>required</span>}
+            </div>
+
+            {opt.choices && opt.choices.length > 0 && (
+                <div style={{ ...styles.choices, marginLeft: indentOffset }}>
+                    {opt.choices.map((choice) => {
+                        const isDefault = opt.default === choice;
+                        return (
+                            <span
+                                key={choice}
+                                style={{
+                                    ...styles.choice,
+                                    ...(isDefault ? styles.choiceDefault : {}),
+                                }}
+                            >
+                                {choice}
+                            </span>
+                        );
+                    })}
+                </div>
+            )}
+
+            {!opt.choices?.length && opt.default !== undefined && opt.default !== null && (
+                <div style={{ ...styles.defaultValue, marginLeft: indentOffset }}>
+                    default: <code>{formatYamlValue(opt.default)}</code>
+                </div>
+            )}
+
+            <div style={{ ...styles.desc, marginLeft: indentOffset }}>
+                {toArray(opt.description).map((paragraph, i) => (
+                    <p
+                        key={i}
+                        style={styles.descParagraph}
+                        dangerouslySetInnerHTML={{
+                            __html: formatAnsibleMarkup(paragraph),
+                        }}
+                    />
+                ))}
+            </div>
+
+            {hasSuboptions && expanded && (
+                <div style={styles.suboptions}>
+                    <ParameterTree options={opt.suboptions ?? {}} />
+                </div>
+            )}
+        </div>
+    );
+}
+
+/**
+ * Recursive parameter documentation tree with collapsible suboptions.
+ * @param root0 - Component props.
+ * @param root0.options - Parameter schema map for the plugin.
+ * @returns The rendered parameter tree.
+ */
+export function ParameterTree({ options }: ParameterTreeProps) {
+    const entries = Object.entries(options).sort((a, b) => a[0].localeCompare(b[0]));
+
+    if (entries.length === 0) {
+        return <div style={styles.empty}>No parameters</div>;
+    }
+
+    return (
+        <div style={styles.tree}>
+            {entries.map(([name, opt]) => (
+                <ParamItem key={name} name={name} opt={opt} />
+            ))}
+        </div>
+    );
+}

--- a/packages/ui/src/components/ReturnValuesTable.tsx
+++ b/packages/ui/src/components/ReturnValuesTable.tsx
@@ -1,0 +1,93 @@
+import type { CSSProperties } from 'react';
+import type { PluginReturn } from '../bridge/plugin-doc';
+import { formatAnsibleMarkup, toArray } from '../utils/ansible-markup';
+
+interface ReturnValuesTableProps {
+    returnValues: PluginReturn;
+}
+
+const styles: Record<string, CSSProperties> = {
+    tree: {
+        fontSize: '12px',
+    },
+    item: {
+        borderBottom: '1px solid var(--ui-border)',
+        padding: '8px 0',
+    },
+    name: {
+        fontFamily: 'var(--ui-font-mono)',
+        fontWeight: 600,
+        color: 'var(--ui-text-primary)',
+    },
+    meta: {
+        fontSize: '11px',
+        color: 'var(--ui-text-secondary)',
+        marginTop: 2,
+    },
+    desc: {
+        color: 'var(--ui-text-primary)',
+        fontSize: '12px',
+        marginTop: 4,
+    },
+    descParagraph: {
+        margin: '0 0 4px 0',
+    },
+    sample: {
+        background: 'var(--ui-bg-surface)',
+        border: '1px solid var(--ui-border)',
+        padding: '6px 10px',
+        borderRadius: 3,
+        fontFamily: 'var(--ui-font-mono)',
+        fontSize: '11px',
+        marginTop: 6,
+        overflowX: 'auto',
+        whiteSpace: 'pre',
+        color: 'var(--ui-text-primary)',
+    },
+    empty: {
+        color: 'var(--ui-text-muted)',
+        fontStyle: 'italic',
+        fontSize: '12px',
+    },
+};
+
+/**
+ * Render documented return values for a plugin.
+ * @param root0 - Component props.
+ * @param root0.returnValues - Return value schema map from plugin documentation.
+ * @returns The rendered return values table.
+ */
+export function ReturnValuesTable({ returnValues }: ReturnValuesTableProps) {
+    const entries = Object.entries(returnValues);
+
+    if (entries.length === 0) {
+        return <div style={styles.empty}>No return values documented</div>;
+    }
+
+    return (
+        <div style={styles.tree}>
+            {entries.map(([name, val]) => (
+                <div key={name} style={styles.item}>
+                    <div style={styles.name}>{name}</div>
+                    <div style={styles.meta}>
+                        {val.type ?? 'unknown'} — returned when: {val.returned ?? 'always'}
+                    </div>
+                    <div style={styles.desc}>
+                        {toArray(val.description).map((paragraph, i) => (
+                            <p
+                                key={i}
+                                style={styles.descParagraph}
+                                dangerouslySetInnerHTML={{
+                                    __html: formatAnsibleMarkup(paragraph),
+                                }}
+                            />
+                        ))}
+                    </div>
+                    {val.sample !== undefined && (
+                        <pre style={styles.sample}>{JSON.stringify(val.sample, null, 2)}</pre>
+                    )}
+                </div>
+            ))}
+        </div>
+    );
+}

--- a/packages/ui/src/components/SampleTaskView.tsx
+++ b/packages/ui/src/components/SampleTaskView.tsx
@@ -1,0 +1,99 @@
+import { useCallback, useMemo, useState } from 'react';
+import type { CSSProperties } from 'react';
+import type { PluginOption } from '../bridge/plugin-doc';
+import { generateSampleYaml } from '../utils/sample-task';
+import type { CommentMode } from '../utils/sample-task';
+import { YamlBlock } from './YamlBlock';
+
+interface SampleTaskViewProps {
+    fqcn: string;
+    options: Record<string, PluginOption>;
+    onCopy?: (text: string) => void;
+}
+
+const styles: Record<string, CSSProperties> = {
+    toolbar: {
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        marginBottom: 12,
+    },
+    toggle: {
+        display: 'flex',
+        background: 'var(--ui-bg-surface)',
+        border: '1px solid var(--ui-border)',
+        borderRadius: 4,
+        overflow: 'hidden',
+    },
+    toggleBtn: {
+        background: 'transparent',
+        border: 'none',
+        color: 'var(--ui-text-muted)',
+        padding: '6px 12px',
+        fontSize: '11px',
+        fontFamily: 'var(--ui-font-family)',
+        cursor: 'pointer',
+    },
+    toggleBtnActive: {
+        background: 'var(--ui-bg-active)',
+        color: 'var(--ui-text-primary)',
+    },
+};
+
+const MODES: { id: CommentMode; label: string }[] = [
+    { id: 'none', label: 'No Comments' },
+    { id: 'optional', label: 'Minimal' },
+    { id: 'descriptions', label: 'Documented' },
+];
+
+/**
+ * Render generated sample task YAML with selectable comment modes.
+ * @param root0 - Component props.
+ * @param root0.fqcn - Fully qualified plugin name.
+ * @param root0.options - Parameter schema map for the plugin.
+ * @param root0.onCopy - Optional callback invoked when sample YAML is copied.
+ * @returns The rendered sample task view.
+ */
+export function SampleTaskView({ fqcn, options, onCopy }: SampleTaskViewProps) {
+    const [commentMode, setCommentMode] = useState<CommentMode>('optional');
+
+    const yamlByMode = useMemo(
+        () => ({
+            none: generateSampleYaml(fqcn, options, 'none'),
+            optional: generateSampleYaml(fqcn, options, 'optional'),
+            descriptions: generateSampleYaml(fqcn, options, 'descriptions'),
+        }),
+        [fqcn, options],
+    );
+
+    const activeYaml = yamlByMode[commentMode];
+
+    const handleModeChange = useCallback((mode: CommentMode) => {
+        setCommentMode(mode);
+    }, []);
+
+    return (
+        <div>
+            <div style={styles.toolbar}>
+                <div style={styles.toggle}>
+                    {MODES.map((mode) => (
+                        <button
+                            key={mode.id}
+                            type="button"
+                            style={{
+                                ...styles.toggleBtn,
+                                ...(commentMode === mode.id ? styles.toggleBtnActive : {}),
+                            }}
+                            onClick={() => {
+                                handleModeChange(mode.id);
+                            }}
+                        >
+                            {mode.label}
+                        </button>
+                    ))}
+                </div>
+            </div>
+            <YamlBlock yaml={activeYaml} copyable onCopy={onCopy} />
+        </div>
+    );
+}

--- a/packages/ui/src/components/YamlBlock.tsx
+++ b/packages/ui/src/components/YamlBlock.tsx
@@ -1,0 +1,111 @@
+import { useCallback, useEffect, useState } from 'react';
+import type { CSSProperties } from 'react';
+import { highlightYaml } from '../utils/yaml-highlight';
+
+interface YamlBlockProps {
+    yaml: string;
+    copyable?: boolean;
+    onCopy?: (text: string) => void | Promise<void>;
+}
+
+const YAML_HIGHLIGHT_CSS = `
+.yaml-key { color: var(--ui-yaml-key, #9cdcfe); }
+.yaml-string { color: var(--ui-yaml-string, #ce9178); }
+.yaml-number { color: var(--ui-yaml-number, #b5cea8); }
+.yaml-bool { color: var(--ui-yaml-bool, #569cd6); }
+.yaml-null { color: var(--ui-yaml-null, #569cd6); }
+.yaml-comment { color: var(--ui-yaml-comment, #6a9955); }
+.yaml-comment-dim { color: var(--ui-yaml-comment-dim, #5a7a4a); }
+.yaml-comment-type { color: var(--ui-yaml-comment-type, #dcdcaa); }
+.yaml-comment-required { color: var(--ui-yaml-comment-required, #f44747); }
+.yaml-comment-optional { color: var(--ui-yaml-comment-optional, #6a9955); }
+.yaml-list-marker { color: var(--ui-yaml-list-marker, #d4d4d4); }
+`;
+
+const styles: Record<string, CSSProperties> = {
+    container: {
+        position: 'relative',
+    },
+    pre: {
+        margin: 0,
+        padding: '10px 12px',
+        fontFamily: 'var(--ui-font-mono)',
+        fontSize: '12px',
+        lineHeight: 1.5,
+        whiteSpace: 'pre',
+        overflowX: 'auto',
+        background: 'var(--ui-bg-surface)',
+        border: '1px solid var(--ui-border)',
+        borderRadius: 4,
+        color: 'var(--ui-text-primary)',
+    },
+    copyBtn: {
+        position: 'absolute',
+        top: 6,
+        right: 6,
+        padding: '2px 8px',
+        fontSize: '11px',
+        fontFamily: 'var(--ui-font-family)',
+        color: 'var(--ui-text-secondary)',
+        background: 'var(--ui-bg-primary)',
+        border: '1px solid var(--ui-border)',
+        borderRadius: 3,
+        cursor: 'pointer',
+    },
+    copyBtnCopied: {
+        color: 'var(--ui-success)',
+        borderColor: 'var(--ui-success)',
+    },
+};
+
+/**
+ * Presentational YAML block with syntax highlighting and optional copy button.
+ * @param root0 - Component props.
+ * @param root0.yaml - YAML text to render.
+ * @param root0.copyable - Whether to show a copy button.
+ * @param root0.onCopy - Optional callback invoked after copying YAML text.
+ * @returns The rendered YAML block.
+ */
+export function YamlBlock({ yaml, copyable = false, onCopy }: YamlBlockProps) {
+    const [copied, setCopied] = useState(false);
+
+    useEffect(() => {
+        if (!document.getElementById('yaml-highlight-styles')) {
+            const style = document.createElement('style');
+            style.id = 'yaml-highlight-styles';
+            style.textContent = YAML_HIGHLIGHT_CSS;
+            document.head.appendChild(style);
+        }
+    }, []);
+
+    const handleCopy = useCallback(() => {
+        const result = onCopy ? onCopy(yaml) : navigator.clipboard.writeText(yaml);
+        if (result instanceof Promise) {
+            void result;
+        }
+        setCopied(true);
+        setTimeout(() => {
+            setCopied(false);
+        }, 2000);
+    }, [yaml, onCopy]);
+
+    const highlighted = highlightYaml(yaml);
+
+    return (
+        <div style={styles.container}>
+            {copyable && (
+                <button
+                    type="button"
+                    style={{
+                        ...styles.copyBtn,
+                        ...(copied ? styles.copyBtnCopied : {}),
+                    }}
+                    onClick={handleCopy}
+                >
+                    {copied ? 'Copied!' : 'Copy'}
+                </button>
+            )}
+            <pre style={styles.pre} dangerouslySetInnerHTML={{ __html: highlighted }} />
+        </div>
+    );
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -9,13 +9,26 @@ export type {
     PythonPackageDetail,
     SystemPackageDetail,
 } from './bridge/ee';
+export type {
+    PluginDocBridge,
+    PluginData,
+    PluginDoc,
+    PluginOption,
+    PluginReturn,
+} from './bridge/plugin-doc';
 
 export { EEDetailView } from './views/EEDetailView';
 export { PythonPackageDetailView } from './views/PythonPackageDetailView';
 export { SystemPackageDetailView } from './views/SystemPackageDetailView';
+export { PluginDocView } from './views/PluginDocView';
 export { PackageList } from './components/PackageList';
 export type { PackageItem } from './components/PackageList';
 export { TabBar } from './components/TabBar';
 export type { Tab } from './components/TabBar';
 export { InfoList } from './components/InfoList';
 export type { InfoItem } from './components/InfoList';
+export { YamlBlock } from './components/YamlBlock';
+export { ParameterTree } from './components/ParameterTree';
+export { SampleTaskView } from './components/SampleTaskView';
+export { ExamplesView } from './components/ExamplesView';
+export { ReturnValuesTable } from './components/ReturnValuesTable';

--- a/packages/ui/src/utils/ansible-markup.ts
+++ b/packages/ui/src/utils/ansible-markup.ts
@@ -1,0 +1,42 @@
+/**
+ * Escape raw text for safe embedding in generated HTML.
+ * @param text - Raw text that may contain HTML metacharacters
+ * @returns HTML-safe text
+ */
+export function escapeHtml(text: string): string {
+    return text
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#039;');
+}
+
+/**
+ * Normalize documentation fields that may be a string or string array.
+ * @param value - Single value or list from plugin documentation metadata
+ * @returns Array form of the value, or an empty array when absent
+ */
+export function toArray(value: string | string[] | undefined): string[] {
+    if (!value) {
+        return [];
+    }
+    return Array.isArray(value) ? value : [value];
+}
+
+/**
+ * Convert ansible-doc text markup into HTML.
+ * Handles I(), C(), B(), U(), :ref:, and backtick code.
+ * @param text - Raw documentation text with ansible-doc formatting
+ * @returns HTML-safe formatted description text
+ */
+export function formatAnsibleMarkup(text: string): string {
+    let html = escapeHtml(text);
+    html = html.replace(/I\(([^)]+)\)/g, '<em>$1</em>');
+    html = html.replace(/C\(([^)]+)\)/g, '<code>$1</code>');
+    html = html.replace(/B\(([^)]+)\)/g, '<strong>$1</strong>');
+    html = html.replace(/U\(([^)]+)\)/g, '<a href="$1" target="_blank" rel="noreferrer">$1</a>');
+    html = html.replace(/:ref:`([^&]+)\s*&lt;[^&]+&gt;`/g, '$1');
+    html = html.replace(/`([^`]+)`/g, '<code>$1</code>');
+    return html;
+}

--- a/packages/ui/src/utils/example-parser.ts
+++ b/packages/ui/src/utils/example-parser.ts
@@ -1,0 +1,139 @@
+import { capitalizeTitle } from './sample-task';
+
+export interface ExampleSection {
+    title: string;
+    beforeState?: string;
+    task: string;
+    taskOutput?: string;
+    afterState?: string;
+}
+
+/**
+ * Parse ansible-doc example text into structured sections.
+ * @param examples - Raw examples string from plugin documentation
+ * @returns Parsed example sections with task YAML and optional state/output blocks
+ */
+export function parseExamples(examples: string): ExampleSection[] {
+    const sections: ExampleSection[] = [];
+
+    const lines = examples.split('\n');
+    let currentSection: ExampleSection | null = null;
+
+    let currentPart: 'start' | 'before' | 'task' | 'output' | 'after' = 'start';
+    let buffer: string[] = [];
+    let sectionHeader: string | null = null;
+    const pending: { before?: string } = {};
+
+    const flushBuffer = () => {
+        const content = buffer.join('\n').trim();
+        if (!content) {
+            buffer = [];
+            return;
+        }
+
+        if (!currentSection) {
+            if (currentPart === 'before') {
+                pending.before = content;
+            }
+            buffer = [];
+            return;
+        }
+
+        switch (currentPart) {
+            case 'before':
+                currentSection.beforeState = content;
+                break;
+            case 'task':
+                currentSection.task =
+                    (currentSection.task ? currentSection.task + '\n\n' : '') + content;
+                break;
+            case 'output':
+                currentSection.taskOutput = content;
+                break;
+            case 'after':
+                currentSection.afterState = content;
+                break;
+        }
+        buffer = [];
+    };
+
+    const saveCurrentSection = () => {
+        if (currentSection) {
+            flushBuffer();
+            if (currentSection.task) {
+                sections.push(currentSection);
+            }
+        }
+        currentSection = null;
+        currentPart = 'start';
+    };
+
+    for (const line of lines) {
+        const trimmedLine = line.trim();
+
+        if (/^#\s*Using\s+\w+/.test(trimmedLine)) {
+            saveCurrentSection();
+            sectionHeader = trimmedLine.replace(/^#\s*/, '');
+            continue;
+        }
+
+        if (/^#\s*Before\s+state:?\s*$/i.test(trimmedLine)) {
+            flushBuffer();
+            currentPart = 'before';
+            continue;
+        }
+
+        if (/^#\s*Task\s+[Oo]utput:?\s*$/i.test(trimmedLine)) {
+            flushBuffer();
+            currentPart = 'output';
+            continue;
+        }
+
+        if (/^#\s*After\s+state:?\s*$/i.test(trimmedLine)) {
+            flushBuffer();
+            currentPart = 'after';
+            continue;
+        }
+
+        if (trimmedLine.startsWith('- name:')) {
+            saveCurrentSection();
+
+            const rawTaskName = trimmedLine
+                .replace(/^-\s*name:\s*/, '')
+                .replace(/^["']|["']$/g, '');
+            const taskName = capitalizeTitle(rawTaskName);
+
+            currentSection = {
+                title: sectionHeader ? `${sectionHeader}: ${taskName}` : taskName,
+                beforeState: pending.before,
+                task: '',
+            };
+            sectionHeader = null;
+            pending.before = undefined;
+            currentPart = 'task';
+            buffer = [line];
+            continue;
+        }
+
+        if (currentPart === 'task' && trimmedLine.startsWith('#') && buffer.length > 0) {
+            const hasYaml = buffer.some((l) => !l.trim().startsWith('#') && l.trim().length > 0);
+            if (hasYaml) {
+                if (/^#\s*-+\s*$/.test(trimmedLine)) {
+                    continue;
+                }
+                flushBuffer();
+                currentPart = 'output';
+                buffer = [line];
+                continue;
+            }
+        }
+
+        if (currentSection || currentPart === 'before') {
+            buffer.push(line);
+        }
+    }
+
+    saveCurrentSection();
+
+    return sections;
+}

--- a/packages/ui/src/utils/sample-task.ts
+++ b/packages/ui/src/utils/sample-task.ts
@@ -1,0 +1,330 @@
+import type { PluginOption } from '../bridge/plugin-doc';
+import { toArray } from './ansible-markup';
+
+export type CommentMode = 'none' | 'optional' | 'descriptions';
+
+/**
+ * Convert example or task titles into title case for display.
+ * @param text - Raw title text from plugin documentation
+ * @returns Title-cased display text
+ */
+export function capitalizeTitle(text: string): string {
+    if (!text) {
+        return text;
+    }
+    return text
+        .split(' ')
+        .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+        .join(' ');
+}
+
+/**
+ * Generate sample task YAML for the requested comment mode.
+ * @param fqcn - Fully qualified plugin name
+ * @param options - Parameter schema map for the plugin
+ * @param commentMode - Comment style to apply to generated YAML
+ * @returns Sample task YAML text
+ */
+export function generateSampleYaml(
+    fqcn: string,
+    options: Record<string, PluginOption>,
+    commentMode: CommentMode,
+): string {
+    const lines: string[] = [];
+    const pluginName = fqcn.split('.').pop() ?? fqcn;
+
+    lines.push(`- name: ${capitalizeTitle(pluginName.replace(/_/g, ' '))} task`);
+    lines.push(`  ${fqcn}:`);
+
+    const sortedOptions = Object.entries(options).sort((a, b) => {
+        const aReq = a[1].required ? 0 : 1;
+        const bReq = b[1].required ? 0 : 1;
+        if (aReq !== bReq) {
+            return aReq - bReq;
+        }
+        return a[0].localeCompare(b[0]);
+    });
+
+    for (const [name, opt] of sortedOptions) {
+        addParamToYaml(lines, name, opt, 4, false, commentMode);
+    }
+
+    return lines.join('\n');
+}
+
+/**
+ * Append one parameter and its suboptions to generated sample YAML lines.
+ * @param lines - Accumulated YAML lines for the sample task
+ * @param name - Parameter name
+ * @param opt - Parameter schema metadata
+ * @param indent - Current indentation level in spaces
+ * @param isFirstInList - Whether this parameter starts a YAML list item
+ * @param commentMode - Comment style to apply to generated YAML
+ */
+function addParamToYaml(
+    lines: string[],
+    name: string,
+    opt: PluginOption,
+    indent: number,
+    isFirstInList = false,
+    commentMode: CommentMode = 'optional',
+): void {
+    const spaces = ' '.repeat(indent);
+
+    let comment = '';
+    if (commentMode === 'descriptions') {
+        const desc = toArray(opt.description)[0] ?? '';
+        const cleanDesc = desc.replace(/\s+/g, ' ').trim();
+        const truncatedDesc =
+            cleanDesc.length > 60 ? cleanDesc.substring(0, 57) + '...' : cleanDesc;
+        const typeStr = opt.type ?? 'str';
+        const reqMarker = opt.required ? 'required' : 'optional';
+        comment = `  # (${typeStr}, ${reqMarker}) ${truncatedDesc}`;
+    } else if (commentMode === 'optional') {
+        comment = opt.required ? '' : '  # optional';
+    }
+
+    const prefix = isFirstInList ? '- ' : '';
+    const prefixSpaces = isFirstInList ? ' '.repeat(indent - 2) : spaces;
+
+    const value = getExampleValue(name, opt);
+
+    if (opt.suboptions && Object.keys(opt.suboptions).length > 0) {
+        const sortedSubopts = Object.entries(opt.suboptions).sort((a, b) => {
+            const aReq = a[1].required ? 0 : 1;
+            const bReq = b[1].required ? 0 : 1;
+            if (aReq !== bReq) {
+                return aReq - bReq;
+            }
+            return a[0].localeCompare(b[0]);
+        });
+
+        if (opt.type === 'list') {
+            lines.push(`${prefixSpaces}${prefix}${name}:${comment}`);
+
+            let isFirst = true;
+            for (const [subName, subOpt] of sortedSubopts) {
+                addParamToYaml(lines, subName, subOpt, indent + 4, isFirst, commentMode);
+                isFirst = false;
+            }
+        } else {
+            lines.push(`${prefixSpaces}${prefix}${name}:${comment}`);
+
+            for (const [subName, subOpt] of sortedSubopts) {
+                addParamToYaml(lines, subName, subOpt, indent + 2, false, commentMode);
+            }
+        }
+    } else if (opt.type === 'list') {
+        const elemValue = getElementValue(name, opt);
+        lines.push(`${prefixSpaces}${prefix}${name}:${comment}`);
+        lines.push(`${spaces}  - ${elemValue}`);
+    } else {
+        lines.push(`${prefixSpaces}${prefix}${name}: ${value}${comment}`);
+    }
+}
+
+/**
+ * Choose a representative example value for a parameter.
+ * @param name - Parameter name
+ * @param opt - Parameter schema metadata
+ * @returns Example YAML value text for the parameter
+ */
+function getExampleValue(name: string, opt: PluginOption): string {
+    if (opt.default !== undefined && opt.default !== null) {
+        return formatYamlValue(opt.default);
+    }
+
+    if (opt.choices && opt.choices.length > 0) {
+        return formatYamlValue(opt.choices[0]);
+    }
+
+    switch (opt.type) {
+        case 'bool':
+        case 'boolean':
+            return 'true';
+        case 'int':
+        case 'integer':
+            return '0';
+        case 'float':
+            return '0.0';
+        case 'path':
+            return '"/path/to/file"';
+        case 'raw':
+        case 'jsonarg':
+            return '{}';
+        case 'dict':
+            return '{}';
+        case 'list':
+            return '[]';
+        case 'str':
+        case 'string':
+        default:
+            return getContextualExample(name);
+    }
+}
+
+/**
+ * Choose an example list element value for a list-typed parameter.
+ * @param name - Parameter name
+ * @param opt - Parameter schema metadata
+ * @returns Example YAML list item value
+ */
+function getElementValue(name: string, opt: PluginOption): string {
+    if (opt.elements) {
+        switch (opt.elements) {
+            case 'dict':
+                return '{}';
+            case 'int':
+            case 'integer':
+                return '1';
+            case 'bool':
+            case 'boolean':
+                return 'true';
+            case 'str':
+            case 'string':
+            default:
+                return `"${name}_item"`;
+        }
+    }
+    return `"${name}_item"`;
+}
+
+/**
+ * Generate a contextual string example based on common parameter names.
+ * @param name - Parameter name used to infer a realistic example
+ * @returns Quoted example string for the parameter
+ */
+function getContextualExample(name: string): string {
+    const lowerName = name.toLowerCase();
+
+    if (lowerName.includes('name')) {
+        return '"example_name"';
+    }
+    if (lowerName.includes('path') || lowerName.includes('dest') || lowerName.includes('src')) {
+        return '"/path/to/file"';
+    }
+    if (lowerName.includes('host')) {
+        return '"hostname.example.com"';
+    }
+    if (lowerName.includes('port')) {
+        return '22';
+    }
+    if (lowerName.includes('user')) {
+        return '"admin"';
+    }
+    if (lowerName.includes('pass') || lowerName.includes('secret')) {
+        return '"{{ vault_password }}"';
+    }
+    if (lowerName.includes('url')) {
+        return '"https://example.com"';
+    }
+    if (lowerName.includes('state')) {
+        return '"present"';
+    }
+    if (lowerName.includes('mode')) {
+        return '"0644"';
+    }
+    if (lowerName.includes('owner')) {
+        return '"root"';
+    }
+    if (lowerName.includes('group')) {
+        return '"root"';
+    }
+    if (lowerName.includes('text') || lowerName.includes('content') || lowerName.includes('data')) {
+        return '"example content"';
+    }
+    if (lowerName.includes('command') || lowerName.includes('cmd')) {
+        return '"echo hello"';
+    }
+    if (lowerName.includes('timeout')) {
+        return '30';
+    }
+    if (lowerName.includes('delay')) {
+        return '5';
+    }
+    if (lowerName.includes('retries') || lowerName.includes('retry')) {
+        return '3';
+    }
+    if (
+        lowerName.includes('regexp') ||
+        lowerName.includes('regex') ||
+        lowerName.includes('pattern')
+    ) {
+        return '"^.*$"';
+    }
+    if (lowerName.includes('line')) {
+        return '"example line"';
+    }
+    if (lowerName.includes('key')) {
+        return '"key_name"';
+    }
+    if (lowerName.includes('value')) {
+        return '"value"';
+    }
+    if (lowerName.includes('version')) {
+        return '"1.0.0"';
+    }
+    if (lowerName.includes('interface')) {
+        return '"eth0"';
+    }
+    if (lowerName.includes('vlan')) {
+        return '100';
+    }
+    if (lowerName.includes('ip') || lowerName.includes('address')) {
+        return '"192.168.1.1"';
+    }
+    if (lowerName.includes('network') || lowerName.includes('subnet')) {
+        return '"192.168.1.0/24"';
+    }
+
+    return `"${name}_value"`;
+}
+
+/**
+ * Format a JavaScript value as YAML literal text.
+ * @param value - Value to render into sample YAML
+ * @returns YAML-safe literal representation
+ */
+export function formatYamlValue(value: unknown): string {
+    if (value === null || value === undefined) {
+        return 'null';
+    }
+    if (typeof value === 'boolean') {
+        return value ? 'true' : 'false';
+    }
+    if (typeof value === 'number') {
+        return String(value);
+    }
+    if (typeof value === 'string') {
+        if (
+            value === '' ||
+            value.includes(':') ||
+            value.includes('#') ||
+            value.includes("'") ||
+            value.includes('"') ||
+            value.includes('\n') ||
+            value.startsWith(' ') ||
+            value.endsWith(' ') ||
+            /^[{[\]|>*&!%@`]/.test(value)
+        ) {
+            return `"${value.replace(/"/g, '\\"')}"`;
+        }
+        if (/^(true|false|yes|no|on|off|null|~|\d+\.?\d*)$/i.test(value)) {
+            return `"${value}"`;
+        }
+        return value;
+    }
+    if (Array.isArray(value)) {
+        if (value.length === 0) {
+            return '[]';
+        }
+        return JSON.stringify(value);
+    }
+    if (typeof value === 'object') {
+        if (Object.keys(value).length === 0) {
+            return '{}';
+        }
+        return JSON.stringify(value);
+    }
+    return JSON.stringify(value);
+}

--- a/packages/ui/src/utils/yaml-highlight.ts
+++ b/packages/ui/src/utils/yaml-highlight.ts
@@ -1,0 +1,117 @@
+import { escapeHtml } from './ansible-markup';
+
+/**
+ * Apply lightweight syntax highlighting to YAML text.
+ * Returns HTML with span-wrapped tokens using yaml-* CSS classes.
+ * @param yaml - YAML text to highlight
+ * @returns HTML with span-wrapped YAML tokens
+ */
+export function highlightYaml(yaml: string): string {
+    const lines = yaml.split('\n');
+    return lines
+        .map((line) => {
+            if (line.trim().startsWith('#')) {
+                return `<span class="yaml-comment">${escapeHtml(line)}</span>`;
+            }
+
+            if (line.trim() === '') {
+                return '';
+            }
+
+            const commentMatch = /^(.+?)( {2}# .*)$/.exec(line);
+            let codePart = line;
+            let commentPart = '';
+
+            if (commentMatch) {
+                codePart = commentMatch[1];
+                commentPart = commentMatch[2];
+            }
+
+            let result = escapeHtml(codePart);
+
+            result = result.replace(
+                /^(\s*)(-\s)([a-zA-Z_][a-zA-Z0-9_]*)(:)/,
+                '$1<span class="yaml-list-marker">$2</span><span class="yaml-key">$3</span>$4',
+            );
+
+            result = result.replace(
+                /^(\s*)(-\s)(&quot;[^&]*&quot;|&#039;[^&]*&#039;)(\s*)$/,
+                '$1<span class="yaml-list-marker">$2</span><span class="yaml-string">$3</span>$4',
+            );
+
+            result = result.replace(
+                /^(\s*)(-\s)([^\s].*)$/,
+                (match: string, spaces: string, marker: string, value: string) => {
+                    if (value.includes('<span')) {
+                        return match;
+                    }
+                    const trimmedValue = value.trim();
+                    let valueClass = 'yaml-string';
+                    if (/^(true|false|yes|no|on|off)$/i.test(trimmedValue)) {
+                        valueClass = 'yaml-bool';
+                    } else if (/^(null|~)$/i.test(trimmedValue)) {
+                        valueClass = 'yaml-null';
+                    } else if (/^-?\d+(\.\d+)?$/.test(trimmedValue)) {
+                        valueClass = 'yaml-number';
+                    }
+                    return `${spaces}<span class="yaml-list-marker">${marker}</span><span class="${valueClass}">${value}</span>`;
+                },
+            );
+
+            result = result.replace(/^(\s*)(-\s)$/, '$1<span class="yaml-list-marker">$2</span>');
+
+            result = result.replace(
+                /^(\s*)([a-zA-Z_][a-zA-Z0-9_]*)(:)(\s|$)/,
+                '$1<span class="yaml-key">$2</span>$3$4',
+            );
+
+            result = result.replace(
+                /:(\s+)(".*?"|'.*?')(\s*)$/,
+                ':$1<span class="yaml-string">$2</span>$3',
+            );
+
+            result = result.replace(/:(\s+)(\S.*)$/, (_match, space: string, value: string) => {
+                const trimmedValue = value.trim();
+                if (/^(true|false|yes|no|on|off)$/i.test(trimmedValue)) {
+                    return `:${space}<span class="yaml-bool">${value}</span>`;
+                }
+                if (/^(null|~)$/i.test(trimmedValue)) {
+                    return `:${space}<span class="yaml-null">${value}</span>`;
+                }
+                if (/^-?\d+(\.\d+)?$/.test(trimmedValue)) {
+                    return `:${space}<span class="yaml-number">${value}</span>`;
+                }
+                return `:${space}<span class="yaml-string">${value}</span>`;
+            });
+
+            if (commentPart) {
+                result += highlightComment(commentPart);
+            }
+
+            return result;
+        })
+        .join('\n');
+}
+
+/**
+ * Highlight inline YAML comments, including structured parameter comments.
+ * Structured format: # (type, required/optional) description
+ * @param comment - Comment text including leading spaces and `#`
+ * @returns HTML with styled comment spans
+ */
+export function highlightComment(comment: string): string {
+    const structuredMatch = /^( {2}# \()([^,]+)(, )(required|optional)(\) )(.*)$/.exec(comment);
+    if (structuredMatch) {
+        const [, prefix, type, comma, reqOpt, closeParen, desc] = structuredMatch;
+        const reqClass = reqOpt === 'required' ? 'yaml-comment-required' : 'yaml-comment-optional';
+        return (
+            `<span class="yaml-comment-dim">${escapeHtml(prefix)}</span>` +
+            `<span class="yaml-comment-type">${escapeHtml(type)}</span>` +
+            `<span class="yaml-comment-dim">${escapeHtml(comma)}</span>` +
+            `<span class="${reqClass}">${escapeHtml(reqOpt)}</span>` +
+            `<span class="yaml-comment-dim">${escapeHtml(closeParen)}${escapeHtml(desc)}</span>`
+        );
+    }
+
+    return `<span class="yaml-comment-dim">${escapeHtml(comment)}</span>`;
+}

--- a/packages/ui/src/views/PluginDocView.tsx
+++ b/packages/ui/src/views/PluginDocView.tsx
@@ -1,0 +1,410 @@
+import { useState, useEffect, useCallback } from 'react';
+import type { CSSProperties } from 'react';
+import { useBridge } from '../bridge/context';
+import type { PluginDocBridge, PluginData, PluginDoc } from '../bridge/plugin-doc';
+import { formatAnsibleMarkup, toArray } from '../utils/ansible-markup';
+import { TabBar } from '../components/TabBar';
+import type { Tab } from '../components/TabBar';
+import { ParameterTree } from '../components/ParameterTree';
+import { SampleTaskView } from '../components/SampleTaskView';
+import { ExamplesView } from '../components/ExamplesView';
+import { ReturnValuesTable } from '../components/ReturnValuesTable';
+
+interface PluginDocViewProps {
+    fqcn: string;
+    pluginType: string;
+}
+
+const styles: Record<string, CSSProperties> = {
+    container: {
+        display: 'flex',
+        flexDirection: 'column',
+        height: '100%',
+        background: 'var(--ui-bg-primary)',
+        overflow: 'hidden',
+    },
+    toolbar: {
+        display: 'flex',
+        alignItems: 'center',
+        gap: 4,
+        padding: '4px 12px',
+        background: 'var(--ui-bg-surface)',
+        borderBottom: '1px solid var(--ui-border)',
+        flexShrink: 0,
+    },
+    toolbarBtn: {
+        background: 'transparent',
+        border: '1px solid var(--ui-border)',
+        color: 'var(--ui-text-primary)',
+        borderRadius: 3,
+        padding: '2px 8px',
+        cursor: 'pointer',
+        fontSize: '12px',
+        fontFamily: 'var(--ui-font-family)',
+    },
+    toolbarDivider: {
+        width: 1,
+        height: 16,
+        background: 'var(--ui-border)',
+        margin: '0 4px',
+    },
+    zoomLabel: {
+        fontSize: '11px',
+        color: 'var(--ui-text-secondary)',
+        minWidth: 36,
+        textAlign: 'center' as const,
+    },
+    scrollArea: {
+        flex: 1,
+        overflow: 'auto',
+    },
+    breadcrumb: {
+        padding: '12px 16px 0',
+        fontSize: '12px',
+        color: 'var(--ui-text-secondary)',
+    },
+    breadcrumbSep: {
+        margin: '0 6px',
+        color: 'var(--ui-text-muted)',
+    },
+    header: {
+        padding: '8px 16px 12px',
+        borderBottom: '1px solid var(--ui-border)',
+    },
+    headerRow: {
+        display: 'flex',
+        alignItems: 'center',
+        gap: 10,
+    },
+    title: {
+        fontSize: '18px',
+        fontWeight: 600,
+        fontFamily: 'var(--ui-font-mono)',
+        color: 'var(--ui-text-primary)',
+        margin: 0,
+    },
+    typeBadge: {
+        display: 'inline-block',
+        padding: '2px 8px',
+        fontSize: '11px',
+        fontFamily: 'var(--ui-font-mono)',
+        color: 'var(--ui-text-secondary)',
+        background: 'var(--ui-bg-surface)',
+        border: '1px solid var(--ui-border)',
+        borderRadius: 3,
+        textTransform: 'lowercase' as const,
+    },
+    shortDesc: {
+        marginTop: 6,
+        fontSize: '13px',
+        color: 'var(--ui-text-secondary)',
+        lineHeight: 1.5,
+    },
+    versionInfo: {
+        marginTop: 4,
+        fontSize: '11px',
+        color: 'var(--ui-text-muted)',
+    },
+    section: {
+        padding: '16px',
+    },
+    sectionTitle: {
+        fontSize: '13px',
+        fontWeight: 600,
+        color: 'var(--ui-text-primary)',
+        marginBottom: 10,
+        margin: 0,
+    },
+    synopsisList: {
+        margin: '8px 0',
+        paddingLeft: 20,
+        lineHeight: 1.7,
+        color: 'var(--ui-text-primary)',
+        fontSize: '13px',
+    },
+    notesList: {
+        margin: '8px 0',
+        paddingLeft: 20,
+        lineHeight: 1.7,
+        color: 'var(--ui-text-primary)',
+        fontSize: '13px',
+    },
+    authorText: {
+        fontSize: '13px',
+        color: 'var(--ui-text-secondary)',
+        fontFamily: 'var(--ui-font-mono)',
+    },
+    loading: {
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: '48px 16px',
+        color: 'var(--ui-text-secondary)',
+        fontSize: '13px',
+    },
+    error: {
+        padding: '16px',
+        color: 'var(--ui-error)',
+        fontSize: '13px',
+    },
+    aiBtn: {
+        background: 'var(--ui-accent)',
+        border: 'none',
+        color: '#fff',
+        borderRadius: 4,
+        padding: '3px 10px',
+        cursor: 'pointer',
+        fontSize: '12px',
+        fontWeight: 600,
+        fontFamily: 'var(--ui-font-family)',
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 4,
+    },
+};
+
+/**
+ * Top-level plugin documentation view.
+ * Fetches doc data via the bridge and composes tabs for synopsis,
+ * parameters, sample task, notes, examples, and return values.
+ * @param root0 - Component props.
+ * @param root0.fqcn - Fully qualified collection name of the plugin.
+ * @param root0.pluginType - Plugin type such as module or lookup.
+ * @returns The rendered plugin documentation view.
+ */
+export function PluginDocView({ fqcn, pluginType }: PluginDocViewProps) {
+    const bridge = useBridge() as PluginDocBridge;
+    const [data, setData] = useState<PluginData | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [zoom, setZoom] = useState(100);
+    const [activeTab, setActiveTab] = useState('synopsis');
+
+    const loadData = useCallback(async () => {
+        setLoading(true);
+        setError(null);
+        try {
+            const result = await bridge.getPluginDoc(fqcn, pluginType);
+            if (!result?.doc) {
+                setError(`No documentation found for ${fqcn}`);
+            } else {
+                setData(result);
+            }
+        } catch (err) {
+            setError(err instanceof Error ? err.message : String(err));
+        } finally {
+            setLoading(false);
+        }
+    }, [bridge, fqcn, pluginType]);
+
+    useEffect(() => {
+        void loadData();
+    }, [loadData]);
+
+    const handleZoom = useCallback(
+        (delta: number) => {
+            setZoom((prev) => {
+                const next = Math.max(50, Math.min(200, prev + delta));
+                void bridge.saveViewSettings({ zoom: next });
+                return next;
+            });
+        },
+        [bridge],
+    );
+
+    const handleCopy = useCallback(
+        (text: string) => {
+            void bridge.copyToClipboard(text);
+        },
+        [bridge],
+    );
+
+    const handleAiPrompt = useCallback(() => {
+        const prompt = `Help me create an Ansible task using the ${fqcn} ${pluginType}, guiding me through the required and optional parameters. Use the build_ansible_task MCP tool to accomplish this.`;
+        void bridge.openChat(prompt);
+    }, [bridge, fqcn, pluginType]);
+
+    if (loading) {
+        return (
+            <div style={styles.container} className="ansible-ui">
+                <div style={styles.loading}>Loading documentation…</div>
+            </div>
+        );
+    }
+
+    if (error || !data?.doc) {
+        return (
+            <div style={styles.container} className="ansible-ui">
+                <div style={styles.error}>Error: {error ?? 'No data available'}</div>
+            </div>
+        );
+    }
+
+    const doc: PluginDoc = data.doc;
+    const parts = fqcn.split('.');
+    const pluginName = parts.pop() ?? fqcn;
+    const collection =
+        parts.length >= 2
+            ? `${parts[parts.length - 2]}.${parts[parts.length - 1]}`
+            : parts.join('.');
+    const namespace = parts.length >= 2 ? parts.slice(0, -1).join('.') : '';
+
+    const tabs: Tab[] = [
+        { id: 'synopsis', label: 'Synopsis' },
+        { id: 'parameters', label: 'Parameters' },
+        { id: 'sample', label: 'Sample Task' },
+    ];
+    if (doc.notes) tabs.push({ id: 'notes', label: 'Notes' });
+    if (data.examples) tabs.push({ id: 'examples', label: 'Examples' });
+    if (data.return) tabs.push({ id: 'return', label: 'Return Values' });
+
+    return (
+        <div style={{ ...styles.container, zoom: `${String(zoom)}%` }} className="ansible-ui">
+            <div style={styles.toolbar}>
+                <button
+                    style={styles.toolbarBtn}
+                    title="Zoom out"
+                    onClick={() => {
+                        handleZoom(-10);
+                    }}
+                >
+                    −
+                </button>
+                <span style={styles.zoomLabel}>{String(zoom)}%</span>
+                <button
+                    style={styles.toolbarBtn}
+                    title="Zoom in"
+                    onClick={() => {
+                        handleZoom(10);
+                    }}
+                >
+                    +
+                </button>
+                {bridge.enableAiFeatures && (
+                    <>
+                        <div style={styles.toolbarDivider} />
+                        <button
+                            style={styles.aiBtn}
+                            title="AI-assisted task builder"
+                            onClick={handleAiPrompt}
+                        >
+                            ✨ AI Task Builder
+                        </button>
+                    </>
+                )}
+            </div>
+
+            <div style={styles.scrollArea}>
+                <div style={styles.breadcrumb}>
+                    {namespace && (
+                        <>
+                            <span>{namespace}</span>
+                            <span style={styles.breadcrumbSep}>›</span>
+                        </>
+                    )}
+                    <span>{collection}</span>
+                    <span style={styles.breadcrumbSep}>›</span>
+                    <span>{pluginType}</span>
+                    <span style={styles.breadcrumbSep}>›</span>
+                    <strong>{pluginName}</strong>
+                </div>
+
+                <div style={styles.header}>
+                    <div style={styles.headerRow}>
+                        <h1 style={styles.title}>{pluginName}</h1>
+                        <span style={styles.typeBadge}>{pluginType}</span>
+                    </div>
+                    {doc.short_description && (
+                        <div style={styles.shortDesc}>{doc.short_description}</div>
+                    )}
+                    {doc.version_added && (
+                        <div style={styles.versionInfo}>Added in version {doc.version_added}</div>
+                    )}
+                </div>
+
+                <TabBar tabs={tabs} activeTab={activeTab} onTabChange={setActiveTab}>
+                    {activeTab === 'synopsis' && <SynopsisTab doc={doc} />}
+                    {activeTab === 'parameters' && (
+                        <div style={styles.section}>
+                            <ParameterTree options={doc.options ?? {}} />
+                        </div>
+                    )}
+                    {activeTab === 'sample' && (
+                        <div style={styles.section}>
+                            <SampleTaskView
+                                fqcn={fqcn}
+                                options={doc.options ?? {}}
+                                onCopy={handleCopy}
+                            />
+                        </div>
+                    )}
+                    {activeTab === 'notes' && doc.notes && (
+                        <div style={styles.section}>
+                            <h2 style={styles.sectionTitle}>Notes</h2>
+                            <ul style={styles.notesList}>
+                                {toArray(doc.notes).map((note, i) => (
+                                    <li
+                                        key={String(i)}
+                                        dangerouslySetInnerHTML={{
+                                            __html: formatAnsibleMarkup(note),
+                                        }}
+                                    />
+                                ))}
+                            </ul>
+                        </div>
+                    )}
+                    {activeTab === 'examples' && data.examples && (
+                        <div style={styles.section}>
+                            <ExamplesView examples={data.examples} onCopy={handleCopy} />
+                        </div>
+                    )}
+                    {activeTab === 'return' && data.return && (
+                        <div style={styles.section}>
+                            <ReturnValuesTable returnValues={data.return} />
+                        </div>
+                    )}
+                </TabBar>
+            </div>
+        </div>
+    );
+}
+
+/**
+ * Synopsis tab content including description, requirements, and author.
+ * @param root0 - Component props.
+ * @param root0.doc - Plugin documentation data.
+ * @returns The rendered synopsis section.
+ */
+function SynopsisTab({ doc }: { doc: PluginDoc }) {
+    return (
+        <div style={styles.section}>
+            <h2 style={styles.sectionTitle}>Synopsis</h2>
+            <ul style={styles.synopsisList}>
+                {toArray(doc.description).map((d, i) => (
+                    <li
+                        key={String(i)}
+                        dangerouslySetInnerHTML={{ __html: formatAnsibleMarkup(d) }}
+                    />
+                ))}
+            </ul>
+
+            {doc.requirements && toArray(doc.requirements).length > 0 && (
+                <>
+                    <h2 style={{ ...styles.sectionTitle, marginTop: 16 }}>Requirements</h2>
+                    <ul style={styles.synopsisList}>
+                        {toArray(doc.requirements).map((r, i) => (
+                            <li key={String(i)}>{r}</li>
+                        ))}
+                    </ul>
+                </>
+            )}
+
+            {doc.author && toArray(doc.author).length > 0 && (
+                <>
+                    <h2 style={{ ...styles.sectionTitle, marginTop: 16 }}>Author</h2>
+                    <div style={styles.authorText}>{toArray(doc.author).join(', ')}</div>
+                </>
+            )}
+        </div>
+    );
+}

--- a/packages/ui/test/tsconfig.json
+++ b/packages/ui/test/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "..",
+    "declaration": false,
+    "declarationMap": false,
+    "sourceMap": false,
+    "noEmit": true
+  },
+  "include": ["../src/**/*", "./**/*"]
+}

--- a/packages/ui/test/utils/ansible-markup.test.ts
+++ b/packages/ui/test/utils/ansible-markup.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import { escapeHtml, toArray, formatAnsibleMarkup } from '../../src/utils/ansible-markup';
+
+describe('escapeHtml', () => {
+    it('escapes ampersand', () => {
+        expect(escapeHtml('a & b')).toBe('a &amp; b');
+    });
+
+    it('escapes angle brackets', () => {
+        expect(escapeHtml('<div>')).toBe('&lt;div&gt;');
+    });
+
+    it('escapes quotes', () => {
+        expect(escapeHtml('"hello" & \'world\'')).toBe('&quot;hello&quot; &amp; &#039;world&#039;');
+    });
+
+    it('returns empty string unchanged', () => {
+        expect(escapeHtml('')).toBe('');
+    });
+
+    it('passes through plain text', () => {
+        expect(escapeHtml('hello world')).toBe('hello world');
+    });
+});
+
+describe('toArray', () => {
+    it('returns empty array for undefined', () => {
+        expect(toArray(undefined)).toEqual([]);
+    });
+
+    it('returns empty array for empty string', () => {
+        expect(toArray('')).toEqual([]);
+    });
+
+    it('wraps a single string in an array', () => {
+        expect(toArray('hello')).toEqual(['hello']);
+    });
+
+    it('returns an array unchanged', () => {
+        expect(toArray(['a', 'b'])).toEqual(['a', 'b']);
+    });
+
+    it('returns empty array as-is', () => {
+        expect(toArray([])).toEqual([]);
+    });
+});
+
+describe('formatAnsibleMarkup', () => {
+    it('converts I() to italic', () => {
+        expect(formatAnsibleMarkup('I(text)')).toBe('<em>text</em>');
+    });
+
+    it('converts C() to code', () => {
+        expect(formatAnsibleMarkup('C(text)')).toBe('<code>text</code>');
+    });
+
+    it('converts B() to bold', () => {
+        expect(formatAnsibleMarkup('B(text)')).toBe('<strong>text</strong>');
+    });
+
+    it('converts U() to link with target and noreferrer', () => {
+        expect(formatAnsibleMarkup('U(https://example.com)')).toBe(
+            '<a href="https://example.com" target="_blank" rel="noreferrer">https://example.com</a>',
+        );
+    });
+
+    it('converts :ref: to plain text', () => {
+        const result = formatAnsibleMarkup('See :ref:`explanation <ref_link>` for details');
+        expect(result).toContain('explanation');
+        expect(result).not.toContain(':ref:');
+        expect(result).not.toContain('ref_link');
+    });
+
+    it('converts backtick code', () => {
+        expect(formatAnsibleMarkup('use `foo` here')).toBe('use <code>foo</code> here');
+    });
+
+    it('escapes HTML before processing markup', () => {
+        expect(formatAnsibleMarkup('Use I(<div>)')).toBe('Use <em>&lt;div&gt;</em>');
+    });
+
+    it('handles multiple markup codes in one string', () => {
+        const result = formatAnsibleMarkup('See B(bold) and I(italic) and C(code)');
+        expect(result).toContain('<strong>bold</strong>');
+        expect(result).toContain('<em>italic</em>');
+        expect(result).toContain('<code>code</code>');
+    });
+
+    it('passes plain text through with HTML escaping', () => {
+        expect(formatAnsibleMarkup('just plain text')).toBe('just plain text');
+    });
+});

--- a/packages/ui/test/utils/example-parser.test.ts
+++ b/packages/ui/test/utils/example-parser.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import { parseExamples } from '../../src/utils/example-parser';
+
+describe('parseExamples', () => {
+    it('parses a single simple task', () => {
+        const examples = `- name: Install package
+  ansible.builtin.yum:
+    name: httpd
+    state: present`;
+        const sections = parseExamples(examples);
+        expect(sections).toHaveLength(1);
+        expect(sections[0].title).toBe('Install Package');
+        expect(sections[0].task).toContain('ansible.builtin.yum');
+    });
+
+    it('parses multiple tasks', () => {
+        const examples = `- name: first task
+  debug:
+    msg: hello
+
+- name: second task
+  debug:
+    msg: world`;
+        const sections = parseExamples(examples);
+        expect(sections).toHaveLength(2);
+        expect(sections[0].title).toBe('First Task');
+        expect(sections[1].title).toBe('Second Task');
+    });
+
+    it('returns empty array for empty input', () => {
+        expect(parseExamples('')).toEqual([]);
+    });
+
+    it('returns empty for input with no tasks', () => {
+        expect(parseExamples('# just a comment\n# another comment')).toEqual([]);
+    });
+
+    it('handles section headers (# Using merged)', () => {
+        const examples = `# Using merged
+- name: merge config
+  some.module:
+    state: merged`;
+        const sections = parseExamples(examples);
+        expect(sections).toHaveLength(1);
+        expect(sections[0].title).toBe('Using merged: Merge Config');
+    });
+
+    it('parses before state blocks', () => {
+        const examples = `# Before state:
+# some context
+- name: do something
+  module:
+    param: value`;
+        const sections = parseExamples(examples);
+        expect(sections).toHaveLength(1);
+        expect(sections[0].task).toContain('module:');
+    });
+
+    it('parses task output blocks', () => {
+        const examples = `- name: run command
+  command: echo hello
+# Task output:
+# ok: [localhost]`;
+        const sections = parseExamples(examples);
+        expect(sections).toHaveLength(1);
+        expect(sections[0].taskOutput).toContain('ok: [localhost]');
+    });
+
+    it('parses after state blocks', () => {
+        const examples = `- name: configure interface
+  module:
+    name: eth0
+# After state:
+# interface is configured`;
+        const sections = parseExamples(examples);
+        expect(sections).toHaveLength(1);
+        expect(sections[0].afterState).toContain('interface is configured');
+    });
+
+    it('strips surrounding quotes from task names', () => {
+        const examples = `- name: "quoted task name"
+  debug:
+    msg: test`;
+        const sections = parseExamples(examples);
+        expect(sections[0].title).toBe('Quoted Task Name');
+    });
+
+    it('skips divider comments', () => {
+        const examples = `- name: task one
+  debug:
+    msg: hello
+# --------
+- name: task two
+  debug:
+    msg: world`;
+        const sections = parseExamples(examples);
+        expect(sections).toHaveLength(2);
+    });
+});

--- a/packages/ui/test/utils/sample-task.test.ts
+++ b/packages/ui/test/utils/sample-task.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect } from 'vitest';
+import { generateSampleYaml, capitalizeTitle, formatYamlValue } from '../../src/utils/sample-task';
+import type { PluginOption } from '../../src/bridge/plugin-doc';
+
+describe('capitalizeTitle', () => {
+    it('capitalizes first letter of each word', () => {
+        expect(capitalizeTitle('hello world')).toBe('Hello World');
+    });
+
+    it('returns empty string for empty input', () => {
+        expect(capitalizeTitle('')).toBe('');
+    });
+
+    it('handles single word', () => {
+        expect(capitalizeTitle('test')).toBe('Test');
+    });
+
+    it('preserves already capitalized words', () => {
+        expect(capitalizeTitle('Hello World')).toBe('Hello World');
+    });
+});
+
+describe('formatYamlValue', () => {
+    it('formats null', () => {
+        expect(formatYamlValue(null)).toBe('null');
+    });
+
+    it('formats undefined', () => {
+        expect(formatYamlValue(undefined)).toBe('null');
+    });
+
+    it('formats boolean true', () => {
+        expect(formatYamlValue(true)).toBe('true');
+    });
+
+    it('formats boolean false', () => {
+        expect(formatYamlValue(false)).toBe('false');
+    });
+
+    it('formats numbers', () => {
+        expect(formatYamlValue(42)).toBe('42');
+        expect(formatYamlValue(3.14)).toBe('3.14');
+    });
+
+    it('formats plain string without quotes', () => {
+        expect(formatYamlValue('hello')).toBe('hello');
+    });
+
+    it('quotes strings containing colons', () => {
+        expect(formatYamlValue('key: value')).toBe('"key: value"');
+    });
+
+    it('quotes strings that look like booleans', () => {
+        expect(formatYamlValue('true')).toBe('"true"');
+        expect(formatYamlValue('yes')).toBe('"yes"');
+    });
+
+    it('quotes strings that look like numbers', () => {
+        expect(formatYamlValue('42')).toBe('"42"');
+    });
+
+    it('quotes empty string', () => {
+        expect(formatYamlValue('')).toBe('""');
+    });
+
+    it('formats empty array', () => {
+        expect(formatYamlValue([])).toBe('[]');
+    });
+
+    it('formats non-empty array as JSON', () => {
+        expect(formatYamlValue([1, 2])).toBe('[1,2]');
+    });
+
+    it('formats empty object', () => {
+        expect(formatYamlValue({})).toBe('{}');
+    });
+
+    it('formats non-empty object as JSON', () => {
+        expect(formatYamlValue({ a: 1 })).toBe('{"a":1}');
+    });
+});
+
+describe('generateSampleYaml', () => {
+    it('generates basic task structure', () => {
+        const options: Record<string, PluginOption> = {
+            name: { type: 'str', required: true },
+        };
+        const yaml = generateSampleYaml('ansible.builtin.copy', options, 'none');
+        expect(yaml).toContain('- name: Copy task');
+        expect(yaml).toContain('  ansible.builtin.copy:');
+        expect(yaml).toContain('    name:');
+    });
+
+    it('sorts required parameters before optional', () => {
+        const options: Record<string, PluginOption> = {
+            optional_param: { type: 'str' },
+            required_param: { type: 'str', required: true },
+        };
+        const yaml = generateSampleYaml('test.module', options, 'none');
+        const lines = yaml.split('\n');
+        const reqIdx = lines.findIndex((l) => l.includes('required_param'));
+        const optIdx = lines.findIndex((l) => l.includes('optional_param'));
+        expect(reqIdx).toBeLessThan(optIdx);
+    });
+
+    it('adds "# optional" comments in optional mode', () => {
+        const options: Record<string, PluginOption> = {
+            param: { type: 'str' },
+        };
+        const yaml = generateSampleYaml('test.module', options, 'optional');
+        expect(yaml).toContain('# optional');
+    });
+
+    it('does not add comments for required in optional mode', () => {
+        const options: Record<string, PluginOption> = {
+            param: { type: 'str', required: true },
+        };
+        const yaml = generateSampleYaml('test.module', options, 'optional');
+        expect(yaml).not.toContain('# optional');
+        expect(yaml).not.toContain('# required');
+    });
+
+    it('adds description comments in descriptions mode', () => {
+        const options: Record<string, PluginOption> = {
+            name: { type: 'str', required: true, description: 'The resource name' },
+        };
+        const yaml = generateSampleYaml('test.module', options, 'descriptions');
+        expect(yaml).toContain('# (str, required)');
+        expect(yaml).toContain('The resource name');
+    });
+
+    it('omits all comments in none mode', () => {
+        const options: Record<string, PluginOption> = {
+            name: { type: 'str', description: 'The name' },
+        };
+        const yaml = generateSampleYaml('test.module', options, 'none');
+        expect(yaml).not.toContain('#');
+    });
+
+    it('generates list parameters with element items', () => {
+        const options: Record<string, PluginOption> = {
+            tags: { type: 'list', elements: 'str' },
+        };
+        const yaml = generateSampleYaml('test.module', options, 'none');
+        expect(yaml).toContain('tags:');
+        expect(yaml).toContain('- "tags_item"');
+    });
+
+    it('generates boolean default value', () => {
+        const options: Record<string, PluginOption> = {
+            enabled: { type: 'bool', default: false },
+        };
+        const yaml = generateSampleYaml('test.module', options, 'none');
+        expect(yaml).toContain('enabled: false');
+    });
+
+    it('uses first choice when available', () => {
+        const options: Record<string, PluginOption> = {
+            state: { type: 'str', choices: ['present', 'absent'] },
+        };
+        const yaml = generateSampleYaml('test.module', options, 'none');
+        expect(yaml).toContain('state: present');
+    });
+
+    it('generates suboptions as nested dict', () => {
+        const options: Record<string, PluginOption> = {
+            config: {
+                type: 'dict',
+                suboptions: {
+                    host: { type: 'str', required: true },
+                    port: { type: 'int' },
+                },
+            },
+        };
+        const yaml = generateSampleYaml('test.module', options, 'none');
+        expect(yaml).toContain('config:');
+        expect(yaml).toContain('host:');
+        expect(yaml).toContain('port:');
+    });
+
+    it('truncates long descriptions to 60 chars', () => {
+        const options: Record<string, PluginOption> = {
+            param: {
+                type: 'str',
+                description:
+                    'This is a very long description that exceeds sixty characters and should be truncated',
+            },
+        };
+        const yaml = generateSampleYaml('test.module', options, 'descriptions');
+        const commentLine = yaml.split('\n').find((l) => l.includes('#'));
+        expect(commentLine).toBeDefined();
+        expect(commentLine?.includes('...')).toBe(true);
+    });
+
+    it('capitalizes plugin name for task name', () => {
+        const yaml = generateSampleYaml('ns.col.my_task', {}, 'none');
+        expect(yaml).toContain('- name: My Task task');
+    });
+});

--- a/packages/ui/test/utils/yaml-highlight.test.ts
+++ b/packages/ui/test/utils/yaml-highlight.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+import { highlightYaml, highlightComment } from '../../src/utils/yaml-highlight';
+
+describe('highlightYaml', () => {
+    it('highlights full-line comments', () => {
+        const result = highlightYaml('# this is a comment');
+        expect(result).toBe('<span class="yaml-comment"># this is a comment</span>');
+    });
+
+    it('returns empty string for blank lines', () => {
+        const result = highlightYaml('');
+        expect(result).toBe('');
+    });
+
+    it('highlights key-value pairs', () => {
+        const result = highlightYaml('name: value');
+        expect(result).toContain('class="yaml-key"');
+        expect(result).toContain('name');
+    });
+
+    it('highlights boolean values', () => {
+        const result = highlightYaml('enabled: true');
+        expect(result).toContain('class="yaml-bool"');
+    });
+
+    it('highlights number values', () => {
+        const result = highlightYaml('count: 42');
+        expect(result).toContain('class="yaml-number"');
+    });
+
+    it('highlights null values', () => {
+        const result = highlightYaml('field: null');
+        expect(result).toContain('class="yaml-null"');
+    });
+
+    it('highlights quoted string values', () => {
+        const result = highlightYaml("name: 'hello'");
+        expect(result).toContain('class="yaml-string"');
+    });
+
+    it('highlights list markers with key', () => {
+        const result = highlightYaml('  - key: value');
+        expect(result).toContain('class="yaml-list-marker"');
+        expect(result).toContain('class="yaml-key"');
+    });
+
+    it('highlights bare list markers', () => {
+        const result = highlightYaml('  - ');
+        expect(result).toContain('class="yaml-list-marker"');
+    });
+
+    it('highlights list markers with boolean value', () => {
+        const result = highlightYaml('  - true');
+        expect(result).toContain('class="yaml-list-marker"');
+        expect(result).toContain('class="yaml-bool"');
+    });
+
+    it('processes multiple lines', () => {
+        const yaml = '# header\nname: value\ncount: 3';
+        const result = highlightYaml(yaml);
+        const lines = result.split('\n');
+        expect(lines).toHaveLength(3);
+        expect(lines[0]).toContain('yaml-comment');
+        expect(lines[1]).toContain('yaml-key');
+        expect(lines[2]).toContain('yaml-number');
+    });
+
+    it('handles inline comments', () => {
+        const result = highlightYaml('name: value  # optional');
+        expect(result).toContain('yaml-comment-dim');
+    });
+
+    it('escapes HTML in values', () => {
+        const result = highlightYaml('html: <div>');
+        expect(result).toContain('&lt;div&gt;');
+        expect(result).not.toContain('<div>');
+    });
+});
+
+describe('highlightComment', () => {
+    it('highlights simple comments as dim', () => {
+        const result = highlightComment('  # optional');
+        expect(result).toBe('<span class="yaml-comment-dim">  # optional</span>');
+    });
+
+    it('highlights structured comments with required', () => {
+        const result = highlightComment('  # (str, required) The name');
+        expect(result).toContain('yaml-comment-type');
+        expect(result).toContain('yaml-comment-required');
+    });
+
+    it('highlights structured comments with optional', () => {
+        const result = highlightComment('  # (int, optional) Timeout value');
+        expect(result).toContain('yaml-comment-type');
+        expect(result).toContain('yaml-comment-optional');
+    });
+
+    it('falls back to dim for non-structured comments', () => {
+        const result = highlightComment('  # just a note');
+        expect(result).toContain('yaml-comment-dim');
+        expect(result).not.toContain('yaml-comment-type');
+    });
+});

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1250,16 +1250,16 @@ Please:
     // Register plugin documentation command
     const showPluginDocCommand = vscode.commands.registerCommand(
         'ansibleDevTools.showPluginDoc',
-        async (pluginFullName: string, pluginType: string) => {
-            await PluginDocPanel.show(context.extensionUri, pluginFullName, pluginType);
+        (pluginFullName: string, pluginType: string) => {
+            PluginDocPanel.show(context.extensionUri, pluginFullName, pluginType);
         },
     );
 
     // Register plugin documentation command for context menu
     const collectionsShowPluginDocCommand = vscode.commands.registerCommand(
         'ansibleDevToolsCollections.showPluginDoc',
-        async (node: { fullName: string; pluginType: string }) => {
-            await PluginDocPanel.show(context.extensionUri, node.fullName, node.pluginType);
+        (node: { fullName: string; pluginType: string }) => {
+            PluginDocPanel.show(context.extensionUri, node.fullName, node.pluginType);
         },
     );
 

--- a/src/panels/PluginDocPanel.ts
+++ b/src/panels/PluginDocPanel.ts
@@ -1,2101 +1,284 @@
 import * as vscode from 'vscode';
 import { CollectionsService } from '@ansible/core';
-import type { PluginOption, PluginReturn, PluginData } from '@ansible/core';
-
-// Helper to normalize string or string[] to string[]
-interface PluginDocMessage {
-    type: string;
-    zoom?: number;
-    theme?: string;
-}
 
 /**
- * Normalize documentation fields that may be a string or string array.
- * @param value - Single value or list from plugin documentation metadata
- * @returns Array form of the value, or an empty array when absent
+ * Thin webview host for plugin documentation.
+ *
+ * All rendering is handled by PluginDocView in @ansible/ui.
+ * This class owns panel lifecycle, HTML shell, and postMessage
+ * RPC routing to CollectionsService.
  */
-function toArray(value: string | string[] | undefined): string[] {
-    if (!value) {
-        return [];
-    }
-    if (Array.isArray(value)) {
-        return value;
-    }
-    return [value];
-}
-
-/** Webview panel that renders Ansible plugin documentation with interactive samples. */
 export class PluginDocPanel {
     private static _panels = new Map<string, PluginDocPanel>();
     public static readonly viewType = 'pluginDocPanel';
-
-    private readonly _panel: vscode.WebviewPanel;
-    private readonly _extensionUri: vscode.Uri;
-    private readonly _pluginKey: string;
     private _disposables: vscode.Disposable[] = [];
 
     /**
-     * Show or reveal plugin documentation for the requested plugin.
-     * @param extensionUri - Extension root used for webview resources
-     * @param pluginFullName - Fully qualified plugin name
-     * @param pluginType - Plugin type such as module or lookup
+     * @param _panel - The VS Code webview panel instance.
+     * @param _pluginKey - Deduplication key (fqcn:type).
+     * @param _fqcn - Fully qualified plugin name.
+     * @param _pluginType - Plugin type such as module or lookup.
      */
-    public static async show(extensionUri: vscode.Uri, pluginFullName: string, pluginType: string) {
+    private constructor(
+        private readonly _panel: vscode.WebviewPanel,
+        private readonly _pluginKey: string,
+        private readonly _fqcn: string,
+        private readonly _pluginType: string,
+    ) {
+        this._panel.onDidDispose(
+            () => {
+                this._dispose();
+            },
+            null,
+            this._disposables,
+        );
+        this._panel.webview.onDidReceiveMessage(
+            (msg: { id?: number; method: string; params?: Record<string, unknown> }) => {
+                void this._handleMessage(msg);
+            },
+            null,
+            this._disposables,
+        );
+    }
+
+    /**
+     * Show or reveal plugin documentation for the requested plugin.
+     * @param extensionUri - Extension root used for webview resources.
+     * @param pluginFullName - Fully qualified plugin name.
+     * @param pluginType - Plugin type such as module or lookup.
+     */
+    public static show(extensionUri: vscode.Uri, pluginFullName: string, pluginType: string): void {
         const pluginKey = `${pluginFullName}:${pluginType}`;
 
-        // If panel for this plugin already exists, reveal it
-        const existingPanel = PluginDocPanel._panels.get(pluginKey);
-        if (existingPanel) {
-            existingPanel._panel.reveal();
+        const existing = PluginDocPanel._panels.get(pluginKey);
+        if (existing) {
+            existing._panel.reveal();
             return;
         }
 
-        // Create new panel in a new tab
         const panel = vscode.window.createWebviewPanel(
             PluginDocPanel.viewType,
             pluginFullName,
             vscode.ViewColumn.Active,
             {
                 enableScripts: true,
-                localResourceRoots: [extensionUri],
+                localResourceRoots: [vscode.Uri.joinPath(extensionUri, 'dist')],
                 retainContextWhenHidden: true,
             },
         );
 
-        const docPanel = new PluginDocPanel(panel, extensionUri, pluginKey);
-        PluginDocPanel._panels.set(pluginKey, docPanel);
-        await docPanel._loadPluginDoc(pluginFullName, pluginType);
-    }
+        const config = vscode.workspace.getConfiguration('ansibleEnvironments');
+        const enableAi = config.get<boolean>('enableAiFeatures', true);
 
-    /**
-     * Create the plugin documentation panel and wire webview message handlers.
-     * @param panel - Webview panel hosting the documentation view
-     * @param extensionUri - Extension root used for webview resources
-     * @param pluginKey - Stable key used to track open documentation panels
-     */
-    private constructor(panel: vscode.WebviewPanel, extensionUri: vscode.Uri, pluginKey: string) {
-        this._panel = panel;
-        this._extensionUri = extensionUri;
-        this._pluginKey = pluginKey;
-
-        this._panel.onDidDispose(
-            () => {
-                this.dispose();
-            },
-            null,
-            this._disposables,
+        panel.iconPath = new vscode.ThemeIcon('book');
+        panel.webview.html = PluginDocPanel._getHtml(
+            panel.webview,
+            extensionUri,
+            pluginFullName,
+            pluginType,
+            enableAi,
         );
 
-        // Handle messages from the webview
-        this._panel.webview.onDidReceiveMessage(
-            async (message: PluginDocMessage) => {
-                if (message.type === 'aiPrompt') {
-                    // Show info message with the copied prompt
-                    void vscode.window
-                        .showInformationMessage(
-                            'AI prompt copied to clipboard. Paste it into an agent chat session.',
-                            'Open Chat',
-                        )
-                        .then((selection) => {
-                            if (selection === 'Open Chat') {
-                                // Try to open the chat panel
-                                void vscode.commands.executeCommand('workbench.action.chat.open');
-                            }
-                        });
-                } else if (message.type === 'updateSettings') {
-                    // Save settings to workspace configuration
-                    const config = vscode.workspace.getConfiguration('ansibleEnvironments');
-                    if (message.zoom !== undefined) {
-                        await config.update(
-                            'pluginDocZoom',
-                            message.zoom,
-                            vscode.ConfigurationTarget.Workspace,
-                        );
-                    }
-                    if (message.theme !== undefined) {
-                        await config.update(
-                            'pluginDocTheme',
-                            message.theme,
-                            vscode.ConfigurationTarget.Workspace,
-                        );
-                    }
-                }
-            },
-            null,
-            this._disposables,
-        );
+        const instance = new PluginDocPanel(panel, pluginKey, pluginFullName, pluginType);
+        PluginDocPanel._panels.set(pluginKey, instance);
     }
 
     /**
-     * Load plugin documentation from the collections cache and render the panel.
-     * @param pluginFullName - Fully qualified plugin name
-     * @param pluginType - Plugin type such as module or lookup
+     * Generate the HTML shell for the webview.
+     * @param webview - Webview instance for URI resolution.
+     * @param extensionUri - Extension root URI.
+     * @param fqcn - Fully qualified plugin name.
+     * @param pluginType - Plugin type.
+     * @param enableAiFeatures - Whether AI features are enabled.
+     * @returns Complete HTML document string.
      */
-    private async _loadPluginDoc(pluginFullName: string, pluginType: string) {
-        this._panel.webview.html = this._getLoadingHtml();
-
-        try {
-            const service = CollectionsService.getInstance();
-            const pluginData = await service.getPluginDocumentation(pluginFullName, pluginType);
-
-            if (!pluginData?.doc) {
-                this._panel.webview.html = this._getErrorHtml('Plugin documentation not found');
-                return;
-            }
-
-            // Get settings
-            const config = vscode.workspace.getConfiguration('ansibleEnvironments');
-            const zoom = config.get<number>('pluginDocZoom', 100);
-            const themeSetting = config.get<string>('pluginDocTheme', 'auto');
-            const enableAiFeatures = config.get<boolean>('enableAiFeatures', true);
-
-            // Resolve 'auto' to actual theme based on VS Code's current theme
-            const vscodeThemeKind = vscode.window.activeColorTheme.kind;
-            const isVsCodeLight =
-                vscodeThemeKind === vscode.ColorThemeKind.Light ||
-                vscodeThemeKind === vscode.ColorThemeKind.HighContrastLight;
-            const resolvedTheme =
-                themeSetting === 'auto' ? (isVsCodeLight ? 'light' : 'dark') : themeSetting;
-
-            this._panel.webview.html = this._getDocHtml(
-                pluginFullName,
-                pluginType,
-                pluginData,
-                zoom,
-                themeSetting,
-                resolvedTheme,
-                enableAiFeatures,
-            );
-        } catch (error) {
-            this._panel.webview.html = this._getErrorHtml(
-                `Failed to load documentation: ${error instanceof Error ? error.message : String(error)}`,
-            );
-        }
-    }
-
-    /**
-     * Generate the loading placeholder HTML for the documentation webview.
-     * @returns Minimal HTML shown while documentation is loading
-     */
-    private _getLoadingHtml(): string {
-        return `<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Loading...</title>
-    <style>
-        body {
-            font-family: var(--vscode-font-family);
-            padding: 40px;
-            color: var(--vscode-foreground);
-            display: flex;
-            justify-content: center;
-            align-items: center;
-            min-height: 200px;
-        }
-        .loader {
-            text-align: center;
-        }
-        .spinner {
-            width: 40px;
-            height: 40px;
-            border: 3px solid var(--vscode-editor-foreground);
-            border-top-color: transparent;
-            border-radius: 50%;
-            animation: spin 1s linear infinite;
-            margin: 0 auto 16px;
-        }
-        @keyframes spin {
-            to { transform: rotate(360deg); }
-        }
-    </style>
-</head>
-<body>
-    <div class="loader">
-        <div class="spinner"></div>
-        <div>Loading documentation...</div>
-    </div>
-</body>
-</html>`;
-    }
-
-    /**
-     * Generate an error page for the documentation webview.
-     * @param message - Error text to display to the user
-     * @returns HTML error page rendered in the webview
-     */
-    private _getErrorHtml(message: string): string {
-        return `<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Error</title>
-    <style>
-        body {
-            font-family: var(--vscode-font-family);
-            padding: 40px;
-            color: var(--vscode-errorForeground);
-        }
-    </style>
-</head>
-<body>
-    <h2>Error</h2>
-    <p>${this._escapeHtml(message)}</p>
-</body>
-</html>`;
-    }
-
-    /**
-     * Generate the full plugin documentation webview HTML.
-     * @param pluginFullName - Fully qualified plugin name
-     * @param pluginType - Plugin type such as module or lookup
-     * @param data - Cached plugin documentation payload
-     * @param initialZoom - Initial zoom percentage for the webview
-     * @param themeSetting - Saved theme preference including auto mode
-     * @param resolvedTheme - Resolved light or dark theme for rendering
-     * @param enableAiFeatures - Whether AI helper actions should be shown
-     * @returns Complete HTML document rendered in the webview
-     */
-    private _getDocHtml(
-        pluginFullName: string,
+    private static _getHtml(
+        webview: vscode.Webview,
+        extensionUri: vscode.Uri,
+        fqcn: string,
         pluginType: string,
-        data: PluginData,
-        initialZoom = 100,
-        themeSetting = 'auto',
-        resolvedTheme = 'dark',
-        enableAiFeatures = true,
+        enableAiFeatures: boolean,
     ): string {
-        const doc = data.doc;
-        if (!doc) {
-            return this._getErrorHtml('Plugin documentation not found');
-        }
-        const parts = pluginFullName.split('.');
-        const namespace = parts[0];
-        const collection = parts[1];
-        const pluginName = parts.slice(2).join('.');
+        const scriptUri = webview.asWebviewUri(
+            vscode.Uri.joinPath(extensionUri, 'dist', 'webview.js'),
+        );
+        const nonce = getNonce();
+        const props = JSON.stringify({ fqcn, pluginType, enableAiFeatures });
 
         return `<!DOCTYPE html>
-<html lang="en" data-theme="${resolvedTheme}" data-theme-setting="${themeSetting}">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>${pluginFullName}</title>
+    <meta http-equiv="Content-Security-Policy"
+          content="default-src 'none'; script-src 'nonce-${nonce}'; style-src 'unsafe-inline';">
+    <title>${escapeHtml(fqcn)}</title>
     <style>
-        /* Dark theme (default) */
-        :root, [data-theme="dark"] {
-            --bg: #0d0d0d;
-            --surface: #161616;
-            --surface-light: #1e1e1e;
-            --border: #333;
-            --text: #e0e0e0;
-            --text-muted: #888;
-            --text-dim: #666;
-            --accent: #fff;
-            --code-bg: #0a0a0a;
-            --required: #e57373;
-            --success: #81c784;
-            /* YAML syntax - dark */
-            --yaml-key: #9cdcfe;
-            --yaml-string: #ce9178;
-            --yaml-number: #b5cea8;
-            --yaml-bool: #569cd6;
-            --yaml-comment: #6a9955;
-            --yaml-anchor: #c586c0;
+        :root {
+            --host-bg-primary: var(--vscode-editor-background);
+            --host-bg-surface: var(--vscode-sideBar-background, var(--vscode-editor-background));
+            --host-bg-hover: var(--vscode-list-hoverBackground);
+            --host-bg-active: var(--vscode-list-activeSelectionBackground);
+            --host-text-primary: var(--vscode-editor-foreground);
+            --host-text-secondary: var(--vscode-descriptionForeground);
+            --host-text-muted: var(--vscode-disabledForeground);
+            --host-text-link: var(--vscode-textLink-foreground);
+            --host-border: var(--vscode-panel-border, var(--vscode-widget-border));
+            --host-border-active: var(--vscode-focusBorder);
+            --host-accent: var(--vscode-button-background);
+            --host-accent-hover: var(--vscode-button-hoverBackground);
+            --host-success: var(--vscode-testing-iconPassed, #4ec9b0);
+            --host-warning: var(--vscode-editorWarning-foreground, #cca700);
+            --host-error: var(--vscode-editorError-foreground, #f44747);
+            --host-font-family: var(--vscode-font-family);
+            --host-font-size: var(--vscode-font-size);
+            --host-font-mono: var(--vscode-editor-font-family);
         }
-        
-        /* Light theme */
-        [data-theme="light"] {
-            --bg: #ffffff;
-            --surface: #f5f5f5;
-            --surface-light: #e8e8e8;
-            --border: #ddd;
-            --text: #1a1a1a;
-            --text-muted: #555;
-            --text-dim: #777;
-            --accent: #000;
-            --code-bg: #f8f8f8;
-            --required: #c62828;
-            --success: #2e7d32;
-            /* YAML syntax - light (higher contrast) */
-            --yaml-key: #0451a5;
-            --yaml-string: #a31515;
-            --yaml-number: #098658;
-            --yaml-bool: #0000ff;
-            --yaml-comment: #008000;
-            --yaml-anchor: #800080;
-        }
-        
-        * { box-sizing: border-box; margin: 0; padding: 0; }
-        
-        body {
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-            font-size: 13px;
-            background: var(--bg);
-            color: var(--text);
-            line-height: 1.5;
-        }
-        
-        .container { max-width: 960px; margin: 0 auto; padding: 16px; }
-        
-        /* Breadcrumb */
-        .breadcrumb {
-            font-size: 11px;
-            color: var(--text-dim);
-            margin-bottom: 12px;
-        }
-        .breadcrumb-separator { margin: 0 4px; }
-        
-        /* Header */
-        .header {
-            border-bottom: 1px solid var(--border);
-            padding-bottom: 12px;
-            margin-bottom: 16px;
-        }
-        .header-title {
-            display: flex;
-            align-items: center;
-            gap: 10px;
-        }
-        .header-title h1 {
-            font-size: 18px;
-            font-weight: 600;
-            font-family: 'SFMono-Regular', Consolas, monospace;
-        }
-        .plugin-type-badge {
-            background: var(--surface-light);
-            border: 1px solid var(--border);
-            color: var(--text-muted);
-            padding: 2px 8px;
-            border-radius: 3px;
-            font-size: 10px;
-            font-weight: 500;
-            text-transform: uppercase;
-            letter-spacing: 0.5px;
-        }
-        .short-desc {
-            color: var(--text-muted);
-            font-size: 12px;
-            margin-top: 6px;
-        }
-        .version-info {
-            font-size: 11px;
-            color: var(--text-dim);
-            margin-top: 4px;
-        }
-        
-        /* Navigation tabs */
-        .nav-tabs {
-            display: flex;
-            gap: 0;
-            border-bottom: 1px solid var(--border);
-            margin-bottom: 16px;
-        }
-        .nav-tab {
-            padding: 8px 14px;
-            font-size: 12px;
-            color: var(--text-muted);
-            border-bottom: 2px solid transparent;
-            margin-bottom: -1px;
-            cursor: pointer;
-        }
-        .nav-tab:hover { color: var(--text); }
-        .nav-tab.active {
-            color: var(--accent);
-            border-bottom-color: var(--accent);
-        }
-        
-        /* Sections */
-        .section { margin-bottom: 20px; }
-        .section-title {
-            font-size: 14px;
-            font-weight: 600;
-            margin-bottom: 10px;
-            color: var(--text);
-        }
-        
-        /* Synopsis */
-        .synopsis {
-            background: var(--surface);
-            border: 1px solid var(--border);
-            border-radius: 4px;
-            padding: 12px;
-            font-size: 12px;
-        }
-        .synopsis ul { margin: 0; padding-left: 16px; }
-        .synopsis li { margin-bottom: 4px; }
-        
-        /* Parameters - Tree Style */
-        .param-tree { font-size: 12px; }
-        
-        .param-item {
-            border-bottom: 1px solid var(--border);
-            padding: 8px 0;
-        }
-        .param-item:last-child { border-bottom: none; }
-        
-        .param-header {
-            display: flex;
-            align-items: flex-start;
-            gap: 8px;
-            cursor: pointer;
-            user-select: none;
-        }
-        .param-toggle {
-            width: 14px;
-            height: 14px;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            font-size: 10px;
-            color: var(--text-dim);
-            flex-shrink: 0;
-            margin-top: 2px;
-        }
-        .param-toggle:empty { visibility: hidden; }
-        
-        .param-name {
-            font-family: 'SFMono-Regular', Consolas, monospace;
-            font-weight: 600;
-            color: var(--text);
-        }
-        .param-type {
-            font-size: 11px;
-            color: var(--text-dim);
-            font-family: monospace;
-        }
-        .param-required {
-            color: var(--required);
-            font-size: 10px;
-            font-weight: 600;
-        }
-        
-        .param-meta {
-            display: flex;
-            gap: 12px;
-            margin-top: 4px;
-            margin-left: 22px;
-        }
-        .param-desc {
-            color: var(--text-muted);
-            margin-top: 4px;
-            margin-left: 22px;
-            font-size: 12px;
-        }
-        .param-desc p { margin: 0 0 4px 0; }
-        
-        .param-choices {
-            margin-top: 4px;
-            margin-left: 22px;
-        }
-        .param-choice {
-            display: inline-block;
-            background: var(--code-bg);
-            border: 1px solid var(--border);
-            padding: 1px 6px;
-            border-radius: 3px;
-            font-family: monospace;
-            font-size: 11px;
-            margin-right: 4px;
-            margin-bottom: 2px;
-        }
-        .param-choice.default {
-            border-color: var(--success);
-            color: var(--success);
-        }
-        
-        .param-default {
-            font-size: 11px;
-            color: var(--success);
-        }
-        
-        /* Suboptions */
-        .suboptions {
-            margin-left: 22px;
-            margin-top: 8px;
-            padding-left: 12px;
-            border-left: 1px solid var(--border);
-            display: none;
-        }
-        .suboptions.expanded { display: block; }
-        
-        /* Notes */
-        .notes {
-            background: var(--surface);
-            border: 1px solid var(--border);
-            border-radius: 4px;
-            padding: 12px;
-            font-size: 12px;
-        }
-        .notes ul { margin: 0; padding-left: 16px; }
-        .notes li { margin-bottom: 4px; }
-        
-        /* Examples */
-        .example-section {
-            margin-bottom: 16px;
-        }
-        .example-header {
-            display: flex;
-            align-items: center;
-            justify-content: space-between;
-            background: var(--surface);
-            border: 1px solid var(--border);
-            border-bottom: none;
-            border-radius: 4px 4px 0 0;
-            padding: 8px 12px;
-        }
-        .example-title {
-            font-weight: 600;
-            font-size: 12px;
-            color: var(--text);
-        }
-        .example-copy-btn {
-            background: var(--surface-light);
-            border: 1px solid var(--border);
-            color: var(--text-muted);
-            padding: 4px 10px;
-            border-radius: 3px;
-            font-size: 11px;
-            cursor: pointer;
-            display: flex;
-            align-items: center;
-            gap: 4px;
-        }
-        .example-copy-btn:hover {
-            background: var(--border);
-            color: var(--text);
-        }
-        .example-copy-btn.copied {
-            color: var(--success);
-            border-color: var(--success);
-        }
-        .example-code {
-            background: var(--code-bg);
-            border: 1px solid var(--border);
-            border-radius: 0 0 4px 4px;
-            padding: 12px;
-            overflow-x: auto;
+        html, body, #root {
             margin: 0;
-        }
-        .example-code pre {
-            font-family: 'SFMono-Regular', Consolas, monospace;
-            font-size: 12px;
-            line-height: 1.5;
-            white-space: pre;
-            color: var(--text);
-            margin: 0;
-        }
-        .example-context {
-            background: var(--surface);
-            border: 1px solid var(--border);
-            border-top: none;
-            padding: 10px 12px;
-            font-size: 11px;
-            color: var(--text-dim);
-            font-family: 'SFMono-Regular', Consolas, monospace;
-            white-space: pre-wrap;
-        }
-        .example-context:first-of-type {
-            border-radius: 4px 4px 0 0;
-            border-top: 1px solid var(--border);
-        }
-        .example-context-label {
-            font-weight: 600;
-            color: var(--text-muted);
-            margin-bottom: 4px;
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-        }
-        
-        /* YAML Syntax Highlighting */
-        .yaml-key { color: var(--yaml-key); }
-        .yaml-string { color: var(--yaml-string); }
-        .yaml-number { color: var(--yaml-number); }
-        .yaml-bool { color: var(--yaml-bool); }
-        .yaml-null { color: var(--yaml-bool); }
-        .yaml-comment { color: var(--yaml-comment); font-style: italic; }
-        .yaml-comment-dim { color: var(--text-dim); font-style: italic; }
-        .yaml-comment-type { color: var(--yaml-bool); font-style: italic; }
-        .yaml-comment-required { color: var(--required); font-style: italic; }
-        .yaml-comment-optional { color: var(--text-dim); font-style: italic; }
-        .yaml-list-marker { color: var(--text-muted); }
-        
-        /* Examples view toggle */
-        .examples-toolbar {
-            display: flex;
-            justify-content: flex-end;
-            margin-bottom: 12px;
-        }
-        .view-toggle {
-            display: flex;
-            background: var(--surface);
-            border: 1px solid var(--border);
-            border-radius: 4px;
+            padding: 0;
+            width: 100%;
+            height: 100%;
             overflow: hidden;
         }
-        .view-toggle-btn {
-            background: transparent;
-            border: none;
-            color: var(--text-muted);
-            padding: 6px 12px;
-            font-size: 11px;
-            cursor: pointer;
-        }
-        .view-toggle-btn:hover {
-            background: var(--surface-light);
-        }
-        .view-toggle-btn.active {
-            background: var(--border);
-            color: var(--text);
-        }
-        .examples-formatted, .examples-raw {
-            display: none;
-        }
-        .examples-formatted.active, .examples-raw.active {
-            display: block;
-        }
-        .sample-view {
-            display: none;
-        }
-        .sample-view.active {
-            display: block;
-        }
-        .raw-examples {
-            background: var(--code-bg);
-            border: 1px solid var(--border);
-            border-radius: 4px;
-            padding: 12px;
-            overflow-x: auto;
-        }
-        .raw-examples pre {
-            font-family: 'SFMono-Regular', Consolas, monospace;
-            font-size: 12px;
-            line-height: 1.5;
-            white-space: pre;
-            color: var(--text);
-            margin: 0;
-        }
-        
-        /* Return values */
-        .return-item {
-            border-bottom: 1px solid var(--border);
-            padding: 8px 0;
-        }
-        .return-item:last-child { border-bottom: none; }
-        .return-name {
-            font-family: 'SFMono-Regular', Consolas, monospace;
-            font-weight: 600;
-        }
-        .return-meta {
-            font-size: 11px;
-            color: var(--text-dim);
-            margin-top: 2px;
-        }
-        .return-desc {
-            color: var(--text-muted);
-            font-size: 12px;
-            margin-top: 4px;
-        }
-        .return-sample {
-            background: var(--code-bg);
-            border: 1px solid var(--border);
-            padding: 6px 10px;
-            border-radius: 3px;
-            font-family: monospace;
-            font-size: 11px;
-            margin-top: 6px;
-            overflow-x: auto;
-            white-space: pre;
-        }
-        
-        /* Author */
-        .author { color: var(--text-dim); font-size: 12px; }
-        
-        /* Tab content */
-        .tab-content { display: none; }
-        .tab-content.active { display: block; }
-        
-        /* Toolbar */
-        .toolbar {
-            position: fixed;
-            top: 12px;
-            right: 20px;
-            display: flex;
-            gap: 4px;
-            z-index: 100;
-            background: var(--surface);
-            border: 1px solid var(--border);
-            border-radius: 6px;
-            padding: 4px;
-        }
-        .toolbar-btn {
-            background: transparent;
-            border: none;
-            color: var(--text-muted);
-            width: 28px;
-            height: 28px;
-            border-radius: 4px;
-            cursor: pointer;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            font-size: 14px;
-            font-weight: 600;
-        }
-        .toolbar-btn:hover {
-            background: var(--surface-light);
-            color: var(--text);
-        }
-        .toolbar-btn.ai-btn {
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-            color: white;
-            font-size: 11px;
-            font-weight: 700;
-            width: auto;
-            padding: 0 10px;
-        }
-        .toolbar-btn.ai-btn:hover {
-            opacity: 0.9;
-        }
-        .toolbar-divider {
-            width: 1px;
-            background: var(--border);
-            margin: 4px 2px;
-        }
-        .zoom-label {
-            font-size: 11px;
-            color: var(--text-dim);
-            display: flex;
-            align-items: center;
-            padding: 0 4px;
-        }
-        
-        /* Inline code */
-        code {
-            background: var(--code-bg);
-            padding: 1px 4px;
-            border-radius: 3px;
-            font-family: 'SFMono-Regular', Consolas, monospace;
-            font-size: 0.9em;
-        }
-        
-        /* Links */
-        a { color: var(--text-muted); text-decoration: underline; }
-        a:hover { color: var(--text); }
     </style>
 </head>
 <body>
-    <div class="toolbar">
-        <button class="toolbar-btn" id="zoom-out-btn" title="Zoom out">−</button>
-        <span class="zoom-label" id="zoom-level">${String(initialZoom)}%</span>
-        <button class="toolbar-btn" id="zoom-in-btn" title="Zoom in">+</button>
-        <div class="toolbar-divider"></div>
-        <button class="toolbar-btn" id="theme-btn" title="Toggle theme">${themeSetting}</button>
-        ${
-            enableAiFeatures
-                ? `
-        <div class="toolbar-divider"></div>
-        <button class="toolbar-btn ai-btn" id="ai-prompt-btn" title="Generate AI prompt for task builder">AI</button>
-        `
-                : ''
-        }
-    </div>
-    
-    <div class="container">
-        <div class="breadcrumb">
-            <span>${namespace}</span>
-            <span class="breadcrumb-separator">›</span>
-            <span>${collection}</span>
-            <span class="breadcrumb-separator">›</span>
-            <span>${pluginType}</span>
-            <span class="breadcrumb-separator">›</span>
-            <strong>${pluginName}</strong>
-        </div>
-        
-        <div class="header">
-            <div class="header-title">
-                <h1>${pluginName}</h1>
-                <span class="plugin-type-badge">${pluginType}</span>
-            </div>
-            <div class="short-desc">${this._escapeHtml(doc.short_description ?? '')}</div>
-            ${doc.version_added ? `<div class="version-info">Added in version ${doc.version_added}</div>` : ''}
-        </div>
-        
-        <div class="nav-tabs">
-            <span class="nav-tab active" data-tab="synopsis">Synopsis</span>
-            <span class="nav-tab" data-tab="parameters">Parameters</span>
-            <span class="nav-tab" data-tab="sample">Sample Task</span>
-            ${doc.notes ? '<span class="nav-tab" data-tab="notes">Notes</span>' : ''}
-            ${data.examples ? '<span class="nav-tab" data-tab="examples">Examples</span>' : ''}
-            ${data.return ? '<span class="nav-tab" data-tab="return">Return Values</span>' : ''}
-        </div>
-        
-        <div id="synopsis" class="tab-content active">
-            <div class="section">
-                <h2 class="section-title">Synopsis</h2>
-                <div class="synopsis">
-                    <ul>
-                        ${toArray(doc.description)
-                            .map((d) => `<li>${this._formatText(d)}</li>`)
-                            .join('')}
-                    </ul>
-                </div>
-            </div>
-            
-            ${
-                doc.requirements
-                    ? `
-            <div class="section">
-                <h2 class="section-title">Requirements</h2>
-                <div class="synopsis">
-                    <ul>
-                        ${toArray(doc.requirements)
-                            .map((r) => `<li>${this._escapeHtml(r)}</li>`)
-                            .join('')}
-                    </ul>
-                </div>
-            </div>
-            `
-                    : ''
-            }
-            
-            ${
-                doc.author
-                    ? `
-            <div class="section">
-                <h2 class="section-title">Author</h2>
-                <div class="author">
-                    ${Array.isArray(doc.author) ? doc.author.join(', ') : doc.author}
-                </div>
-            </div>
-            `
-                    : ''
-            }
-        </div>
-        
-        <div id="parameters" class="tab-content">
-            <div class="section">
-                <h2 class="section-title">Parameters</h2>
-                ${this._renderParameters(doc.options ?? {})}
-            </div>
-        </div>
-        
-        <div id="sample" class="tab-content">
-            <div class="section">
-                <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 12px;">
-                    <h2 class="section-title" style="margin-bottom: 0;">Sample Task</h2>
-                    <button class="example-copy-btn" id="copy-btn-sample" onclick="copySampleTask()">
-                        Copy
-                    </button>
-                </div>
-                <p style="color: var(--text-muted); font-size: 12px; margin-bottom: 12px;">
-                    A template task showing all available parameters with their defaults or example values.
-                </p>
-                ${this._renderSampleTask(pluginFullName, doc.options ?? {})}
-            </div>
-        </div>
-        
-        ${
-            doc.notes
-                ? `
-        <div id="notes" class="tab-content">
-            <div class="section">
-                <h2 class="section-title">Notes</h2>
-                <div class="notes">
-                    <ul>
-                        ${toArray(doc.notes)
-                            .map((n) => `<li>${this._formatText(n)}</li>`)
-                            .join('')}
-                    </ul>
-                </div>
-            </div>
-        </div>
-        `
-                : ''
-        }
-        
-        ${
-            data.examples
-                ? `
-        <div id="examples" class="tab-content">
-            <div class="section">
-                <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 12px;">
-                    <h2 class="section-title" style="margin-bottom: 0;">Examples</h2>
-                    <div class="view-toggle">
-                        <button class="view-toggle-btn active" id="btn-formatted" onclick="toggleExamplesView('formatted')">Formatted</button>
-                        <button class="view-toggle-btn" id="btn-raw" onclick="toggleExamplesView('raw')">Raw</button>
-                    </div>
-                </div>
-                <div class="examples-formatted active" id="examples-formatted">
-                    ${this._renderExamples(data.examples)}
-                </div>
-                <div class="examples-raw" id="examples-raw">
-                    <div class="raw-examples">
-                        <pre>${this._highlightYaml(data.examples)}</pre>
-                    </div>
-                </div>
-            </div>
-        </div>
-        `
-                : ''
-        }
-        
-        ${
-            data.return
-                ? `
-        <div id="return" class="tab-content">
-            <div class="section">
-                <h2 class="section-title">Return Values</h2>
-                ${this._renderReturnValues(data.return)}
-            </div>
-        </div>
-        `
-                : ''
-        }
-    </div>
-    
-    <script>
-        // Tab switching
-        document.querySelectorAll('.nav-tab').forEach(tab => {
-            tab.addEventListener('click', () => {
-                document.querySelectorAll('.nav-tab').forEach(t => t.classList.remove('active'));
-                document.querySelectorAll('.tab-content').forEach(c => c.classList.remove('active'));
-                tab.classList.add('active');
-                document.getElementById(tab.dataset.tab).classList.add('active');
-            });
-        });
-        
-        // Collapsible suboptions
-        function toggleSub(id) {
-            const el = document.getElementById(id);
-            if (el) {
-                el.classList.toggle('expanded');
-                const header = el.previousElementSibling?.previousElementSibling?.previousElementSibling;
-                if (header) {
-                    const toggle = header.querySelector('.param-toggle');
-                    if (toggle) {
-                        toggle.textContent = el.classList.contains('expanded') ? '▼' : '▶';
-                    }
-                }
-            }
-        }
-        
-        // Copy to clipboard
-        function copyExample(id) {
-            const el = document.getElementById('task-' + id);
-            if (el) {
-                const text = el.getAttribute('data-raw');
-                navigator.clipboard.writeText(text).then(() => {
-                    const btn = document.getElementById('copy-btn-' + id);
-                    if (btn) {
-                        btn.classList.add('copied');
-                        btn.innerHTML = '✓ Copied';
-                        setTimeout(() => {
-                            btn.classList.remove('copied');
-                            btn.innerHTML = 'Copy';
-                        }, 2000);
-                    }
-                });
-            }
-        }
-        
-        // Toggle between formatted and raw examples view
-        function toggleExamplesView(view) {
-            const formatted = document.getElementById('examples-formatted');
-            const raw = document.getElementById('examples-raw');
-            const btnFormatted = document.getElementById('btn-formatted');
-            const btnRaw = document.getElementById('btn-raw');
-            
-            if (view === 'formatted') {
-                formatted.classList.add('active');
-                raw.classList.remove('active');
-                btnFormatted.classList.add('active');
-                btnRaw.classList.remove('active');
-            } else {
-                formatted.classList.remove('active');
-                raw.classList.add('active');
-                btnFormatted.classList.remove('active');
-                btnRaw.classList.add('active');
-            }
-        }
-        
-        // Track current sample view
-        let currentSampleView = 'optional';
-        
-        // Switch sample task view
-        function switchSampleView(view) {
-            currentSampleView = view;
-            
-            // Update buttons
-            document.querySelectorAll('.sample-toolbar .view-toggle-btn').forEach(btn => {
-                btn.classList.remove('active');
-            });
-            document.getElementById('btn-no-comments')?.classList.toggle('active', view === 'none');
-            document.getElementById('btn-optional')?.classList.toggle('active', view === 'optional');
-            document.getElementById('btn-descriptions')?.classList.toggle('active', view === 'descriptions');
-            
-            // Update visible view
-            document.querySelectorAll('.sample-view').forEach(v => v.classList.remove('active'));
-            const viewMap = { 'none': 'sample-none', 'optional': 'sample-optional', 'descriptions': 'sample-descriptions' };
-            document.getElementById(viewMap[view])?.classList.add('active');
-        }
-        
-        // Copy current sample task to clipboard
-        function copySampleTask() {
-            const viewMap = { 'none': 'sample-none', 'optional': 'sample-optional', 'descriptions': 'sample-descriptions' };
-            const el = document.getElementById(viewMap[currentSampleView]);
-            if (el) {
-                const text = el.getAttribute('data-raw');
-                navigator.clipboard.writeText(text).then(() => {
-                    const btn = document.getElementById('copy-btn-sample');
-                    if (btn) {
-                        btn.classList.add('copied');
-                        btn.innerHTML = '✓ Copied';
-                        setTimeout(() => {
-                            btn.classList.remove('copied');
-                            btn.innerHTML = 'Copy';
-                        }, 2000);
-                    }
-                });
-            }
-        }
-        
-        // Initialize sample view
-        switchSampleView('optional');
-        
-        // VS Code API for messaging
-        const vscode = acquireVsCodeApi();
-        
-        // Zoom functionality
-        (function() {
-            let currentZoom = ${String(initialZoom)};
-            const minZoom = 50;
-            const maxZoom = 200;
-            const zoomStep = 10;
-            
-            const zoomInBtn = document.getElementById('zoom-in-btn');
-            const zoomOutBtn = document.getElementById('zoom-out-btn');
-            const zoomLevel = document.getElementById('zoom-level');
-            const mainContent = document.querySelector('.container');
-            
-            // Apply initial zoom
-            if (mainContent && currentZoom !== 100) {
-                mainContent.style.zoom = (currentZoom / 100);
-            }
-            
-            function updateZoom(save = true) {
-                if (mainContent) {
-                    mainContent.style.zoom = (currentZoom / 100);
-                }
-                if (zoomLevel) zoomLevel.textContent = currentZoom + '%';
-                if (save) {
-                    vscode.postMessage({ type: 'updateSettings', zoom: currentZoom });
-                }
-            }
-            
-            if (zoomInBtn) {
-                zoomInBtn.onclick = function() {
-                    if (currentZoom < maxZoom) {
-                        currentZoom += zoomStep;
-                        updateZoom();
-                    }
-                };
-            }
-            
-            if (zoomOutBtn) {
-                zoomOutBtn.onclick = function() {
-                    if (currentZoom > minZoom) {
-                        currentZoom -= zoomStep;
-                        updateZoom();
-                    }
-                };
-            }
-        })();
-        
-        // Theme toggle functionality
-        (function() {
-            const themes = ['auto', 'light', 'dark'];
-            let currentThemeSetting = '${themeSetting}';
-            
-            const themeBtn = document.getElementById('theme-btn');
-            
-            function updateThemeButton() {
-                if (themeBtn) {
-                    themeBtn.textContent = currentThemeSetting;
-                    themeBtn.title = 'Theme: ' + currentThemeSetting + ' (click to cycle)';
-                }
-            }
-            
-            if (themeBtn) {
-                themeBtn.onclick = function() {
-                    const currentIndex = themes.indexOf(currentThemeSetting);
-                    currentThemeSetting = themes[(currentIndex + 1) % themes.length];
-                    
-                    // For auto, we can't resolve here without VS Code - just toggle between light/dark
-                    // The next reload will properly resolve 'auto'
-                    const displayTheme = currentThemeSetting === 'auto' ? 'dark' : currentThemeSetting;
-                    document.documentElement.setAttribute('data-theme', displayTheme);
-                    document.documentElement.setAttribute('data-theme-setting', currentThemeSetting);
-                    
-                    updateThemeButton();
-                    vscode.postMessage({ type: 'updateSettings', theme: currentThemeSetting });
-                };
-            }
-        })();
-        
-        // AI prompt generation (only if AI features enabled)
-        const pluginFullName = "${pluginFullName}";
-        const pluginType = "${pluginType}";
-        const aiBtn = document.getElementById('ai-prompt-btn');
-        if (aiBtn) {
-            aiBtn.addEventListener('click', function() {
-                const prompt = \`Help me create an Ansible task using the \${pluginFullName} \${pluginType}, guiding me through the required and optional parameters. Use the build_ansible_task MCP tool to accomplish this.\`;
-                
-                // Copy to clipboard
-                const btn = this;
-                const originalText = btn.innerHTML;
-                navigator.clipboard.writeText(prompt).then(() => {
-                    btn.innerHTML = '✓';
-                    btn.style.background = 'var(--success)';
-                    setTimeout(() => {
-                        btn.innerHTML = originalText;
-                        btn.style.background = '';
-                    }, 2000);
-                });
-                
-                // Also send message to extension to open chat
-                vscode.postMessage({
-                    type: 'aiPrompt',
-                    prompt: prompt
-                });
-            });
-        }
-    </script>
+    <div id="root"
+         data-view="plugin-doc"
+         data-props="${escapeAttr(props)}"></div>
+    <script nonce="${nonce}" src="${String(scriptUri)}"></script>
 </body>
 </html>`;
     }
 
     /**
-     * Render plugin parameter documentation as nested HTML.
-     * @param options - Parameter schema map for the plugin
-     * @param depth - Current nesting depth for suboptions
-     * @returns HTML fragment for the parameter tree
+     * Handle incoming postMessage RPC from the webview.
+     * @param msg - The message payload with optional correlation ID.
+     * @param msg.id - Correlation ID for request/response pairing.
+     * @param msg.method - The RPC method name.
+     * @param msg.params - Arbitrary parameters from the webview.
      */
-    private _renderParameters(options: Record<string, PluginOption>, depth = 0): string {
-        if (Object.keys(options).length === 0) {
-            return '<p style="color: var(--text-dim);">No parameters</p>';
-        }
+    private async _handleMessage(msg: {
+        id?: number;
+        method: string;
+        params?: Record<string, unknown>;
+    }): Promise<void> {
+        const { id, method, params } = msg;
 
-        const sortedOptions = Object.entries(options).sort((a, b) => a[0].localeCompare(b[0]));
-        const items = sortedOptions
-            .map(([name, opt]) => this._renderParamItem(name, opt, depth))
-            .join('');
-
-        if (depth === 0) {
-            return `<div class="param-tree">${items}</div>`;
-        }
-        return `<div class="suboptions" id="sub-${String(Date.now())}-${Math.random().toString(36).substring(2, 11)}">${items}</div>`;
-    }
-
-    /**
-     * Render a single parameter item and its nested suboptions.
-     * @param name - Parameter name
-     * @param opt - Parameter schema metadata
-     * @param depth - Current nesting depth for suboptions
-     * @returns HTML fragment for one parameter row
-     */
-    private _renderParamItem(name: string, opt: PluginOption, depth: number): string {
-        const typeStr = opt.type ?? 'str';
-        const elementsStr = opt.elements ? `/${opt.elements}` : '';
-        const hasSuboptions = opt.suboptions && Object.keys(opt.suboptions).length > 0;
-        const subId = `sub-${name}-${String(depth)}-${Math.random().toString(36).substring(2, 11)}`;
-
-        return `
-        <div class="param-item">
-            <div class="param-header" ${hasSuboptions ? `onclick="toggleSub('${subId}')"` : ''}>
-                <span class="param-toggle">${hasSuboptions ? '▶' : ''}</span>
-                <span class="param-name">${name}</span>
-                <span class="param-type">(${typeStr}${elementsStr})</span>
-                ${opt.required ? '<span class="param-required">required</span>' : ''}
-            </div>
-            ${this._renderChoicesDefaults(opt, depth)}
-            <div class="param-desc">
-                ${toArray(opt.description)
-                    .map((d) => `<p>${this._formatText(d)}</p>`)
-                    .join('')}
-            </div>
-            ${
-                hasSuboptions
-                    ? `<div class="suboptions" id="${subId}">${Object.entries(opt.suboptions ?? {})
-                          .sort((a, b) => a[0].localeCompare(b[0]))
-                          .map(([n, o]) => this._renderParamItem(n, o, depth + 1))
-                          .join('')}</div>`
-                    : ''
+        if (method === 'showToast') {
+            const text = params?.message;
+            const safeText =
+                typeof text === 'string' ? text : text != null ? JSON.stringify(text) : '';
+            if (safeText) {
+                void vscode.window.showInformationMessage(safeText);
             }
-        </div>`;
+            return;
+        }
+
+        if (method === 'openChat') {
+            const prompt = typeof params?.prompt === 'string' ? params.prompt : undefined;
+            void this._openChatWithPrompt(prompt);
+            return;
+        }
+
+        if (id === undefined) return;
+
+        try {
+            const result = await this._dispatch(method, params ?? {});
+            void this._panel.webview.postMessage({ id, result });
+        } catch (err) {
+            const errMessage = err instanceof Error ? err.message : String(err);
+            void this._panel.webview.postMessage({ id, error: errMessage });
+        }
     }
 
     /**
-     * Render parameter choices or default values beneath a parameter header.
-     * @param opt - Parameter schema metadata
-     * @param depth - Current nesting depth used for indentation
-     * @returns HTML fragment for choices and defaults
+     * Route an RPC method call to the appropriate service.
+     * @param method - The RPC method name.
+     * @param params - Parameters from the webview.
+     * @returns The result to send back to the webview.
      */
-    private _renderChoicesDefaults(opt: PluginOption, depth = 0): string {
-        let html = '';
-        const marginLeft = depth > 0 ? '' : 'margin-left: 22px;';
-
-        if (opt.choices && opt.choices.length > 0) {
-            html += `<div class="param-choices" style="${marginLeft}">`;
-            html += opt.choices
-                .map((c) => {
-                    const isDefault = opt.default === c;
-                    return `<span class="param-choice${isDefault ? ' default' : ''}">${this._escapeHtml(c)}</span>`;
-                })
-                .join('');
-            html += '</div>';
-        } else if (opt.default !== undefined && opt.default !== null) {
-            html += `<div class="param-default" style="${marginLeft}">default: <code>${this._escapeHtml(JSON.stringify(opt.default))}</code></div>`;
-        }
-
-        return html;
-    }
-
-    /**
-     * Render documented return values for the plugin.
-     * @param returnVals - Return value schema map from plugin documentation
-     * @returns HTML fragment for the return values section
-     */
-    private _renderReturnValues(returnVals: PluginReturn): string {
-        const entries = Object.entries(returnVals);
-        if (entries.length === 0) {
-            return '<p style="color: var(--text-dim);">No return values documented</p>';
-        }
-
-        return `<div class="param-tree">
-            ${entries
-                .map(
-                    ([name, val]) => `
-            <div class="return-item">
-                <div class="return-name">${name}</div>
-                <div class="return-meta">${val.type ?? 'unknown'} — returned: ${val.returned ?? 'always'}</div>
-                <div class="return-desc">${Array.isArray(val.description) ? val.description.join(' ') : (val.description ?? '')}</div>
-                ${val.sample !== undefined ? `<div class="return-sample">${this._escapeHtml(JSON.stringify(val.sample, null, 2))}</div>` : ''}
-            </div>
-            `,
-                )
-                .join('')}
-        </div>`;
-    }
-
-    /**
-     * Render plugin examples as structured sections with copy buttons.
-     * @param examples - Raw examples text from plugin documentation
-     * @returns HTML fragment for the examples section
-     */
-    private _renderExamples(examples: string): string {
-        // Parse examples into sections based on the pattern
-        const sections = this._parseExamples(examples);
-
-        if (sections.length === 0) {
-            // Fallback: just show the raw examples with syntax highlighting
-            return `<div class="example-section">
-                <div class="example-code">
-                    <pre>${this._highlightYaml(examples)}</pre>
-                </div>
-            </div>`;
-        }
-
-        return sections
-            .map((section, index) => {
-                const taskId = `example-${String(index)}`;
-                const escapedRaw = this._escapeHtml(section.task)
-                    .replace(/'/g, '&#39;')
-                    .replace(/"/g, '&quot;');
-
-                let html = `<div class="example-section">`;
-
-                // Header with title and copy button
-                html += `<div class="example-header">
-                <span class="example-title">${this._escapeHtml(section.title)}</span>
-                <button class="example-copy-btn" id="copy-btn-${taskId}" onclick="copyExample('${taskId}')">
-                    Copy
-                </button>
-            </div>`;
-
-                // Before state context (if present)
-                if (section.beforeState) {
-                    html += `<div class="example-context">
-                    <div class="example-context-label">Before state:</div>
-${this._escapeHtml(section.beforeState)}</div>`;
+    private async _dispatch(method: string, params: Record<string, unknown>): Promise<unknown> {
+        switch (method) {
+            case 'getPluginDoc': {
+                const fqcn = typeof params.fqcn === 'string' ? params.fqcn : this._fqcn;
+                const pType =
+                    typeof params.pluginType === 'string' ? params.pluginType : this._pluginType;
+                return CollectionsService.getInstance().getPluginDocumentation(fqcn, pType);
+            }
+            case 'copyToClipboard': {
+                if (typeof params.text === 'string') {
+                    await vscode.env.clipboard.writeText(params.text);
                 }
-
-                // The actual task YAML with syntax highlighting
-                html += `<div class="example-code" id="task-${taskId}" data-raw="${escapedRaw}">
-                <pre>${this._highlightYaml(section.task)}</pre>
-            </div>`;
-
-                // Task output context (if present)
-                if (section.taskOutput) {
-                    html += `<div class="example-context">
-                    <div class="example-context-label">Task Output:</div>
-${this._escapeHtml(section.taskOutput)}</div>`;
-                }
-
-                // After state context (if present)
-                if (section.afterState) {
-                    html += `<div class="example-context">
-                    <div class="example-context-label">After state:</div>
-${this._escapeHtml(section.afterState)}</div>`;
-                }
-
-                html += `</div>`;
-                return html;
-            })
-            .join('');
-    }
-
-    /**
-     * Parse raw example text into titled task sections and context blocks.
-     * @param examples - Raw examples text from plugin documentation
-     * @returns Parsed example sections used by the examples renderer
-     */
-    private _parseExamples(examples: string): {
-        title: string;
-        beforeState?: string;
-        task: string;
-        taskOutput?: string;
-        afterState?: string;
-    }[] {
-        const sections: {
-            title: string;
-            beforeState?: string;
-            task: string;
-            taskOutput?: string;
-            afterState?: string;
-        }[] = [];
-
-        const lines = examples.split('\n');
-        let currentSection: {
-            title: string;
-            beforeState?: string;
-            task: string;
-            taskOutput?: string;
-            afterState?: string;
-        } | null = null;
-
-        let currentPart: 'start' | 'before' | 'task' | 'output' | 'after' = 'start';
-        let buffer: string[] = [];
-        let sectionHeader: string | null = null; // For "# Using merged" style headers
-
-        const flushBuffer = () => {
-            if (!currentSection) {
-                return;
+                return undefined;
             }
-            const content = buffer.join('\n').trim();
-            if (!content) {
-                buffer = [];
-                return;
+            case 'saveViewSettings':
+                return undefined;
+            case 'getResolvedTheme': {
+                const kind = vscode.window.activeColorTheme.kind;
+                return kind === vscode.ColorThemeKind.Light ||
+                    kind === vscode.ColorThemeKind.HighContrastLight
+                    ? 'light'
+                    : 'dark';
             }
-
-            switch (currentPart) {
-                case 'before':
-                    currentSection.beforeState = content;
-                    break;
-                case 'task':
-                    currentSection.task =
-                        (currentSection.task ? currentSection.task + '\n\n' : '') + content;
-                    break;
-                case 'output':
-                    currentSection.taskOutput = content;
-                    break;
-                case 'after':
-                    currentSection.afterState = content;
-                    break;
-            }
-            buffer = [];
-        };
-
-        const saveCurrentSection = () => {
-            if (currentSection) {
-                flushBuffer();
-                if (currentSection.task) {
-                    sections.push(currentSection);
-                }
-            }
-            currentSection = null;
-            currentPart = 'start';
-        };
-
-        for (const line of lines) {
-            const trimmedLine = line.trim();
-
-            // Check for section header (# Using merged, # Using replaced, etc.)
-            if (/^#\s*Using\s+\w+/.test(trimmedLine)) {
-                saveCurrentSection();
-                sectionHeader = trimmedLine.replace(/^#\s*/, '');
-                continue;
-            }
-
-            // Check for state markers
-            if (/^#\s*Before\s+state:?\s*$/i.test(trimmedLine)) {
-                flushBuffer();
-                currentPart = 'before';
-                continue;
-            }
-
-            if (/^#\s*Task\s+[Oo]utput:?\s*$/i.test(trimmedLine)) {
-                flushBuffer();
-                currentPart = 'output';
-                continue;
-            }
-
-            if (/^#\s*After\s+state:?\s*$/i.test(trimmedLine)) {
-                flushBuffer();
-                currentPart = 'after';
-                continue;
-            }
-
-            // Check if this is a new task (starts with "- name:")
-            if (trimmedLine.startsWith('- name:')) {
-                // Save previous section if we have one
-                saveCurrentSection();
-
-                // Extract task name for title and capitalize it
-                const rawTaskName = trimmedLine
-                    .replace(/^-\s*name:\s*/, '')
-                    .replace(/^["']|["']$/g, '');
-                const taskName = this._capitalizeTitle(rawTaskName);
-
-                // Start new section
-                currentSection = {
-                    title: sectionHeader ? `${sectionHeader}: ${taskName}` : taskName,
-                    task: '',
-                };
-                sectionHeader = null; // Clear header after use
-                currentPart = 'task';
-                buffer = [line];
-                continue;
-            }
-
-            // If we're in a task and hit a comment line after yaml content, check if it's output/after
-            if (currentPart === 'task' && trimmedLine.startsWith('#') && buffer.length > 0) {
-                // Check if the previous lines look like YAML (not all comments)
-                const hasYaml = buffer.some(
-                    (l) => !l.trim().startsWith('#') && l.trim().length > 0,
-                );
-                if (hasYaml) {
-                    // Skip divider lines
-                    if (/^#\s*-+\s*$/.test(trimmedLine)) {
-                        continue;
-                    }
-                    flushBuffer();
-                    currentPart = 'output';
-                    buffer = [line];
-                    continue;
-                }
-            }
-
-            // Add line to current buffer if we have an active section
-            if (currentSection) {
-                buffer.push(line);
-            }
-        }
-
-        // Save final section
-        saveCurrentSection();
-
-        return sections;
-    }
-
-    /**
-     * Convert example or task titles into title case for display.
-     * @param text - Raw title text from plugin documentation
-     * @returns Title-cased display text
-     */
-    private _capitalizeTitle(text: string): string {
-        if (!text) {
-            return text;
-        }
-        // Capitalize first letter of each word
-        return text
-            .split(' ')
-            .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-            .join(' ');
-    }
-
-    /**
-     * Render the interactive sample task builder with comment mode toggles.
-     * @param pluginFullName - Fully qualified plugin name
-     * @param options - Parameter schema map for the plugin
-     * @returns HTML fragment for the sample task section
-     */
-    private _renderSampleTask(
-        pluginFullName: string,
-        options: Record<string, PluginOption>,
-    ): string {
-        const yamlNoComments = this._generateSampleYaml(pluginFullName, options, 'none');
-        const yamlOptionalComments = this._generateSampleYaml(pluginFullName, options, 'optional');
-        const yamlDescComments = this._generateSampleYaml(pluginFullName, options, 'descriptions');
-
-        return `
-        <div class="sample-toolbar" style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 12px;">
-            <div class="view-toggle">
-                <button class="view-toggle-btn" id="btn-no-comments" onclick="switchSampleView('none')">No Comments</button>
-                <button class="view-toggle-btn active" id="btn-optional" onclick="switchSampleView('optional')">Minimal</button>
-                <button class="view-toggle-btn" id="btn-descriptions" onclick="switchSampleView('descriptions')">Documented</button>
-            </div>
-            <button class="example-copy-btn" id="copy-btn-sample" onclick="copySampleTask()">
-                Copy
-            </button>
-        </div>
-        
-        <div class="sample-view active" id="sample-none" data-raw="${this._escapeAttr(yamlNoComments)}">
-            <div class="example-code">
-                <pre>${this._highlightYaml(yamlNoComments)}</pre>
-            </div>
-        </div>
-        
-        <div class="sample-view" id="sample-optional" data-raw="${this._escapeAttr(yamlOptionalComments)}">
-            <div class="example-code">
-                <pre>${this._highlightYaml(yamlOptionalComments)}</pre>
-            </div>
-        </div>
-        
-        <div class="sample-view" id="sample-descriptions" data-raw="${this._escapeAttr(yamlDescComments)}">
-            <div class="example-code">
-                <pre>${this._highlightYaml(yamlDescComments)}</pre>
-            </div>
-        </div>`;
-    }
-
-    /**
-     * Escape text for safe use inside HTML attribute values.
-     * @param text - Raw text to embed in a data attribute
-     * @returns HTML-escaped attribute-safe text
-     */
-    private _escapeAttr(text: string): string {
-        return text
-            .replace(/'/g, '&#39;')
-            .replace(/"/g, '&quot;')
-            .replace(/</g, '&lt;')
-            .replace(/>/g, '&gt;');
-    }
-
-    /**
-     * Generate sample task YAML for the requested comment mode.
-     * @param pluginFullName - Fully qualified plugin name
-     * @param options - Parameter schema map for the plugin
-     * @param commentMode - Comment style to apply to generated YAML
-     * @returns Sample task YAML text
-     */
-    private _generateSampleYaml(
-        pluginFullName: string,
-        options: Record<string, PluginOption>,
-        commentMode: 'none' | 'optional' | 'descriptions',
-    ): string {
-        const lines: string[] = [];
-        const pluginName = pluginFullName.split('.').pop() ?? pluginFullName;
-
-        lines.push(`- name: ${this._capitalizeTitle(pluginName.replace(/_/g, ' '))} task`);
-        lines.push(`  ${pluginFullName}:`);
-
-        // Sort: required first, then alphabetical
-        const sortedOptions = Object.entries(options).sort((a, b) => {
-            const aReq = a[1].required ? 0 : 1;
-            const bReq = b[1].required ? 0 : 1;
-            if (aReq !== bReq) {
-                return aReq - bReq;
-            }
-            return a[0].localeCompare(b[0]);
-        });
-
-        for (const [name, opt] of sortedOptions) {
-            this._addParamToYaml(lines, name, opt, 4, false, commentMode);
-        }
-
-        return lines.join('\n');
-    }
-
-    /**
-     * Append one parameter and its suboptions to generated sample YAML lines.
-     * @param lines - Accumulated YAML lines for the sample task
-     * @param name - Parameter name
-     * @param opt - Parameter schema metadata
-     * @param indent - Current indentation level in spaces
-     * @param isFirstInList - Whether this parameter starts a YAML list item
-     * @param commentMode - Comment style to apply to generated YAML
-     */
-    private _addParamToYaml(
-        lines: string[],
-        name: string,
-        opt: PluginOption,
-        indent: number,
-        isFirstInList = false,
-        commentMode: 'none' | 'optional' | 'descriptions' = 'optional',
-    ): void {
-        const spaces = ' '.repeat(indent);
-
-        // Build the comment suffix based on mode
-        let comment = '';
-        if (commentMode === 'descriptions') {
-            const desc = toArray(opt.description)[0] ?? '';
-            // Truncate long descriptions and clean up
-            const cleanDesc = desc.replace(/\s+/g, ' ').trim();
-            const truncatedDesc =
-                cleanDesc.length > 60 ? cleanDesc.substring(0, 57) + '...' : cleanDesc;
-            const typeStr = opt.type ?? 'str';
-            const reqMarker = opt.required ? 'required' : 'optional';
-            comment = `  # (${typeStr}, ${reqMarker}) ${truncatedDesc}`;
-        } else if (commentMode === 'optional') {
-            comment = opt.required ? '' : '  # optional';
-        }
-        // commentMode === 'none' leaves comment as ''
-
-        // If this is the first item in a list, we need to prefix with "- "
-        const prefix = isFirstInList ? '- ' : '';
-        const prefixSpaces = isFirstInList ? ' '.repeat(indent - 2) : spaces;
-
-        // Generate example value based on type and available info
-        const value = this._getExampleValue(name, opt);
-
-        if (opt.suboptions && Object.keys(opt.suboptions).length > 0) {
-            // Sort suboptions: required first
-            const sortedSubopts = Object.entries(opt.suboptions).sort((a, b) => {
-                const aReq = a[1].required ? 0 : 1;
-                const bReq = b[1].required ? 0 : 1;
-                if (aReq !== bReq) {
-                    return aReq - bReq;
-                }
-                return a[0].localeCompare(b[0]);
-            });
-
-            if (opt.type === 'list') {
-                lines.push(`${prefixSpaces}${prefix}${name}:${comment}`);
-
-                // First suboption gets the list marker
-                let isFirst = true;
-                for (const [subName, subOpt] of sortedSubopts) {
-                    this._addParamToYaml(lines, subName, subOpt, indent + 4, isFirst, commentMode);
-                    isFirst = false;
-                }
-            } else {
-                lines.push(`${prefixSpaces}${prefix}${name}:${comment}`);
-
-                for (const [subName, subOpt] of sortedSubopts) {
-                    this._addParamToYaml(lines, subName, subOpt, indent + 2, false, commentMode);
-                }
-            }
-        } else if (opt.type === 'list') {
-            const elemValue = this._getElementValue(name, opt);
-            lines.push(`${prefixSpaces}${prefix}${name}:${comment}`);
-            lines.push(`${spaces}  - ${elemValue}`);
-        } else {
-            lines.push(`${prefixSpaces}${prefix}${name}: ${value}${comment}`);
-        }
-    }
-
-    /**
-     * Choose a representative example value for a parameter.
-     * @param name - Parameter name
-     * @param opt - Parameter schema metadata
-     * @returns Example YAML value text for the parameter
-     */
-    private _getExampleValue(name: string, opt: PluginOption): string {
-        // If there's a default, use it
-        if (opt.default !== undefined && opt.default !== null) {
-            return this._formatYamlValue(opt.default);
-        }
-
-        // If there are choices, use the first one
-        if (opt.choices && opt.choices.length > 0) {
-            return this._formatYamlValue(opt.choices[0]);
-        }
-
-        // Generate based on type
-        switch (opt.type) {
-            case 'bool':
-            case 'boolean':
-                return 'true';
-            case 'int':
-            case 'integer':
-                return '0';
-            case 'float':
-                return '0.0';
-            case 'path':
-                return '"/path/to/file"';
-            case 'raw':
-            case 'jsonarg':
-                return '{}';
-            case 'dict':
-                return '{}';
-            case 'list':
-                return '[]';
-            case 'str':
-            case 'string':
             default:
-                // Generate contextual example based on parameter name
-                return this._getContextualExample(name);
+                throw new Error(`Unknown method: ${method}`);
         }
     }
 
     /**
-     * Choose an example list element value for a list-typed parameter.
-     * @param name - Parameter name
-     * @param opt - Parameter schema metadata
-     * @returns Example YAML list item value
+     * Open the chat panel with a prompt.
+     * @param prompt - Optional prompt text to send to the chat provider.
      */
-    private _getElementValue(name: string, opt: PluginOption): string {
-        if (opt.elements) {
-            switch (opt.elements) {
-                case 'dict':
-                    return '{}';
-                case 'int':
-                case 'integer':
-                    return '1';
-                case 'bool':
-                case 'boolean':
-                    return 'true';
-                case 'str':
-                case 'string':
-                default:
-                    return `"${name}_item"`;
+    private async _openChatWithPrompt(prompt?: string): Promise<void> {
+        try {
+            await vscode.commands.executeCommand('workbench.action.chat.open', prompt ?? '');
+        } catch {
+            if (prompt) {
+                await vscode.env.clipboard.writeText(prompt);
             }
-        }
-        return `"${name}_item"`;
-    }
-
-    /**
-     * Generate a contextual string example based on common parameter names.
-     * @param name - Parameter name used to infer a realistic example
-     * @returns Quoted example string for the parameter
-     */
-    private _getContextualExample(name: string): string {
-        // Provide contextual examples based on common parameter names
-        const lowerName = name.toLowerCase();
-
-        if (lowerName.includes('name')) {
-            return '"example_name"';
-        }
-        if (lowerName.includes('path') || lowerName.includes('dest') || lowerName.includes('src')) {
-            return '"/path/to/file"';
-        }
-        if (lowerName.includes('host')) {
-            return '"hostname.example.com"';
-        }
-        if (lowerName.includes('port')) {
-            return '22';
-        }
-        if (lowerName.includes('user')) {
-            return '"admin"';
-        }
-        if (lowerName.includes('pass') || lowerName.includes('secret')) {
-            return '"{{ vault_password }}"';
-        }
-        if (lowerName.includes('url')) {
-            return '"https://example.com"';
-        }
-        if (lowerName.includes('state')) {
-            return '"present"';
-        }
-        if (lowerName.includes('mode')) {
-            return '"0644"';
-        }
-        if (lowerName.includes('owner')) {
-            return '"root"';
-        }
-        if (lowerName.includes('group')) {
-            return '"root"';
-        }
-        if (
-            lowerName.includes('text') ||
-            lowerName.includes('content') ||
-            lowerName.includes('data')
-        ) {
-            return '"example content"';
-        }
-        if (lowerName.includes('command') || lowerName.includes('cmd')) {
-            return '"echo hello"';
-        }
-        if (lowerName.includes('timeout')) {
-            return '30';
-        }
-        if (lowerName.includes('delay')) {
-            return '5';
-        }
-        if (lowerName.includes('retries') || lowerName.includes('retry')) {
-            return '3';
-        }
-        if (
-            lowerName.includes('regexp') ||
-            lowerName.includes('regex') ||
-            lowerName.includes('pattern')
-        ) {
-            return '"^.*$"';
-        }
-        if (lowerName.includes('line')) {
-            return '"example line"';
-        }
-        if (lowerName.includes('key')) {
-            return '"key_name"';
-        }
-        if (lowerName.includes('value')) {
-            return '"value"';
-        }
-        if (lowerName.includes('version')) {
-            return '"1.0.0"';
-        }
-        if (lowerName.includes('interface')) {
-            return '"eth0"';
-        }
-        if (lowerName.includes('vlan')) {
-            return '100';
-        }
-        if (lowerName.includes('ip') || lowerName.includes('address')) {
-            return '"192.168.1.1"';
-        }
-        if (lowerName.includes('network') || lowerName.includes('subnet')) {
-            return '"192.168.1.0/24"';
-        }
-
-        return `"${name}_value"`;
-    }
-
-    /**
-     * Format a JavaScript value as YAML literal text.
-     * @param value - Value to render into sample YAML
-     * @returns YAML-safe literal representation
-     */
-    private _formatYamlValue(value: unknown): string {
-        if (value === null || value === undefined) {
-            return 'null';
-        }
-        if (typeof value === 'boolean') {
-            return value ? 'true' : 'false';
-        }
-        if (typeof value === 'number') {
-            return String(value);
-        }
-        if (typeof value === 'string') {
-            // Check if it needs quoting
-            if (
-                value === '' ||
-                value.includes(':') ||
-                value.includes('#') ||
-                value.includes("'") ||
-                value.includes('"') ||
-                value.includes('\n') ||
-                value.startsWith(' ') ||
-                value.endsWith(' ') ||
-                /^[{[\]|>*&!%@`]/.test(value)
-            ) {
-                return `"${value.replace(/"/g, '\\"')}"`;
-            }
-            // Quote strings that look like booleans or numbers
-            if (/^(true|false|yes|no|on|off|null|~|\d+\.?\d*)$/i.test(value)) {
-                return `"${value}"`;
-            }
-            return value;
-        }
-        if (Array.isArray(value)) {
-            if (value.length === 0) {
-                return '[]';
-            }
-            return JSON.stringify(value);
-        }
-        if (typeof value === 'object') {
-            if (Object.keys(value).length === 0) {
-                return '{}';
-            }
-            return JSON.stringify(value);
-        }
-        return JSON.stringify(value);
-    }
-
-    /**
-     * Apply lightweight syntax highlighting to YAML example text.
-     * @param yaml - YAML text to highlight
-     * @returns HTML with span-wrapped YAML tokens
-     */
-    private _highlightYaml(yaml: string): string {
-        const lines = yaml.split('\n');
-        return lines
-            .map((line) => {
-                // Full line comments
-                if (line.trim().startsWith('#')) {
-                    return `<span class="yaml-comment">${this._escapeHtml(line)}</span>`;
-                }
-
-                // Empty lines
-                if (line.trim() === '') {
-                    return '';
-                }
-
-                // Check if line has an inline comment
-                const commentMatch = /^(.+?)( {2}# .*)$/.exec(line);
-                let codePart = line;
-                let commentPart = '';
-
-                if (commentMatch) {
-                    codePart = commentMatch[1];
-                    commentPart = commentMatch[2];
-                }
-
-                let result = this._escapeHtml(codePart);
-
-                // List markers with inline key (e.g., "- neighbor_address: value")
-                result = result.replace(
-                    /^(\s*)(-\s)([a-zA-Z_][a-zA-Z0-9_]*)(:)/,
-                    '$1<span class="yaml-list-marker">$2</span><span class="yaml-key">$3</span>$4',
-                );
-
-                // List markers with string value (e.g., '- "peers_item"')
-                result = result.replace(
-                    /^(\s*)(-\s)(&quot;[^&]*&quot;|&#039;[^&]*&#039;)(\s*)$/,
-                    '$1<span class="yaml-list-marker">$2</span><span class="yaml-string">$3</span>$4',
-                );
-
-                // List markers with simple value (e.g., '- true', '- 123')
-                result = result.replace(
-                    /^(\s*)(-\s)([^\s].*)$/,
-                    (match: string, spaces: string, marker: string, value: string) => {
-                        // Skip if already processed (contains span)
-                        if (value.includes('<span')) {
-                            return match;
-                        }
-                        const trimmedValue = value.trim();
-                        let valueClass = 'yaml-string';
-                        if (/^(true|false|yes|no|on|off)$/i.test(trimmedValue)) {
-                            valueClass = 'yaml-bool';
-                        } else if (/^(null|~)$/i.test(trimmedValue)) {
-                            valueClass = 'yaml-null';
-                        } else if (/^-?\d+(\.\d+)?$/.test(trimmedValue)) {
-                            valueClass = 'yaml-number';
-                        }
-                        return `${spaces}<span class="yaml-list-marker">${marker}</span><span class="${valueClass}">${value}</span>`;
-                    },
-                );
-
-                // Regular list markers (no inline value)
-                result = result.replace(
-                    /^(\s*)(-\s)$/,
-                    '$1<span class="yaml-list-marker">$2</span>',
-                );
-
-                // Key-value pairs (not starting with list marker)
-                result = result.replace(
-                    /^(\s*)([a-zA-Z_][a-zA-Z0-9_]*)(:)(\s|$)/,
-                    '$1<span class="yaml-key">$2</span>$3$4',
-                );
-
-                // After colon values
-                result = result.replace(
-                    /:(\s+)(".*?"|'.*?')(\s*)$/,
-                    ':$1<span class="yaml-string">$2</span>$3',
-                );
-
-                // Unquoted strings after colon (simple cases)
-                result = result.replace(/:(\s+)(\S.*)$/, (_match, space: string, value: string) => {
-                    const trimmedValue = value.trim();
-                    // Check for booleans
-                    if (/^(true|false|yes|no|on|off)$/i.test(trimmedValue)) {
-                        return `:${space}<span class="yaml-bool">${value}</span>`;
-                    }
-                    // Check for null
-                    if (/^(null|~)$/i.test(trimmedValue)) {
-                        return `:${space}<span class="yaml-null">${value}</span>`;
-                    }
-                    // Check for numbers
-                    if (/^-?\d+(\.\d+)?$/.test(trimmedValue)) {
-                        return `:${space}<span class="yaml-number">${value}</span>`;
-                    }
-                    // String values
-                    return `:${space}<span class="yaml-string">${value}</span>`;
-                });
-
-                // Add highlighted comment if present
-                if (commentPart) {
-                    result += this._highlightComment(commentPart);
-                }
-
-                return result;
-            })
-            .join('\n');
-    }
-
-    /**
-     * Highlight inline YAML comments, including structured parameter comments.
-     * @param comment - Comment text including leading spaces and `#`
-     * @returns HTML with styled comment spans
-     */
-    private _highlightComment(comment: string): string {
-        // Check for structured comment: # (type, required/optional) description
-        const structuredMatch = /^( {2}# \()([^,]+)(, )(required|optional)(\) )(.*)$/.exec(comment);
-        if (structuredMatch) {
-            const [, prefix, type, comma, reqOpt, closeParen, desc] = structuredMatch;
-            const reqClass =
-                reqOpt === 'required' ? 'yaml-comment-required' : 'yaml-comment-optional';
-            return (
-                `<span class="yaml-comment-dim">${this._escapeHtml(prefix)}</span>` +
-                `<span class="yaml-comment-type">${this._escapeHtml(type)}</span>` +
-                `<span class="yaml-comment-dim">${this._escapeHtml(comma)}</span>` +
-                `<span class="${reqClass}">${this._escapeHtml(reqOpt)}</span>` +
-                `<span class="yaml-comment-dim">${this._escapeHtml(closeParen)}${this._escapeHtml(desc)}</span>`
+            void vscode.window.showInformationMessage(
+                'AI prompt copied to clipboard. Paste it into a chat session.',
             );
         }
-
-        // Simple comment (# optional)
-        return `<span class="yaml-comment-dim">${this._escapeHtml(comment)}</span>`;
     }
 
-    /**
-     * Convert ansible-doc text markup into HTML for parameter descriptions.
-     * @param text - Raw documentation text with ansible-doc formatting
-     * @returns HTML-safe formatted description text
-     */
-    private _formatText(text: string): string {
-        // Convert Ansible doc formatting to HTML
-        let html = this._escapeHtml(text);
-
-        // I(text) -> italic
-        html = html.replace(/I\(([^)]+)\)/g, '<em>$1</em>');
-        // C(text) -> code
-        html = html.replace(/C\(([^)]+)\)/g, '<code>$1</code>');
-        // B(text) -> bold
-        html = html.replace(/B\(([^)]+)\)/g, '<strong>$1</strong>');
-        // U(url) -> link
-        html = html.replace(/U\(([^)]+)\)/g, '<a href="$1" target="_blank">$1</a>');
-        // :ref:`text <reference>` -> text
-        html = html.replace(/:ref:`([^<]+)\s*<[^>]+>`/g, '$1');
-        // `text` -> code
-        html = html.replace(/`([^`]+)`/g, '<code>$1</code>');
-
-        return html;
-    }
-
-    /**
-     * Escape raw text for safe embedding in generated HTML.
-     * @param text - Raw text that may contain HTML metacharacters
-     * @returns HTML-safe text
-     */
-    private _escapeHtml(text: string): string {
-        return text
-            .replace(/&/g, '&amp;')
-            .replace(/</g, '&lt;')
-            .replace(/>/g, '&gt;')
-            .replace(/"/g, '&quot;')
-            .replace(/'/g, '&#039;');
-    }
-
-    /** Dispose the panel, listeners, and cached panel registry entry. */
-    public dispose() {
+    /** Clean up panel resources. */
+    private _dispose(): void {
         PluginDocPanel._panels.delete(this._pluginKey);
-        this._panel.dispose();
-        while (this._disposables.length) {
-            const x = this._disposables.pop();
-            if (x) {
-                x.dispose();
-            }
-        }
+        for (const d of this._disposables) d.dispose();
+        this._disposables.length = 0;
     }
+}
+
+/**
+ * Generate a random nonce for CSP.
+ * @returns A 32-character nonce string.
+ */
+function getNonce(): string {
+    const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+    let nonce = '';
+    for (let i = 0; i < 32; i++) {
+        nonce += chars.charAt(Math.floor(Math.random() * chars.length));
+    }
+    return nonce;
+}
+
+/**
+ * Escape HTML special characters.
+ * @param s - Input string.
+ * @returns Escaped string safe for HTML content.
+ */
+function escapeHtml(s: string): string {
+    return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+/**
+ * Escape double quotes for HTML attribute values.
+ * @param s - Input string.
+ * @returns Escaped string safe for HTML attributes.
+ */
+function escapeAttr(s: string): string {
+    return s.replace(/&/g, '&amp;').replace(/"/g, '&quot;');
 }

--- a/src/panels/bridges/VsCodeBridge.ts
+++ b/src/panels/bridges/VsCodeBridge.ts
@@ -6,6 +6,8 @@ import type {
     EEPackage,
     PythonPackageDetail,
     SystemPackageDetail,
+    PluginDocBridge,
+    PluginData,
 } from '@ansible/ui';
 
 type VsCodeApi = {
@@ -24,7 +26,8 @@ type VsCodeApi = {
 /** Timeout for RPC requests in milliseconds. */
 const RPC_TIMEOUT_MS = 30_000;
 
-export class VsCodeBridge implements EEBridge {
+export class VsCodeBridge implements EEBridge, PluginDocBridge {
+    enableAiFeatures = false;
     private _nextId = 1;
     private _pending = new Map<
         number,
@@ -116,5 +119,17 @@ export class VsCodeBridge implements EEBridge {
             method: 'openPackageDetail',
             params: { eeName, packageName, packageType },
         });
+    }
+
+    async getPluginDoc(fqcn: string, pluginType: string): Promise<PluginData | null> {
+        return this._request('getPluginDoc', { fqcn, pluginType });
+    }
+
+    async copyToClipboard(text: string): Promise<void> {
+        return this._request('copyToClipboard', { text });
+    }
+
+    async openChat(prompt?: string): Promise<void> {
+        this._vscode.postMessage({ method: 'openChat', params: { prompt } });
     }
 }

--- a/src/panels/webview-entry.tsx
+++ b/src/panels/webview-entry.tsx
@@ -12,6 +12,7 @@ import {
     EEDetailView,
     PythonPackageDetailView,
     SystemPackageDetailView,
+    PluginDocView,
 } from '@ansible/ui';
 import { VsCodeBridge } from './bridges/VsCodeBridge';
 // esbuild imports CSS as text via loader config; inject at runtime
@@ -30,6 +31,10 @@ if (!root) throw new Error('Missing #root element');
 const viewName = root.dataset.view;
 const props = JSON.parse(root.dataset.props ?? '{}') as Record<string, unknown>;
 
+if (typeof props.enableAiFeatures === 'boolean') {
+    bridge.enableAiFeatures = props.enableAiFeatures;
+}
+
 function App() {
     const content = (() => {
         switch (viewName) {
@@ -47,6 +52,13 @@ function App() {
                     <SystemPackageDetailView
                         eeName={props.eeName as string}
                         packageName={props.packageName as string}
+                    />
+                );
+            case 'plugin-doc':
+                return (
+                    <PluginDocView
+                        fqcn={props.fqcn as string}
+                        pluginType={props.pluginType as string}
                     />
                 );
             default:

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -42,6 +42,14 @@ export default defineConfig({
             },
             {
                 test: {
+                    name: 'ui',
+                    root: 'packages/ui',
+                    include: ['test/**/*.test.ts'],
+                    environment: 'node',
+                },
+            },
+            {
+                test: {
                     name: 'ext',
                     include: ['test/unit/**/*.test.ts'],
                     environment: 'node',


### PR DESCRIPTION
## Summary
- Migrate the 2100-line monolithic `PluginDocPanel` (inline HTML/CSS/JS template strings) to shared React components in `@ansible/ui`
- Rewrite the panel as a thin host (~250 LOC) with RPC dispatch to `CollectionsService`
- Add 76 unit tests for all extracted utilities

## Changes

### New shared components (`packages/ui/src/components/`)
- **`YamlBlock`** — reusable syntax-highlighted YAML display with optional copy button
- **`ParameterTree`** — recursive collapsible parameter tree with required badges, type display, choices chips, defaults
- **`SampleTaskView`** — 3-mode generated sample YAML (No Comments / Minimal / Documented)
- **`ExamplesView`** — formatted/raw toggle with section parsing, context blocks, per-task copy
- **`ReturnValuesTable`** — return value documentation (name, type, returned-when, description, sample)

### New shared utilities (`packages/ui/src/utils/`)
- **`ansible-markup.ts`** — `formatAnsibleMarkup()`, `escapeHtml()`, `toArray()`
- **`yaml-highlight.ts`** — `highlightYaml()`, `highlightComment()` with YAML token CSS classes
- **`sample-task.ts`** — `generateSampleYaml()`, `capitalizeTitle()`, `formatYamlValue()`
- **`example-parser.ts`** — `parseExamples()` with section/state/output block parsing

### New orchestrator view
- **`PluginDocView`** — top-level view with breadcrumb, header, TabBar (Synopsis, Parameters, Sample Task, Notes, Examples, Return Values), zoom toolbar, and ✨ AI Task Builder button

### Bridge and host wiring
- **`PluginDocBridge`** interface with `getPluginDoc`, `copyToClipboard`, `openChat`, `enableAiFeatures`
- **`PluginDocPanel`** rewritten as thin host: HTML shell + `_dispatch` routing to `CollectionsService`
- **`VsCodeBridge`** extended with `PluginDocBridge` methods
- **`webview-entry.tsx`** gains `plugin-doc` route with AI features prop forwarding

### Testing
- 76 new unit tests across 4 files: `ansible-markup`, `yaml-highlight`, `sample-task`, `example-parser`
- Test tsconfig added at `packages/ui/test/tsconfig.json`
- Vitest config gains `ui` project

### Net LOC impact
- ~2000 lines removed from `PluginDocPanel.ts` monolith
- ~1000 lines of new shared React components + utilities
- ~500 lines of new unit tests

## Test plan
- [x] `npx eslint .` passes
- [x] `npx tsc -b` compiles cleanly
- [x] `npx vitest run` passes (572/572 tests, 32 files)
- [x] `npm run build` bundles all 4 outputs cleanly
- [ ] Manual: open plugin doc from collections tree, verify visual parity
- [ ] Manual: test AI Task Builder button opens chat with prompt
- [ ] Manual: test zoom +/-, tab switching, copy buttons