### PR TITLE
refactor(core): centralize AI prompts in @ansible/core

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,7 +8,8 @@
     "*": {
       "utils/creatorArgs": ["./out/utils/creatorArgs.d.ts"],
       "services/PlaybookConfigService": ["./out/services/PlaybookConfigService.d.ts"],
-      "types/playbook": ["./out/types/playbook.d.ts"]
+      "types/playbook": ["./out/types/playbook.d.ts"],
+      "prompts/plugin-doc": ["./out/prompts/plugin-doc.d.ts"]
     }
   },
   "license": "MIT",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -101,5 +101,23 @@ export type {
     PlaybookRunOptions,
 } from './types/playbook';
 
-export { buildTaskAnalysisPrompt, buildPlaybookSummaryPrompt } from './prompts/playbook';
-export type { TaskAnalysisInput } from './prompts/playbook';
+// --- AI Prompt Builders ---
+export {
+    buildCollectionsSummaryPrompt,
+    buildCollectionSummaryPrompt,
+    buildPluginExplanationPrompt,
+    buildCollectionSourcesOverviewPrompt,
+    buildGalaxySourceSummaryPrompt,
+    buildGithubOrgSourceSummaryPrompt,
+    buildEESummaryPrompt,
+    buildEEDetailPrompt,
+    buildCreatorOverviewPrompt,
+    buildCreatorCommandWalkthroughPrompt,
+    buildTaskBuilderPrompt,
+    buildSkillLoadPrompt,
+    buildSkillClipboardPrompt,
+    buildMcpToolExamplePrompt,
+    buildTaskAnalysisPrompt,
+    buildPlaybookSummaryPrompt,
+} from './prompts';
+export type { CollectionSourcesInput, TaskAnalysisInput } from './prompts';

--- a/packages/core/src/prompts/collections.ts
+++ b/packages/core/src/prompts/collections.ts
@@ -1,0 +1,140 @@
+/**
+ * AI prompt builders for Ansible collections.
+ * Centralized here so they can be reused across extension, MCP server, or CLI.
+ */
+
+/**
+ * Build a prompt to summarize all installed collections in the workspace.
+ *
+ * @returns Prompt instructing the AI to list and categorize installed collections.
+ */
+export function buildCollectionsSummaryPrompt(): string {
+    return `Generate a summary of the installed Ansible collections in this workspace.
+
+Use the \`list_ansible_collections\` MCP tool to get the list of installed collections, then provide:
+1. A brief overview of the collection categories (networking, cloud, system, etc.)
+2. Key capabilities provided by these collections
+3. Any recommendations for commonly paired collections that might be missing
+
+After your summary, ask the user if they would like to search for additional collections. If they say yes, use the \`search_available_collections\` MCP tool to find relevant collections based on their use case (you can filter by source: "galaxy" or a GitHub org name).
+
+**IMPORTANT**: To install any collection, use the \`install_ansible_collection\` MCP tool.
+Do NOT suggest using \`ansible-galaxy collection install\` directly.`;
+}
+
+/**
+ * Build a prompt to summarize a single collection.
+ *
+ * @param collectionName - Fully qualified collection name (e.g. "cisco.nxos").
+ * @returns Prompt instructing the AI to describe the collection's plugins and use cases.
+ */
+export function buildCollectionSummaryPrompt(collectionName: string): string {
+    return `Generate a summary of the Ansible collection "${collectionName}".
+
+Use the \`get_collection_plugins\` MCP tool with collection="${collectionName}" to get all plugins in this collection, then provide:
+1. A brief description of what this collection is for
+2. The key modules, plugins, and roles it provides
+3. Common use cases and example scenarios
+4. Any dependencies or requirements`;
+}
+
+/**
+ * Build a prompt to explain a specific plugin.
+ *
+ * @param fullName - Fully qualified plugin name (e.g. "ansible.builtin.copy").
+ * @param pluginType - Plugin type (module, lookup, filter, etc.).
+ * @returns Prompt instructing the AI to document the plugin with examples.
+ */
+export function buildPluginExplanationPrompt(fullName: string, pluginType: string): string {
+    return `Explain the Ansible ${pluginType} plugin "${fullName}".
+
+Use the \`get_plugin_documentation\` MCP tool with plugin_name="${fullName}" and plugin_type="${pluginType}" to get the full documentation, then provide:
+1. What this plugin does in plain language
+2. The most important parameters and when to use them
+3. A practical example task showing common usage
+4. Any gotchas or best practices`;
+}
+
+/** Input for building a collection sources overview prompt. */
+export interface CollectionSourcesInput {
+    galaxyCount: number;
+    githubOrgs: { name: string; count: number }[];
+}
+
+/**
+ * Build a prompt to summarize all configured collection sources.
+ *
+ * @param input - Source counts for Galaxy and GitHub orgs.
+ * @returns Prompt comparing Galaxy vs GitHub sources with install guidance.
+ */
+export function buildCollectionSourcesOverviewPrompt(input: CollectionSourcesInput): string {
+    const orgDetails = input.githubOrgs
+        .map((org) => `  - ${org.name}: ${String(org.count)} collections`)
+        .join('\n');
+    const githubTotal = input.githubOrgs.reduce((sum, org) => sum + org.count, 0);
+
+    return `I have access to Ansible collections from multiple sources:
+
+**Ansible Galaxy**: ${input.galaxyCount.toLocaleString()} collections available
+
+**GitHub Organizations** (${String(githubTotal)} total collections):
+${orgDetails}
+
+Please help me understand:
+1. What types of collections are typically found on Galaxy vs GitHub organizations?
+2. How do I decide which source to use for a particular use case?
+3. Are there any notable collections in these GitHub organizations I should know about?
+
+Use the \`search_available_collections\` MCP tool to search for collections if needed.
+
+**IMPORTANT**: To install any collection, use the \`install_ansible_collection\` MCP tool.
+Do NOT suggest using \`ansible-galaxy collection install\` directly.`;
+}
+
+/**
+ * Build a prompt to summarize Ansible Galaxy as a collection source.
+ *
+ * @param collectionCount - Number of collections available on Galaxy.
+ * @returns Prompt describing Galaxy and how to search/install from it.
+ */
+export function buildGalaxySourceSummaryPrompt(collectionCount: number): string {
+    return `Generate a summary of Ansible Galaxy as a collection source.
+
+Galaxy has ${collectionCount.toLocaleString()} collections available.
+
+Please describe:
+1. What is Ansible Galaxy and what types of collections are typically found there?
+2. How do I search for and evaluate collections on Galaxy?
+3. What are some of the most popular/useful collections on Galaxy?
+
+Use the \`list_source_collections\` MCP tool with source: "galaxy" to see the most popular collections.
+Use the \`search_available_collections\` MCP tool to search for specific collections.
+
+**IMPORTANT**: To install any collection, use the \`install_ansible_collection\` MCP tool.
+Do NOT suggest using \`ansible-galaxy collection install\` directly.`;
+}
+
+/**
+ * Build a prompt to summarize a GitHub organization as a collection source.
+ *
+ * @param orgId - GitHub org identifier.
+ * @param collectionCount - Number of collections in this org.
+ * @returns Prompt describing the org's collections with install guidance.
+ */
+export function buildGithubOrgSourceSummaryPrompt(orgId: string, collectionCount: number): string {
+    return `Generate a summary of the "${orgId}" GitHub organization as an Ansible collection source.
+
+This organization has ${String(collectionCount)} collections.
+
+First, use the \`list_source_collections\` MCP tool with source: "${orgId}" to get the complete list of collections.
+
+Then describe:
+1. What is this organization and what types of collections do they provide?
+2. What are the main use cases for these collections?
+3. Which collections should I consider for my Ansible automation?
+
+Use the \`search_available_collections\` MCP tool to search for specific collections if needed.
+
+**IMPORTANT**: To install any collection, use the \`install_ansible_collection\` MCP tool.
+Do NOT suggest using \`ansible-galaxy collection install\` directly.`;
+}

--- a/packages/core/src/prompts/creator.ts
+++ b/packages/core/src/prompts/creator.ts
@@ -1,0 +1,46 @@
+/**
+ * AI prompt builders for ansible-creator scaffolding.
+ * Centralized here so they can be reused across extension, MCP server, or CLI.
+ */
+
+/**
+ * Build a prompt to explain ansible-creator capabilities.
+ *
+ * @returns Prompt requesting an overview of ansible-creator's scaffolding features.
+ */
+export function buildCreatorOverviewPrompt(): string {
+    return `Explain the ansible-creator scaffolding tool and summarize its capabilities.
+
+Use the \`get_ansible_creator_schema\` MCP tool to get the full schema, then provide:
+1. What ansible-creator is and why it's useful
+2. A summary of each content type it can scaffold (collections, playbooks, plugins, etc.)
+3. The key parameters for each scaffolding command
+4. Best practices for starting new Ansible projects
+5. How the generated structure follows Ansible best practices`;
+}
+
+/**
+ * Build a prompt to walk through a specific ansible-creator command.
+ *
+ * @param commandStr - Human-readable command string (e.g. "ansible-creator add plugin filter").
+ * @param toolName - MCP tool name for this command (e.g. "ac_add_plug_filter").
+ * @param description - Optional description of what the command does.
+ * @returns Prompt guiding the user through the scaffolding command's parameters.
+ */
+export function buildCreatorCommandWalkthroughPrompt(
+    commandStr: string,
+    toolName: string,
+    description?: string,
+): string {
+    const descLine = description ? `\nThis command: ${description}\n` : '';
+
+    return `Help me use the "${commandStr}" command to scaffold new Ansible content.
+${descLine}
+Use the \`${toolName}\` MCP tool to execute this command once I provide the required parameters.
+
+Please:
+1. Explain what this command creates and the resulting directory structure
+2. Walk me through the required and optional parameters
+3. Suggest best practices for the values I should provide
+4. After I provide the details, use the \`${toolName}\` tool to run the command`;
+}

--- a/packages/core/src/prompts/execution-environments.ts
+++ b/packages/core/src/prompts/execution-environments.ts
@@ -1,0 +1,42 @@
+/**
+ * AI prompt builders for Ansible Execution Environments.
+ * Centralized here so they can be reused across extension, MCP server, or CLI.
+ */
+
+/**
+ * Build a prompt to summarize all available execution environments.
+ *
+ * @returns Prompt instructing the AI to list and compare EEs.
+ */
+export function buildEESummaryPrompt(): string {
+    return `Generate a summary of the available Ansible Execution Environments.
+
+Use the \`list_execution_environments\` MCP tool to get the list of available EEs, then provide:
+1. An overview of each execution environment and its purpose
+2. Key tools and collections included in each
+3. Recommendations for which EE to use for different scenarios`;
+}
+
+/**
+ * Build a prompt to describe a specific execution environment in detail.
+ *
+ * @param eeName - Name/label of the execution environment.
+ * @returns Prompt requesting detailed EE analysis.
+ */
+export function buildEEDetailPrompt(eeName: string): string {
+    return `Generate a detailed summary of the Ansible Execution Environment "${eeName}".
+
+Use the \`get_ee_details\` MCP tool with ee_name="${eeName}" to get all information about this EE.
+
+The tool returns complete details including:
+- Container base OS and Ansible version
+- ALL installed Python packages with versions
+- ALL installed Ansible collections with versions
+- System packages (if available)
+
+Based on the tool output, provide:
+1. A summary of the container image and its base OS
+2. Key Python packages and what they enable
+3. Notable Ansible collections included and their use cases
+4. Best use cases for this execution environment`;
+}

--- a/packages/core/src/prompts/index.ts
+++ b/packages/core/src/prompts/index.ts
@@ -1,0 +1,31 @@
+/**
+ * Centralized AI prompt builders.
+ *
+ * All user-facing AI prompts are defined here so they can be:
+ * 1. Reused across extension, MCP server, and CLI
+ * 2. Customized by users in the future
+ * 3. Maintained in a single location
+ */
+
+export {
+    buildCollectionsSummaryPrompt,
+    buildCollectionSummaryPrompt,
+    buildPluginExplanationPrompt,
+    buildCollectionSourcesOverviewPrompt,
+    buildGalaxySourceSummaryPrompt,
+    buildGithubOrgSourceSummaryPrompt,
+} from './collections';
+export type { CollectionSourcesInput } from './collections';
+
+export { buildEESummaryPrompt, buildEEDetailPrompt } from './execution-environments';
+
+export { buildCreatorOverviewPrompt, buildCreatorCommandWalkthroughPrompt } from './creator';
+
+export { buildTaskBuilderPrompt } from './plugin-doc';
+
+export { buildSkillLoadPrompt, buildSkillClipboardPrompt } from './skills';
+
+export { buildMcpToolExamplePrompt } from './mcp-examples';
+
+export { buildTaskAnalysisPrompt, buildPlaybookSummaryPrompt } from './playbook';
+export type { TaskAnalysisInput } from './playbook';

--- a/packages/core/src/prompts/mcp-examples.ts
+++ b/packages/core/src/prompts/mcp-examples.ts
@@ -1,0 +1,63 @@
+/**
+ * AI prompt builders for MCP tool example prompts.
+ * These generate example chat prompts that demonstrate how to use MCP tools.
+ * Centralized here so they can be reused across extension, MCP server, or CLI.
+ */
+
+/** Known MCP tool names with curated example prompts. */
+const TOOL_EXAMPLES: Record<string, string> = {
+    search_ansible_plugins:
+        'Search for Ansible plugins that can copy files, use the search_ansible_plugins MCP tool to accomplish this',
+    get_plugin_documentation:
+        'Show me the documentation for ansible.builtin.copy, use the get_plugin_documentation MCP tool to accomplish this',
+    list_ansible_collections:
+        'List what Ansible collections are installed, use the list_ansible_collections MCP tool to accomplish this',
+    generate_ansible_task:
+        'Generate an Ansible task to copy /etc/hosts to /tmp/hosts.backup, use the generate_ansible_task MCP tool to accomplish this',
+    build_ansible_task:
+        'Help me build an Ansible task for the apt module step by step, use the build_ansible_task MCP tool to accomplish this',
+    generate_ansible_playbook:
+        'Create a playbook to install and configure nginx on webservers, use the generate_ansible_playbook MCP tool to accomplish this',
+    list_execution_environments:
+        'List what execution environments are available, use the list_execution_environments MCP tool to accomplish this',
+    get_ee_details:
+        'Show me the details of the creator-ee execution environment, use the get_ee_details MCP tool to accomplish this',
+    list_ansible_dev_tools:
+        'List what ansible-dev-tools packages are installed, use the list_ansible_dev_tools MCP tool to accomplish this',
+    install_ansible_collection:
+        'Install the community.general Ansible collection, use the install_ansible_collection MCP tool to accomplish this',
+    get_collection_plugins:
+        'List all plugins in the cisco.nxos collection, use the get_collection_plugins MCP tool to accomplish this',
+    get_ansible_creator_schema:
+        'Show me what content types ansible-creator can scaffold, use the get_ansible_creator_schema MCP tool to accomplish this',
+};
+
+/**
+ * Generate an example chat prompt demonstrating how to use a specific MCP tool.
+ *
+ * For well-known tools, returns a curated example. For `ac_*` creator tools and
+ * other unknown tools, derives the example from the tool's description.
+ *
+ * @param toolName - MCP tool name (e.g. "search_ansible_plugins").
+ * @param toolDescription - Tool description text (used as fallback for unknown tools).
+ * @returns Example prompt suitable for injection into chat.
+ */
+export function buildMcpToolExamplePrompt(toolName: string, toolDescription: string): string {
+    const curated = TOOL_EXAMPLES[toolName];
+    if (curated) {
+        return curated;
+    }
+
+    if (toolName.startsWith('ac_')) {
+        const firstLine = toolDescription.split('\n')[0].trim();
+        const action = firstLine.endsWith('.') ? firstLine.slice(0, -1) : firstLine;
+        return `${action}, use the ${toolName} MCP tool to accomplish this`;
+    }
+
+    const desc = toolDescription.split('\n')[0].trim();
+    if (desc && desc.length > 10) {
+        const action = desc.endsWith('.') ? desc.slice(0, -1) : desc;
+        return `${action}, use the ${toolName} MCP tool to accomplish this`;
+    }
+    return `Run the ${toolName.replace(/_/g, ' ')} command, use the ${toolName} MCP tool to accomplish this`;
+}

--- a/packages/core/src/prompts/plugin-doc.ts
+++ b/packages/core/src/prompts/plugin-doc.ts
@@ -1,0 +1,15 @@
+/**
+ * AI prompt builders for plugin documentation interaction.
+ * Centralized here so they can be reused across extension, MCP server, or CLI.
+ */
+
+/**
+ * Build a prompt to interactively create a task using a specific plugin.
+ *
+ * @param fqcn - Fully qualified collection name of the plugin (e.g. "ansible.builtin.copy").
+ * @param pluginType - Plugin type (module, lookup, filter, etc.).
+ * @returns Prompt that guides the user through building a task with the AI task builder.
+ */
+export function buildTaskBuilderPrompt(fqcn: string, pluginType: string): string {
+    return `Help me create an Ansible task using the ${fqcn} ${pluginType}, guiding me through the required and optional parameters. Use the build_ansible_task MCP tool to accomplish this.`;
+}

--- a/packages/core/src/prompts/skills.ts
+++ b/packages/core/src/prompts/skills.ts
@@ -1,0 +1,42 @@
+/**
+ * AI prompt builders for skill loading and application.
+ * Centralized here so they can be reused across extension, MCP server, or CLI.
+ */
+
+/**
+ * Build a prompt to load a skill via MCP and apply its guidance.
+ *
+ * @param skillName - Human-readable skill name.
+ * @param skillId - Unique skill identifier.
+ * @param skillDescription - Brief description of what the skill helps with.
+ * @returns Prompt instructing the AI to load and follow the skill.
+ */
+export function buildSkillLoadPrompt(
+    skillName: string,
+    skillId: string,
+    skillDescription: string,
+): string {
+    return (
+        `Use the skill_get tool to load the "${skillName}" skill (ID: "${skillId}"), ` +
+        `then follow its guidance to help me with: ${skillDescription}`
+    );
+}
+
+/**
+ * Build a prompt for copying to clipboard that loads and applies a skill.
+ *
+ * @param skillName - Human-readable skill name.
+ * @param skillId - Unique skill identifier.
+ * @param skillDescription - Brief description of what the skill helps with.
+ * @returns Prompt using explicit MCP tool call syntax for clipboard use.
+ */
+export function buildSkillClipboardPrompt(
+    skillName: string,
+    skillId: string,
+    skillDescription: string,
+): string {
+    return (
+        `Use the MCP tool skill_get({ skill_id: "${skillId}" }) to load the ` +
+        `"${skillName}" skill, then apply its guidance to help me with: ${skillDescription}`
+    );
+}

--- a/packages/core/test/prompts/collections.test.ts
+++ b/packages/core/test/prompts/collections.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import {
+    buildCollectionsSummaryPrompt,
+    buildCollectionSummaryPrompt,
+    buildPluginExplanationPrompt,
+    buildCollectionSourcesOverviewPrompt,
+    buildGalaxySourceSummaryPrompt,
+    buildGithubOrgSourceSummaryPrompt,
+} from '../../src/prompts/collections';
+
+describe('collections prompts', () => {
+    describe('buildCollectionsSummaryPrompt', () => {
+        it('includes MCP tool reference', () => {
+            const result = buildCollectionsSummaryPrompt();
+            expect(result).toContain('list_ansible_collections');
+            expect(result).toContain('search_available_collections');
+        });
+
+        it('includes install guidance', () => {
+            const result = buildCollectionsSummaryPrompt();
+            expect(result).toContain('install_ansible_collection');
+            expect(result).toContain('Do NOT suggest using');
+        });
+    });
+
+    describe('buildCollectionSummaryPrompt', () => {
+        it('includes collection name and tool reference', () => {
+            const result = buildCollectionSummaryPrompt('cisco.nxos');
+            expect(result).toContain('cisco.nxos');
+            expect(result).toContain('get_collection_plugins');
+        });
+    });
+
+    describe('buildPluginExplanationPrompt', () => {
+        it('includes plugin name, type, and tool reference', () => {
+            const result = buildPluginExplanationPrompt('ansible.builtin.copy', 'module');
+            expect(result).toContain('ansible.builtin.copy');
+            expect(result).toContain('module');
+            expect(result).toContain('get_plugin_documentation');
+        });
+    });
+
+    describe('buildCollectionSourcesOverviewPrompt', () => {
+        it('includes Galaxy count and org details', () => {
+            const result = buildCollectionSourcesOverviewPrompt({
+                galaxyCount: 1500,
+                githubOrgs: [
+                    { name: 'ansible-network', count: 12 },
+                    { name: 'redhat-cop', count: 8 },
+                ],
+            });
+            expect(result).toContain('1,500');
+            expect(result).toContain('ansible-network: 12 collections');
+            expect(result).toContain('redhat-cop: 8 collections');
+            expect(result).toContain('20 total collections');
+        });
+    });
+
+    describe('buildGalaxySourceSummaryPrompt', () => {
+        it('includes count and tool references', () => {
+            const result = buildGalaxySourceSummaryPrompt(2000);
+            expect(result).toContain('2,000');
+            expect(result).toContain('list_source_collections');
+            expect(result).toContain('install_ansible_collection');
+        });
+    });
+
+    describe('buildGithubOrgSourceSummaryPrompt', () => {
+        it('includes org name and count', () => {
+            const result = buildGithubOrgSourceSummaryPrompt('ansible-network', 15);
+            expect(result).toContain('ansible-network');
+            expect(result).toContain('15 collections');
+            expect(result).toContain('list_source_collections');
+        });
+    });
+});

--- a/packages/core/test/prompts/creator.test.ts
+++ b/packages/core/test/prompts/creator.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import {
+    buildCreatorOverviewPrompt,
+    buildCreatorCommandWalkthroughPrompt,
+} from '../../src/prompts/creator';
+
+describe('creator prompts', () => {
+    describe('buildCreatorOverviewPrompt', () => {
+        it('includes tool reference and key topics', () => {
+            const result = buildCreatorOverviewPrompt();
+            expect(result).toContain('get_ansible_creator_schema');
+            expect(result).toContain('ansible-creator');
+            expect(result).toContain('scaffold');
+        });
+    });
+
+    describe('buildCreatorCommandWalkthroughPrompt', () => {
+        it('includes command string and tool name', () => {
+            const result = buildCreatorCommandWalkthroughPrompt(
+                'ansible-creator add plugin filter',
+                'ac_add_plug_filter',
+            );
+            expect(result).toContain('ansible-creator add plugin filter');
+            expect(result).toContain('ac_add_plug_filter');
+        });
+
+        it('includes description when provided', () => {
+            const result = buildCreatorCommandWalkthroughPrompt(
+                'ansible-creator init collection',
+                'ac_init_coll',
+                'Initialize a new Ansible collection',
+            );
+            expect(result).toContain('Initialize a new Ansible collection');
+        });
+
+        it('works without description', () => {
+            const result = buildCreatorCommandWalkthroughPrompt(
+                'ansible-creator add resource',
+                'ac_add_res',
+            );
+            expect(result).not.toContain('undefined');
+            expect(result).toContain('ac_add_res');
+        });
+    });
+});

--- a/packages/core/test/prompts/execution-environments.test.ts
+++ b/packages/core/test/prompts/execution-environments.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import {
+    buildEESummaryPrompt,
+    buildEEDetailPrompt,
+} from '../../src/prompts/execution-environments';
+
+describe('execution-environments prompts', () => {
+    describe('buildEESummaryPrompt', () => {
+        it('includes MCP tool reference', () => {
+            const result = buildEESummaryPrompt();
+            expect(result).toContain('list_execution_environments');
+        });
+    });
+
+    describe('buildEEDetailPrompt', () => {
+        it('includes EE name and tool reference', () => {
+            const result = buildEEDetailPrompt('creator-ee');
+            expect(result).toContain('creator-ee');
+            expect(result).toContain('get_ee_details');
+        });
+
+        it('mentions expected output fields', () => {
+            const result = buildEEDetailPrompt('my-ee');
+            expect(result).toContain('Python packages');
+            expect(result).toContain('Ansible collections');
+        });
+    });
+});

--- a/packages/core/test/prompts/mcp-examples.test.ts
+++ b/packages/core/test/prompts/mcp-examples.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { buildMcpToolExamplePrompt } from '../../src/prompts/mcp-examples';
+
+describe('mcp-examples prompts', () => {
+    describe('buildMcpToolExamplePrompt', () => {
+        it('returns curated prompt for known tools', () => {
+            const result = buildMcpToolExamplePrompt('search_ansible_plugins', 'Search plugins');
+            expect(result).toContain('copy files');
+            expect(result).toContain('search_ansible_plugins');
+        });
+
+        it('returns curated prompt for get_plugin_documentation', () => {
+            const result = buildMcpToolExamplePrompt('get_plugin_documentation', 'Get docs');
+            expect(result).toContain('ansible.builtin.copy');
+        });
+
+        it('derives prompt from description for ac_ tools', () => {
+            const result = buildMcpToolExamplePrompt(
+                'ac_add_plug_filter',
+                'Add a filter plugin to a collection.\nMore details here.',
+            );
+            expect(result).toContain('Add a filter plugin to a collection');
+            expect(result).toContain('ac_add_plug_filter');
+            expect(result).not.toContain('More details');
+        });
+
+        it('removes trailing period from ac_ tool descriptions', () => {
+            const result = buildMcpToolExamplePrompt(
+                'ac_init_coll',
+                'Initialize a new collection.',
+            );
+            expect(result).toContain('Initialize a new collection, use the ac_init_coll');
+            expect(result).not.toContain('.,');
+        });
+
+        it('falls back to description for unknown tools', () => {
+            const result = buildMcpToolExamplePrompt(
+                'custom_tool',
+                'Do something interesting with the data',
+            );
+            expect(result).toContain('Do something interesting with the data');
+            expect(result).toContain('custom_tool');
+        });
+
+        it('falls back to name-based prompt for short descriptions', () => {
+            const result = buildMcpToolExamplePrompt('my_tool', 'Short');
+            expect(result).toContain('Run the my tool command');
+        });
+    });
+});

--- a/packages/core/test/prompts/plugin-doc.test.ts
+++ b/packages/core/test/prompts/plugin-doc.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { buildTaskBuilderPrompt } from '../../src/prompts/plugin-doc';
+
+describe('plugin-doc prompts', () => {
+    describe('buildTaskBuilderPrompt', () => {
+        it('includes FQCN, type, and MCP tool reference', () => {
+            const result = buildTaskBuilderPrompt('ansible.builtin.copy', 'module');
+            expect(result).toContain('ansible.builtin.copy');
+            expect(result).toContain('module');
+            expect(result).toContain('build_ansible_task');
+        });
+
+        it('works with different plugin types', () => {
+            const result = buildTaskBuilderPrompt('ansible.builtin.dict', 'filter');
+            expect(result).toContain('ansible.builtin.dict');
+            expect(result).toContain('filter');
+        });
+    });
+});

--- a/packages/core/test/prompts/skills.test.ts
+++ b/packages/core/test/prompts/skills.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { buildSkillLoadPrompt, buildSkillClipboardPrompt } from '../../src/prompts/skills';
+
+describe('skills prompts', () => {
+    describe('buildSkillLoadPrompt', () => {
+        it('includes skill name, ID, and description', () => {
+            const result = buildSkillLoadPrompt(
+                'Code Review',
+                'code-review',
+                'Review code changes',
+            );
+            expect(result).toContain('Code Review');
+            expect(result).toContain('code-review');
+            expect(result).toContain('Review code changes');
+            expect(result).toContain('skill_get');
+        });
+    });
+
+    describe('buildSkillClipboardPrompt', () => {
+        it('uses explicit MCP tool call syntax', () => {
+            const result = buildSkillClipboardPrompt('Bugfix', 'bugfix-workflow', 'Fix a bug');
+            expect(result).toContain('skill_get({ skill_id: "bugfix-workflow" })');
+            expect(result).toContain('Bugfix');
+            expect(result).toContain('Fix a bug');
+        });
+    });
+});

--- a/packages/ui/src/views/PluginDocView.tsx
+++ b/packages/ui/src/views/PluginDocView.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import type { CSSProperties } from 'react';
 import { useBridge } from '../bridge/context';
 import type { PluginDocBridge, PluginData, PluginDoc } from '../bridge/plugin-doc';
+import { buildTaskBuilderPrompt } from '@ansible/core/prompts/plugin-doc';
 import { formatAnsibleMarkup, toArray } from '../utils/ansible-markup';
 import { TabBar } from '../components/TabBar';
 import type { Tab } from '../components/TabBar';
@@ -220,8 +221,7 @@ export function PluginDocView({ fqcn, pluginType }: PluginDocViewProps) {
     );
 
     const handleAiPrompt = useCallback(() => {
-        const prompt = `Help me create an Ansible task using the ${fqcn} ${pluginType}, guiding me through the required and optional parameters. Use the build_ansible_task MCP tool to accomplish this.`;
-        void bridge.openChat(prompt);
+        void bridge.openChat(buildTaskBuilderPrompt(fqcn, pluginType));
     }, [bridge, fqcn, pluginType]);
 
     if (loading) {

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -17,7 +17,8 @@
     "sourceMap": true,
     "isolatedModules": true,
     "paths": {
-      "@ansible/core": ["../core/src/index.ts"]
+      "@ansible/core": ["../core/src/index.ts"],
+      "@ansible/core/prompts/plugin-doc": ["../core/src/prompts/plugin-doc.ts"]
     }
   },
   "include": ["src/**/*"],

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -40,6 +40,13 @@ import {
     cacheSelectedEnvironment,
     getCommandService,
     SkillRegistry,
+    buildCollectionsSummaryPrompt,
+    buildCollectionSummaryPrompt,
+    buildPluginExplanationPrompt,
+    buildEESummaryPrompt,
+    buildEEDetailPrompt,
+    buildCreatorOverviewPrompt,
+    buildCreatorCommandWalkthroughPrompt,
 } from '@ansible/core';
 import type { PythonEnvironment, SchemaNode, SkillSource, SkillEntry } from '@ansible/core';
 import { SkillsProvider, openChatWithSkill, copySkillPrompt } from '@src/views/SkillsProvider';
@@ -715,19 +722,7 @@ export function activate(context: vscode.ExtensionContext) {
     const collectionsAiSummaryCommand = vscode.commands.registerCommand(
         'ansibleDevToolsCollections.aiSummary',
         async () => {
-            const prompt = `Generate a summary of the installed Ansible collections in this workspace.
-
-Use the \`list_ansible_collections\` MCP tool to get the list of installed collections, then provide:
-1. A brief overview of the collection categories (networking, cloud, system, etc.)
-2. Key capabilities provided by these collections
-3. Any recommendations for commonly paired collections that might be missing
-
-After your summary, ask the user if they would like to search for additional collections. If they say yes, use the \`search_available_collections\` MCP tool to find relevant collections based on their use case (you can filter by source: "galaxy" or a GitHub org name).
-
-**IMPORTANT**: To install any collection, use the \`install_ansible_collection\` MCP tool.
-Do NOT suggest using \`ansible-galaxy collection install\` directly.`;
-
-            await openChatWithPrompt(prompt);
+            await openChatWithPrompt(buildCollectionsSummaryPrompt());
         },
     );
 
@@ -737,15 +732,7 @@ Do NOT suggest using \`ansible-galaxy collection install\` directly.`;
             if (!node.name) {
                 return;
             }
-            const prompt = `Generate a summary of the Ansible collection "${node.name}".
-
-Use the \`get_collection_plugins\` MCP tool with collection="${node.name}" to get all plugins in this collection, then provide:
-1. A brief description of what this collection is for
-2. The key modules, plugins, and roles it provides
-3. Common use cases and example scenarios
-4. Any dependencies or requirements`;
-
-            await openChatWithPrompt(prompt);
+            await openChatWithPrompt(buildCollectionSummaryPrompt(node.name));
         },
     );
 
@@ -755,15 +742,7 @@ Use the \`get_collection_plugins\` MCP tool with collection="${node.name}" to ge
             if (!node.fullName) {
                 return;
             }
-            const prompt = `Explain the Ansible ${node.pluginType} plugin "${node.fullName}".
-
-Use the \`get_plugin_documentation\` MCP tool with plugin_name="${node.fullName}" and plugin_type="${node.pluginType}" to get the full documentation, then provide:
-1. What this plugin does in plain language
-2. The most important parameters and when to use them
-3. A practical example task showing common usage
-4. Any gotchas or best practices`;
-
-            await openChatWithPrompt(prompt);
+            await openChatWithPrompt(buildPluginExplanationPrompt(node.fullName, node.pluginType));
         },
     );
 
@@ -771,14 +750,7 @@ Use the \`get_plugin_documentation\` MCP tool with plugin_name="${node.fullName}
     const eeAiSummaryCommand = vscode.commands.registerCommand(
         'ansibleExecutionEnvironments.aiSummary',
         async () => {
-            const prompt = `Generate a summary of the available Ansible Execution Environments.
-
-Use the \`list_execution_environments\` MCP tool to get the list of available EEs, then provide:
-1. An overview of each execution environment and its purpose
-2. Key tools and collections included in each
-3. Recommendations for which EE to use for different scenarios`;
-
-            await openChatWithPrompt(prompt);
+            await openChatWithPrompt(buildEESummaryPrompt());
         },
     );
 
@@ -788,23 +760,7 @@ Use the \`list_execution_environments\` MCP tool to get the list of available EE
             if (!node.label) {
                 return;
             }
-            const prompt = `Generate a detailed summary of the Ansible Execution Environment "${node.label}".
-
-Use the \`get_ee_details\` MCP tool with ee_name="${node.label}" to get all information about this EE.
-
-The tool returns complete details including:
-- Container base OS and Ansible version
-- ALL installed Python packages with versions
-- ALL installed Ansible collections with versions
-- System packages (if available)
-
-Based on the tool output, provide:
-1. A summary of the container image and its base OS
-2. Key Python packages and what they enable
-3. Notable Ansible collections included and their use cases
-4. Best use cases for this execution environment`;
-
-            await openChatWithPrompt(prompt);
+            await openChatWithPrompt(buildEEDetailPrompt(node.label));
         },
     );
 
@@ -812,16 +768,7 @@ Based on the tool output, provide:
     const creatorAiSummaryCommand = vscode.commands.registerCommand(
         'ansibleCreator.aiSummary',
         async () => {
-            const prompt = `Explain the ansible-creator scaffolding tool and summarize its capabilities.
-
-Use the \`get_ansible_creator_schema\` MCP tool to get the full schema, then provide:
-1. What ansible-creator is and why it's useful
-2. A summary of each content type it can scaffold (collections, playbooks, plugins, etc.)
-3. The key parameters for each scaffolding command
-4. Best practices for starting new Ansible projects
-5. How the generated structure follows Ansible best practices`;
-
-            await openChatWithPrompt(prompt);
+            await openChatWithPrompt(buildCreatorOverviewPrompt());
         },
     );
 
@@ -836,7 +783,6 @@ Use the \`get_ansible_creator_schema\` MCP tool to get the full schema, then pro
                 return;
             }
             const commandStr = `ansible-creator ${node.commandPath.join(' ')}`;
-            // Build the tool name from the command path (e.g., ['add', 'plugin', 'filter'] -> 'ac_add_plug_filter')
             const toolName = `ac_${node.commandPath
                 .map((p: string) => {
                     const abbr: Record<string, string> = {
@@ -854,18 +800,11 @@ Use the \`get_ansible_creator_schema\` MCP tool to get the full schema, then pro
                 })
                 .join('_')}`;
 
-            const prompt = `Help me use the "${commandStr}" command to scaffold new Ansible content.
-
-${node.schema.description ? `This command: ${node.schema.description}` : ''}
-
-Use the \`${toolName}\` MCP tool to execute this command once I provide the required parameters.
-
-Please:
-1. Explain what this command creates and the resulting directory structure
-2. Walk me through the required and optional parameters
-3. Suggest best practices for the values I should provide
-4. After I provide the details, use the \`${toolName}\` tool to run the command`;
-
+            const prompt = buildCreatorCommandWalkthroughPrompt(
+                commandStr,
+                toolName,
+                node.schema.description,
+            );
             await openChatWithPrompt(prompt);
         },
     );

--- a/src/views/CollectionSourcesProvider.ts
+++ b/src/views/CollectionSourcesProvider.ts
@@ -1,5 +1,11 @@
 import * as vscode from 'vscode';
-import { GalaxyCollectionCache, GitHubCollectionCache } from '@ansible/core';
+import {
+    GalaxyCollectionCache,
+    GitHubCollectionCache,
+    buildCollectionSourcesOverviewPrompt,
+    buildGalaxySourceSummaryPrompt,
+    buildGithubOrgSourceSummaryPrompt,
+} from '@ansible/core';
 
 // Logging function
 let extensionLog: (msg: string) => void = console.log;
@@ -550,30 +556,12 @@ export class CollectionSourcesProvider implements vscode.TreeDataProvider<Collec
         const orgs = this._getConfiguredOrgs();
         const galaxyCount = this._galaxyCache.getCollections().length;
 
-        let githubTotal = 0;
-        const orgDetails: string[] = [];
-        for (const org of orgs) {
-            const count = this._githubCache.getCount(org);
-            githubTotal += count;
-            orgDetails.push(`  - ${org}: ${String(count)} collections`);
-        }
+        const githubOrgs = orgs.map((org) => ({
+            name: org,
+            count: this._githubCache.getCount(org),
+        }));
 
-        const prompt = `I have access to Ansible collections from multiple sources:
-
-**Ansible Galaxy**: ${galaxyCount.toLocaleString()} collections available
-
-**GitHub Organizations** (${String(githubTotal)} total collections):
-${orgDetails.join('\n')}
-
-Please help me understand:
-1. What types of collections are typically found on Galaxy vs GitHub organizations?
-2. How do I decide which source to use for a particular use case?
-3. Are there any notable collections in these GitHub organizations I should know about?
-
-Use the \`search_available_collections\` MCP tool to search for collections if needed.
-
-**IMPORTANT**: To install any collection, use the \`install_ansible_collection\` MCP tool.
-Do NOT suggest using \`ansible-galaxy collection install\` directly.`;
+        const prompt = buildCollectionSourcesOverviewPrompt({ galaxyCount, githubOrgs });
 
         await openChatWithPrompt(prompt);
     }
@@ -583,40 +571,10 @@ Do NOT suggest using \`ansible-galaxy collection install\` directly.`;
      * @param source - Collection source to summarize in chat
      */
     public async generateSourceAiSummary(source: CollectionSourceInfo): Promise<void> {
-        let prompt: string;
-
-        if (source.type === 'galaxy') {
-            prompt = `Generate a summary of Ansible Galaxy as a collection source.
-
-Galaxy has ${source.count.toLocaleString()} collections available.
-
-Please describe:
-1. What is Ansible Galaxy and what types of collections are typically found there?
-2. How do I search for and evaluate collections on Galaxy?
-3. What are some of the most popular/useful collections on Galaxy?
-
-Use the \`list_source_collections\` MCP tool with source: "galaxy" to see the most popular collections.
-Use the \`search_available_collections\` MCP tool to search for specific collections.
-
-**IMPORTANT**: To install any collection, use the \`install_ansible_collection\` MCP tool.
-Do NOT suggest using \`ansible-galaxy collection install\` directly.`;
-        } else {
-            prompt = `Generate a summary of the "${source.id}" GitHub organization as an Ansible collection source.
-
-This organization has ${String(source.count)} collections.
-
-First, use the \`list_source_collections\` MCP tool with source: "${source.id}" to get the complete list of collections.
-
-Then describe:
-1. What is this organization and what types of collections do they provide?
-2. What are the main use cases for these collections?
-3. Which collections should I consider for my Ansible automation?
-
-Use the \`search_available_collections\` MCP tool to search for specific collections if needed.
-
-**IMPORTANT**: To install any collection, use the \`install_ansible_collection\` MCP tool.
-Do NOT suggest using \`ansible-galaxy collection install\` directly.`;
-        }
+        const prompt =
+            source.type === 'galaxy'
+                ? buildGalaxySourceSummaryPrompt(source.count)
+                : buildGithubOrgSourceSummaryPrompt(source.id, source.count);
 
         await openChatWithPrompt(prompt);
     }

--- a/src/views/McpToolsProvider.ts
+++ b/src/views/McpToolsProvider.ts
@@ -7,7 +7,7 @@
 
 import * as vscode from 'vscode';
 import { STATIC_TOOLS, type McpToolDefinition, CreatorToolGenerator } from '@ansible/mcp-server';
-import { CreatorService } from '@ansible/core';
+import { CreatorService, buildMcpToolExamplePrompt } from '@ansible/core';
 import { log } from '@src/extension';
 import { getMcpStatus, McpStatus } from '@src/mcp/cursorConfig';
 
@@ -250,52 +250,7 @@ export class McpToolsProvider implements vscode.TreeDataProvider<ToolTreeItem> {
      * @returns Example prompt suitable for injection into chat
      */
     private _generateExamplePrompt(tool: McpToolDefinition): string {
-        const name = tool.name;
-
-        // Format: "Do the specific task, use the TOOL_NAME MCP tool to accomplish this"
-        switch (name) {
-            case 'search_ansible_plugins':
-                return `Search for Ansible plugins that can copy files, use the ${name} MCP tool to accomplish this`;
-            case 'get_plugin_documentation':
-                return `Show me the documentation for ansible.builtin.copy, use the ${name} MCP tool to accomplish this`;
-            case 'list_ansible_collections':
-                return `List what Ansible collections are installed, use the ${name} MCP tool to accomplish this`;
-            case 'generate_ansible_task':
-                return `Generate an Ansible task to copy /etc/hosts to /tmp/hosts.backup, use the ${name} MCP tool to accomplish this`;
-            case 'build_ansible_task':
-                return `Help me build an Ansible task for the apt module step by step, use the ${name} MCP tool to accomplish this`;
-            case 'generate_ansible_playbook':
-                return `Create a playbook to install and configure nginx on webservers, use the ${name} MCP tool to accomplish this`;
-            case 'list_execution_environments':
-                return `List what execution environments are available, use the ${name} MCP tool to accomplish this`;
-            case 'get_ee_details':
-                return `Show me the details of the creator-ee execution environment, use the ${name} MCP tool to accomplish this`;
-            case 'list_ansible_dev_tools':
-                return `List what ansible-dev-tools packages are installed, use the ${name} MCP tool to accomplish this`;
-            case 'install_ansible_collection':
-                return `Install the community.general Ansible collection, use the ${name} MCP tool to accomplish this`;
-            case 'get_collection_plugins':
-                return `List all plugins in the cisco.nxos collection, use the ${name} MCP tool to accomplish this`;
-            case 'get_ansible_creator_schema':
-                return `Show me what content types ansible-creator can scaffold, use the ${name} MCP tool to accomplish this`;
-            default:
-                // For creator tools (ac_*), extract action from the description
-                if (name.startsWith('ac_')) {
-                    // Get the first line of the description (the main help text)
-                    const firstLine = tool.description.split('\n')[0].trim();
-                    // Remove trailing period if present
-                    const action = firstLine.endsWith('.') ? firstLine.slice(0, -1) : firstLine;
-                    return `${action}, use the ${name} MCP tool to accomplish this`;
-                }
-                {
-                    const desc = tool.description.split('\n')[0].trim();
-                    if (desc && desc.length > 10) {
-                        const action = desc.endsWith('.') ? desc.slice(0, -1) : desc;
-                        return `${action}, use the ${name} MCP tool to accomplish this`;
-                    }
-                    return `Run the ${name.replace(/_/g, ' ')} command, use the ${name} MCP tool to accomplish this`;
-                }
-        }
+        return buildMcpToolExamplePrompt(tool.name, tool.description);
     }
 
     /**

--- a/src/views/SkillsProvider.ts
+++ b/src/views/SkillsProvider.ts
@@ -6,7 +6,7 @@
  */
 
 import * as vscode from 'vscode';
-import { SkillRegistry } from '@ansible/core';
+import { SkillRegistry, buildSkillLoadPrompt, buildSkillClipboardPrompt } from '@ansible/core';
 import type { SkillEntry, SkillSource } from '@ansible/core';
 import { log } from '@src/extension';
 
@@ -247,9 +247,7 @@ export class SkillsProvider implements vscode.TreeDataProvider<TreeNode> {
  * @param skill - The skill entry to use.
  */
 export async function openChatWithSkill(skill: SkillEntry): Promise<void> {
-    const prompt =
-        `Use the skill_get tool to load the "${skill.name}" skill (ID: "${skill.id}"), ` +
-        `then follow its guidance to help me with: ${skill.description}`;
+    const prompt = buildSkillLoadPrompt(skill.name, skill.id, skill.description);
 
     try {
         await vscode.commands.executeCommand('workbench.action.chat.open', prompt);
@@ -271,9 +269,7 @@ export async function openChatWithSkill(skill: SkillEntry): Promise<void> {
  * @param skill - The skill entry to copy the prompt for.
  */
 export async function copySkillPrompt(skill: SkillEntry): Promise<void> {
-    const prompt =
-        `Use the MCP tool skill_get({ skill_id: "${skill.id}" }) to load the ` +
-        `"${skill.name}" skill, then apply its guidance to help me with: ${skill.description}`;
+    const prompt = buildSkillClipboardPrompt(skill.name, skill.id, skill.description);
     await vscode.env.clipboard.writeText(prompt);
     void vscode.window.showInformationMessage(`Prompt for "${skill.name}" copied to clipboard.`);
 }


### PR DESCRIPTION
## Summary
- Moves all user-facing AI prompt strings from scattered extension code into dedicated prompt builder modules in `packages/core/src/prompts/`
- Enables future user customization of prompts and ensures consistency across extension, MCP server, and CLI consumers

## Changes
- Created 6 prompt builder modules in `packages/core/src/prompts/`:
  - `collections.ts` — collection summaries, plugin explanation, source overviews
  - `execution-environments.ts` — EE summary and detail prompts
  - `creator.ts` — ansible-creator overview and command walkthrough
  - `plugin-doc.ts` — AI task builder prompt
  - `skills.ts` — skill loading and clipboard prompts
  - `mcp-examples.ts` — MCP tool example prompts (curated + fallback logic)
- Created barrel `packages/core/src/prompts/index.ts` re-exporting all builders including the existing `playbook.ts`
- Updated `@ansible/core` barrel to export all prompt builders
- Replaced inline prompt strings in:
  - `src/extension.ts` (collections, EE, creator AI commands)
  - `src/views/CollectionSourcesProvider.ts` (source summaries)
  - `src/views/McpToolsProvider.ts` (example prompt generation)
  - `src/views/SkillsProvider.ts` (skill load/clipboard prompts)
  - `packages/ui/src/views/PluginDocView.tsx` (AI task builder)
- Added comprehensive unit tests (36 tests across 6 test files)

## Test plan
- [x] `npm exec tsc -- -b` compiles cleanly
- [x] `npm exec eslint -- .` passes on all modified files
- [x] `npm exec vitest -- run` passes (665 tests, 41 files)
- [ ] Functional: AI summary commands produce identical prompts to before