### PR TITLE
chore: update artifact upload action in CI workflow [DNM test PR] 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -504,9 +504,8 @@ jobs:
           rm -rf out/e2e/tmp/home/.cache || true
 
       - name: Upload test logs and reports as logs-${{ steps.setup.outputs.OS_VERSION }}-${{ matrix.task-name }}.zip
-        # git-leaks not support on Windows
         if: ${{ !cancelled() && runner.os != 'Windows'}}
-        uses: ansible/actions/upload-artifact@main
+        uses: actions/upload-artifact@v7
         with:
           name: logs-${{ steps.setup.outputs.OS_VERSION }}-${{ matrix.id }}-${{ github.run_attempt }}.zip
           path: |


### PR DESCRIPTION
Replaced the artifact upload action from `ansible/actions/upload-artifact@main` to `actions/upload-artifact@v7` in the CI workflow configuration. This change ensures compatibility and leverages the latest features of the upload action.

- Updated the action used for uploading test logs and reports in `.github/workflows/ci.yaml`. Replaced the artifact upload action from `ansible/actions/upload-artifact@main` to `actions/upload-artifact@v7` in the CI workflow configuration. This change ensures compatibility and leverages the latest features of the upload action.

- Updated the action used for uploading test logs and reports in `.github/workflows/ci.yaml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated the artifact upload action in the CI workflow from the custom `ansible/actions/upload-artifact@main` to the standard `actions/upload-artifact@v7`. This change ensures compatibility and leverages the latest features of the official upload action while maintaining the same conditional logic for non-Windows runners.

- Replaced `ansible/actions/upload-artifact@main` with `actions/upload-artifact@v7` in the build job's test logs and reports upload step

<!-- end of auto-generated comment: release notes by coderabbit.ai -->