### PR TITLE
feat(panels): add schema-driven creator form with background execution

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,6 +4,11 @@
   "description": "Shared Ansible development tools services - vscode-independent domain logic",
   "main": "./out/index.js",
   "types": "./out/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "utils/creatorArgs": ["./out/utils/creatorArgs.d.ts"]
+    }
+  },
   "license": "MIT",
   "engines": {
     "node": ">=18.0.0"

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -69,6 +69,16 @@ export type {
     RepoFormat,
 } from './services/SkillRegistry';
 
+export {
+    buildCommandArgs,
+    buildPreviewString,
+    getPositionalKeys,
+    quoteIfNeeded,
+    valueToString,
+    formatLabel,
+    CREATOR_FILTERED_KEYS,
+} from './utils/creatorArgs';
+
 export { setLogFunction, log, getLogFunction } from './utils/logging';
 export { SimpleEventEmitter } from './utils/SimpleEventEmitter';
 export type { Disposable } from './utils/SimpleEventEmitter';

--- a/packages/core/src/services/CreatorService.ts
+++ b/packages/core/src/services/CreatorService.ts
@@ -9,6 +9,7 @@ try {
     // Running standalone (not in VS Code)
 }
 
+import { getPositionalKeys } from '../utils/creatorArgs';
 import { SimpleEventEmitter } from '../utils/SimpleEventEmitter';
 
 /**
@@ -448,7 +449,6 @@ export class CreatorService {
             return [];
         }
 
-        // Navigate to the command in the schema
         let node: SchemaNode | undefined = this._schema;
         for (const segment of path) {
             node = node.subcommands?.[segment];
@@ -457,17 +457,7 @@ export class CreatorService {
             }
         }
 
-        // Find parameters without aliases (these are positional)
-        const positionalArgs: string[] = [];
-        if (node.parameters?.properties) {
-            for (const [name, param] of Object.entries(node.parameters.properties)) {
-                if (!param.aliases || param.aliases.length === 0) {
-                    positionalArgs.push(name);
-                }
-            }
-        }
-
-        return positionalArgs;
+        return getPositionalKeys(node);
     }
 
     /**

--- a/packages/core/src/utils/creatorArgs.ts
+++ b/packages/core/src/utils/creatorArgs.ts
@@ -1,0 +1,208 @@
+import type { SchemaNode } from '../services/CreatorService';
+
+/** Schema parameter keys omitted from creator form UI. */
+export const CREATOR_FILTERED_KEYS = [
+    'no_ansi',
+    'log_file',
+    'log_level',
+    'log_append',
+    'json',
+    'verbose',
+];
+
+/**
+ * Returns parameter names that should be treated as positional (no aliases).
+ *
+ * @param schema - Command schema node whose parameters are inspected.
+ * @returns Positional parameter keys in schema property order.
+ */
+export function getPositionalKeys(schema: SchemaNode): string[] {
+    const keys: string[] = [];
+    if (schema.parameters?.properties) {
+        for (const [name, param] of Object.entries(schema.parameters.properties)) {
+            if (!param.aliases || param.aliases.length === 0) {
+                keys.push(name);
+            }
+        }
+    }
+    return keys;
+}
+
+/**
+ * Shell-safe quoting for values containing spaces or quotes.
+ *
+ * @param value - Raw argument value.
+ * @returns Quoted value when shell escaping is required.
+ */
+export function quoteIfNeeded(value: string): string {
+    if (value.includes(' ') || value.includes('"') || value.includes("'")) {
+        return `"${value.replace(/"/g, '\\"')}"`;
+    }
+    return value;
+}
+
+/**
+ * Converts any form value to a CLI string.
+ *
+ * @param value - Form field value of any supported type.
+ * @returns String representation suitable for CLI arguments.
+ */
+export function valueToString(value: unknown): string {
+    if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+        return String(value);
+    }
+    return JSON.stringify(value);
+}
+
+/**
+ * Picks the preferred flag from aliases (prefers `--long` form, strips placeholders).
+ *
+ * @param aliases - CLI aliases from the schema parameter.
+ * @returns Primary flag token without placeholder suffix.
+ */
+function getPreferredFlag(aliases: string[]): string {
+    const flag = aliases.find((a) => a.startsWith('--')) ?? aliases[0];
+    return flag.split(' ')[0];
+}
+
+/**
+ * Builds canonical CLI argument tokens (excluding the `ansible-creator` executable).
+ *
+ * @param path - Command path segments after `ansible-creator`.
+ * @param schema - Command schema node for parameter metadata.
+ * @param values - Form values keyed by parameter name.
+ * @returns Ordered CLI argument tokens.
+ */
+export function buildCommandArgs(
+    path: string[],
+    schema: SchemaNode,
+    values: Record<string, unknown>,
+): string[] {
+    const args: string[] = [...path];
+    const properties = schema.parameters?.properties;
+    const positionalKeys = getPositionalKeys(schema);
+    const usedKeys = new Set<string>();
+
+    for (const key of positionalKeys) {
+        const value = values[key];
+        if (value === undefined || value === null || value === '') {
+            continue;
+        }
+        args.push(valueToString(value));
+        usedKeys.add(key);
+    }
+
+    for (const [key, value] of Object.entries(values)) {
+        if (usedKeys.has(key)) {
+            continue;
+        }
+        if (value === undefined || value === null || value === '') {
+            continue;
+        }
+        if (Array.isArray(value) && value.length === 0) {
+            continue;
+        }
+
+        const prop = properties?.[key];
+
+        if (typeof value === 'boolean') {
+            if (value) {
+                if (prop?.aliases?.length) {
+                    args.push(getPreferredFlag(prop.aliases));
+                } else {
+                    args.push(`--${key}`);
+                }
+            }
+        } else if (Array.isArray(value)) {
+            const flag = prop?.aliases?.length ? getPreferredFlag(prop.aliases) : `--${key}`;
+            for (const item of value) {
+                if (item !== undefined && item !== null && item !== '') {
+                    args.push(flag, String(item));
+                }
+            }
+        } else {
+            const flag = prop?.aliases?.length ? getPreferredFlag(prop.aliases) : `--${key}`;
+            args.push(flag, valueToString(value));
+        }
+    }
+
+    return args;
+}
+
+/**
+ * Builds a preview command string, omitting optional flags at their schema defaults.
+ *
+ * @param path - Command path segments after `ansible-creator`.
+ * @param schema - Command schema node for parameter metadata.
+ * @param values - Form values keyed by parameter name.
+ * @returns Full `ansible-creator` command string for display.
+ */
+export function buildPreviewString(
+    path: string[],
+    schema: SchemaNode,
+    values: Record<string, unknown>,
+): string {
+    const args: string[] = [...path];
+    const properties = schema.parameters?.properties;
+    const positionalKeys = getPositionalKeys(schema);
+    const usedKeys = new Set<string>();
+
+    for (const key of positionalKeys) {
+        const value = values[key];
+        if (value === undefined || value === null || value === '') {
+            continue;
+        }
+        args.push(quoteIfNeeded(valueToString(value)));
+        usedKeys.add(key);
+    }
+
+    for (const [key, value] of Object.entries(values)) {
+        if (usedKeys.has(key)) {
+            continue;
+        }
+        if (value === undefined || value === null || value === '' || value === false) {
+            continue;
+        }
+
+        const prop = properties?.[key];
+
+        if (value === prop?.default) {
+            continue;
+        }
+
+        if (typeof value === 'boolean' && value) {
+            if (prop?.aliases?.length) {
+                args.push(getPreferredFlag(prop.aliases));
+            } else {
+                args.push(`--${key}`);
+            }
+        } else if (Array.isArray(value)) {
+            if (value.length > 0) {
+                const flag = prop?.aliases?.length ? getPreferredFlag(prop.aliases) : `--${key}`;
+                for (const item of value) {
+                    if (item !== undefined && item !== null && item !== '') {
+                        args.push(flag, quoteIfNeeded(String(item)));
+                    }
+                }
+            }
+        } else if (typeof value !== 'boolean') {
+            const flag = prop?.aliases?.length ? getPreferredFlag(prop.aliases) : `--${key}`;
+            args.push(flag, quoteIfNeeded(valueToString(value)));
+        }
+    }
+
+    return `ansible-creator ${args.join(' ')}`;
+}
+
+/**
+ * Converts a parameter key to a human-readable label.
+ *
+ * @param name - Schema parameter name (snake_case or kebab-case).
+ * @returns Title-cased label for form display.
+ */
+export function formatLabel(name: string): string {
+    return name
+        .split(/[_-]/)
+        .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+        .join(' ');
+}

--- a/packages/core/test/utils/creatorArgs.test.ts
+++ b/packages/core/test/utils/creatorArgs.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect } from 'vitest';
+import {
+    getPositionalKeys,
+    quoteIfNeeded,
+    valueToString,
+    buildCommandArgs,
+    buildPreviewString,
+    formatLabel,
+    CREATOR_FILTERED_KEYS,
+} from '../../src/utils/creatorArgs';
+import type { SchemaNode } from '../../src/services/CreatorService';
+
+const LEAF_SCHEMA: SchemaNode = {
+    name: 'playbook',
+    description: 'Initialize a playbook project',
+    parameters: {
+        type: 'object',
+        properties: {
+            project: { type: 'string', description: 'Project name' },
+            'scm-org': {
+                type: 'string',
+                description: 'SCM org',
+                aliases: ['--scm-org'],
+            },
+            'scm-project': {
+                type: 'string',
+                description: 'SCM project',
+                aliases: ['--scm-project'],
+            },
+            output: {
+                type: 'string',
+                description: 'Output directory',
+                default: './',
+                aliases: ['-o', '--output'],
+            },
+            overwrite: {
+                type: 'boolean',
+                description: 'Overwrite existing files',
+                aliases: ['--overwrite'],
+            },
+        },
+        required: ['project'],
+    },
+};
+
+describe('creatorArgs', () => {
+    describe('CREATOR_FILTERED_KEYS', () => {
+        it('contains expected noise parameters', () => {
+            expect(CREATOR_FILTERED_KEYS).toContain('no_ansi');
+            expect(CREATOR_FILTERED_KEYS).toContain('verbose');
+            expect(CREATOR_FILTERED_KEYS).toContain('json');
+        });
+    });
+
+    describe('getPositionalKeys', () => {
+        it('returns params without aliases', () => {
+            expect(getPositionalKeys(LEAF_SCHEMA)).toEqual(['project']);
+        });
+
+        it('returns empty array for schema without parameters', () => {
+            expect(getPositionalKeys({ name: 'empty' })).toEqual([]);
+        });
+    });
+
+    describe('quoteIfNeeded', () => {
+        it('returns plain value when no special chars', () => {
+            expect(quoteIfNeeded('hello')).toBe('hello');
+        });
+
+        it('quotes values with spaces', () => {
+            expect(quoteIfNeeded('hello world')).toBe('"hello world"');
+        });
+
+        it('escapes double quotes inside value', () => {
+            expect(quoteIfNeeded('say "hi"')).toBe('"say \\"hi\\""');
+        });
+
+        it('quotes values with single quotes', () => {
+            expect(quoteIfNeeded("it's")).toBe('"it\'s"');
+        });
+    });
+
+    describe('valueToString', () => {
+        it('returns string values as-is', () => {
+            expect(valueToString('hello')).toBe('hello');
+        });
+
+        it('converts numbers to strings', () => {
+            expect(valueToString(42)).toBe('42');
+        });
+
+        it('converts booleans to strings', () => {
+            expect(valueToString(true)).toBe('true');
+        });
+
+        it('JSON-stringifies objects', () => {
+            expect(valueToString({ a: 1 })).toBe('{"a":1}');
+        });
+    });
+
+    describe('buildCommandArgs', () => {
+        it('places positional args before flags', () => {
+            const args = buildCommandArgs(['init', 'playbook'], LEAF_SCHEMA, {
+                project: 'myproj',
+                'scm-org': 'acme',
+            });
+            expect(args).toEqual(['init', 'playbook', 'myproj', '--scm-org', 'acme']);
+        });
+
+        it('uses preferred long flag from aliases', () => {
+            const args = buildCommandArgs(['init', 'playbook'], LEAF_SCHEMA, {
+                project: 'p',
+                output: '/tmp/out',
+            });
+            expect(args).toEqual(['init', 'playbook', 'p', '--output', '/tmp/out']);
+        });
+
+        it('emits boolean flags only when true', () => {
+            const args = buildCommandArgs(['init', 'playbook'], LEAF_SCHEMA, {
+                project: 'p',
+                overwrite: true,
+            });
+            expect(args).toContain('--overwrite');
+        });
+
+        it('skips false boolean flags', () => {
+            const args = buildCommandArgs(['init', 'playbook'], LEAF_SCHEMA, {
+                project: 'p',
+                overwrite: false,
+            });
+            expect(args).not.toContain('--overwrite');
+        });
+
+        it('skips empty/null/undefined values', () => {
+            const args = buildCommandArgs(['init', 'playbook'], LEAF_SCHEMA, {
+                project: 'p',
+                'scm-org': '',
+                'scm-project': undefined,
+            });
+            expect(args).toEqual(['init', 'playbook', 'p']);
+        });
+
+        it('falls back to --key for unknown params', () => {
+            const args = buildCommandArgs(['init', 'playbook'], LEAF_SCHEMA, {
+                project: 'p',
+                custom: 'val',
+            });
+            expect(args).toContain('--custom');
+            expect(args).toContain('val');
+        });
+
+        it('preserves values with spaces as single args', () => {
+            const args = buildCommandArgs(['init', 'playbook'], LEAF_SCHEMA, {
+                project: 'my project',
+            });
+            expect(args).toContain('my project');
+        });
+    });
+
+    describe('buildPreviewString', () => {
+        it('prefixes with ansible-creator', () => {
+            const preview = buildPreviewString(['init', 'playbook'], LEAF_SCHEMA, {
+                project: 'myproj',
+            });
+            expect(preview).toMatch(/^ansible-creator init playbook/);
+        });
+
+        it('omits optional flags at their default value', () => {
+            const preview = buildPreviewString(['init', 'playbook'], LEAF_SCHEMA, {
+                project: 'p',
+                output: './',
+            });
+            expect(preview).toBe('ansible-creator init playbook p');
+        });
+
+        it('includes optional flags when differing from default', () => {
+            const preview = buildPreviewString(['init', 'playbook'], LEAF_SCHEMA, {
+                project: 'p',
+                output: '/custom',
+            });
+            expect(preview).toContain('--output /custom');
+        });
+
+        it('skips false boolean values', () => {
+            const preview = buildPreviewString(['init', 'playbook'], LEAF_SCHEMA, {
+                project: 'p',
+                overwrite: false,
+            });
+            expect(preview).not.toContain('overwrite');
+        });
+    });
+
+    describe('formatLabel', () => {
+        it('converts snake_case to Title Case', () => {
+            expect(formatLabel('scm_org')).toBe('Scm Org');
+        });
+
+        it('converts kebab-case to Title Case', () => {
+            expect(formatLabel('init-path')).toBe('Init Path');
+        });
+
+        it('handles single word', () => {
+            expect(formatLabel('project')).toBe('Project');
+        });
+    });
+});

--- a/packages/ui/src/bridge/creator.ts
+++ b/packages/ui/src/bridge/creator.ts
@@ -1,0 +1,54 @@
+import type { HostBridgeCore } from './core';
+
+/**
+ * Schema for a command parameter from ansible-creator.
+ */
+export interface ParameterSchema {
+    type: string;
+    description: string;
+    default?: unknown;
+    enum?: string[];
+    aliases?: string[];
+}
+
+/**
+ * Schema node representing an ansible-creator command or subcommand.
+ */
+export interface SchemaNode {
+    name: string;
+    description?: string;
+    parameters?: {
+        type: string;
+        properties: Record<string, ParameterSchema>;
+        required: string[];
+    };
+    subcommands?: Record<string, SchemaNode>;
+}
+
+/** Payload sent when execution begins. */
+export interface ExecutionStartedEvent {
+    command: string;
+}
+
+/** Payload sent when execution completes. */
+export interface ExecutionFinishedEvent {
+    exitCode: number;
+    output: string;
+}
+
+/**
+ * Bridge contract for creator form views.
+ * Host implementations execute commands via CommandService (VS Code)
+ * or direct process spawning (standalone).
+ */
+export interface CreatorBridge extends HostBridgeCore {
+    /** Run the ansible-creator command with the given form values. */
+    execute(commandPath: string[], values: Record<string, unknown>): Promise<void>;
+    /** Close the creator form panel. */
+    cancel(): void;
+    /** Workspace root path for pre-filling path fields. */
+    workspacePath: string;
+    /** Subscribe to execution lifecycle events. Returns an unsubscribe function. */
+    onExecutionStarted(cb: (event: ExecutionStartedEvent) => void): () => void;
+    onExecutionFinished(cb: (event: ExecutionFinishedEvent) => void): () => void;
+}

--- a/packages/ui/src/bridge/index.ts
+++ b/packages/ui/src/bridge/index.ts
@@ -1,3 +1,4 @@
 export type { HostBridgeCore, Disposable } from './core';
 export { BridgeProvider, useBridge } from './context';
 export type { EEBridge, EEPackage, EEPythonPackage, EECollection, EEInfo } from './ee';
+export type { CreatorBridge, SchemaNode, ParameterSchema } from './creator';

--- a/packages/ui/src/components/SchemaForm.tsx
+++ b/packages/ui/src/components/SchemaForm.tsx
@@ -1,0 +1,300 @@
+import { useState, useCallback, useMemo } from 'react';
+import type { CSSProperties } from 'react';
+import type { SchemaNode, ParameterSchema } from '../bridge/creator';
+import { FormTextField } from './form/FormTextField';
+import { FormSelect } from './form/FormSelect';
+import { FormCheckbox } from './form/FormCheckbox';
+import { FormSection } from './form/FormSection';
+import { FormListBuilder } from './form/FormListBuilder';
+
+/** Default schema parameter keys hidden from the creator form UI. */
+const DEFAULT_FILTERED_KEYS = ['no_ansi', 'log_file', 'log_level', 'log_append', 'json', 'verbose'];
+
+interface SchemaFormProps {
+    schema: SchemaNode;
+    workspacePath?: string;
+    filteredKeys?: string[];
+    onExecute: (values: Record<string, unknown>) => void;
+    onCancel?: () => void;
+    buildPreview: (values: Record<string, unknown>) => string;
+}
+
+/**
+ * Safely converts an unknown value to a display string.
+ *
+ * @param value - Value to stringify without risking `[object Object]`.
+ * @returns String representation suitable for form display.
+ */
+function safeStr(value: unknown): string {
+    if (value === undefined || value === null) return '';
+    if (typeof value === 'string') return value;
+    if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+    return JSON.stringify(value);
+}
+
+/**
+ * Converts a parameter key to a human-readable label.
+ *
+ * @param name - Schema parameter name (snake_case or kebab-case).
+ * @returns Title-cased label for form display.
+ */
+function toLabel(name: string): string {
+    return name
+        .split(/[_-]/)
+        .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+        .join(' ');
+}
+
+/**
+ * Schema-driven form that renders ansible-creator command parameters.
+ * @param root0 - Component props.
+ * @param root0.schema - Command schema node with parameter definitions.
+ * @param root0.workspacePath - Optional workspace root for pre-filling path fields.
+ * @param root0.filteredKeys - Parameter keys to hide from the form.
+ * @param root0.onExecute - Callback invoked with form values when Run is clicked.
+ * @param root0.onCancel - Optional callback invoked when Cancel is clicked.
+ * @param root0.buildPreview - Builds the command preview string from current form values.
+ * @returns The rendered schema form.
+ */
+export function SchemaForm({
+    schema,
+    workspacePath,
+    filteredKeys,
+    onExecute,
+    onCancel,
+    buildPreview,
+}: SchemaFormProps) {
+    const properties = schema.parameters?.properties ?? {};
+    const requiredKeys = useMemo(() => schema.parameters?.required ?? [], [schema]);
+    const filtered = useMemo(() => new Set(filteredKeys ?? DEFAULT_FILTERED_KEYS), [filteredKeys]);
+
+    const [formValues, setFormValues] = useState<Record<string, unknown>>(() => {
+        const initial: Record<string, unknown> = {};
+        for (const [key, prop] of Object.entries(properties)) {
+            if (filtered.has(key)) continue;
+            if (prop.default !== undefined && prop.default !== null) {
+                initial[key] = prop.default;
+            }
+            if ((key === 'path' || key === 'init_path') && workspacePath) {
+                initial[key] = workspacePath;
+            }
+        }
+        return initial;
+    });
+
+    const updateValue = useCallback((key: string, value: unknown) => {
+        setFormValues((prev) => ({ ...prev, [key]: value }));
+    }, []);
+
+    const sortedKeys = useMemo(() => {
+        return Object.keys(properties)
+            .filter((k) => !filtered.has(k))
+            .sort((a, b) => {
+                const aReq = requiredKeys.includes(a);
+                const bReq = requiredKeys.includes(b);
+                if (aReq && !bReq) return -1;
+                if (!aReq && bReq) return 1;
+                return a.localeCompare(b);
+            });
+    }, [properties, requiredKeys, filtered]);
+
+    const requiredFields = useMemo(
+        () => sortedKeys.filter((k) => requiredKeys.includes(k)),
+        [sortedKeys, requiredKeys],
+    );
+    const optionalFields = useMemo(
+        () => sortedKeys.filter((k) => !requiredKeys.includes(k)),
+        [sortedKeys, requiredKeys],
+    );
+
+    const isValid = useMemo(() => {
+        for (const key of requiredKeys) {
+            if (filtered.has(key)) continue;
+            const val = formValues[key];
+            if (val === undefined || val === null || val === '') return false;
+        }
+        return true;
+    }, [requiredKeys, formValues, filtered]);
+
+    const preview = useMemo(() => buildPreview(formValues), [buildPreview, formValues]);
+
+    const handleExecute = useCallback(() => {
+        if (isValid) {
+            onExecute(formValues);
+        }
+    }, [isValid, formValues, onExecute]);
+
+    const renderField = useCallback(
+        (key: string) => {
+            const prop: ParameterSchema = properties[key];
+            const isRequired = requiredKeys.includes(key);
+            const label = toLabel(key);
+            const isPath = key === 'path' || key === 'init_path';
+
+            if (prop.type === 'boolean') {
+                return (
+                    <FormCheckbox
+                        key={key}
+                        label={label}
+                        checked={formValues[key] === true}
+                        onChange={(checked) => {
+                            updateValue(key, checked);
+                        }}
+                        description={prop.description}
+                    />
+                );
+            }
+
+            if (prop.type === 'array') {
+                const currentItems = Array.isArray(formValues[key])
+                    ? (formValues[key] as string[])
+                    : [];
+                return (
+                    <FormListBuilder
+                        key={key}
+                        label={label}
+                        items={currentItems}
+                        onChange={(items) => {
+                            updateValue(key, items);
+                        }}
+                        description={prop.description}
+                        defaultValue={
+                            prop.default !== undefined ? safeStr(prop.default) : undefined
+                        }
+                        required={isRequired}
+                    />
+                );
+            }
+
+            if (prop.enum && prop.enum.length > 0) {
+                return (
+                    <FormSelect
+                        key={key}
+                        label={label}
+                        value={safeStr(formValues[key])}
+                        onChange={(v) => {
+                            updateValue(key, v);
+                        }}
+                        options={prop.enum}
+                        description={prop.description}
+                        defaultValue={
+                            prop.default !== undefined ? safeStr(prop.default) : undefined
+                        }
+                        required={isRequired}
+                        placeholder={isRequired ? undefined : '-- Select --'}
+                    />
+                );
+            }
+
+            return (
+                <FormTextField
+                    key={key}
+                    label={label}
+                    value={safeStr(formValues[key])}
+                    onChange={(v) => {
+                        updateValue(key, v);
+                    }}
+                    placeholder={prop.description}
+                    description={prop.description}
+                    defaultValue={
+                        prop.default !== undefined && prop.type !== 'boolean'
+                            ? safeStr(prop.default)
+                            : undefined
+                    }
+                    required={isRequired}
+                    isPath={isPath}
+                />
+            );
+        },
+        [properties, requiredKeys, formValues, updateValue],
+    );
+
+    const styles: Record<string, CSSProperties> = {
+        previewSection: { marginTop: 24 },
+        previewLabel: {
+            fontSize: 11,
+            fontWeight: 600,
+            color: 'var(--ui-text-secondary)',
+            marginBottom: 8,
+            textTransform: 'uppercase' as const,
+            letterSpacing: 0.5,
+        },
+        preview: {
+            padding: '12px 16px',
+            background: 'var(--ui-bg-surface)',
+            border: '1px solid var(--ui-border)',
+            borderRadius: 4,
+            fontFamily: "'SF Mono', Consolas, monospace",
+            fontSize: 12,
+            whiteSpace: 'pre-wrap',
+            wordBreak: 'break-all',
+            lineHeight: 1.5,
+            color: 'var(--ui-text-primary)',
+        },
+        buttonRow: {
+            display: 'flex',
+            justifyContent: 'flex-end',
+            gap: 12,
+            marginTop: 24,
+            paddingTop: 20,
+            borderTop: '1px solid var(--ui-border)',
+        },
+        cancelBtn: {
+            padding: '8px 16px',
+            background: 'transparent',
+            color: 'var(--ui-text-primary)',
+            border: '1px solid var(--ui-border)',
+            borderRadius: 4,
+            fontSize: 13,
+            cursor: 'pointer',
+        },
+        executeBtn: {
+            padding: '8px 16px',
+            background: 'var(--ui-accent, var(--vscode-button-background, #007acc))',
+            color: 'var(--ui-accent-fg, var(--vscode-button-foreground, #fff))',
+            border: 'none',
+            borderRadius: 4,
+            fontSize: 13,
+            fontWeight: 600,
+            cursor: isValid ? 'pointer' : 'default',
+            opacity: isValid ? 1 : 0.5,
+        },
+    };
+
+    return (
+        <>
+            {requiredFields.length > 0 && (
+                <FormSection title="Required Parameters">
+                    {requiredFields.map(renderField)}
+                </FormSection>
+            )}
+
+            {optionalFields.length > 0 && (
+                <FormSection title="Optional Parameters">
+                    {optionalFields.map(renderField)}
+                </FormSection>
+            )}
+
+            <div style={styles.previewSection}>
+                <div style={styles.previewLabel}>Command Preview</div>
+                <div style={styles.preview}>{preview}</div>
+            </div>
+
+            <div style={styles.buttonRow}>
+                {onCancel && (
+                    <button type="button" style={styles.cancelBtn} onClick={onCancel}>
+                        Cancel
+                    </button>
+                )}
+                <button
+                    type="button"
+                    style={styles.executeBtn}
+                    disabled={!isValid}
+                    onClick={handleExecute}
+                >
+                    Run
+                </button>
+            </div>
+        </>
+    );
+}

--- a/packages/ui/src/components/form/FormCheckbox.tsx
+++ b/packages/ui/src/components/form/FormCheckbox.tsx
@@ -1,0 +1,63 @@
+import type { CSSProperties } from 'react';
+
+interface FormCheckboxProps {
+    label: string;
+    checked: boolean;
+    onChange: (checked: boolean) => void;
+    description?: string;
+}
+
+/**
+ * Checkbox field with inline label and optional description.
+ * @param root0 - Component props.
+ * @param root0.label - Checkbox label text.
+ * @param root0.checked - Whether the checkbox is checked.
+ * @param root0.onChange - Callback invoked when the checked state changes.
+ * @param root0.description - Optional help text below the label.
+ * @returns The rendered checkbox field.
+ */
+export function FormCheckbox({ label, checked, onChange, description }: FormCheckboxProps) {
+    const styles: Record<string, CSSProperties> = {
+        group: { marginBottom: 20 },
+        wrapper: {
+            display: 'flex',
+            alignItems: 'flex-start',
+            gap: 8,
+        },
+        checkbox: {
+            marginTop: 2,
+            accentColor: 'var(--ui-accent, var(--vscode-checkbox-background, #007acc))',
+        },
+        content: { flex: 1 },
+        label: {
+            fontWeight: 600,
+            fontSize: 13,
+            color: 'var(--ui-text-primary)',
+        },
+        description: {
+            fontSize: 11,
+            color: 'var(--ui-text-secondary)',
+            marginTop: 4,
+            lineHeight: 1.4,
+        },
+    };
+
+    return (
+        <div style={styles.group}>
+            <div style={styles.wrapper}>
+                <input
+                    type="checkbox"
+                    style={styles.checkbox}
+                    checked={checked}
+                    onChange={(e) => {
+                        onChange(e.target.checked);
+                    }}
+                />
+                <div style={styles.content}>
+                    <div style={styles.label}>{label}</div>
+                    {description && <div style={styles.description}>{description}</div>}
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/packages/ui/src/components/form/FormListBuilder.tsx
+++ b/packages/ui/src/components/form/FormListBuilder.tsx
@@ -1,0 +1,201 @@
+import { useState, useCallback } from 'react';
+import type { CSSProperties } from 'react';
+
+interface FormListBuilderProps {
+    label: string;
+    items: string[];
+    onChange: (items: string[]) => void;
+    description?: string;
+    defaultValue?: string;
+    required?: boolean;
+    placeholder?: string;
+}
+
+/**
+ * List builder that lets users add/remove string items one at a time.
+ * Replaces raw JSON array display for repeatable CLI parameters.
+ * @param root0 - Component props.
+ * @param root0.label - Field label shown above the input.
+ * @param root0.items - Current list of string values.
+ * @param root0.onChange - Callback invoked with the updated items array.
+ * @param root0.description - Optional help text below the list.
+ * @param root0.defaultValue - Optional default value shown as hint text.
+ * @param root0.required - Whether to show a required indicator.
+ * @param root0.placeholder - Optional placeholder text for the input.
+ * @returns The rendered list builder field.
+ */
+export function FormListBuilder({
+    label,
+    items,
+    onChange,
+    description,
+    defaultValue,
+    required,
+    placeholder,
+}: FormListBuilderProps) {
+    const [draft, setDraft] = useState('');
+
+    const addItem = useCallback(() => {
+        const trimmed = draft.trim();
+        if (!trimmed) return;
+        onChange([...items, trimmed]);
+        setDraft('');
+    }, [draft, items, onChange]);
+
+    const removeItem = useCallback(
+        (index: number) => {
+            onChange(items.filter((_, i) => i !== index));
+        },
+        [items, onChange],
+    );
+
+    const handleKeyDown = useCallback(
+        (e: React.KeyboardEvent) => {
+            if (e.key === 'Enter') {
+                e.preventDefault();
+                addItem();
+            }
+        },
+        [addItem],
+    );
+
+    const styles: Record<string, CSSProperties> = {
+        group: { marginBottom: 20 },
+        label: {
+            display: 'block',
+            marginBottom: 6,
+            fontWeight: 600,
+            fontSize: 13,
+            color: 'var(--ui-text-primary)',
+        },
+        required: {
+            color: 'var(--ui-error, var(--vscode-errorForeground, #f44))',
+            marginLeft: 4,
+        },
+        inputRow: {
+            display: 'flex',
+            gap: 6,
+        },
+        input: {
+            flex: 1,
+            padding: '6px 10px',
+            background: 'var(--ui-input-bg, var(--vscode-input-background))',
+            color: 'var(--ui-input-fg, var(--vscode-input-foreground))',
+            border: '1px solid var(--ui-input-border, var(--vscode-input-border, transparent))',
+            borderRadius: 4,
+            fontSize: 13,
+            outline: 'none',
+            boxSizing: 'border-box' as const,
+        },
+        addBtn: {
+            padding: '6px 12px',
+            background: 'var(--ui-accent, var(--vscode-button-background, #007acc))',
+            color: 'var(--ui-accent-fg, var(--vscode-button-foreground, #fff))',
+            border: 'none',
+            borderRadius: 4,
+            fontSize: 13,
+            fontWeight: 600,
+            cursor: 'pointer',
+            whiteSpace: 'nowrap',
+        },
+        list: {
+            listStyle: 'none',
+            margin: '8px 0 0',
+            padding: 0,
+        },
+        item: {
+            display: 'flex',
+            alignItems: 'center',
+            gap: 8,
+            padding: '4px 8px',
+            marginBottom: 4,
+            background: 'var(--ui-bg-surface, var(--vscode-editor-background))',
+            border: '1px solid var(--ui-border, var(--vscode-widget-border, #333))',
+            borderRadius: 4,
+            fontSize: 13,
+        },
+        itemText: {
+            flex: 1,
+            fontFamily: 'var(--vscode-editor-font-family, monospace)',
+            fontSize: 12,
+            wordBreak: 'break-all',
+        },
+        removeBtn: {
+            background: 'transparent',
+            border: 'none',
+            color: 'var(--ui-text-secondary)',
+            cursor: 'pointer',
+            fontSize: 16,
+            lineHeight: 1,
+            padding: '2px 4px',
+            borderRadius: 3,
+        },
+        help: {
+            fontSize: 11,
+            color: 'var(--ui-text-secondary)',
+            marginTop: 6,
+            lineHeight: 1.4,
+        },
+        default: {
+            fontSize: 11,
+            color: 'var(--ui-text-secondary)',
+            fontStyle: 'italic',
+            marginTop: 4,
+        },
+    };
+
+    return (
+        <div style={styles.group}>
+            <label style={styles.label}>
+                {label}
+                {required && <span style={styles.required}>*</span>}
+            </label>
+            <div style={styles.inputRow}>
+                <input
+                    type="text"
+                    style={styles.input}
+                    value={draft}
+                    onChange={(e) => {
+                        setDraft(e.target.value);
+                    }}
+                    onKeyDown={handleKeyDown}
+                    placeholder={placeholder ?? 'Type a value and press Enter or Add'}
+                    onFocus={(e) => {
+                        e.target.style.borderColor =
+                            'var(--ui-input-focus-border, var(--vscode-focusBorder, #007acc))';
+                    }}
+                    onBlur={(e) => {
+                        e.target.style.borderColor =
+                            'var(--ui-input-border, var(--vscode-input-border, transparent))';
+                    }}
+                />
+                <button type="button" style={styles.addBtn} onClick={addItem}>
+                    Add
+                </button>
+            </div>
+            {items.length > 0 && (
+                <ul style={styles.list}>
+                    {items.map((item, idx) => (
+                        <li key={`${String(idx)}-${item}`} style={styles.item}>
+                            <span style={styles.itemText}>{item}</span>
+                            <button
+                                type="button"
+                                style={styles.removeBtn}
+                                onClick={() => {
+                                    removeItem(idx);
+                                }}
+                                title="Remove"
+                            >
+                                &times;
+                            </button>
+                        </li>
+                    ))}
+                </ul>
+            )}
+            {description && <div style={styles.help}>{description}</div>}
+            {defaultValue !== undefined && (
+                <div style={styles.default}>Default: {defaultValue}</div>
+            )}
+        </div>
+    );
+}

--- a/packages/ui/src/components/form/FormSection.tsx
+++ b/packages/ui/src/components/form/FormSection.tsx
@@ -1,0 +1,42 @@
+import type { CSSProperties, ReactNode } from 'react';
+
+interface FormSectionProps {
+    title: string;
+    children: ReactNode;
+}
+
+/**
+ * Visual section grouping form fields with a titled header.
+ * @param root0 - Component props.
+ * @param root0.title - Section title displayed above the fields.
+ * @param root0.children - Form fields rendered inside the section.
+ * @returns The rendered form section.
+ */
+export function FormSection({ title, children }: FormSectionProps) {
+    const styles: Record<string, CSSProperties> = {
+        section: {
+            marginBottom: 24,
+            background: 'var(--ui-bg-surface)',
+            border: '1px solid var(--ui-border)',
+            borderRadius: 6,
+            padding: 16,
+        },
+        title: {
+            fontSize: 13,
+            fontWeight: 600,
+            marginBottom: 16,
+            paddingBottom: 10,
+            borderBottom: '1px solid var(--ui-border)',
+            textTransform: 'uppercase' as const,
+            letterSpacing: 0.5,
+            color: 'var(--ui-text-primary)',
+        },
+    };
+
+    return (
+        <div style={styles.section}>
+            <div style={styles.title}>{title}</div>
+            {children}
+        </div>
+    );
+}

--- a/packages/ui/src/components/form/FormSelect.tsx
+++ b/packages/ui/src/components/form/FormSelect.tsx
@@ -1,0 +1,102 @@
+import type { CSSProperties } from 'react';
+
+interface FormSelectProps {
+    label: string;
+    value: string;
+    onChange: (value: string) => void;
+    options: string[];
+    description?: string;
+    defaultValue?: string;
+    required?: boolean;
+    placeholder?: string;
+}
+
+/**
+ * Dropdown select field with label, options, and optional empty placeholder.
+ * @param root0 - Component props.
+ * @param root0.label - Field label shown above the select.
+ * @param root0.value - Currently selected option value.
+ * @param root0.onChange - Callback invoked when the selection changes.
+ * @param root0.options - List of selectable option values.
+ * @param root0.description - Optional help text below the select.
+ * @param root0.defaultValue - Optional default value shown as hint text.
+ * @param root0.required - Whether to show a required indicator.
+ * @param root0.placeholder - Optional empty option label.
+ * @returns The rendered select field.
+ */
+export function FormSelect({
+    label,
+    value,
+    onChange,
+    options,
+    description,
+    defaultValue,
+    required,
+    placeholder,
+}: FormSelectProps) {
+    const styles: Record<string, CSSProperties> = {
+        group: { marginBottom: 20 },
+        label: {
+            display: 'block',
+            marginBottom: 6,
+            fontWeight: 600,
+            fontSize: 13,
+            color: 'var(--ui-text-primary)',
+        },
+        required: {
+            color: 'var(--ui-error, var(--vscode-errorForeground, #f44))',
+            marginLeft: 4,
+        },
+        select: {
+            width: '100%',
+            padding: '6px 10px',
+            background:
+                'var(--ui-input-bg, var(--vscode-dropdown-background, var(--vscode-input-background)))',
+            color: 'var(--ui-input-fg, var(--vscode-dropdown-foreground, var(--vscode-input-foreground)))',
+            border: '1px solid var(--ui-input-border, var(--vscode-dropdown-border, var(--vscode-input-border, transparent)))',
+            borderRadius: 4,
+            fontSize: 13,
+            outline: 'none',
+            boxSizing: 'border-box' as const,
+        },
+        help: {
+            fontSize: 11,
+            color: 'var(--ui-text-secondary)',
+            marginTop: 6,
+            lineHeight: 1.4,
+        },
+        default: {
+            fontSize: 11,
+            color: 'var(--ui-text-secondary)',
+            fontStyle: 'italic',
+            marginTop: 4,
+        },
+    };
+
+    return (
+        <div style={styles.group}>
+            <label style={styles.label}>
+                {label}
+                {required && <span style={styles.required}>*</span>}
+            </label>
+            <select
+                style={styles.select}
+                value={value}
+                onChange={(e) => {
+                    onChange(e.target.value);
+                }}
+            >
+                {placeholder && <option value="">{placeholder}</option>}
+                {options.map((opt) => (
+                    <option key={opt} value={opt}>
+                        {opt}
+                    </option>
+                ))}
+            </select>
+            {description && <div style={styles.help}>{description}</div>}
+            {defaultValue !== undefined && (
+                <div style={styles.default}>Default: {defaultValue}</div>
+            )}
+        </div>
+    );
+}

--- a/packages/ui/src/components/form/FormTextField.tsx
+++ b/packages/ui/src/components/form/FormTextField.tsx
@@ -1,0 +1,105 @@
+import type { CSSProperties } from 'react';
+
+interface FormTextFieldProps {
+    label: string;
+    value: string;
+    onChange: (value: string) => void;
+    placeholder?: string;
+    description?: string;
+    defaultValue?: string;
+    required?: boolean;
+    isPath?: boolean;
+}
+
+/**
+ * Text input field with label, description, required indicator, and default display.
+ * @param root0 - Component props.
+ * @param root0.label - Field label shown above the input.
+ * @param root0.value - Current input value.
+ * @param root0.onChange - Callback invoked when the input value changes.
+ * @param root0.placeholder - Optional placeholder text.
+ * @param root0.description - Optional help text below the input.
+ * @param root0.defaultValue - Optional default value shown as hint text.
+ * @param root0.required - Whether to show a required indicator.
+ * @param root0.isPath - Whether to use monospace font for path fields.
+ * @returns The rendered text field.
+ */
+export function FormTextField({
+    label,
+    value,
+    onChange,
+    placeholder,
+    description,
+    defaultValue,
+    required,
+    isPath,
+}: FormTextFieldProps) {
+    const styles: Record<string, CSSProperties> = {
+        group: { marginBottom: 20 },
+        label: {
+            display: 'block',
+            marginBottom: 6,
+            fontWeight: 600,
+            fontSize: 13,
+            color: 'var(--ui-text-primary)',
+        },
+        required: {
+            color: 'var(--ui-error, var(--vscode-errorForeground, #f44))',
+            marginLeft: 4,
+        },
+        input: {
+            width: '100%',
+            padding: '6px 10px',
+            background: 'var(--ui-input-bg, var(--vscode-input-background))',
+            color: 'var(--ui-input-fg, var(--vscode-input-foreground))',
+            border: '1px solid var(--ui-input-border, var(--vscode-input-border, transparent))',
+            borderRadius: 4,
+            fontSize: 13,
+            fontFamily: isPath ? 'var(--vscode-editor-font-family, monospace)' : 'inherit',
+            outline: 'none',
+            boxSizing: 'border-box' as const,
+        },
+        help: {
+            fontSize: 11,
+            color: 'var(--ui-text-secondary)',
+            marginTop: 6,
+            lineHeight: 1.4,
+        },
+        default: {
+            fontSize: 11,
+            color: 'var(--ui-text-secondary)',
+            fontStyle: 'italic',
+            marginTop: 4,
+        },
+    };
+
+    return (
+        <div style={styles.group}>
+            <label style={styles.label}>
+                {label}
+                {required && <span style={styles.required}>*</span>}
+            </label>
+            <input
+                type="text"
+                style={styles.input}
+                value={value}
+                onChange={(e) => {
+                    onChange(e.target.value);
+                }}
+                placeholder={placeholder}
+                onFocus={(e) => {
+                    e.target.style.borderColor =
+                        'var(--ui-input-focus-border, var(--vscode-focusBorder, #007acc))';
+                }}
+                onBlur={(e) => {
+                    e.target.style.borderColor =
+                        'var(--ui-input-border, var(--vscode-input-border, transparent))';
+                }}
+            />
+            {description && <div style={styles.help}>{description}</div>}
+            {defaultValue !== undefined && (
+                <div style={styles.default}>Default: {defaultValue}</div>
+            )}
+        </div>
+    );
+}

--- a/packages/ui/src/components/form/index.ts
+++ b/packages/ui/src/components/form/index.ts
@@ -1,0 +1,5 @@
+export { FormTextField } from './FormTextField';
+export { FormSelect } from './FormSelect';
+export { FormCheckbox } from './FormCheckbox';
+export { FormSection } from './FormSection';
+export { FormListBuilder } from './FormListBuilder';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -32,3 +32,17 @@ export { ParameterTree } from './components/ParameterTree';
 export { SampleTaskView } from './components/SampleTaskView';
 export { ExamplesView } from './components/ExamplesView';
 export { ReturnValuesTable } from './components/ReturnValuesTable';
+
+export type {
+    CreatorBridge,
+    SchemaNode,
+    ParameterSchema,
+    ExecutionStartedEvent,
+    ExecutionFinishedEvent,
+} from './bridge/creator';
+export { FormTextField } from './components/form/FormTextField';
+export { FormSelect } from './components/form/FormSelect';
+export { FormCheckbox } from './components/form/FormCheckbox';
+export { FormSection } from './components/form/FormSection';
+export { SchemaForm } from './components/SchemaForm';
+export { CreatorFormView } from './views/CreatorFormView';

--- a/packages/ui/src/views/CreatorFormView.tsx
+++ b/packages/ui/src/views/CreatorFormView.tsx
@@ -1,0 +1,361 @@
+import { useState, useCallback, useMemo, useEffect } from 'react';
+import type { CSSProperties } from 'react';
+import { useBridge } from '../bridge/context';
+import type { CreatorBridge, SchemaNode } from '../bridge/creator';
+import { SchemaForm } from '../components/SchemaForm';
+
+interface CreatorFormViewProps {
+    commandPath: string[];
+    schema: SchemaNode;
+    buildPreview: (values: Record<string, unknown>) => string;
+}
+
+type ExecutionState =
+    | { status: 'idle' }
+    | { status: 'running'; command: string }
+    | { status: 'done'; command: string; exitCode: number; output: string };
+
+/**
+ * Converts a schema name to a display title.
+ *
+ * @param name - Schema node name (snake_case or kebab-case).
+ * @returns Title-cased display string.
+ */
+function toTitle(name: string): string {
+    return name
+        .split(/[_-]/)
+        .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+        .join(' ');
+}
+
+/**
+ * Orchestrator view that connects SchemaForm to the creator bridge.
+ * @param root0 - Component props.
+ * @param root0.commandPath - Command path segments after `ansible-creator`.
+ * @param root0.schema - Command schema node with parameter definitions.
+ * @param root0.buildPreview - Builds the command preview string from form values.
+ * @returns The rendered creator form view.
+ */
+export function CreatorFormView({ commandPath, schema, buildPreview }: CreatorFormViewProps) {
+    const bridge = useBridge() as CreatorBridge;
+    const [zoom, setZoom] = useState(100);
+    const [execution, setExecution] = useState<ExecutionState>({ status: 'idle' });
+
+    useEffect(() => {
+        const unsubStart = bridge.onExecutionStarted((event) => {
+            setExecution({ status: 'running', command: event.command });
+        });
+        const unsubFinish = bridge.onExecutionFinished((event) => {
+            setExecution((prev) => ({
+                status: 'done',
+                command: prev.status !== 'idle' ? prev.command : '',
+                exitCode: event.exitCode,
+                output: event.output,
+            }));
+        });
+        return () => {
+            unsubStart();
+            unsubFinish();
+        };
+    }, [bridge]);
+
+    const handleExecute = useCallback(
+        (values: Record<string, unknown>) => {
+            void bridge.execute(commandPath, values);
+        },
+        [bridge, commandPath],
+    );
+
+    const handleCancel = useCallback(() => {
+        bridge.cancel();
+    }, [bridge]);
+
+    const handleReset = useCallback(() => {
+        setExecution({ status: 'idle' });
+    }, []);
+
+    const handleZoomIn = useCallback(() => {
+        setZoom((z) => Math.min(z + 10, 200));
+    }, []);
+
+    const handleZoomOut = useCallback(() => {
+        setZoom((z) => Math.max(z - 10, 50));
+    }, []);
+
+    const title = useMemo(() => toTitle(schema.name), [schema.name]);
+    const pathDisplay = useMemo(() => `ansible-creator ${commandPath.join(' ')}`, [commandPath]);
+
+    const styles: Record<string, CSSProperties> = {
+        toolbar: {
+            position: 'fixed',
+            top: 12,
+            right: 20,
+            zIndex: 100,
+            display: 'flex',
+            alignItems: 'center',
+            gap: 4,
+            background: 'var(--ui-bg-primary)',
+            border: '1px solid var(--ui-border)',
+            borderRadius: 6,
+            padding: 4,
+        },
+        toolbarBtn: {
+            background: 'transparent',
+            border: 'none',
+            color: 'var(--ui-text-primary)',
+            opacity: 0.7,
+            padding: '4px 8px',
+            borderRadius: 4,
+            cursor: 'pointer',
+            fontSize: 14,
+            fontWeight: 600,
+            minWidth: 28,
+            height: 28,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+        },
+        zoomLabel: {
+            fontSize: 11,
+            color: 'var(--ui-text-primary)',
+            opacity: 0.7,
+            minWidth: 40,
+            textAlign: 'center',
+        },
+        mainContent: {
+            padding: 20,
+            paddingTop: 60,
+            zoom: zoom / 100,
+        },
+        container: {
+            maxWidth: 600,
+            margin: '0 auto',
+        },
+        header: {
+            marginBottom: 24,
+            paddingBottom: 16,
+            borderBottom: '1px solid var(--ui-border)',
+        },
+        title: {
+            fontSize: 18,
+            margin: '0 0 8px 0',
+            fontWeight: 600,
+            color: 'var(--ui-text-primary)',
+        },
+        commandPath: {
+            fontFamily: 'monospace',
+            color: 'var(--ui-text-secondary)',
+            fontSize: 12,
+        },
+        description: {
+            color: 'var(--ui-text-secondary)',
+            marginBottom: 24,
+            fontSize: 13,
+        },
+        outputSection: {
+            marginTop: 24,
+        },
+        outputLabel: {
+            fontSize: 11,
+            fontWeight: 600,
+            color: 'var(--ui-text-secondary)',
+            marginBottom: 8,
+            textTransform: 'uppercase' as const,
+            letterSpacing: 0.5,
+        },
+        outputBox: {
+            padding: '12px 16px',
+            background: 'var(--ui-bg-surface)',
+            border: '1px solid var(--ui-border)',
+            borderRadius: 4,
+            fontFamily: "'SF Mono', Consolas, monospace",
+            fontSize: 12,
+            whiteSpace: 'pre-wrap',
+            wordBreak: 'break-all',
+            lineHeight: 1.5,
+            color: 'var(--ui-text-primary)',
+            maxHeight: 400,
+            overflowY: 'auto',
+        },
+        successBadge: {
+            display: 'inline-block',
+            padding: '2px 8px',
+            borderRadius: 3,
+            fontSize: 11,
+            fontWeight: 600,
+            background: 'rgba(40, 167, 69, 0.15)',
+            color: '#28a745',
+            marginBottom: 12,
+        },
+        errorBadge: {
+            display: 'inline-block',
+            padding: '2px 8px',
+            borderRadius: 3,
+            fontSize: 11,
+            fontWeight: 600,
+            background: 'rgba(220, 53, 69, 0.15)',
+            color: '#dc3545',
+            marginBottom: 12,
+        },
+        runningIndicator: {
+            padding: '12px 16px',
+            background: 'var(--ui-bg-surface)',
+            border: '1px solid var(--ui-border)',
+            borderRadius: 4,
+            fontSize: 13,
+            color: 'var(--ui-text-secondary)',
+        },
+        resetBtn: {
+            marginTop: 16,
+            padding: '8px 16px',
+            background: 'transparent',
+            color: 'var(--ui-text-primary)',
+            border: '1px solid var(--ui-border)',
+            borderRadius: 4,
+            fontSize: 13,
+            cursor: 'pointer',
+        },
+    };
+
+    if (execution.status === 'running') {
+        return (
+            <>
+                <div style={styles.toolbar}>
+                    <button
+                        type="button"
+                        style={styles.toolbarBtn}
+                        title="Zoom out"
+                        onClick={handleZoomOut}
+                    >
+                        −
+                    </button>
+                    <span style={styles.zoomLabel}>{zoom}%</span>
+                    <button
+                        type="button"
+                        style={styles.toolbarBtn}
+                        title="Zoom in"
+                        onClick={handleZoomIn}
+                    >
+                        +
+                    </button>
+                </div>
+                <div style={styles.mainContent}>
+                    <div style={styles.container}>
+                        <div style={styles.header}>
+                            <h1 style={styles.title}>{title}</h1>
+                            <div style={styles.commandPath}>{pathDisplay}</div>
+                        </div>
+                        <div style={styles.outputSection}>
+                            <div style={styles.outputLabel}>Running</div>
+                            <div style={styles.runningIndicator}>Executing command&hellip;</div>
+                            <div style={{ ...styles.outputBox, marginTop: 12 }}>
+                                $ {execution.command}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </>
+        );
+    }
+
+    if (execution.status === 'done') {
+        const isSuccess = execution.exitCode === 0;
+        return (
+            <>
+                <div style={styles.toolbar}>
+                    <button
+                        type="button"
+                        style={styles.toolbarBtn}
+                        title="Zoom out"
+                        onClick={handleZoomOut}
+                    >
+                        −
+                    </button>
+                    <span style={styles.zoomLabel}>{zoom}%</span>
+                    <button
+                        type="button"
+                        style={styles.toolbarBtn}
+                        title="Zoom in"
+                        onClick={handleZoomIn}
+                    >
+                        +
+                    </button>
+                </div>
+                <div style={styles.mainContent}>
+                    <div style={styles.container}>
+                        <div style={styles.header}>
+                            <h1 style={styles.title}>{title}</h1>
+                            <div style={styles.commandPath}>{pathDisplay}</div>
+                        </div>
+                        <div style={styles.outputSection}>
+                            <div style={isSuccess ? styles.successBadge : styles.errorBadge}>
+                                {isSuccess
+                                    ? 'Success'
+                                    : `Failed (exit code ${String(execution.exitCode)})`}
+                            </div>
+                            <div style={styles.outputBox}>
+                                <div
+                                    style={{
+                                        color: 'var(--ui-text-secondary)',
+                                        marginBottom: 8,
+                                    }}
+                                >
+                                    $ {execution.command}
+                                </div>
+                                {execution.output || '(no output)'}
+                            </div>
+                            <button type="button" style={styles.resetBtn} onClick={handleReset}>
+                                Run Again
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            </>
+        );
+    }
+
+    return (
+        <>
+            <div style={styles.toolbar}>
+                <button
+                    type="button"
+                    style={styles.toolbarBtn}
+                    title="Zoom out"
+                    onClick={handleZoomOut}
+                >
+                    −
+                </button>
+                <span style={styles.zoomLabel}>{zoom}%</span>
+                <button
+                    type="button"
+                    style={styles.toolbarBtn}
+                    title="Zoom in"
+                    onClick={handleZoomIn}
+                >
+                    +
+                </button>
+            </div>
+
+            <div style={styles.mainContent}>
+                <div style={styles.container}>
+                    <div style={styles.header}>
+                        <h1 style={styles.title}>{title}</h1>
+                        <div style={styles.commandPath}>{pathDisplay}</div>
+                    </div>
+
+                    {schema.description && (
+                        <div style={styles.description}>{schema.description}</div>
+                    )}
+
+                    <SchemaForm
+                        schema={schema}
+                        workspacePath={bridge.workspacePath}
+                        onExecute={handleExecute}
+                        onCancel={handleCancel}
+                        buildPreview={buildPreview}
+                    />
+                </div>
+            </div>
+        </>
+    );
+}

--- a/src/panels/CreatorFormPanel.ts
+++ b/src/panels/CreatorFormPanel.ts
@@ -1,40 +1,11 @@
 import * as vscode from 'vscode';
 import { log } from '@src/extension';
-import { TerminalService } from '@src/services/TerminalService';
+import { buildCommandArgs, getCommandService, type SchemaNode } from '@ansible/core';
 
-interface SchemaNode {
-    name: string;
-    description?: string;
-    parameters?: {
-        type: string;
-        properties: Record<string, ParameterSchema>;
-        required: string[];
-    };
-    subcommands?: Record<string, SchemaNode>;
-}
-
-interface ParameterSchema {
-    type: string;
-    description: string;
-    default?: unknown;
-    enum?: string[];
-    aliases?: string[];
-}
-
-interface CreatorFormMessage {
-    command: string;
-    values?: Record<string, unknown>;
-    zoom?: number;
-    theme?: string;
-}
-
-/** Webview panel that renders an ansible-creator command form from schema metadata. */
+/** Thin webview host for the creator form. Delegates UI to @ansible/ui SchemaForm. */
 export class CreatorFormPanel {
     public static currentPanel: CreatorFormPanel | undefined;
     private readonly _panel: vscode.WebviewPanel;
-    private readonly _extensionUri: vscode.Uri;
-    private readonly _commandPath: string[];
-    private readonly _schema: SchemaNode;
     private _disposables: vscode.Disposable[] = [];
 
     /**
@@ -44,19 +15,22 @@ export class CreatorFormPanel {
      * @param schema - Schema definition used to build the form
      */
     public static show(extensionUri: vscode.Uri, commandPath: string[], schema: SchemaNode): void {
-        const column = vscode.ViewColumn.One;
-
-        // Close existing panel
         if (CreatorFormPanel.currentPanel) {
             CreatorFormPanel.currentPanel._panel.dispose();
         }
 
         const title = `Create: ${commandPath.join(' → ')}`;
 
-        const panel = vscode.window.createWebviewPanel('creatorForm', title, column, {
-            enableScripts: true,
-            localResourceRoots: [extensionUri],
-        });
+        const panel = vscode.window.createWebviewPanel(
+            'creatorForm',
+            title,
+            vscode.ViewColumn.One,
+            {
+                enableScripts: true,
+                retainContextWhenHidden: true,
+                localResourceRoots: [vscode.Uri.joinPath(extensionUri, 'dist')],
+            },
+        );
 
         CreatorFormPanel.currentPanel = new CreatorFormPanel(
             panel,
@@ -68,52 +42,24 @@ export class CreatorFormPanel {
 
     /**
      * Create the creator form panel and wire webview message handlers.
-     * @param panel - Webview panel hosting the creator form
-     * @param extensionUri - Extension root used for webview resources
-     * @param commandPath - ansible-creator command path segments
-     * @param schema - Schema definition used to build the form
+     *
+     * @param panel - Webview panel hosting the creator form.
+     * @param extensionUri - Extension root used for webview resources.
+     * @param _commandPath - ansible-creator command path segments.
+     * @param _schema - Schema definition used to build the form.
      */
     private constructor(
         panel: vscode.WebviewPanel,
         extensionUri: vscode.Uri,
-        commandPath: string[],
-        schema: SchemaNode,
+        private readonly _commandPath: string[],
+        private readonly _schema: SchemaNode,
     ) {
         this._panel = panel;
-        this._extensionUri = extensionUri;
-        this._commandPath = commandPath;
-        this._schema = schema;
-
-        this._panel.webview.html = this._getHtml();
+        this._panel.webview.html = this._getHtml(extensionUri);
 
         this._panel.webview.onDidReceiveMessage(
-            async (message: CreatorFormMessage) => {
-                switch (message.command) {
-                    case 'execute':
-                        await this._executeCommand(message.values ?? {});
-                        break;
-                    case 'cancel':
-                        this._panel.dispose();
-                        break;
-                    case 'updateSettings': {
-                        const config = vscode.workspace.getConfiguration('ansibleEnvironments');
-                        if (message.zoom !== undefined) {
-                            await config.update(
-                                'pluginDocZoom',
-                                message.zoom,
-                                vscode.ConfigurationTarget.Workspace,
-                            );
-                        }
-                        if (message.theme !== undefined) {
-                            await config.update(
-                                'pluginDocTheme',
-                                message.theme,
-                                vscode.ConfigurationTarget.Workspace,
-                            );
-                        }
-                        break;
-                    }
-                }
+            (msg: { id?: number; method: string; params?: Record<string, unknown> }) => {
+                void this._handleMessage(msg);
             },
             null,
             this._disposables,
@@ -129,724 +75,171 @@ export class CreatorFormPanel {
     }
 
     /**
-     * Build and run the ansible-creator command from submitted form values.
-     * @param values - Form field values keyed by schema parameter name
+     * Routes incoming webview messages to the appropriate handler.
+     *
+     * @param msg - Webview message.
+     * @param msg.id - Correlation ID for RPC requests.
+     * @param msg.method - RPC method name.
+     * @param msg.params - Method parameters.
      */
-    private async _executeCommand(values: Record<string, unknown>): Promise<void> {
-        try {
-            // Build the command
-            const args = this._buildCommandArgs(values);
-            const commandStr = `ansible-creator ${this._commandPath.join(' ')} ${args}`;
+    private async _handleMessage(msg: {
+        id?: number;
+        method: string;
+        params?: Record<string, unknown>;
+    }): Promise<void> {
+        const { id, method, params } = msg;
 
-            log(`CreatorFormPanel: Executing: ${commandStr}`);
-
-            // Use TerminalService for proper venv handling
-            const terminalService = TerminalService.getInstance();
-            const managed = await terminalService.createActivatedTerminal({
-                name: `ansible-creator ${this._commandPath.join(' ')}`,
-                show: true,
-            });
-            void managed.sendCommand(commandStr, { waitForCompletion: false });
-
-            // Close the form panel
+        // Fire-and-forget messages
+        if (method === 'showToast' && typeof params?.message === 'string') {
+            void vscode.window.showInformationMessage(params.message);
+            return;
+        }
+        if (method === 'cancel') {
             this._panel.dispose();
+            return;
+        }
 
-            vscode.window.showInformationMessage(
-                `Running: ansible-creator ${this._commandPath.join(' ')}`,
-            );
-        } catch (error) {
-            vscode.window.showErrorMessage(
-                `Failed to execute command: ${error instanceof Error ? error.message : String(error)}`,
-            );
+        // RPC requests
+        if (id !== undefined) {
+            try {
+                const result = await this._dispatch(method, params ?? {});
+                this._panel.webview.postMessage({ id, result });
+            } catch (err) {
+                const message = err instanceof Error ? err.message : String(err);
+                this._panel.webview.postMessage({ id, error: message });
+            }
         }
     }
 
     /**
-     * Convert form values into ansible-creator CLI arguments.
-     * @param values - Form field values keyed by schema parameter name
-     * @returns Shell-ready argument string for ansible-creator
+     * Dispatches an RPC method to the correct handler.
+     *
+     * @param method - RPC method name.
+     * @param params - Method parameters from the webview.
+     * @returns Method result to send back to the webview.
      */
-    private _buildCommandArgs(values: Record<string, unknown>): string {
-        const args: string[] = [];
-        const properties = this._schema.parameters?.properties ?? {};
-        const required = this._schema.parameters?.required ?? [];
-
-        for (const [key, value] of Object.entries(values)) {
-            if (value === undefined || value === null || value === '') {
-                continue;
+    private async _dispatch(method: string, params: Record<string, unknown>): Promise<unknown> {
+        switch (method) {
+            case 'execute': {
+                const commandPath = params.commandPath as string[];
+                const values = params.values as Record<string, unknown>;
+                await this._executeCommand(commandPath, values);
+                return undefined;
             }
-
-            if (!(key in properties)) {
-                args.push(this._quoteIfNeeded(this._valueToString(value)));
-                continue;
-            }
-            const prop = properties[key];
-
-            // Check if it's a positional argument (required and no aliases)
-            const isPositional = required.includes(key) && (prop.aliases?.length ?? 0) === 0;
-
-            if (isPositional) {
-                // Positional arguments are added directly
-                args.push(this._quoteIfNeeded(this._valueToString(value)));
-            } else if (prop.type === 'boolean') {
-                // Boolean flags
-                if (value === true && prop.aliases) {
-                    // Use the long form alias (usually the second one)
-                    const flag = prop.aliases.find((a) => a.startsWith('--')) ?? prop.aliases[0];
-                    args.push(flag);
+            case 'openFile': {
+                if (typeof params.path === 'string') {
+                    await vscode.commands.executeCommand(
+                        'vscode.open',
+                        vscode.Uri.file(params.path),
+                    );
                 }
-            } else if (prop.aliases && prop.aliases.length > 0) {
-                // Optional arguments with values
-                const aliases = prop.aliases;
-                const flag = aliases.find((a) => a.startsWith('--')) ?? aliases[0];
-                // Clean up flag (remove <placeholder> parts)
-                const cleanFlag = flag.split(' ')[0];
-                args.push(`${cleanFlag} ${this._quoteIfNeeded(this._valueToString(value))}`);
+                return undefined;
             }
+            case 'saveViewSettings':
+                return undefined;
+            default:
+                throw new Error(`Unknown method: ${method}`);
         }
-
-        return args.join(' ');
     }
 
     /**
-     * Convert a form value into a CLI-safe string representation.
-     * @param value - Form value of any supported schema type
-     * @returns String value suitable for command-line arguments
+     * Builds and runs the ansible-creator command from submitted form values.
+     *
+     * @param commandPath - Command path segments.
+     * @param values - Form field values keyed by schema parameter name.
      */
-    private _valueToString(value: unknown): string {
-        if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
-            return String(value);
+    private async _executeCommand(
+        commandPath: string[],
+        values: Record<string, unknown>,
+    ): Promise<void> {
+        const args = buildCommandArgs(commandPath, this._schema, values);
+        log(`CreatorFormPanel: Executing: ansible-creator ${args.join(' ')}`);
+
+        this._panel.webview.postMessage({
+            method: 'executionStarted',
+            params: { command: `ansible-creator ${args.join(' ')}` },
+        });
+
+        const commandService = getCommandService();
+        const toolPath = await commandService.getToolPath('ansible-creator');
+        if (!toolPath) {
+            this._panel.webview.postMessage({
+                method: 'executionFinished',
+                params: {
+                    exitCode: 1,
+                    output: 'ansible-creator not found. Install ansible-dev-tools first.',
+                },
+            });
+            return;
         }
-        return JSON.stringify(value);
+
+        const result = await commandService.runCommandArgs(toolPath, args);
+        const output = [result.stdout, result.stderr].filter(Boolean).join('\n');
+
+        this._panel.webview.postMessage({
+            method: 'executionFinished',
+            params: { exitCode: result.exitCode, output },
+        });
+
+        if (result.exitCode === 0) {
+            void vscode.window.showInformationMessage(
+                `ansible-creator ${commandPath.join(' ')} completed successfully`,
+            );
+        } else {
+            void vscode.window.showErrorMessage(
+                `ansible-creator ${commandPath.join(' ')} failed (exit code ${String(result.exitCode)})`,
+            );
+        }
     }
 
     /**
-     * Quote argument values that contain shell-sensitive characters.
-     * @param value - Argument value to escape when needed
-     * @returns Quoted or unchanged argument text
+     * Generates the HTML shell that loads the shared webview bundle.
+     *
+     * @param extensionUri - Extension root for resolving resource URIs.
+     * @returns HTML document string for the webview.
      */
-    private _quoteIfNeeded(value: string): string {
-        if (value.includes(' ') || value.includes('"') || value.includes("'")) {
-            return `"${value.replace(/"/g, '\\"')}"`;
-        }
-        return value;
-    }
-
-    /**
-     * Generate the creator form webview HTML and client-side script.
-     * @returns Complete HTML document rendered in the webview
-     */
-    private _getHtml(): string {
-        const schemaJson = JSON.stringify(this._schema);
-        const commandPathJson = JSON.stringify(this._commandPath);
+    private _getHtml(extensionUri: vscode.Uri): string {
+        const webviewUri = this._panel.webview.asWebviewUri(
+            vscode.Uri.joinPath(extensionUri, 'dist', 'webview.js'),
+        );
         const workspacePath = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? './';
+        const nonce = getNonce();
 
-        // Get settings
-        const config = vscode.workspace.getConfiguration('ansibleEnvironments');
-        const zoom = config.get<number>('pluginDocZoom', 100);
-        const themeSetting = config.get<string>('pluginDocTheme', 'auto');
-
-        // Resolve 'auto' to actual theme based on VS Code's current theme
-        const vscodeThemeKind = vscode.window.activeColorTheme.kind;
-        const isVsCodeLight =
-            vscodeThemeKind === vscode.ColorThemeKind.Light ||
-            vscodeThemeKind === vscode.ColorThemeKind.HighContrastLight;
-        const resolvedTheme =
-            themeSetting === 'auto' ? (isVsCodeLight ? 'light' : 'dark') : themeSetting;
+        const propsJson = JSON.stringify({
+            commandPath: this._commandPath,
+            schema: this._schema,
+            workspacePath,
+        });
 
         return `<!DOCTYPE html>
-<html lang="en" data-theme="${resolvedTheme}" data-theme-setting="${themeSetting}">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'nonce-${nonce}';">
     <title>ansible-creator</title>
-    <script src="https://unpkg.com/@vscode-elements/elements@1.6.0/dist/bundled.js" type="module"></script>
     <style>
         :root {
-            --bg: var(--vscode-editor-background);
-            --fg: var(--vscode-editor-foreground);
-            --border: var(--vscode-panel-border);
-            --input-bg: var(--vscode-input-background);
-            --button-bg: var(--vscode-button-background);
-            --button-fg: var(--vscode-button-foreground);
-            --error: var(--vscode-errorForeground);
-            --toolbar-bg: var(--vscode-editor-background);
-            --toolbar-border: var(--vscode-panel-border);
-            --success: #28a745;
+            --host-bg-primary: var(--vscode-editor-background);
+            --host-bg-surface: var(--vscode-sideBar-background, rgba(128, 128, 128, 0.08));
+            --host-text-primary: var(--vscode-editor-foreground);
+            --host-text-secondary: var(--vscode-descriptionForeground);
+            --host-border: var(--vscode-panel-border);
+            --host-accent: var(--vscode-button-background);
         }
-        
-        /* Light theme overrides */
-        [data-theme="light"] {
-            --bg: #ffffff;
-            --fg: #1b1f24;
-            --border: #d0d7de;
-            --input-bg: #f6f8fa;
-            --section-bg: #f6f8fa;
-            --desc-fg: #656d76;
-            --label-fg: #1b1f24;
-            --toolbar-bg: rgba(255, 255, 255, 0.95);
-        }
-        
-        /* Dark theme overrides */
-        [data-theme="dark"] {
-            --bg: #0d1117;
-            --fg: #e6edf3;
-            --border: #30363d;
-            --input-bg: #161b22;
-            --section-bg: rgba(128, 128, 128, 0.08);
-            --desc-fg: #8b949e;
-            --toolbar-bg: rgba(13, 17, 23, 0.95);
-        }
-        
-        * { box-sizing: border-box; }
-        
         body {
+            margin: 0;
+            padding: 0;
+            background: var(--vscode-editor-background);
+            color: var(--vscode-editor-foreground);
             font-family: var(--vscode-font-family);
             font-size: var(--vscode-font-size);
-            color: var(--fg);
-            background: var(--bg);
-            padding: 0;
-            margin: 0;
-        }
-        
-        .toolbar {
-            position: fixed;
-            top: 12px;
-            right: 20px;
-            z-index: 100;
-            display: flex;
-            align-items: center;
-            gap: 4px;
-            background: var(--toolbar-bg);
-            border: 1px solid var(--border);
-            border-radius: 6px;
-            padding: 4px;
-            backdrop-filter: blur(8px);
-        }
-        
-        .toolbar-btn {
-            background: transparent;
-            border: none;
-            color: var(--fg);
-            opacity: 0.7;
-            padding: 4px 8px;
-            border-radius: 4px;
-            cursor: pointer;
-            font-size: 14px;
-            font-weight: 600;
-            min-width: 28px;
-            height: 28px;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-        }
-        
-        .toolbar-btn:hover {
-            background: var(--input-bg);
-            opacity: 1;
-        }
-        
-        .zoom-label {
-            font-size: 11px;
-            color: var(--fg);
-            opacity: 0.7;
-            min-width: 40px;
-            text-align: center;
-        }
-        
-        .toolbar-divider {
-            width: 1px;
-            height: 16px;
-            background: var(--border);
-            margin: 0 4px;
-        }
-        
-        .main-content {
-            padding: 20px;
-            padding-top: 60px;
-            zoom: ${String(zoom / 100)};
-        }
-        
-        .container {
-            max-width: 600px;
-            margin: 0 auto;
-        }
-        
-        .header {
-            margin-bottom: 24px;
-            padding-bottom: 16px;
-            border-bottom: 1px solid var(--border);
-        }
-        
-        .header h1 {
-            font-size: 18px;
-            margin: 0 0 8px 0;
-            font-weight: 600;
-        }
-        
-        .header .command-path {
-            font-family: monospace;
-            color: var(--desc-fg, var(--vscode-descriptionForeground));
-            font-size: 12px;
-        }
-        
-        .description {
-            color: var(--desc-fg, var(--vscode-descriptionForeground));
-            margin-bottom: 24px;
-            font-size: 13px;
-        }
-        
-        .section {
-            margin-bottom: 24px;
-            background: var(--section-bg, rgba(128, 128, 128, 0.08));
-            border: 1px solid var(--border);
-            border-radius: 6px;
-            padding: 16px;
-        }
-        
-        .section-title {
-            font-size: 13px;
-            font-weight: 600;
-            margin-bottom: 16px;
-            padding-bottom: 10px;
-            border-bottom: 1px solid var(--border);
-            text-transform: uppercase;
-            letter-spacing: 0.5px;
-            color: var(--fg);
-        }
-        
-        .form-group {
-            margin-bottom: 20px;
-        }
-        
-        .form-group:last-child {
-            margin-bottom: 0;
-        }
-        
-        .form-group label {
-            display: block;
-            margin-bottom: 6px;
-            font-weight: 600;
-            font-size: 13px;
-            color: var(--fg);
-        }
-        
-        .form-group .required {
-            color: var(--error);
-            margin-left: 4px;
-        }
-        
-        .form-group .help-text {
-            font-size: 11px;
-            color: var(--desc-fg, var(--vscode-descriptionForeground));
-            margin-top: 6px;
-            line-height: 1.4;
-        }
-        
-        .form-group .default-text {
-            font-size: 11px;
-            color: var(--desc-fg, var(--vscode-descriptionForeground));
-            font-style: italic;
-            margin-top: 4px;
-        }
-        
-        vscode-textfield, vscode-dropdown {
-            width: 100%;
-        }
-        
-        vscode-checkbox {
-            color: var(--desc-fg, var(--vscode-descriptionForeground));
-        }
-        
-        .button-row {
-            display: flex;
-            justify-content: flex-end;
-            gap: 12px;
-            margin-top: 24px;
-            padding-top: 20px;
-            border-top: 1px solid var(--border);
-        }
-        
-        .preview-section {
-            margin-top: 24px;
-        }
-        
-        .preview-label {
-            font-size: 11px;
-            font-weight: 600;
-            color: var(--desc-fg, var(--vscode-descriptionForeground));
-            margin-bottom: 8px;
-            text-transform: uppercase;
-            letter-spacing: 0.5px;
-        }
-        
-        .preview {
-            padding: 12px 16px;
-            background: var(--vscode-textCodeBlock-background);
-            border: 1px solid var(--border);
-            border-radius: 4px;
-            font-family: 'SF Mono', Consolas, monospace;
-            font-size: 12px;
-            white-space: pre-wrap;
-            word-break: break-all;
-            line-height: 1.5;
         }
     </style>
 </head>
 <body>
-    <div class="toolbar">
-        <button id="zoom-out-btn" class="toolbar-btn" title="Zoom out">−</button>
-        <span class="zoom-label" id="zoom-level">${String(zoom)}%</span>
-        <button id="zoom-in-btn" class="toolbar-btn" title="Zoom in">+</button>
-        <div class="toolbar-divider"></div>
-        <button id="theme-toggle-btn" class="toolbar-btn" title="Toggle theme">${themeSetting}</button>
-    </div>
-    <div class="main-content">
-    <div class="container">
-        <div class="header">
-            <h1 id="title">ansible-creator</h1>
-            <div class="command-path" id="commandPath"></div>
-        </div>
-        
-        <div class="description" id="description"></div>
-        
-        <div id="requiredSection" class="section" style="display: none;">
-            <div class="section-title">Required Parameters</div>
-            <div id="requiredFields"></div>
-        </div>
-        
-        <div id="optionalSection" class="section" style="display: none;">
-            <div class="section-title">Optional Parameters</div>
-            <div id="optionalFields"></div>
-        </div>
-        
-        <div class="preview-section">
-            <div class="preview-label">Command Preview</div>
-            <div class="preview" id="preview">ansible-creator</div>
-        </div>
-        
-        <div class="button-row">
-            <vscode-button id="cancelBtn" appearance="secondary">Cancel</vscode-button>
-            <vscode-button id="executeBtn">Run</vscode-button>
-        </div>
-    </div>
-    </div>
-    
-    <script>
-        const vscode = acquireVsCodeApi();
-        
-        // Zoom functionality
-        (function() {
-            let currentZoom = ${String(zoom)};
-            const minZoom = 50;
-            const maxZoom = 200;
-            const zoomStep = 10;
-            
-            const zoomInBtn = document.getElementById('zoom-in-btn');
-            const zoomOutBtn = document.getElementById('zoom-out-btn');
-            const zoomLevel = document.getElementById('zoom-level');
-            const mainContent = document.querySelector('.main-content');
-            
-            function updateZoom(save) {
-                if (mainContent) {
-                    mainContent.style.zoom = (currentZoom / 100);
-                }
-                if (zoomLevel) zoomLevel.textContent = currentZoom + '%';
-                if (save) {
-                    vscode.postMessage({ command: 'updateSettings', zoom: currentZoom });
-                }
-            }
-            
-            if (zoomInBtn) {
-                zoomInBtn.onclick = function() {
-                    if (currentZoom < maxZoom) {
-                        currentZoom += zoomStep;
-                        updateZoom(true);
-                    }
-                };
-            }
-            
-            if (zoomOutBtn) {
-                zoomOutBtn.onclick = function() {
-                    if (currentZoom > minZoom) {
-                        currentZoom -= zoomStep;
-                        updateZoom(true);
-                    }
-                };
-            }
-        })();
-        
-        // Theme toggle functionality
-        (function() {
-            const themeToggleBtn = document.getElementById('theme-toggle-btn');
-            const themes = ['auto', 'light', 'dark'];
-            let currentThemeSetting = document.documentElement.getAttribute('data-theme-setting') || 'auto';
-            
-            function updateThemeButton() {
-                if (themeToggleBtn) {
-                    themeToggleBtn.textContent = currentThemeSetting;
-                }
-            }
-            
-            if (themeToggleBtn) {
-                themeToggleBtn.onclick = function() {
-                    const currentIndex = themes.indexOf(currentThemeSetting);
-                    currentThemeSetting = themes[(currentIndex + 1) % themes.length];
-                    
-                    // For 'auto', we keep the current resolved theme but update the setting
-                    const displayTheme = currentThemeSetting === 'auto' ? 'dark' : currentThemeSetting;
-                    document.documentElement.setAttribute('data-theme', displayTheme);
-                    document.documentElement.setAttribute('data-theme-setting', currentThemeSetting);
-                    
-                    updateThemeButton();
-                    vscode.postMessage({ command: 'updateSettings', theme: currentThemeSetting });
-                };
-            }
-        })();
-        const schema = ${schemaJson};
-        const commandPath = ${commandPathJson};
-        const workspacePath = ${JSON.stringify(workspacePath)};
-        
-        // Current form values
-        const formValues = {};
-        
-        function init() {
-            // Set header
-            document.getElementById('title').textContent = formatLabel(schema.name);
-            document.getElementById('commandPath').textContent = 'ansible-creator ' + commandPath.join(' ');
-            document.getElementById('description').textContent = schema.description || '';
-            
-            const properties = schema.parameters?.properties || {};
-            const required = schema.parameters?.required || [];
-            
-            const requiredFields = document.getElementById('requiredFields');
-            const optionalFields = document.getElementById('optionalFields');
-            
-            let requiredCount = 0;
-            let optionalCount = 0;
-            
-            // Sort properties: required first, then alphabetically
-            const sortedKeys = Object.keys(properties).sort((a, b) => {
-                const aReq = required.includes(a);
-                const bReq = required.includes(b);
-                if (aReq && !bReq) return -1;
-                if (!aReq && bReq) return 1;
-                return a.localeCompare(b);
-            });
-            
-            for (const key of sortedKeys) {
-                const prop = properties[key];
-                const isRequired = required.includes(key);
-                
-                // Skip common/noise parameters
-                if (['no_ansi', 'log_file', 'log_level', 'log_append', 'json', 'verbose'].includes(key)) {
-                    continue;
-                }
-                
-                const field = createField(key, prop, isRequired);
-                
-                if (isRequired) {
-                    requiredFields.appendChild(field);
-                    requiredCount++;
-                } else {
-                    optionalFields.appendChild(field);
-                    optionalCount++;
-                }
-                
-                // Set default value
-                if (prop.default !== undefined && prop.default !== null) {
-                    formValues[key] = prop.default;
-                }
-            }
-            
-            // Show/hide sections
-            if (requiredCount > 0) {
-                document.getElementById('requiredSection').style.display = 'block';
-            }
-            if (optionalCount > 0) {
-                document.getElementById('optionalSection').style.display = 'block';
-            }
-            
-            // Set up buttons
-            document.getElementById('executeBtn').addEventListener('click', execute);
-            document.getElementById('cancelBtn').addEventListener('click', cancel);
-            
-            updatePreview();
-            validateForm();
-        }
-        
-        function validateForm() {
-            const required = schema.parameters?.required || [];
-            let isValid = true;
-            
-            for (const key of required) {
-                const value = formValues[key];
-                if (value === undefined || value === null || value === '') {
-                    isValid = false;
-                    break;
-                }
-            }
-            
-            const executeBtn = document.getElementById('executeBtn');
-            if (isValid) {
-                executeBtn.removeAttribute('disabled');
-            } else {
-                executeBtn.setAttribute('disabled', '');
-            }
-        }
-        
-        function createField(key, prop, isRequired) {
-            const group = document.createElement('div');
-            group.className = 'form-group';
-            
-            const label = document.createElement('label');
-            label.textContent = formatLabel(key);
-            if (isRequired) {
-                const req = document.createElement('span');
-                req.className = 'required';
-                req.textContent = '*';
-                label.appendChild(req);
-            }
-            group.appendChild(label);
-            
-            let input;
-            
-            if (prop.type === 'boolean') {
-                input = document.createElement('vscode-checkbox');
-                input.textContent = prop.description;
-                if (prop.default === true) {
-                    input.setAttribute('checked', '');
-                }
-                input.addEventListener('change', (e) => {
-                    formValues[key] = e.target.checked;
-                    updatePreview();
-                    validateForm();
-                });
-            } else if (prop.enum) {
-                input = document.createElement('vscode-dropdown');
-                
-                // Add empty option for optional fields
-                if (!isRequired) {
-                    const emptyOpt = document.createElement('vscode-option');
-                    emptyOpt.textContent = '-- Select --';
-                    emptyOpt.value = '';
-                    input.appendChild(emptyOpt);
-                }
-                
-                for (const choice of prop.enum) {
-                    const opt = document.createElement('vscode-option');
-                    opt.textContent = choice;
-                    opt.value = choice;
-                    if (prop.default === choice) {
-                        opt.setAttribute('selected', '');
-                    }
-                    input.appendChild(opt);
-                }
-                input.addEventListener('change', (e) => {
-                    formValues[key] = e.target.value;
-                    updatePreview();
-                    validateForm();
-                });
-            } else {
-                input = document.createElement('vscode-textfield');
-                input.setAttribute('placeholder', prop.description);
-                
-                // Set default value
-                if (prop.default !== undefined && prop.default !== null) {
-                    input.value = String(prop.default);
-                }
-                
-                // Special handling for path fields
-                if (key === 'path' || key === 'init_path') {
-                    input.value = workspacePath;
-                    formValues[key] = workspacePath;
-                }
-                
-                input.addEventListener('input', (e) => {
-                    formValues[key] = e.target.value;
-                    updatePreview();
-                    validateForm();
-                });
-            }
-            
-            group.appendChild(input);
-            
-            // Help text
-            if (prop.description && prop.type !== 'boolean') {
-                const help = document.createElement('div');
-                help.className = 'help-text';
-                help.textContent = prop.description;
-                group.appendChild(help);
-            }
-            
-            // Default indicator
-            if (prop.default !== undefined && prop.default !== null && prop.type !== 'boolean') {
-                const defaultText = document.createElement('div');
-                defaultText.className = 'default-text';
-                defaultText.textContent = 'Default: ' + JSON.stringify(prop.default);
-                group.appendChild(defaultText);
-            }
-            
-            return group;
-        }
-        
-        function formatLabel(name) {
-            return name
-                .split(/[_-]/)
-                .map(word => word.charAt(0).toUpperCase() + word.slice(1))
-                .join(' ');
-        }
-        
-        function updatePreview() {
-            const properties = schema.parameters?.properties || {};
-            const required = schema.parameters?.required || [];
-            const args = [];
-            
-            for (const [key, value] of Object.entries(formValues)) {
-                if (value === undefined || value === null || value === '' || value === false) {
-                    continue;
-                }
-                
-                const prop = properties[key];
-                const isPositional = required.includes(key) && (!prop?.aliases || prop.aliases.length === 0);
-                
-                if (isPositional) {
-                    args.push(quoteIfNeeded(String(value)));
-                } else if (prop?.type === 'boolean' && value === true && prop.aliases) {
-                    const flag = prop.aliases.find(a => a.startsWith('--')) || prop.aliases[0];
-                    args.push(flag);
-                } else if (prop?.aliases && value !== prop.default) {
-                    const flag = prop.aliases.find(a => a.startsWith('--')) || prop.aliases[0];
-                    const cleanFlag = flag.split(' ')[0];
-                    args.push(cleanFlag + ' ' + quoteIfNeeded(String(value)));
-                }
-            }
-            
-            const preview = 'ansible-creator ' + commandPath.join(' ') + (args.length ? ' ' + args.join(' ') : '');
-            document.getElementById('preview').textContent = preview;
-        }
-        
-        function quoteIfNeeded(value) {
-            if (value.includes(' ') || value.includes('"') || value.includes("'")) {
-                return '"' + value.replace(/"/g, '\\\\"') + '"';
-            }
-            return value;
-        }
-        
-        function execute() {
-            vscode.postMessage({
-                command: 'execute',
-                values: formValues
-            });
-        }
-        
-        function cancel() {
-            vscode.postMessage({ command: 'cancel' });
-        }
-        
-        // Initialize
-        init();
-    </script>
+    <div id="root" data-view="creator-form" data-props='${propsJson.replace(/'/g, '&#39;')}'></div>
+    <script nonce="${nonce}" src="${webviewUri.toString()}"></script>
 </body>
 </html>`;
     }
@@ -857,9 +250,21 @@ export class CreatorFormPanel {
         this._panel.dispose();
         while (this._disposables.length) {
             const x = this._disposables.pop();
-            if (x) {
-                x.dispose();
-            }
+            x?.dispose();
         }
     }
+}
+
+/**
+ * Generates a random nonce string for Content Security Policy.
+ *
+ * @returns 32-character alphanumeric nonce.
+ */
+function getNonce(): string {
+    const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+    let nonce = '';
+    for (let i = 0; i < 32; i++) {
+        nonce += chars.charAt(Math.floor(Math.random() * chars.length));
+    }
+    return nonce;
 }

--- a/src/panels/bridges/VsCodeBridge.ts
+++ b/src/panels/bridges/VsCodeBridge.ts
@@ -8,6 +8,9 @@ import type {
     SystemPackageDetail,
     PluginDocBridge,
     PluginData,
+    CreatorBridge,
+    ExecutionStartedEvent,
+    ExecutionFinishedEvent,
 } from '@ansible/ui';
 
 type VsCodeApi = {
@@ -26,17 +29,28 @@ type VsCodeApi = {
 /** Timeout for RPC requests in milliseconds. */
 const RPC_TIMEOUT_MS = 30_000;
 
-export class VsCodeBridge implements EEBridge, PluginDocBridge {
+export class VsCodeBridge implements EEBridge, PluginDocBridge, CreatorBridge {
     enableAiFeatures = false;
+    workspacePath = '';
     private _nextId = 1;
     private _pending = new Map<
         number,
         { resolve: (v: unknown) => void; reject: (e: Error) => void; timer: ReturnType<typeof setTimeout> }
     >();
+    private _executionStartedListeners = new Set<(e: ExecutionStartedEvent) => void>();
+    private _executionFinishedListeners = new Set<(e: ExecutionFinishedEvent) => void>();
 
     constructor(private _vscode: VsCodeApi) {
         window.addEventListener('message', (event: MessageEvent) => {
-            const msg = event.data as { id?: number; result?: unknown; error?: string };
+            const msg = event.data as {
+                id?: number;
+                result?: unknown;
+                error?: string;
+                method?: string;
+                params?: Record<string, unknown>;
+            };
+
+            // RPC responses
             if (msg.id !== undefined && this._pending.has(msg.id)) {
                 const handler = this._pending.get(msg.id)!;
                 clearTimeout(handler.timer);
@@ -46,6 +60,16 @@ export class VsCodeBridge implements EEBridge, PluginDocBridge {
                 } else {
                     handler.resolve(msg.result);
                 }
+                return;
+            }
+
+            // Push notifications from extension
+            if (msg.method === 'executionStarted') {
+                const params = msg.params as unknown as ExecutionStartedEvent;
+                for (const cb of this._executionStartedListeners) cb(params);
+            } else if (msg.method === 'executionFinished') {
+                const params = msg.params as unknown as ExecutionFinishedEvent;
+                for (const cb of this._executionFinishedListeners) cb(params);
             }
         });
     }
@@ -131,5 +155,23 @@ export class VsCodeBridge implements EEBridge, PluginDocBridge {
 
     async openChat(prompt?: string): Promise<void> {
         this._vscode.postMessage({ method: 'openChat', params: { prompt } });
+    }
+
+    async execute(commandPath: string[], values: Record<string, unknown>): Promise<void> {
+        return this._request('execute', { commandPath, values });
+    }
+
+    onExecutionStarted(cb: (event: ExecutionStartedEvent) => void): () => void {
+        this._executionStartedListeners.add(cb);
+        return () => { this._executionStartedListeners.delete(cb); };
+    }
+
+    onExecutionFinished(cb: (event: ExecutionFinishedEvent) => void): () => void {
+        this._executionFinishedListeners.add(cb);
+        return () => { this._executionFinishedListeners.delete(cb); };
+    }
+
+    cancel(): void {
+        this._vscode.postMessage({ method: 'cancel' });
     }
 }

--- a/src/panels/webview-entry.tsx
+++ b/src/panels/webview-entry.tsx
@@ -13,7 +13,10 @@ import {
     PythonPackageDetailView,
     SystemPackageDetailView,
     PluginDocView,
+    CreatorFormView,
 } from '@ansible/ui';
+import type { SchemaNode } from '@ansible/ui';
+import { buildPreviewString } from '@ansible/core/utils/creatorArgs';
 import { VsCodeBridge } from './bridges/VsCodeBridge';
 // esbuild imports CSS as text via loader config; inject at runtime
 import tokensCss from '@ansible/ui/styles/tokens.css';
@@ -33,6 +36,10 @@ const props = JSON.parse(root.dataset.props ?? '{}') as Record<string, unknown>;
 
 if (typeof props.enableAiFeatures === 'boolean') {
     bridge.enableAiFeatures = props.enableAiFeatures;
+}
+
+if (typeof props.workspacePath === 'string') {
+    bridge.workspacePath = props.workspacePath;
 }
 
 function App() {
@@ -61,6 +68,19 @@ function App() {
                         pluginType={props.pluginType as string}
                     />
                 );
+            case 'creator-form': {
+                const cmdPath = props.commandPath as string[];
+                const schema = props.schema as SchemaNode;
+                const preview = (values: Record<string, unknown>) =>
+                    buildPreviewString(cmdPath, schema, values);
+                return (
+                    <CreatorFormView
+                        commandPath={cmdPath}
+                        schema={schema}
+                        buildPreview={preview}
+                    />
+                );
+            }
             default:
                 return <div>Unknown view: {viewName}</div>;
         }


### PR DESCRIPTION
## Summary
- Replace terminal-paste execution with background `execFile` via `CommandService.runCommandArgs` — eliminates shell quoting issues (zsh glob expansion on `[]`, broken array args)
- Add schema-driven form UI (`SchemaForm`) with proper field types including a `FormListBuilder` for repeatable CLI arguments
- Show execution output inline in the webview panel with success/failure status

## Changes
- **`packages/ui/src/components/form/FormListBuilder.tsx`** — New list builder widget (type + Enter/Add, remove items)
- **`packages/ui/src/components/SchemaForm.tsx`** — Schema-driven form rendering (text, boolean, select, array fields)
- **`packages/ui/src/views/CreatorFormView.tsx`** — Orchestrator view with execution state (idle → running → done)
- **`packages/ui/src/bridge/creator.ts`** — Bridge contract with `ExecutionStartedEvent`/`ExecutionFinishedEvent` push events
- **`packages/core/src/utils/creatorArgs.ts`** — `buildCommandArgs` emits repeated `--flag value` for arrays; no shell quoting (execFile-safe)
- **`packages/core/package.json`** — Added `typesVersions` for subpath TypeScript resolution (no `exports` to avoid breaking LS imports)
- **`src/panels/CreatorFormPanel.ts`** — Refactored to use `CommandService.runCommandArgs` and post execution events to webview
- **`src/panels/bridges/VsCodeBridge.ts`** — Added push notification handling for execution lifecycle events

## Test plan
- [x] `npm exec tsc -- -b` compiles cleanly (all packages including language-server)
- [x] `npm run build` (esbuild) produces all 4 bundles without errors
- [x] Manual test: creator form renders array fields with list builder
- [x] Manual test: execution runs in background, output shown inline
- [ ] CI lint passes (language-server lint errors are pre-existing on `next`)
- [ ] CI build-and-test passes