### PR TITLE
feat: add ansible.config.path

### DIFF
--- a/docs/als/settings.md
+++ b/docs/als/settings.md
@@ -14,6 +14,11 @@ Toggle usage of fully qualified collection names (FQCN) when inserting module na
 . Default value:
 ``true``
 
+## [`ansible.config.path`](#config.path) { #config.path data-toc-label=config.path }
+Path to the &#x60;ansible.cfg&#x60; file used by the language server for Ansible commands and diagnostics. Supports relative paths and &#x60;${workspaceFolder}&#x60;.
+. Default value:
+``""``
+
 ## [`ansible.python.interpreterPath`](#python.interpreterPath) { #python.interpreterPath data-toc-label=python.interpreterPath }
 Path to the python/python3 executable. This settings may be used to make the extension work with ansible and ansible-lint installations in a python virtual environment
 . Default value:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,6 +6,9 @@ any level (User, Remote, Workspace and/or Folder).
 ## Basic Configuration
 
 - `ansible.ansible.path`: Path to the `ansible` executable.
+- `ansible.config.path`: Path to the `ansible.cfg` file used by the language
+  server for Ansible commands and diagnostics. Supports relative paths and
+  `${workspaceFolder}`.
 - `ansible.ansible.reuseTerminal`: Enabling this will cause ansible commands run
   through VS Code to reuse the same Ansible Terminal.
 - `ansible.ansible.useFullyQualifiedCollectionNames`: Toggles use of fully

--- a/package.json
+++ b/package.json
@@ -228,17 +228,24 @@
             "scope": "machine-overridable",
             "type": "string"
           },
+          "ansible.config.path": {
+            "default": "",
+            "markdownDescription": "Path to the `ansible.cfg` file used by the language server for Ansible commands and diagnostics. Supports relative paths and `${workspaceFolder}`.",
+            "order": 1,
+            "scope": "resource",
+            "type": "string"
+          },
           "ansible.ansible.reuseTerminal": {
             "default": false,
             "markdownDescription": "Enabling this will cause ansible commands run through VS Code to reuse the same Ansible Terminal.",
-            "order": 2,
+            "order": 3,
             "scope": "machine-overridable",
             "type": "boolean"
           },
           "ansible.ansible.useFullyQualifiedCollectionNames": {
             "default": true,
             "markdownDescription": "Always use fully qualified collection names (FQCN) when inserting a module name. Disabling it will only use FQCNs when necessary.",
-            "order": 1,
+            "order": 2,
             "scope": "resource",
             "type": "boolean"
           }

--- a/packages/ansible-language-server/src/interfaces/extensionSettings.ts
+++ b/packages/ansible-language-server/src/interfaces/extensionSettings.ts
@@ -26,6 +26,9 @@ export interface ExtensionSettings extends ExtensionSettingsType {
     path: string;
     useFullyQualifiedCollectionNames: boolean;
   };
+  config: {
+    path: string;
+  };
   completion: {
     provideRedirectModules: boolean;
     provideModuleOptionAliases: boolean;
@@ -95,6 +98,7 @@ export interface ExtensionSettingsWithDescriptionBase {
 
 export interface ExtensionSettingsWithDescription extends ExtensionSettingsWithDescriptionBase {
   ansible: AnsibleSettingsWithDescription;
+  config: ConfigSettingsWithDescription;
   completion: CompletionSettingsWithDescription;
   validation: ValidationSettingsWithDescription;
   executionEnvironment: ExecutionEnvironmentSettingsWithDescription;
@@ -108,6 +112,13 @@ interface AnsibleSettingsWithDescription extends SettingsEntry {
   };
   useFullyQualifiedCollectionNames: {
     default: boolean;
+    description: string;
+  };
+}
+
+interface ConfigSettingsWithDescription extends SettingsEntry {
+  path: {
+    default: string;
     description: string;
   };
 }

--- a/packages/ansible-language-server/src/services/executionEnvironment.ts
+++ b/packages/ansible-language-server/src/services/executionEnvironment.ts
@@ -249,6 +249,7 @@ export class ExecutionEnvironment {
   public wrapContainerArgs(
     command: string,
     mountPaths?: Set<string>,
+    envOverrides: NodeJS.ProcessEnv = {},
   ): string[] | undefined {
     /* v8 ignore next 10 */
     if (
@@ -297,8 +298,11 @@ export class ExecutionEnvironment {
     }
 
     // handle Ansible environment variables
-    for (const [envVarKey, envVarValue] of Object.entries(process.env)) {
-      if (envVarKey.startsWith("ANSIBLE_")) {
+    for (const [envVarKey, envVarValue] of Object.entries({
+      ...process.env,
+      ...envOverrides,
+    })) {
+      if (envVarKey.startsWith("ANSIBLE_") && typeof envVarValue === "string") {
         containerCommand.push("-e", `${envVarKey}=${envVarValue}`);
       }
     }

--- a/packages/ansible-language-server/src/services/settingsManager.ts
+++ b/packages/ansible-language-server/src/services/settingsManager.ts
@@ -41,6 +41,13 @@ export class SettingsManager {
           "Toggle usage of fully qualified collection names (FQCN) when inserting module names",
       },
     },
+    config: {
+      path: {
+        default: "",
+        description:
+          "Path to the `ansible.cfg` file used by the language server for Ansible commands and diagnostics. Supports relative paths and `${workspaceFolder}`.",
+      },
+    },
     python: {
       interpreterPath: {
         default: "",

--- a/packages/ansible-language-server/src/utils/commandRunner.ts
+++ b/packages/ansible-language-server/src/utils/commandRunner.ts
@@ -1,9 +1,16 @@
+import * as os from "node:os";
+import * as path from "node:path";
 import { URI } from "vscode-uri";
 import { Connection } from "vscode-languageserver";
 import { withInterpreter, asyncExec, asyncSpawn } from "@src/utils/misc.js";
 import { getAnsibleCommandExecPath } from "@src/utils/execPath.js";
 import { WorkspaceFolderContext } from "@src/services/workspaceManager.js";
 import type { ExtensionSettings } from "@src/interfaces/extensionSettings.js";
+
+interface PreparedCommand {
+  command: string | string[] | undefined;
+  env: NodeJS.ProcessEnv;
+}
 
 export class CommandRunner {
   private connection: Connection | undefined;
@@ -29,58 +36,40 @@ export class CommandRunner {
     stdout: string;
     stderr: string;
   }> {
-    let executablePath: string;
-    let command: string | string[] | undefined;
-    let runEnv: NodeJS.ProcessEnv;
     const isEEEnabled = this.settings.executionEnvironment.enabled;
-    let interpreterPathFromConfig = this.settings.python.interpreterPath;
-    if (interpreterPathFromConfig.includes("${workspaceFolder}")) {
-      const workspaceFolder = URI.parse(this.context.workspaceFolder.uri).path;
-      interpreterPathFromConfig = interpreterPathFromConfig.replace(
-        "${workspaceFolder}",
-        workspaceFolder,
-      );
-    }
+    const workspaceFolder = URI.parse(this.context.workspaceFolder.uri).fsPath;
+    const currentWorkingDirectory = workingDirectory
+      ? workingDirectory
+      : workspaceFolder;
+    const ansibleConfigPath = this.resolveConfigPath(workspaceFolder);
+    const executablePath = this.resolveExecutablePath(executable, isEEEnabled);
+    const interpreterPath = this.resolveInterpreterPath(
+      workspaceFolder,
+      isEEEnabled,
+    );
+    const preparedCommand = isEEEnabled
+      ? await this.prepareExecutionEnvironmentCommand(
+          executable,
+          args,
+          currentWorkingDirectory,
+          mountPaths,
+          ansibleConfigPath,
+        )
+      : this.prepareLocalCommand(
+          executablePath,
+          args,
+          interpreterPath,
+          ansibleConfigPath,
+        );
+    const { command, env } = preparedCommand;
 
-    const interpreterPath = isEEEnabled ? "python3" : interpreterPathFromConfig;
-    if (executable.startsWith("ansible")) {
-      executablePath = isEEEnabled
-        ? executable
-        : getAnsibleCommandExecPath(executable, this.settings);
-    } else {
-      executablePath = executable;
-    }
-
-    // prepare command and env for local run
-    if (!isEEEnabled) {
-      const result = withInterpreter(
-        executablePath,
-        args,
-        interpreterPath,
-        this.settings.python.activationScript,
-      );
-      command = result.command;
-      runEnv = result.env;
-    } else {
-      // prepare command and env for execution environment run
-      const executionEnvironment = await this.context.executionEnvironment;
-      command = executionEnvironment.wrapContainerArgs(
-        `${executable} ${args}`,
-        mountPaths,
-      );
-      runEnv = process.env;
-    }
     if (command === undefined) {
       return { stdout: "", stderr: "" };
     }
-
-    const currentWorkingDirectory = workingDirectory
-      ? workingDirectory
-      : URI.parse(this.context.workspaceFolder.uri).path;
     const spawnOptions = {
       encoding: "utf-8" as const,
       cwd: currentWorkingDirectory,
-      env: runEnv,
+      env,
       maxBuffer: 10 * 1000 * 1000,
     };
 
@@ -92,6 +81,101 @@ export class CommandRunner {
     const result = await asyncExec(command, spawnOptions);
 
     return result;
+  }
+
+  private resolveExecutablePath(
+    executable: string,
+    isEEEnabled: boolean,
+  ): string {
+    if (!executable.startsWith("ansible") || isEEEnabled) {
+      return executable;
+    }
+    return getAnsibleCommandExecPath(executable, this.settings);
+  }
+
+  private resolveInterpreterPath(
+    workspaceFolder: string,
+    isEEEnabled: boolean,
+  ): string {
+    if (isEEEnabled) {
+      return "python3";
+    }
+    return this.settings.python.interpreterPath.replaceAll(
+      "${workspaceFolder}",
+      workspaceFolder,
+    );
+  }
+
+  private prepareLocalCommand(
+    executablePath: string,
+    args: string,
+    interpreterPath: string,
+    ansibleConfigPath?: string,
+  ): PreparedCommand {
+    const result = withInterpreter(
+      executablePath,
+      args,
+      interpreterPath,
+      this.settings.python.activationScript,
+    );
+    return {
+      command: result.command,
+      env: {
+        ...result.env,
+        ...(ansibleConfigPath ? { ANSIBLE_CONFIG: ansibleConfigPath } : {}),
+      },
+    };
+  }
+
+  private async prepareExecutionEnvironmentCommand(
+    executable: string,
+    args: string,
+    currentWorkingDirectory: string,
+    mountPaths: Set<string> | undefined,
+    ansibleConfigPath: string | undefined,
+  ): Promise<PreparedCommand> {
+    const executionEnvironment = await this.context.executionEnvironment;
+    const effectiveMountPaths = mountPaths
+      ? new Set(mountPaths)
+      : new Set<string>([currentWorkingDirectory]);
+    if (ansibleConfigPath) {
+      effectiveMountPaths.add(path.dirname(ansibleConfigPath));
+    }
+    return {
+      command: executionEnvironment.wrapContainerArgs(
+        `${executable} ${args}`,
+        effectiveMountPaths,
+        ansibleConfigPath ? { ANSIBLE_CONFIG: ansibleConfigPath } : {},
+      ),
+      env: { ...process.env },
+    };
+  }
+
+  private resolveConfigPath(workspaceFolder: string): string | undefined {
+    const configuredPath = this.settings.config?.path?.trim();
+
+    if (!configuredPath) {
+      return undefined;
+    }
+
+    let resolvedPath = configuredPath;
+
+    if (resolvedPath === "~") {
+      resolvedPath = os.homedir();
+    } else if (resolvedPath.startsWith("~/")) {
+      resolvedPath = path.join(os.homedir(), resolvedPath.slice(2));
+    }
+
+    resolvedPath = resolvedPath.replaceAll(
+      "${workspaceFolder}",
+      workspaceFolder,
+    );
+
+    if (!path.isAbsolute(resolvedPath)) {
+      resolvedPath = path.resolve(workspaceFolder, resolvedPath);
+    }
+
+    return resolvedPath;
   }
 
   /**

--- a/packages/ansible-language-server/test/services/executionEnvironment.test.ts
+++ b/packages/ansible-language-server/test/services/executionEnvironment.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { expect } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import sinon from "sinon";
 import { Connection } from "vscode-languageserver";
 import { ExecutionEnvironment } from "@src/services/executionEnvironment.js";
@@ -164,9 +164,12 @@ describe("@ee", () => {
       (ee as any)._container_image = "test-image";
       (ee as any).settingsVolumeMounts = [];
       (ee as any).settingsContainerOptions = "";
-      const result = ee.wrapContainerArgs("echo hello", new Set(["/tmp"]));
+      const result = ee.wrapContainerArgs("echo hello", new Set(["/tmp"]), {
+        ANSIBLE_CONFIG: "/tmp/ansible.cfg",
+      });
       expect(result).toBeDefined();
       expect(result?.join(" ")).toContain("docker run --rm");
+      expect(result?.join(" ")).toContain("-e ANSIBLE_CONFIG=/tmp/ansible.cfg");
       expect(result).toContain("test-image");
       expect(result).toContain("echo");
       expect(result).toContain("hello");

--- a/packages/ansible-language-server/test/utils/runCommand.test.ts
+++ b/packages/ansible-language-server/test/utils/runCommand.test.ts
@@ -1,10 +1,15 @@
 import { CommandRunner } from "@src/utils/commandRunner.js";
-import { expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { AssertionError } from "assert";
 import { WorkspaceManager } from "@src/services/workspaceManager.js";
+import type { WorkspaceFolderContext } from "@src/services/workspaceManager.js";
+import type { ExtensionSettings } from "@src/interfaces/extensionSettings.js";
 import { createConnection } from "vscode-languageserver/node";
 import { getDoc } from "@test/helper.js";
 import { ExecException } from "child_process";
+import { URI } from "vscode-uri";
+import * as os from "node:os";
+import * as path from "node:path";
 
 describe("commandRunner", function () {
   const tests = [
@@ -60,15 +65,46 @@ describe("commandRunner", function () {
       pythonInterpreterPath: "path-before-python/bin/python",
       activationScript: `${process.env.VIRTUAL_ENV}/bin/activate`,
     },
+    {
+      args: ["printenv", "ANSIBLE_CONFIG"],
+      rc: 0,
+      stdout: "/tmp/ansible.cfg",
+      stderr: "",
+      pythonInterpreterPath: "",
+      activationScript: "",
+      ansibleConfigPath: "/tmp/ansible.cfg",
+    },
+    {
+      args: ["printenv", "ANSIBLE_CONFIG"],
+      rc: 0,
+      stdout: path.join(os.homedir(), "ansible.cfg"),
+      stderr: "",
+      pythonInterpreterPath: "",
+      activationScript: "",
+      ansibleConfigPath: "~/ansible.cfg",
+    },
+    {
+      args: ["printenv", "ANSIBLE_CONFIG"],
+      rc: 0,
+      stdout: os.homedir(),
+      stderr: "",
+      pythonInterpreterPath: "",
+      activationScript: "",
+      ansibleConfigPath: "~",
+    },
   ];
 
   tests.forEach(
-    ({ args, rc, stdout, stderr, pythonInterpreterPath, activationScript }) => {
+    ({
+      args,
+      rc,
+      stdout,
+      stderr,
+      pythonInterpreterPath,
+      activationScript,
+      ansibleConfigPath,
+    }) => {
       it(`call ${args.join(" ")}`, { timeout: 10000 }, async () => {
-        // try to enforce ansible to output ANSI in order to check if we are
-        // still able to disable it at runtime in order to keep output parsable.
-        process.env.ANSIBLE_FORCE_COLOR = "1";
-
         process.argv.push("--node-ipc");
         const connection = createConnection();
         const workspaceManager = new WorkspaceManager(connection);
@@ -81,6 +117,9 @@ describe("commandRunner", function () {
           }
           if (activationScript) {
             settings.python.activationScript = activationScript;
+          }
+          if (ansibleConfigPath) {
+            settings.config.path = ansibleConfigPath;
           }
 
           const commandRunner = new CommandRunner(
@@ -110,4 +149,88 @@ describe("commandRunner", function () {
       });
     },
   );
+
+  it.each([
+    {
+      configuredPath: "ansible/ansible.cfg",
+      expectedRelativePath: "ansible/ansible.cfg",
+    },
+    {
+      configuredPath:
+        "${workspaceFolder}/ansible/${workspaceFolder}/ansible.cfg",
+      expectedPath: `${process.cwd()}/ansible/${process.cwd()}/ansible.cfg`,
+    },
+    { configuredPath: "" },
+  ])(
+    "passes $configuredPath to the execution environment",
+    async ({
+      configuredPath,
+      expectedRelativePath,
+      expectedPath: pathValue,
+    }) => {
+      const workspaceFolder = process.cwd();
+      const expectedPath =
+        pathValue ??
+        (expectedRelativePath
+          ? path.join(workspaceFolder, expectedRelativePath)
+          : undefined);
+      const wrapContainerArgs = vi.fn().mockReturnValue(["printf", "ok"]);
+      const context = {
+        workspaceFolder: { uri: URI.file(workspaceFolder).toString() },
+        executionEnvironment: Promise.resolve({ wrapContainerArgs }),
+      } as unknown as WorkspaceFolderContext;
+      const settings = {
+        config: { path: configuredPath },
+        executionEnvironment: { enabled: true },
+        python: { interpreterPath: "", activationScript: "" },
+      } as ExtensionSettings;
+      const commandRunner = new CommandRunner(undefined, context, settings);
+
+      const result = await commandRunner.runCommand("ansible", "--version");
+
+      expect(result.stdout).toBe("ok");
+      expect(wrapContainerArgs).toHaveBeenCalledOnce();
+      const [, mountPaths, envOverrides] = wrapContainerArgs.mock.calls[0];
+      expect(envOverrides).toEqual(
+        expectedPath ? { ANSIBLE_CONFIG: expectedPath } : {},
+      );
+      expect(mountPaths).toEqual(
+        new Set(
+          expectedPath
+            ? [workspaceFolder, path.dirname(expectedPath)]
+            : [workspaceFolder],
+        ),
+      );
+    },
+  );
+
+  it("returns an empty result when the execution environment is unavailable", async () => {
+    const wrapContainerArgs = vi.fn().mockReturnValue(undefined);
+    const workspaceFolder = process.cwd();
+    const context = {
+      workspaceFolder: { uri: URI.file(workspaceFolder).toString() },
+      executionEnvironment: Promise.resolve({ wrapContainerArgs }),
+    } as unknown as WorkspaceFolderContext;
+    const settings = {
+      config: { path: "/tmp/ansible.cfg" },
+      executionEnvironment: { enabled: true },
+      python: { interpreterPath: "", activationScript: "" },
+    } as ExtensionSettings;
+    const commandRunner = new CommandRunner(undefined, context, settings);
+    const mountPaths = new Set(["/tmp/custom-mount"]);
+
+    const result = await commandRunner.runCommand(
+      "ansible",
+      "--version",
+      workspaceFolder,
+      mountPaths,
+    );
+
+    expect(result).toEqual({ stdout: "", stderr: "" });
+    expect(wrapContainerArgs).toHaveBeenCalledWith(
+      "ansible --version",
+      new Set(["/tmp/custom-mount", "/tmp"]),
+      { ANSIBLE_CONFIG: "/tmp/ansible.cfg" },
+    );
+  });
 });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -96,6 +96,7 @@ import { MainPanel as createDevcontainerPanel } from "@src/features/contentCreat
 import { getRoleNameFromFilePath } from "@src/features/lightspeed/utils/getRoleNameFromFilePath";
 import { getRoleNamePathFromFilePath } from "@src/features/lightspeed/utils/getRoleNamePathFromFilePath";
 import { getRoleYamlFiles } from "@src/features/lightspeed/utils/data";
+import { resolveInterpreterPath as resolveConfiguredPath } from "@src/features/utils/interpreterPathResolver";
 
 let client: LanguageClient;
 export let lightSpeedManager: LightSpeedManager;
@@ -1527,6 +1528,33 @@ export function makeConfigurationMiddleware(
     return config;
   }
 
+  function resolveConfigPath(
+    scopeUri: string,
+    config: Record<string, unknown>,
+  ): Record<string, unknown> {
+    const configSettings = config.config as Record<string, unknown> | undefined;
+    const rawConfigPath = configSettings?.path;
+
+    if (typeof rawConfigPath !== "string" || !rawConfigPath) {
+      return config;
+    }
+
+    const scope = scopeUri ? vscode.Uri.parse(scopeUri) : undefined;
+    const resolvedConfigPath = resolveConfiguredPath(rawConfigPath, scope);
+
+    if (!resolvedConfigPath || resolvedConfigPath === rawConfigPath) {
+      return config;
+    }
+
+    return {
+      ...config,
+      config: {
+        ...configSettings,
+        path: resolvedConfigPath,
+      },
+    };
+  }
+
   return (
     params: ConfigurationParams,
     token: CancellationToken,
@@ -1564,21 +1592,23 @@ export function makeConfigurationMiddleware(
           | undefined;
         const rawInterpreterPath = pythonConfig?.interpreterPath;
 
+        let updatedConfig: Record<string, unknown>;
         if (typeof rawInterpreterPath === "string" && rawInterpreterPath) {
-          result[i] = await resolveUserConfiguredPath(
+          updatedConfig = await resolveUserConfiguredPath(
             scopeUri,
             rawInterpreterPath,
             config,
             pythonConfig,
           );
-          continue;
+        } else {
+          updatedConfig = await resolveAutoDetectedPath(
+            scopeUri,
+            config,
+            pythonConfig,
+          );
         }
 
-        result[i] = await resolveAutoDetectedPath(
-          scopeUri,
-          config,
-          pythonConfig,
-        );
+        result[i] = resolveConfigPath(scopeUri, updatedConfig);
       }
       return result;
     })();

--- a/test/unit/configurationMiddleware.test.ts
+++ b/test/unit/configurationMiddleware.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import * as vscode from "vscode";
 import { makeConfigurationMiddleware } from "@src/extension";
 import type { PythonEnvironmentService } from "@src/services/PythonEnvironmentService";
 import type {
@@ -36,9 +37,20 @@ describe("makeConfigurationMiddleware", function () {
   beforeEach(() => {
     vi.clearAllMocks();
 
+    Object.defineProperty(vscode.workspace, "getWorkspaceFolder", {
+      configurable: true,
+      value: vi.fn().mockReturnValue({
+        uri: {
+          fsPath: "/workspace/project",
+        },
+      }),
+    });
+
     mockPythonEnvService = {
       getExecutablePath: vi.fn(),
-      resolveInterpreterPath: vi.fn((userPath) => Promise.resolve(userPath)),
+      resolveInterpreterPath: vi.fn((userPath: string) =>
+        Promise.resolve(userPath),
+      ),
     };
 
     mockOutputChannel = {
@@ -344,5 +356,69 @@ describe("makeConfigurationMiddleware", function () {
     expect(mockOutputChannel.appendLine).toHaveBeenCalledWith(
       expect.stringMatching(/user-configured interpreterPath.*~.*resolved:/),
     );
+  });
+
+  it("should resolve user-configured config.path relative to workspaceFolder", async function () {
+    vi.mocked(vscode.Uri.parse).mockImplementation(
+      (value: string) =>
+        ({
+          fsPath: value.replace("file://", ""),
+          path: value.replace("file://", ""),
+        }) as unknown as import("vscode").Uri,
+    );
+
+    const params: ConfigurationParams = {
+      items: [
+        { section: "ansible", scopeUri: "file:///workspace/project/site.yml" },
+      ],
+    };
+    const originalResult = [
+      {
+        config: {
+          path: "${workspaceFolder}/ansible/ansible.cfg",
+        },
+      },
+    ];
+    mockNext.mockResolvedValue(originalResult);
+
+    const result = await invokeMiddleware(params);
+
+    const config = (result as Record<string, unknown>[])[0];
+    const configSettings = config.config as Record<string, unknown>;
+    expect(configSettings.path).toBe("/workspace/project/ansible/ansible.cfg");
+  });
+
+  it("should resolve config.path when interpreterPath is user-configured", async function () {
+    vi.mocked(vscode.Uri.parse).mockImplementation(
+      (value: string) =>
+        ({
+          fsPath: value.replace("file://", ""),
+          path: value.replace("file://", ""),
+        }) as unknown as import("vscode").Uri,
+    );
+
+    const params: ConfigurationParams = {
+      items: [
+        { section: "ansible", scopeUri: "file:///workspace/project/site.yml" },
+      ],
+    };
+    const originalResult = [
+      {
+        python: { interpreterPath: "/usr/local/bin/python3" },
+        config: {
+          path: "${workspaceFolder}/ansible/ansible.cfg",
+        },
+      },
+    ];
+    mockNext.mockResolvedValue(originalResult);
+
+    const result = await invokeMiddleware(params);
+
+    const config = (result as Record<string, unknown>[])[0];
+    const pythonConfig = config.python as Record<string, unknown>;
+    const configSettings = config.config as Record<string, unknown>;
+    expect(pythonConfig.interpreterPath).toBe("/usr/local/bin/python3");
+    expect(configSettings.path).toBe("/workspace/project/ansible/ansible.cfg");
+    expect(mockPythonEnvService.getExecutablePath).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- add a workspace-scoped `ansible.config.path` setting
- resolve relative and `${workspaceFolder}` values before passing them to the language server
- export `ANSIBLE_CONFIG` for local and execution-environment command runners
- document and test the new setting

## Testing
- `pnpm exec vitest run test/unit/configurationMiddleware.test.ts packages/ansible-language-server/test/utils/runCommand.test.ts packages/ansible-language-server/test/providers/settingsManager.test.ts`
- `SKIP_PODMAN=1 SKIP_DOCKER=1 pnpm --filter @ansible/ansible-language-server run test-without-ee`
- `pnpm run build`
- `node packages/ansible-language-server/dist/cli.cjs --generate-docs docs/als/settings.md`
- `pnpm run vite-build && pnpm run build:extension`
- `pnpm run package`

related: #2175


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
feat: add ansible.config.path adds workspace-scoped ansible.cfg resolution so the language server and command runners honor the intended Ansible setup. The extension normalizes per-scope config.path by expanding ${workspaceFolder} and converting relative/~/ paths before dispatch, and propagates ANSIBLE_CONFIG for both local and execution-environment runs.

- Added ansible.config.path setting to extension schema/types/defaults and documented relative path and ${workspaceFolder} behavior
- Updated configuration middleware to resolve and rewrite config.path per scopeUri before the language server consumes it
- Enhanced command execution to resolve the config path and inject ANSIBLE_CONFIG for local and container/EE runners (including mounting the config directory)
- Extended tests to validate ${workspaceFolder} expansion and ANSIBLE_CONFIG propagation

Fixes: `#2175`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->