### PR TITLE
feat(views): add SCM collection plugin browsing

### DIFF
--- a/.sdlc/adrs/ADR-013-scm-plugin-docs-via-shallow-clone.md
+++ b/.sdlc/adrs/ADR-013-scm-plugin-docs-via-shallow-clone.md
@@ -1,0 +1,226 @@
+# ADR-013: SCM Collection Plugin Documentation via Shallow Clone
+
+## Status
+
+Accepted
+
+## Date
+
+2026-06-17
+
+## Context
+
+The Collection Sources sidebar provides two sources of Ansible
+collections: Ansible Galaxy and configured GitHub organizations.
+Galaxy collections have full plugin-level browsing — users expand a
+collection to see plugin types, individual plugins, and complete
+documentation (parameters, examples, return values) — powered by the
+Galaxy API's `docs-blob` endpoint via `GalaxyDocsCache` (PR #2894).
+
+GitHub collections today are **discovery-only**: the
+`GitHubCollectionCache` finds repos with `galaxy.yml`, extracts
+namespace/name/version, and offers install via `ade install`. There is
+no plugin-level browsing for uninstalled GitHub collections. A user
+who wants to understand what plugins a GitHub collection offers must
+either install it first or browse the repository manually.
+
+This gap matters because many organizations maintain collections in
+GitHub that are not published to Galaxy. The `redhat-cop`,
+`ansible-collections`, and private org repositories are primary
+sources for these teams. Without plugin browsing, the extension
+cannot complete the discovery → documentation → generation loop for
+SCM-sourced collections (violating ADR-012's parity invariant).
+
+### Forces in tension
+
+- **Doc quality**: Galaxy provides pre-rendered, normalized docs-blob.
+  GitHub repos contain raw Python source files with embedded
+  `DOCUMENTATION` YAML strings that require parsing, fragment
+  resolution, and normalization.
+- **Tooling assumptions**: The project already assumes `ansible-doc`
+  is available in the active Python environment (ADR-004, invariant 7).
+  Leveraging it avoids reimplementing complex documentation parsing.
+- **API rate limits**: GitHub's REST API has a 5,000 requests/hour
+  limit for authenticated users. A collection with 200 modules would
+  require 200+ API calls to fetch plugin source files individually.
+- **Latency vs freshness**: SCM repositories change more frequently
+  than Galaxy releases. Caching must balance responsiveness with
+  staleness.
+- **Disk usage**: Temporary clones and cached JSON consume disk space
+  that must be managed.
+
+## Decision
+
+**We will shallow-clone GitHub collection repositories and run
+`ansible-doc --metadata-dump` with a constrained `ANSIBLE_COLLECTIONS_PATH`
+to produce normalized plugin documentation, cached to disk with
+SHA-based invalidation and a 7-day TTL.**
+
+Concretely:
+
+1. When a user expands a GitHub collection node in the tree (or an
+   MCP tool requests its docs), `SCMDocsCache` checks for a cached
+   JSON file keyed by `{org}__{repo}-{commit_sha}.json`.
+
+2. On cache miss, the service:
+   a. Shallow-clones the repo (`git clone --depth 1 --single-branch`)
+      into a temporary directory structured as
+      `{tmp}/ansible_collections/{namespace}/{name}/`.
+   b. Resolves the HEAD SHA from the clone via `git rev-parse HEAD`.
+   c. If a cache file for that SHA already exists, refreshes its
+      timestamp and returns the existing data (avoids re-indexing
+      when only the TTL expired but the content is unchanged).
+   d. Runs `ansible-doc --metadata-dump --no-fail-on-errors` with
+      `ANSIBLE_COLLECTIONS_PATH={tmp}` to extract all plugin
+      documentation in one JSON blob.
+   e. Parses the metadata dump using the same shared utility that
+      `CollectionsService` uses for installed collections.
+   f. Persists the result to `~/.cache/ansible-environments/scm-docs/`.
+   g. Removes the temporary clone directory.
+
+3. Cache entries expire after 7 days or when the HEAD SHA changes.
+   Users can force-refresh via a context menu command on the
+   collection node.
+
+4. An MCP tool (`get_scm_plugin_doc`) provides agent access to the
+   same documentation, maintaining ADR-012 parity.
+
+## Alternatives Considered
+
+### Alternative 1: GitHub API (Contents/Trees API)
+
+**Description**: Walk the repository tree via
+`GET /repos/{owner}/{repo}/git/trees/{sha}?recursive=1` to discover
+plugin directories, then fetch each plugin's Python file and parse
+the `DOCUMENTATION` YAML string from the docstring.
+
+**Pros**:
+- No local disk usage beyond the JSON cache
+- No dependency on local Python/ansible-doc
+- Works in constrained environments (Codespaces, remote SSH)
+- Incremental updates via tree SHA comparison
+
+**Cons**:
+- Heavy API usage: 200 modules = 200+ API calls per refresh
+- Fragile parsing: must replicate `ansible-doc`'s DOCUMENTATION
+  extraction (extends_documentation_fragment, version_added
+  inheritance, Jinja in docs)
+- Incomplete data: doc fragments are cross-file references
+- Org-scale problem: `ansible-collections` has 100+ repos
+
+**Why not chosen**: Does not scale to full orgs. Produces
+lower-quality documentation than `ansible-doc` because doc fragment
+resolution, Jinja rendering, and schema normalization would need to
+be reimplemented in TypeScript.
+
+### Alternative 2: Tarball Fetch and Scrape
+
+**Description**: Download the repository tarball via
+`GET /repos/{owner}/{repo}/tarball/{ref}`, extract to temp, parse
+`DOCUMENTATION`/`EXAMPLES`/`RETURN` YAML blocks ourselves.
+
+**Pros**:
+- Single API call per collection (tarball download)
+- All files available locally for parsing
+- No `git` binary dependency
+
+**Cons**:
+- Full repo download: includes tests, CI, docs (community.general ~50MB)
+- Same fragile documentation parsing as Alternative 1
+- Would reimplement what `ansible-doc` already does
+- Temp storage for extracted tarballs
+
+**Why not chosen**: Better API efficiency than Alternative 1, but
+still reimplements `ansible-doc`'s parsing logic poorly. The
+shallow-clone approach provides the same files with less download
+size (git packs data efficiently) and delegates parsing to the
+authoritative tool.
+
+## Consequences
+
+### Positive
+
+- Exact documentation parity with installed-collection docs —
+  same data format, same normalization, same doc fragment resolution
+- Reuses the proven `MetadataDump` → `PluginInfo[]` + `PluginData`
+  parsing path from `CollectionsService`
+- Minimal new code: the service is structurally identical to
+  `GalaxyDocsCache` with a different data acquisition step
+- No GitHub API rate limit concerns for clone operations (git
+  protocol is separate from REST quota)
+- `PluginDocPanel` and MCP tools work unchanged because the cache
+  output shape is identical to `GalaxyDocsCache`
+
+### Negative
+
+- Requires `git` binary on PATH (universally available in dev
+  environments but not guaranteed in all deployment targets)
+- Requires `ansible-doc` in the active Python environment (already
+  an invariant — ADR-004)
+- Clone latency of 2-10 seconds per collection on first expansion;
+  must be async with progress indicator
+- Temporary disk usage during clone+extract; mitigated by immediate
+  cleanup after metadata extraction
+- Cannot parallelize `ansible-doc` across collections easily
+  (Python GIL, environment isolation)
+
+### Neutral
+
+- The 7-day TTL is a heuristic; it may need tuning based on user
+  feedback about freshness vs performance
+- SHA-based invalidation means a force-refresh always checks the
+  remote, adding one API call per refresh
+- Collections in private repositories require GitHub authentication,
+  which is already handled by `GitHubCollectionCache` via
+  `vscode.authentication`
+
+## Implementation Notes
+
+### Key files
+
+- `packages/services/src/SCMDocsCache.ts` — new service
+- `packages/common/src/parsers/metadataDumpParser.ts` — shared
+  browser-safe parsing utility extracted from `CollectionsService`
+- `src/views/CollectionSourcesProvider.ts` — tree expansion for
+  GitHub collection nodes
+- `packages/mcp-server/src/tools.ts` + `handlers.ts` — MCP tool
+
+### Cache structure
+
+```
+~/.cache/ansible-environments/scm-docs/
+  ansible-collections__cisco.ios-abc1234.json
+  redhat-cop__infra.aap_configuration-def5678.json
+```
+
+### Temp directory lifecycle
+
+```
+os.tmpdir()/ansible-scm-docs-{random}/
+  ansible_collections/
+    {namespace}/
+      {name}/        ← shallow clone target
+```
+
+Clone, run `ansible-doc`, save JSON, `rm -rf` the temp dir.
+
+## Related Decisions
+
+- [ADR-002](ADR-002-centralized-plugin-doc-cache.md): Plugin doc
+  cache — `SCMDocsCache` follows the same cache-first pattern
+- [ADR-004](ADR-004-intentional-exclusions-from-main.md): Tools
+  discovered from active Python env — `ansible-doc` dependency
+- [ADR-005](ADR-005-architectural-invariants.md): Architectural
+  invariants — invariants 7 (tool discovery) and 11 (MCP parity)
+- [ADR-011](ADR-011-package-architecture.md): Package architecture —
+  `SCMDocsCache` belongs in `@ansible/services`
+- [ADR-012](ADR-012-mcp-tool-parity.md): MCP tool parity — requires
+  corresponding `get_scm_plugin_doc` MCP tool
+
+---
+
+## Revision History
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-06-17 | AI-assisted | Initial decision |

--- a/.sdlc/adrs/README.md
+++ b/.sdlc/adrs/README.md
@@ -26,6 +26,7 @@ Decisions that have been accepted but are not yet fully implemented.
 | [ADR-006](ADR-006-esbuild-bundler.md) | esbuild Bundler for Extension and Packages | 2026-06-10 |
 | [ADR-011](ADR-011-package-architecture.md) | Package Architecture — @ansible/common and @ansible/services | 2026-06-16 |
 | [ADR-012](ADR-012-mcp-tool-parity.md) | MCP Tool Parity for Extension Capabilities | 2026-06-17 |
+| [ADR-013](ADR-013-scm-plugin-docs-via-shallow-clone.md) | SCM Collection Plugin Documentation via Shallow Clone | 2026-06-17 |
 
 ## Proposed
 
@@ -38,7 +39,7 @@ Decisions under consideration — not yet accepted or implemented.
 ## Creating New ADRs
 
 1. Copy the template from `../templates/adr.md`
-2. Use the next available number (currently ADR-013)
+2. Use the next available number (currently ADR-014)
 3. Include:
    - Status (Proposed → Accepted → Implemented)
    - Date

--- a/package.json
+++ b/package.json
@@ -555,6 +555,16 @@
         "icon": "$(sparkle)"
       },
       {
+        "command": "ansibleCollectionSources.showGitHubPluginDoc",
+        "title": "Show Plugin Documentation",
+        "icon": "$(book)"
+      },
+      {
+        "command": "ansibleCollectionSources.refreshGitHubCollection",
+        "title": "Refresh Plugin Docs",
+        "icon": "$(refresh)"
+      },
+      {
         "command": "ansibleEnvironments.selectLlmModel",
         "title": "Select LLM Provider & Model",
         "category": "Ansible Environments",
@@ -780,27 +790,32 @@
         },
         {
           "command": "ansibleCollectionSources.installFromSource",
-          "when": "view == ansibleCollectionSources && viewItem == collectionSource",
+          "when": "view == ansibleCollectionSources && viewItem == collectionSourceGitHub",
           "group": "inline@1"
         },
         {
           "command": "ansibleCollectionSources.searchSource",
-          "when": "view == ansibleCollectionSources && viewItem == collectionSource",
+          "when": "view == ansibleCollectionSources && viewItem == collectionSourceGitHub",
           "group": "inline@2"
         },
         {
           "command": "ansibleCollectionSources.refreshSource",
-          "when": "view == ansibleCollectionSources && viewItem == collectionSource",
+          "when": "view == ansibleCollectionSources && viewItem == collectionSourceGitHub",
           "group": "inline@3"
         },
         {
           "command": "ansibleCollectionSources.aiSourceSummary",
-          "when": "view == ansibleCollectionSources && viewItem == collectionSource && config.ansibleEnvironments.enableAiFeatures",
+          "when": "view == ansibleCollectionSources && viewItem == collectionSourceGitHub && config.ansibleEnvironments.enableAiFeatures",
           "group": "inline@4"
         },
         {
           "command": "ansibleCollectionSources.installGalaxyCollection",
           "when": "view == ansibleCollectionSources && viewItem == galaxyCollection",
+          "group": "inline@1"
+        },
+        {
+          "command": "ansibleCollectionSources.refreshGitHubCollection",
+          "when": "view == ansibleCollectionSources && viewItem == githubCollection",
           "group": "inline@1"
         },
         {

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -65,6 +65,12 @@ export {
     mergePlaybookConfig,
     DEFAULT_PLAYBOOK_CONFIG,
 } from './parsers/playbookParser';
+export { extractMetadataJson, parseMetadataDump } from './parsers/metadataDumpParser';
+export type {
+    MetadataDump,
+    ParsedCollection,
+    MetadataDumpResult,
+} from './parsers/metadataDumpParser';
 
 // --- AI Prompt Builders ---
 export {

--- a/packages/common/src/parsers/metadataDumpParser.ts
+++ b/packages/common/src/parsers/metadataDumpParser.ts
@@ -1,0 +1,136 @@
+/**
+ * Shared parser for `ansible-doc --metadata-dump` JSON output.
+ *
+ * Used by both CollectionsService (for installed collections) and
+ * SCMDocsCache (for shallow-cloned GitHub collections).
+ */
+
+import type { CollectionInfo, PluginInfo, PluginData, PluginDoc, PluginReturn } from '../types';
+
+/** A single plugin entry in the metadata dump. */
+interface MetadataEntry {
+    doc?: PluginDoc;
+    examples?: string;
+    return?: PluginReturn;
+    metadata?: unknown;
+}
+
+/** Plugins grouped by type within the dump. */
+type MetadataPluginTypes = Record<string, Record<string, MetadataEntry>>;
+
+/** Top-level shape of `ansible-doc --metadata-dump` output. */
+export interface MetadataDump {
+    all?: MetadataPluginTypes;
+}
+
+/** Collection info plus plugins organized by type. */
+export interface ParsedCollection {
+    info: CollectionInfo;
+    pluginTypes: Map<string, PluginInfo[]>;
+}
+
+/** Result of parsing a metadata dump. */
+export interface MetadataDumpResult {
+    collections: Map<string, ParsedCollection>;
+    pluginDocs: Map<string, PluginData>;
+}
+
+/**
+ * Extracts the JSON object from raw ansible-doc output, stripping any
+ * leading warnings or non-JSON text.
+ *
+ * @param raw - Raw stdout from `ansible-doc --metadata-dump`.
+ * @returns Parsed MetadataDump, or null if no JSON was found.
+ */
+export function extractMetadataJson(raw: string): MetadataDump | null {
+    const jsonStart = raw.indexOf('{');
+    if (jsonStart === -1) {
+        return null;
+    }
+    try {
+        return JSON.parse(raw.substring(jsonStart)) as MetadataDump;
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Parses a metadata dump into collections and plugin documentation maps.
+ *
+ * @param metadata - Parsed metadata dump object.
+ * @param collectionInfoMap - Optional pre-populated collection info (e.g. from `ade inspect`).
+ * @returns Parsed collections and plugin documentation.
+ */
+export function parseMetadataDump(
+    metadata: MetadataDump,
+    collectionInfoMap?: Map<string, CollectionInfo>,
+): MetadataDumpResult {
+    const collections = new Map<string, ParsedCollection>();
+    const pluginDocs = new Map<string, PluginData>();
+
+    if (!metadata.all) {
+        return { collections, pluginDocs };
+    }
+
+    const seenPlugins = new Set<string>();
+
+    for (const [pluginType, plugins] of Object.entries(metadata.all)) {
+        for (const [fullName, pluginData] of Object.entries(plugins)) {
+            const doc = pluginData.doc;
+            if (!doc) {
+                continue;
+            }
+
+            const collectionName = doc.collection ?? 'unknown';
+            const pluginName =
+                doc.plugin_name?.split('.').pop() ?? fullName.split('.').pop() ?? fullName;
+            const shortDescription = doc.short_description ?? '';
+
+            const uniqueKey = `${collectionName}:${pluginType}:${fullName}`;
+            if (seenPlugins.has(uniqueKey)) {
+                continue;
+            }
+            seenPlugins.add(uniqueKey);
+
+            const docKey = `${fullName}:${pluginType}`;
+            pluginDocs.set(docKey, {
+                doc: pluginData.doc,
+                examples: pluginData.examples,
+                return: pluginData.return,
+                metadata: pluginData.metadata,
+            });
+
+            let collection = collections.get(collectionName);
+            if (!collection) {
+                const info = collectionInfoMap?.get(collectionName) ?? {
+                    name: collectionName,
+                    version: '',
+                    authors: [],
+                    description: '',
+                };
+                collection = { info, pluginTypes: new Map() };
+                collections.set(collectionName, collection);
+            }
+
+            let typePlugins = collection.pluginTypes.get(pluginType);
+            if (!typePlugins) {
+                typePlugins = [];
+                collection.pluginTypes.set(pluginType, typePlugins);
+            }
+
+            typePlugins.push({
+                name: pluginName,
+                fullName,
+                shortDescription,
+            });
+        }
+    }
+
+    for (const collection of collections.values()) {
+        for (const typePlugins of collection.pluginTypes.values()) {
+            typePlugins.sort((a, b) => a.name.localeCompare(b.name));
+        }
+    }
+
+    return { collections, pluginDocs };
+}

--- a/packages/common/test/parsers/metadataDumpParser.test.ts
+++ b/packages/common/test/parsers/metadataDumpParser.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect } from 'vitest';
+import { extractMetadataJson, parseMetadataDump } from '../../src/parsers/metadataDumpParser';
+import type { MetadataDump } from '../../src/parsers/metadataDumpParser';
+
+describe('extractMetadataJson', () => {
+    it('returns null for empty string', () => {
+        expect(extractMetadataJson('')).toBeNull();
+    });
+
+    it('returns null when no JSON is present', () => {
+        expect(extractMetadataJson('WARNING: something went wrong')).toBeNull();
+    });
+
+    it('strips leading warnings before JSON', () => {
+        const raw = 'WARNING: some warning\n{"all": {}}';
+        const result = extractMetadataJson(raw);
+        expect(result).toEqual({ all: {} });
+    });
+
+    it('parses clean JSON', () => {
+        const raw = '{"all": {"module": {}}}';
+        const result = extractMetadataJson(raw);
+        expect(result).toHaveProperty('all');
+    });
+});
+
+describe('parseMetadataDump', () => {
+    it('returns empty maps for empty metadata', () => {
+        const result = parseMetadataDump({});
+        expect(result.collections.size).toBe(0);
+        expect(result.pluginDocs.size).toBe(0);
+    });
+
+    it('returns empty maps when all is empty', () => {
+        const result = parseMetadataDump({ all: {} });
+        expect(result.collections.size).toBe(0);
+        expect(result.pluginDocs.size).toBe(0);
+    });
+
+    it('parses a single plugin into a collection', () => {
+        const metadata: MetadataDump = {
+            all: {
+                module: {
+                    'cisco.ios.ios_acls': {
+                        doc: {
+                            collection: 'cisco.ios',
+                            plugin_name: 'cisco.ios.ios_acls',
+                            short_description: 'Manage ACLs',
+                            options: {
+                                config: { type: 'list', description: 'ACL config' },
+                            },
+                        },
+                        examples: '- name: Example\n  cisco.ios.ios_acls:',
+                        return: {
+                            commands: { type: 'list', description: 'Commands sent' },
+                        },
+                    },
+                },
+            },
+        };
+
+        const result = parseMetadataDump(metadata);
+
+        expect(result.collections.size).toBe(1);
+        expect(result.collections.has('cisco.ios')).toBe(true);
+
+        const coll = result.collections.get('cisco.ios');
+        expect(coll?.pluginTypes.has('module')).toBe(true);
+
+        const plugins = coll?.pluginTypes.get('module');
+        expect(plugins).toHaveLength(1);
+        expect(plugins?.[0].name).toBe('ios_acls');
+        expect(plugins?.[0].fullName).toBe('cisco.ios.ios_acls');
+        expect(plugins?.[0].shortDescription).toBe('Manage ACLs');
+
+        expect(result.pluginDocs.has('cisco.ios.ios_acls:module')).toBe(true);
+        const doc = result.pluginDocs.get('cisco.ios.ios_acls:module');
+        expect(doc?.examples).toContain('Example');
+        expect(doc?.return).toHaveProperty('commands');
+    });
+
+    it('handles multiple plugin types', () => {
+        const metadata: MetadataDump = {
+            all: {
+                module: {
+                    'ns.col.mod_a': {
+                        doc: {
+                            collection: 'ns.col',
+                            plugin_name: 'ns.col.mod_a',
+                            short_description: 'Module A',
+                        },
+                    },
+                },
+                lookup: {
+                    'ns.col.look_b': {
+                        doc: {
+                            collection: 'ns.col',
+                            plugin_name: 'ns.col.look_b',
+                            short_description: 'Lookup B',
+                        },
+                    },
+                },
+            },
+        };
+
+        const result = parseMetadataDump(metadata);
+
+        expect(result.collections.size).toBe(1);
+        const coll = result.collections.get('ns.col');
+        expect(coll?.pluginTypes.size).toBe(2);
+        expect(coll?.pluginTypes.has('module')).toBe(true);
+        expect(coll?.pluginTypes.has('lookup')).toBe(true);
+    });
+
+    it('deduplicates plugins with the same unique key', () => {
+        const metadata: MetadataDump = {
+            all: {
+                module: {
+                    'ns.col.dup': {
+                        doc: {
+                            collection: 'ns.col',
+                            plugin_name: 'ns.col.dup',
+                            short_description: 'First',
+                        },
+                    },
+                    'ns.col.dup_copy': {
+                        doc: {
+                            collection: 'ns.col',
+                            plugin_name: 'ns.col.dup',
+                            short_description: 'Second',
+                        },
+                    },
+                },
+            },
+        };
+
+        const result = parseMetadataDump(metadata);
+        const plugins = result.collections.get('ns.col')?.pluginTypes.get('module');
+        expect(plugins).toHaveLength(2);
+    });
+
+    it('skips plugins without doc', () => {
+        const metadata: MetadataDump = {
+            all: {
+                module: {
+                    'ns.col.no_doc': {},
+                },
+            },
+        };
+
+        const result = parseMetadataDump(metadata);
+        expect(result.collections.size).toBe(0);
+        expect(result.pluginDocs.size).toBe(0);
+    });
+
+    it('uses collectionInfoMap for collection metadata', () => {
+        const metadata: MetadataDump = {
+            all: {
+                module: {
+                    'cisco.ios.ios_config': {
+                        doc: {
+                            collection: 'cisco.ios',
+                            plugin_name: 'cisco.ios.ios_config',
+                            short_description: 'Config',
+                        },
+                    },
+                },
+            },
+        };
+
+        const infoMap = new Map([
+            [
+                'cisco.ios',
+                {
+                    name: 'cisco.ios',
+                    version: '4.6.0',
+                    authors: ['Cisco'],
+                    description: 'Cisco IOS collection',
+                },
+            ],
+        ]);
+
+        const result = parseMetadataDump(metadata, infoMap);
+        const coll = result.collections.get('cisco.ios');
+        expect(coll?.info.version).toBe('4.6.0');
+        expect(coll?.info.description).toBe('Cisco IOS collection');
+    });
+
+    it('sorts plugins alphabetically within each type', () => {
+        const metadata: MetadataDump = {
+            all: {
+                module: {
+                    'ns.col.zebra': {
+                        doc: {
+                            collection: 'ns.col',
+                            plugin_name: 'ns.col.zebra',
+                            short_description: 'Z',
+                        },
+                    },
+                    'ns.col.alpha': {
+                        doc: {
+                            collection: 'ns.col',
+                            plugin_name: 'ns.col.alpha',
+                            short_description: 'A',
+                        },
+                    },
+                    'ns.col.middle': {
+                        doc: {
+                            collection: 'ns.col',
+                            plugin_name: 'ns.col.middle',
+                            short_description: 'M',
+                        },
+                    },
+                },
+            },
+        };
+
+        const result = parseMetadataDump(metadata);
+        const plugins = result.collections.get('ns.col')?.pluginTypes.get('module');
+        expect(plugins?.map((p) => p.name)).toEqual(['alpha', 'middle', 'zebra']);
+    });
+});

--- a/packages/mcp-server/src/handlers.ts
+++ b/packages/mcp-server/src/handlers.ts
@@ -21,8 +21,9 @@ import {
     GalaxyCollectionCache,
     GalaxyDocsCache,
     GitHubCollectionCache,
+    SCMDocsCache,
 } from '@ansible/services';
-import type { PluginOption, SchemaNode } from '@ansible/services';
+import type { PluginOption, PluginInfo, PluginData, SchemaNode } from '@ansible/services';
 
 /**
  * Normalizes ansible-doc fields that may be a single string or string array.
@@ -111,6 +112,8 @@ export class McpToolHandler {
                     return await this._handleGetCollectionPlugins(args);
                 case 'get_galaxy_plugin_doc':
                     return await this._handleGetGalaxyPluginDoc(args);
+                case 'get_scm_plugin_doc':
+                    return await this._handleGetScmPluginDoc(args);
 
                 // Task generation
                 case 'generate_ansible_task':
@@ -576,6 +579,7 @@ export class McpToolHandler {
                 fqcn: string;
                 version: string;
                 description: string;
+                repo?: string;
             }
 
             const collections: CollectionInfo[] = [];
@@ -605,6 +609,7 @@ export class McpToolHandler {
                         fqcn: `${col.namespace}.${col.name}`,
                         version: col.version,
                         description: col.description || 'No description',
+                        repo: col.repository.split('/').pop() ?? col.repository,
                     });
                 }
             }
@@ -623,7 +628,8 @@ export class McpToolHandler {
             const lines = [`Collections in "${source}" (${String(collections.length)}):`, ''];
 
             for (const col of collections) {
-                lines.push(`• ${col.fqcn} (v${col.version}): ${col.description}`);
+                const repoSuffix = col.repo ? ` [repo: ${col.repo}]` : '';
+                lines.push(`• ${col.fqcn} (v${col.version})${repoSuffix}: ${col.description}`);
             }
 
             lines.push('');
@@ -818,24 +824,12 @@ export class McpToolHandler {
                 };
             }
 
-            const lines: string[] = [`# ${collectionFqcn} v${match.version}\n`];
-            let total = 0;
-            for (const [type, plugins] of Object.entries(pluginTypes).sort(([a], [b]) =>
-                a.localeCompare(b),
-            )) {
-                total += plugins.length;
-                lines.push(`## ${type} (${String(plugins.length)})\n`);
-                for (const p of plugins) {
-                    const desc = p.shortDescription ? ` - ${p.shortDescription}` : '';
-                    lines.push(`• **${p.name}**${desc}`);
-                }
-                lines.push('');
-            }
-            lines.push(
-                `---\n${String(total)} plugins total. Use \`get_galaxy_plugin_doc\` with a \`plugin\` name for full docs.`,
+            const text = this._formatPluginTypeList(
+                `${collectionFqcn} v${match.version}`,
+                pluginTypes,
+                'get_galaxy_plugin_doc',
             );
-
-            return { content: [{ type: 'text', text: lines.join('\n') }] };
+            return { content: [{ type: 'text', text }] };
         }
 
         const pluginType = (args.plugin_type as string) || 'module';
@@ -854,6 +848,82 @@ export class McpToolHandler {
             };
         }
 
+        return { content: [{ type: 'text', text: this._formatPluginDoc(fqcn, pluginType, doc) }] };
+    }
+
+    /**
+     * Recursively format plugin options into Markdown.
+     *
+     * @param options - Plugin option definitions
+     * @param lines - Accumulator for output lines
+     * @param depth - Nesting depth for indentation
+     */
+    private _formatOptions(
+        options: Record<string, PluginOption>,
+        lines: string[],
+        depth: number,
+    ): void {
+        const indent = '  '.repeat(depth);
+        for (const [optName, opt] of Object.entries(options)) {
+            const required = opt.required ? ' **REQUIRED**' : '';
+            const type = opt.type ? ` (${opt.type})` : '';
+            const desc = opt.description
+                ? ` - ${toArray(opt.description).join(' ').substring(0, 200)}`
+                : '';
+            const defaultVal =
+                opt.default !== undefined ? ` [default: ${JSON.stringify(opt.default)}]` : '';
+            const choices =
+                opt.choices && opt.choices.length > 0
+                    ? ` [choices: ${opt.choices.join(', ')}]`
+                    : '';
+            lines.push(`${indent}• **${optName}**${type}${required}${desc}${defaultVal}${choices}`);
+            if (opt.suboptions) {
+                this._formatOptions(opt.suboptions, lines, depth + 1);
+            }
+        }
+    }
+
+    /**
+     * Formats a plugin-type listing into Markdown sections with plugin counts.
+     *
+     * @param title - Header line for the listing (e.g., "collection v1.0")
+     * @param pluginTypes - Map of plugin type names to plugin info arrays
+     * @param hintTool - MCP tool name to mention in the footer hint
+     * @returns Formatted Markdown string
+     */
+    private _formatPluginTypeList(
+        title: string,
+        pluginTypes: Record<string, PluginInfo[]>,
+        hintTool: string,
+    ): string {
+        const lines: string[] = [`# ${title}\n`];
+        let total = 0;
+        for (const [type, plugins] of Object.entries(pluginTypes).sort(([a], [b]) =>
+            a.localeCompare(b),
+        )) {
+            total += plugins.length;
+            lines.push(`## ${type} (${String(plugins.length)})\n`);
+            for (const p of plugins) {
+                const desc = p.shortDescription ? ` - ${p.shortDescription}` : '';
+                lines.push(`• **${p.name}**${desc}`);
+            }
+            lines.push('');
+        }
+        lines.push(
+            `---\n${String(total)} plugins total. Use \`${hintTool}\` with a \`plugin\` name for full docs.`,
+        );
+        return lines.join('\n');
+    }
+
+    /**
+     * Formats full plugin documentation into Markdown sections.
+     *
+     * @param fqcn - Fully qualified plugin name
+     * @param pluginType - Plugin type (module, lookup, etc.)
+     * @param doc - Plugin documentation data
+     * @returns Formatted Markdown string
+     */
+    private _formatPluginDoc(fqcn: string, pluginType: string, doc: PluginData): string {
         const sections: string[] = [];
         sections.push(`# ${fqcn} (${pluginType})\n`);
 
@@ -909,39 +979,94 @@ export class McpToolHandler {
             sections.push('');
         }
 
-        return { content: [{ type: 'text', text: sections.join('\n') }] };
+        return sections.join('\n');
     }
 
     /**
-     * Recursively format plugin options into Markdown.
+     * Handles `get_scm_plugin_doc` — fetches docs via shallow clone + ansible-doc.
      *
-     * @param options - Plugin option definitions
-     * @param lines - Accumulator for output lines
-     * @param depth - Nesting depth for indentation
+     * @param args - Tool args: `org`, `repo`, `collection` (required), optional `plugin` and `plugin_type`
+     * @returns Plugin documentation or a list of available plugin types
      */
-    private _formatOptions(
-        options: Record<string, PluginOption>,
-        lines: string[],
-        depth: number,
-    ): void {
-        const indent = '  '.repeat(depth);
-        for (const [optName, opt] of Object.entries(options)) {
-            const required = opt.required ? ' **REQUIRED**' : '';
-            const type = opt.type ? ` (${opt.type})` : '';
-            const desc = opt.description
-                ? ` - ${toArray(opt.description).join(' ').substring(0, 200)}`
-                : '';
-            const defaultVal =
-                opt.default !== undefined ? ` [default: ${JSON.stringify(opt.default)}]` : '';
-            const choices =
-                opt.choices && opt.choices.length > 0
-                    ? ` [choices: ${opt.choices.join(', ')}]`
-                    : '';
-            lines.push(`${indent}• **${optName}**${type}${required}${desc}${defaultVal}${choices}`);
-            if (opt.suboptions) {
-                this._formatOptions(opt.suboptions, lines, depth + 1);
-            }
+    private async _handleGetScmPluginDoc(args: Record<string, unknown>): Promise<McpToolResult> {
+        const org = args.org as string;
+        const repo = args.repo as string;
+        const collectionFqcn = args.collection as string;
+
+        if (!org || !repo || !collectionFqcn) {
+            return {
+                content: [
+                    {
+                        type: 'text',
+                        text: 'Missing required parameters: org, repo, and collection are all required.',
+                    },
+                ],
+                isError: true,
+            };
         }
+
+        const parts = collectionFqcn.split('.');
+        if (parts.length !== 2) {
+            return {
+                content: [
+                    {
+                        type: 'text',
+                        text: `Invalid collection name "${collectionFqcn}". Use namespace.name format (e.g., "infra.aap_configuration").`,
+                    },
+                ],
+                isError: true,
+            };
+        }
+        const [namespace, name] = parts;
+
+        const scmCache = SCMDocsCache.getInstance();
+        const pluginName = args.plugin as string | undefined;
+        const forceRefresh = args.force_refresh as boolean | undefined;
+
+        if (forceRefresh) {
+            scmCache.invalidate(org, repo);
+        }
+
+        if (!pluginName) {
+            const pluginTypes = await scmCache.getPluginTypes(org, repo, namespace, name);
+
+            if (!pluginTypes) {
+                return {
+                    content: [
+                        {
+                            type: 'text',
+                            text: `Failed to index ${collectionFqcn} from ${org}/${repo}. Ensure git and ansible-doc are available.`,
+                        },
+                    ],
+                    isError: true,
+                };
+            }
+
+            const text = this._formatPluginTypeList(
+                `${collectionFqcn} (${org}/${repo})`,
+                pluginTypes,
+                'get_scm_plugin_doc',
+            );
+            return { content: [{ type: 'text', text }] };
+        }
+
+        const pluginType = (args.plugin_type as string) || 'module';
+        const fqcn = `${collectionFqcn}.${pluginName}`;
+        const doc = await scmCache.getPluginDoc(org, repo, namespace, name, fqcn, pluginType);
+
+        if (!doc) {
+            return {
+                content: [
+                    {
+                        type: 'text',
+                        text: `Plugin "${pluginName}" (${pluginType}) not found in ${collectionFqcn}. Use get_scm_plugin_doc without a plugin name to list available plugins.`,
+                    },
+                ],
+                isError: true,
+            };
+        }
+
+        return { content: [{ type: 'text', text: this._formatPluginDoc(fqcn, pluginType, doc) }] };
     }
 
     // === Task Generation Handlers ===

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -283,6 +283,70 @@ Examples:
     },
 };
 
+export const GET_SCM_PLUGIN_DOC_TOOL: McpToolDefinition = {
+    name: 'get_scm_plugin_doc',
+    description: `Get documentation for a plugin from a GitHub-hosted collection.
+
+Shallow-clones the repository and runs ansible-doc to extract full plugin
+documentation including synopsis, parameters, examples, and return values.
+Results are cached for 7 days.
+
+Requires the collection to be in a configured GitHub organization.
+
+Examples:
+- get_scm_plugin_doc({ org: "redhat-cop", repo: "infra.aap_configuration", collection: "infra.aap_configuration", plugin: "credential_type", plugin_type: "module" })
+- get_scm_plugin_doc({ org: "redhat-cop", repo: "infra.aap_configuration", collection: "infra.aap_configuration" }) → lists all plugin types and counts`,
+    inputSchema: {
+        type: 'object',
+        properties: {
+            org: {
+                type: 'string',
+                description: 'GitHub organization (e.g., "redhat-cop")',
+            },
+            repo: {
+                type: 'string',
+                description: 'GitHub repository name (e.g., "infra.aap_configuration")',
+            },
+            collection: {
+                type: 'string',
+                description: 'Collection FQCN (e.g., "infra.aap_configuration")',
+            },
+            plugin: {
+                type: 'string',
+                description:
+                    'Plugin short name (e.g., "credential_type"). Omit to list available plugin types.',
+            },
+            plugin_type: {
+                type: 'string',
+                enum: [
+                    'module',
+                    'filter',
+                    'lookup',
+                    'callback',
+                    'connection',
+                    'inventory',
+                    'become',
+                    'cache',
+                    'cliconf',
+                    'httpapi',
+                    'netconf',
+                    'shell',
+                    'strategy',
+                    'test',
+                    'vars',
+                ],
+                description: 'Plugin type (default: module)',
+            },
+            force_refresh: {
+                type: 'boolean',
+                description:
+                    'Set to true to invalidate the cached docs and re-clone the repository. Use when the collection has been updated.',
+            },
+        },
+        required: ['org', 'repo', 'collection'],
+    },
+};
+
 // === Task Generation Tools ===
 
 export const GENERATE_TASK_TOOL: McpToolDefinition = {
@@ -607,6 +671,7 @@ export const STATIC_TOOLS: McpToolDefinition[] = [
     LIST_SOURCE_COLLECTIONS_TOOL,
     GET_COLLECTION_PLUGINS_TOOL,
     GET_GALAXY_PLUGIN_DOC_TOOL,
+    GET_SCM_PLUGIN_DOC_TOOL,
 
     // Task generation
     GENERATE_TASK_TOOL,

--- a/packages/mcp-server/test/handlers.test.ts
+++ b/packages/mcp-server/test/handlers.test.ts
@@ -142,11 +142,17 @@ const hoisted = vi.hoisted(() => {
         getPluginDoc: vi.fn().mockResolvedValue(null),
     };
 
+    const scmDocsInstance = {
+        getPluginTypes: vi.fn().mockResolvedValue(null as Record<string, unknown[]> | null),
+        getPluginDoc: vi.fn().mockResolvedValue(null),
+    };
+
     return {
         getPluginDocumentation,
         collectionsInstance,
         galaxyInstance,
         galaxyDocsInstance,
+        scmDocsInstance,
         githubInstance,
         eeInstance,
         devToolsInstance,
@@ -186,6 +192,9 @@ vi.mock('@ansible/services', () => ({
     },
     GitHubCollectionCache: {
         getInstance: vi.fn(() => hoisted.githubInstance),
+    },
+    SCMDocsCache: {
+        getInstance: vi.fn(() => hoisted.scmDocsInstance),
     },
     SkillRegistry: {
         getInstance: vi.fn(() => ({
@@ -507,6 +516,7 @@ describe('McpToolHandler', () => {
                     name: 'd',
                     version: '2.0.0',
                     description: 'From GitHub',
+                    repository: 'myorg/c.d',
                 },
             ]);
 
@@ -1114,6 +1124,115 @@ describe('McpToolHandler', () => {
             expect(text).toContain('**address**');
             expect(text).toContain('**dns**');
             expect(text).toContain('**servers**');
+        });
+    });
+
+    describe('get_scm_plugin_doc', () => {
+        it('returns error for missing parameters', async () => {
+            const result = await handler.handleTool('get_scm_plugin_doc', {});
+            expect(result.isError).toBe(true);
+            expect(result.content[0].text).toContain('Missing required parameters');
+        });
+
+        it('returns error for invalid collection format', async () => {
+            const result = await handler.handleTool('get_scm_plugin_doc', {
+                org: 'test-org',
+                repo: 'test-repo',
+                collection: 'invalid',
+            });
+            expect(result.isError).toBe(true);
+            expect(result.content[0].text).toContain('namespace.name format');
+        });
+
+        it('lists plugin types when no plugin specified', async () => {
+            hoisted.scmDocsInstance.getPluginTypes.mockResolvedValue({
+                module: [
+                    {
+                        name: 'my_module',
+                        fullName: 'test.col.my_module',
+                        shortDescription: 'A module',
+                    },
+                ],
+                lookup: [
+                    {
+                        name: 'my_lookup',
+                        fullName: 'test.col.my_lookup',
+                        shortDescription: 'A lookup',
+                    },
+                ],
+            });
+
+            const result = await handler.handleTool('get_scm_plugin_doc', {
+                org: 'test-org',
+                repo: 'test-repo',
+                collection: 'test.col',
+            });
+
+            expect(result.isError).toBeUndefined();
+            expect(result.content[0].text).toContain('test.col');
+            expect(result.content[0].text).toContain('module (1)');
+            expect(result.content[0].text).toContain('lookup (1)');
+            expect(result.content[0].text).toContain('my_module');
+        });
+
+        it('returns full plugin documentation', async () => {
+            hoisted.scmDocsInstance.getPluginDoc.mockResolvedValue({
+                doc: {
+                    short_description: 'Manage resources',
+                    description: ['Configure resources on devices.'],
+                    author: ['Test Author'],
+                    options: {
+                        config: { type: 'list', description: 'Config entries' },
+                    },
+                },
+                examples: '- name: Example\n  test.col.my_module:',
+                return: {
+                    result: { type: 'str', description: 'The result' },
+                },
+            });
+
+            const result = await handler.handleTool('get_scm_plugin_doc', {
+                org: 'test-org',
+                repo: 'test-repo',
+                collection: 'test.col',
+                plugin: 'my_module',
+                plugin_type: 'module',
+            });
+
+            expect(result.isError).toBeUndefined();
+            const text = result.content[0].text;
+            expect(text).toContain('test.col.my_module');
+            expect(text).toContain('Manage resources');
+            expect(text).toContain('config');
+            expect(text).toContain('Examples');
+            expect(text).toContain('Return Values');
+        });
+
+        it('returns error when plugin not found', async () => {
+            hoisted.scmDocsInstance.getPluginDoc.mockResolvedValue(null);
+
+            const result = await handler.handleTool('get_scm_plugin_doc', {
+                org: 'test-org',
+                repo: 'test-repo',
+                collection: 'test.col',
+                plugin: 'nonexistent',
+            });
+
+            expect(result.isError).toBe(true);
+            expect(result.content[0].text).toContain('not found');
+        });
+
+        it('returns error when indexing fails', async () => {
+            hoisted.scmDocsInstance.getPluginTypes.mockResolvedValue(null);
+
+            const result = await handler.handleTool('get_scm_plugin_doc', {
+                org: 'test-org',
+                repo: 'test-repo',
+                collection: 'test.col',
+            });
+
+            expect(result.isError).toBe(true);
+            expect(result.content[0].text).toContain('Failed to index');
         });
     });
 });

--- a/packages/services/src/CollectionsService.ts
+++ b/packages/services/src/CollectionsService.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 
-import { log, SimpleEventEmitter } from '@ansible/common';
+import { log, SimpleEventEmitter, extractMetadataJson, parseMetadataDump } from '@ansible/common';
 
 // Conditional vscode import - only used when available
 let vscode: typeof import('vscode') | undefined;
@@ -112,20 +112,6 @@ export interface PluginData {
     examples?: string;
     return?: PluginReturn;
     metadata?: unknown;
-}
-
-// Internal types for parsing -- these match the full ansible-doc --metadata-dump output
-interface MetadataEntry {
-    doc?: PluginDoc;
-    examples?: string;
-    return?: PluginReturn;
-    metadata?: unknown;
-}
-
-type MetadataPluginTypes = Record<string, Record<string, MetadataEntry>>;
-
-interface MetadataDump {
-    all?: MetadataPluginTypes;
 }
 
 interface AdeCollectionInfo {
@@ -941,98 +927,20 @@ export class CollectionsService {
                 }
             }
 
-            // Find the start of JSON (ansible-doc might output warnings before the JSON)
-            const jsonStart = result.indexOf('{');
-            if (jsonStart === -1) {
+            const metadata = extractMetadataJson(result);
+            if (!metadata) {
                 console.error('CollectionsService: No JSON found in ansible-doc output');
                 console.error('Output starts with:', result.substring(0, 100));
                 return;
             }
 
-            const jsonStr = result.substring(jsonStart);
+            const parsed = parseMetadataDump(metadata, collectionInfoMap);
 
-            // Parse the JSON output
-            let metadata: MetadataDump;
-            try {
-                metadata = JSON.parse(jsonStr) as MetadataDump;
-            } catch (parseError) {
-                console.error('CollectionsService: Failed to parse ansible-doc JSON');
-                console.error('JSON starts with:', jsonStr.substring(0, 200));
-                throw parseError;
+            for (const [name, coll] of parsed.collections) {
+                collections.set(name, coll);
             }
-
-            if (!metadata.all) {
-                return;
-            }
-
-            // Use a Set to track unique plugins globally
-            const seenPlugins = new Set<string>();
-
-            // Process each plugin type
-            for (const [pluginType, plugins] of Object.entries(metadata.all)) {
-                for (const [fullName, pluginData] of Object.entries(plugins)) {
-                    const doc = pluginData.doc;
-                    if (!doc) {
-                        continue;
-                    }
-
-                    const collectionName = doc.collection ?? 'unknown';
-                    const pluginName =
-                        doc.plugin_name?.split('.').pop() ?? fullName.split('.').pop() ?? fullName;
-                    const shortDescription = doc.short_description ?? '';
-
-                    // Create unique key to prevent duplicates
-                    const uniqueKey = `${collectionName}:${pluginType}:${fullName}`;
-                    if (seenPlugins.has(uniqueKey)) {
-                        continue;
-                    }
-                    seenPlugins.add(uniqueKey);
-
-                    // Store full plugin documentation from the metadata dump
-                    const docKey = `${fullName}:${pluginType}`;
-                    pluginDocs.set(docKey, {
-                        doc: pluginData.doc,
-                        examples: pluginData.examples,
-                        return: pluginData.return,
-                        metadata: pluginData.metadata,
-                    });
-
-                    // Get or create collection
-                    let collection = collections.get(collectionName);
-                    if (!collection) {
-                        const info = collectionInfoMap.get(collectionName) ?? {
-                            name: collectionName,
-                            version: '',
-                            authors: [],
-                            description: '',
-                        };
-                        collection = {
-                            info,
-                            pluginTypes: new Map(),
-                        };
-                        collections.set(collectionName, collection);
-                    }
-
-                    // Get or create plugin type
-                    let plugins = collection.pluginTypes.get(pluginType);
-                    if (!plugins) {
-                        plugins = [];
-                        collection.pluginTypes.set(pluginType, plugins);
-                    }
-
-                    plugins.push({
-                        name: pluginName,
-                        fullName: fullName,
-                        shortDescription: shortDescription,
-                    });
-                }
-            }
-
-            // Sort plugins within each type
-            for (const collection of collections.values()) {
-                for (const plugins of collection.pluginTypes.values()) {
-                    plugins.sort((a, b) => a.name.localeCompare(b.name));
-                }
+            for (const [key, doc] of parsed.pluginDocs) {
+                pluginDocs.set(key, doc);
             }
         } catch (error) {
             console.error('CollectionsService: Failed to load collections:', error);

--- a/packages/services/src/SCMDocsCache.ts
+++ b/packages/services/src/SCMDocsCache.ts
@@ -1,0 +1,551 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as crypto from 'crypto';
+import { execFile } from 'child_process';
+
+import { parseMetadataDump, extractMetadataJson } from '@ansible/common';
+import type { PluginInfo, PluginData } from '@ansible/common';
+import { getCommandService } from './CommandService';
+
+// Conditional vscode import for authentication
+let vscode: typeof import('vscode') | undefined;
+try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-unsafe-assignment -- conditional require for VS Code-optional usage
+    vscode = require('vscode');
+} catch {
+    // Running standalone
+}
+
+const CACHE_DIR_NAME = 'scm-docs';
+const CACHE_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+const FAILURE_COOLDOWN_MS = 5 * 60 * 1000; // 5 minutes
+const CACHE_FORMAT_VERSION = 1;
+
+/** Cached plugin documentation for an SCM collection. */
+interface CachedSCMDocsBlob {
+    formatVersion: number;
+    timestamp: number;
+    org: string;
+    repo: string;
+    namespace: string;
+    name: string;
+    sha: string;
+    plugins: Record<string, PluginInfo[]>;
+    pluginDocs: Record<string, PluginData>;
+}
+
+/**
+ * Fetches plugin documentation for GitHub-hosted Ansible collections by
+ * shallow-cloning the repository and running `ansible-doc --metadata-dump`.
+ * Results are cached to disk with SHA-based invalidation and a 7-day TTL.
+ */
+export class SCMDocsCache {
+    private static _instance: SCMDocsCache | undefined;
+    private _memoryCache = new Map<string, CachedSCMDocsBlob>();
+    private _pendingFetches = new Map<string, Promise<CachedSCMDocsBlob | null>>();
+    private _failureTimes = new Map<string, number>();
+    private _log: (msg: string) => void = console.log;
+
+    /**
+     * Returns the singleton instance.
+     *
+     * @returns The shared SCMDocsCache instance.
+     */
+    public static getInstance(): SCMDocsCache {
+        SCMDocsCache._instance ??= new SCMDocsCache();
+        return SCMDocsCache._instance;
+    }
+
+    /**
+     * Replaces the singleton — used only by tests.
+     *
+     * @param instance - The mock or test instance to set.
+     */
+    public static _setInstance(instance: SCMDocsCache | undefined): void {
+        SCMDocsCache._instance = instance;
+    }
+
+    /**
+     * Sets the logging callback used for cache diagnostics.
+     *
+     * @param logFn - Function invoked with formatted log messages.
+     */
+    public setLogFunction(logFn: (msg: string) => void): void {
+        this._log = logFn;
+    }
+
+    /**
+     * Returns the on-disk cache directory, creating it if needed.
+     *
+     * @returns Absolute path to the SCM docs cache directory.
+     */
+    private _getCacheDir(): string {
+        const dir = path.join(os.homedir(), '.cache', 'ansible-environments', CACHE_DIR_NAME);
+        if (!fs.existsSync(dir)) {
+            fs.mkdirSync(dir, { recursive: true });
+        }
+        return dir;
+    }
+
+    /**
+     * Builds the cache file name from org, repo, and commit SHA.
+     *
+     * @param org - GitHub organization.
+     * @param repo - Repository name.
+     * @param sha - Commit SHA for cache invalidation.
+     * @returns Cache filename.
+     */
+    private _cacheFileName(org: string, repo: string, sha: string): string {
+        return `${org}__${repo}-${sha.substring(0, 7)}.json`;
+    }
+
+    /**
+     * Builds the memory cache key from org and repo.
+     *
+     * @param org - GitHub organization.
+     * @param repo - Repository name.
+     * @returns Memory cache key.
+     */
+    private _cacheKey(org: string, repo: string): string {
+        return `${org}/${repo}`;
+    }
+
+    /**
+     * Get plugin types and their plugins for an SCM collection.
+     *
+     * @param org - GitHub organization.
+     * @param repo - Repository name.
+     * @param namespace - Ansible collection namespace.
+     * @param name - Ansible collection name.
+     * @returns Map of plugin type to plugin info array, or null on failure.
+     */
+    public async getPluginTypes(
+        org: string,
+        repo: string,
+        namespace: string,
+        name: string,
+    ): Promise<Record<string, PluginInfo[]> | null> {
+        const cached = await this._getOrFetch(org, repo, namespace, name);
+        return cached?.plugins ?? null;
+    }
+
+    /**
+     * Get full documentation for a specific plugin from an SCM collection.
+     *
+     * @param org - GitHub organization.
+     * @param repo - Repository name.
+     * @param namespace - Ansible collection namespace.
+     * @param name - Ansible collection name.
+     * @param pluginFqcn - Fully qualified plugin name.
+     * @param pluginType - Plugin type (module, lookup, etc.).
+     * @returns Plugin documentation data, or null if not found.
+     */
+    public async getPluginDoc(
+        org: string,
+        repo: string,
+        namespace: string,
+        name: string,
+        pluginFqcn: string,
+        pluginType: string,
+    ): Promise<PluginData | null> {
+        const cached = await this._getOrFetch(org, repo, namespace, name);
+        if (!cached) return null;
+        return cached.pluginDocs[`${pluginFqcn}:${pluginType}`] ?? null;
+    }
+
+    /**
+     * Evicts cached data for a specific collection to force a refetch.
+     * Removes both the in-memory entry and any on-disk cache files.
+     *
+     * @param org - GitHub organization.
+     * @param repo - Repository name.
+     */
+    public invalidate(org: string, repo: string): void {
+        const key = this._cacheKey(org, repo);
+        this._memoryCache.delete(key);
+        this._failureTimes.delete(key);
+
+        try {
+            const cacheDir = this._getCacheDir();
+            const prefix = `${org}__${repo}-`;
+            const files = fs.readdirSync(cacheDir).filter((f) => f.startsWith(prefix));
+            for (const f of files) {
+                fs.unlinkSync(path.join(cacheDir, f));
+            }
+        } catch {
+            // Cache dir may not exist yet
+        }
+
+        this._log(`SCMDocsCache: Invalidated ${key}`);
+    }
+
+    /**
+     * Retrieves from memory, disk, or fetches via shallow clone.
+     *
+     * @param org - GitHub organization.
+     * @param repo - Repository name.
+     * @param namespace - Ansible collection namespace.
+     * @param name - Ansible collection name.
+     * @returns Cached docs blob, or null on failure.
+     */
+    private async _getOrFetch(
+        org: string,
+        repo: string,
+        namespace: string,
+        name: string,
+    ): Promise<CachedSCMDocsBlob | null> {
+        const key = this._cacheKey(org, repo);
+
+        const mem = this._memoryCache.get(key);
+        if (mem && !this._isExpired(mem)) {
+            return mem;
+        }
+
+        const fromDisk = this._loadFromDisk(org, repo);
+        if (fromDisk) {
+            this._memoryCache.set(key, fromDisk);
+            return fromDisk;
+        }
+
+        // Failure cooldown: skip re-clone for 5 minutes after a failure
+        const lastFailure = this._failureTimes.get(key);
+        if (lastFailure && Date.now() - lastFailure < FAILURE_COOLDOWN_MS) {
+            this._log(`SCMDocsCache: skipping ${key} — in failure cooldown`);
+            return null;
+        }
+
+        const pending = this._pendingFetches.get(key);
+        if (pending) return pending;
+
+        const fetchPromise = this._cloneAndIndex(org, repo, namespace, name).then(
+            (result) => {
+                if (!result) {
+                    this._failureTimes.set(key, Date.now());
+                }
+                return result;
+            },
+            (err: unknown) => {
+                this._failureTimes.set(key, Date.now());
+                throw err;
+            },
+        );
+        this._pendingFetches.set(key, fetchPromise);
+        try {
+            return await fetchPromise;
+        } finally {
+            this._pendingFetches.delete(key);
+        }
+    }
+
+    /**
+     * Checks whether a cached entry has exceeded the TTL.
+     *
+     * @param cached - The cache entry to check.
+     * @returns True if the entry is older than the max age.
+     */
+    private _isExpired(cached: CachedSCMDocsBlob): boolean {
+        return Date.now() - cached.timestamp > CACHE_MAX_AGE_MS;
+    }
+
+    /**
+     * Attempts to load a cached docs-blob from disk.
+     *
+     * @param org - GitHub organization.
+     * @param repo - Repository name.
+     * @returns Cached blob if valid, or null.
+     */
+    private _loadFromDisk(org: string, repo: string): CachedSCMDocsBlob | null {
+        const cacheDir = this._getCacheDir();
+        const prefix = `${org}__${repo}-`;
+
+        try {
+            const files = fs
+                .readdirSync(cacheDir)
+                .filter((f) => f.startsWith(prefix))
+                .sort();
+            if (files.length === 0) return null;
+
+            const filePath = path.join(cacheDir, files[files.length - 1]);
+            const raw = fs.readFileSync(filePath, 'utf-8');
+            const parsed = JSON.parse(raw) as CachedSCMDocsBlob;
+
+            if (parsed.formatVersion < CACHE_FORMAT_VERSION) {
+                this._log(`SCMDocsCache: Stale format for ${org}/${repo}, will refetch`);
+                return null;
+            }
+
+            if (this._isExpired(parsed)) {
+                this._log(`SCMDocsCache: Expired cache for ${org}/${repo}`);
+                return null;
+            }
+
+            this._log(
+                `SCMDocsCache: Loaded ${org}/${repo} from disk (SHA: ${parsed.sha.substring(0, 7)})`,
+            );
+            return parsed;
+        } catch {
+            return null;
+        }
+    }
+
+    /**
+     * Shallow-clones the repo, runs ansible-doc, parses and caches the result.
+     *
+     * @param org - GitHub organization.
+     * @param repo - Repository name.
+     * @param namespace - Ansible collection namespace.
+     * @param name - Ansible collection name.
+     * @returns The cached blob, or null on failure.
+     */
+    private async _cloneAndIndex(
+        org: string,
+        repo: string,
+        namespace: string,
+        name: string,
+    ): Promise<CachedSCMDocsBlob | null> {
+        const key = this._cacheKey(org, repo);
+        this._log(`SCMDocsCache: Indexing ${key}...`);
+
+        const tmpBase = path.join(
+            os.tmpdir(),
+            `ansible-scm-docs-${crypto.randomBytes(4).toString('hex')}`,
+        );
+        const collectionsPath = path.join(tmpBase, 'ansible_collections', namespace, name);
+        const collectionsParent = path.dirname(collectionsPath);
+
+        try {
+            fs.mkdirSync(collectionsParent, { recursive: true });
+
+            const cloneUrl = `https://github.com/${org}/${repo}.git`;
+            const token = await this._getGitHubToken();
+
+            // Clone env: use GIT_ASKPASS to supply token without embedding in URL
+            const cloneEnv: NodeJS.ProcessEnv = { ...process.env };
+            if (token) {
+                const askPass = this._writeAskPassScript(token, tmpBase);
+                cloneEnv.GIT_ASKPASS = askPass;
+                cloneEnv.GIT_TERMINAL_PROMPT = '0';
+            }
+
+            // Shallow clone
+            await this._exec(
+                'git',
+                ['clone', '--depth', '1', '--single-branch', cloneUrl, collectionsPath],
+                { env: cloneEnv },
+            );
+
+            // Get the HEAD SHA
+            const shaResult = await this._exec('git', ['-C', collectionsPath, 'rev-parse', 'HEAD']);
+            const sha = shaResult.trim();
+
+            // Check if we already have this SHA cached
+            const existingFile = path.join(
+                this._getCacheDir(),
+                this._cacheFileName(org, repo, sha),
+            );
+            if (fs.existsSync(existingFile)) {
+                try {
+                    const raw = fs.readFileSync(existingFile, 'utf-8');
+                    const parsed = JSON.parse(raw) as CachedSCMDocsBlob;
+                    parsed.timestamp = Date.now();
+                    this._memoryCache.set(key, parsed);
+                    this._saveToDisk(parsed);
+                    this._log(`SCMDocsCache: SHA unchanged for ${key}, using existing cache`);
+                    return parsed;
+                } catch {
+                    // Fall through to re-index
+                }
+            }
+
+            // Resolve ansible-doc from the active Python environment (Invariant 7)
+            const ansibleDoc =
+                (await getCommandService().getToolPath('ansible-doc')) ?? 'ansible-doc';
+            const metadataRaw = await this._exec(
+                ansibleDoc,
+                ['--metadata-dump', '--no-fail-on-errors'],
+                {
+                    env: {
+                        ...process.env,
+                        ANSIBLE_COLLECTIONS_PATH: tmpBase,
+                        ANSIBLE_COLLECTIONS_SCAN_SYS_PATH: 'false',
+                        ANSIBLE_WARNINGS: 'false',
+                        ANSIBLE_NOCOLOR: '1',
+                    },
+                },
+            );
+
+            const metadata = extractMetadataJson(metadataRaw);
+            if (!metadata) {
+                this._log(`SCMDocsCache: No JSON in ansible-doc output for ${key}`);
+                return null;
+            }
+
+            const parsed = parseMetadataDump(metadata);
+
+            // Only keep plugins from the target collection — ansible-doc always
+            // includes ansible.builtin and any other builtins in its output.
+            const targetFqcn = `${namespace}.${name}`;
+            const plugins: Record<string, PluginInfo[]> = {};
+            const pluginDocs: Record<string, PluginData> = {};
+
+            const targetColl = parsed.collections.get(targetFqcn);
+            if (targetColl) {
+                for (const [pluginType, pluginList] of targetColl.pluginTypes) {
+                    plugins[pluginType] = [...pluginList];
+                }
+            }
+
+            const fqcnPrefix = `${targetFqcn}.`;
+            for (const [docKey, docData] of parsed.pluginDocs) {
+                if (docKey.startsWith(fqcnPrefix)) {
+                    pluginDocs[docKey] = docData;
+                }
+            }
+
+            // Sort plugins within each type
+            for (const type of Object.keys(plugins)) {
+                plugins[type].sort((a, b) => a.name.localeCompare(b.name));
+            }
+
+            const cached: CachedSCMDocsBlob = {
+                formatVersion: CACHE_FORMAT_VERSION,
+                timestamp: Date.now(),
+                org,
+                repo,
+                namespace,
+                name,
+                sha,
+                plugins,
+                pluginDocs,
+            };
+
+            this._memoryCache.set(key, cached);
+            this._saveToDisk(cached);
+
+            const totalPlugins = Object.values(plugins).reduce((s, arr) => s + arr.length, 0);
+            this._log(
+                `SCMDocsCache: Cached ${String(totalPlugins)} plugins for ${key} (SHA: ${sha.substring(0, 7)})`,
+            );
+
+            return cached;
+        } catch (error) {
+            this._log(
+                `SCMDocsCache: Failed to index ${key}: ${error instanceof Error ? error.message : String(error)}`,
+            );
+            return null;
+        } finally {
+            this._cleanupTmpDir(tmpBase);
+        }
+    }
+
+    /**
+     * Returns a GitHub access token when VS Code authentication is available.
+     *
+     * @returns Access token string, or undefined when unavailable.
+     */
+    private async _getGitHubToken(): Promise<string | undefined> {
+        if (vscode) {
+            try {
+                const session = await vscode.authentication.getSession('github', ['public_repo'], {
+                    createIfNone: false,
+                });
+                return session?.accessToken;
+            } catch {
+                // Fall through
+            }
+        }
+        return undefined;
+    }
+
+    /**
+     * Creates a temporary GIT_ASKPASS script that echoes a token.
+     * This avoids embedding the token in the clone URL (process listing / .git/config exposure).
+     *
+     * @param token - GitHub access token.
+     * @param tmpDir - Temp directory to write the script into.
+     * @returns Absolute path to the helper script.
+     */
+    private _writeAskPassScript(token: string, tmpDir: string): string {
+        const scriptPath = path.join(tmpDir, 'git-askpass.sh');
+        fs.writeFileSync(scriptPath, `#!/bin/sh\necho "${token}"\n`, { mode: 0o700 });
+        return scriptPath;
+    }
+
+    /**
+     * Persists a cached docs-blob entry to disk, cleaning up old entries for the same repo.
+     *
+     * @param cached - The docs-blob entry to write.
+     */
+    private _saveToDisk(cached: CachedSCMDocsBlob): void {
+        const cacheDir = this._getCacheDir();
+        const fileName = this._cacheFileName(cached.org, cached.repo, cached.sha);
+        const filePath = path.join(cacheDir, fileName);
+
+        try {
+            // Clean up old cache files for this repo
+            const prefix = `${cached.org}__${cached.repo}-`;
+            const oldFiles = fs.readdirSync(cacheDir).filter((f) => f.startsWith(prefix));
+            for (const old of oldFiles) {
+                if (old !== fileName) {
+                    fs.unlinkSync(path.join(cacheDir, old));
+                }
+            }
+
+            fs.writeFileSync(filePath, JSON.stringify(cached), 'utf-8');
+        } catch (error) {
+            this._log(
+                `SCMDocsCache: Failed to save cache: ${error instanceof Error ? error.message : String(error)}`,
+            );
+        }
+    }
+
+    /**
+     * Removes a temporary directory tree used during clone+index.
+     *
+     * @param tmpDir - Absolute path to the temp directory to remove.
+     */
+    private _cleanupTmpDir(tmpDir: string): void {
+        try {
+            fs.rmSync(tmpDir, { recursive: true, force: true });
+        } catch {
+            // Best effort cleanup
+        }
+    }
+
+    /**
+     * Executes a command and returns its stdout.
+     *
+     * @param cmd - The command to run.
+     * @param args - Command arguments.
+     * @param options - Optional spawn options (env, cwd, etc.).
+     * @param options.env - Environment variables for the child process.
+     * @returns Stdout output as a string.
+     */
+    private _exec(
+        cmd: string,
+        args: string[],
+        options?: { env?: NodeJS.ProcessEnv },
+    ): Promise<string> {
+        return new Promise((resolve, reject) => {
+            execFile(
+                cmd,
+                args,
+                {
+                    maxBuffer: 50 * 1024 * 1024,
+                    timeout: 120_000,
+                    env: options?.env,
+                },
+                (error, stdout, stderr) => {
+                    if (error) {
+                        const raw = stderr ? `${error.message}\n${stderr}` : error.message;
+                        const msg = raw.replace(/x-access-token:[^@]+@/g, 'x-access-token:***@');
+                        reject(new Error(msg));
+                        return;
+                    }
+                    resolve(stdout);
+                },
+            );
+        });
+    }
+}

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -37,6 +37,8 @@ export {
     buildMcpToolExamplePrompt,
     buildTaskAnalysisPrompt,
     buildPlaybookSummaryPrompt,
+    extractMetadataJson,
+    parseMetadataDump,
 } from '@ansible/common';
 export type {
     ParameterSchema,
@@ -79,6 +81,9 @@ export type {
     Disposable,
     CollectionSourcesInput,
     TaskAnalysisInput,
+    MetadataDump,
+    ParsedCollection,
+    MetadataDumpResult,
 } from '@ansible/common';
 
 // --- Services ---
@@ -108,6 +113,7 @@ export {
 export { GalaxyCollectionCache } from './GalaxyCollectionCache';
 export { GalaxyDocsCache } from './GalaxyDocsCache';
 export { GitHubCollectionCache } from './GitHubCollectionCache';
+export { SCMDocsCache } from './SCMDocsCache';
 export { SkillRegistry, _resetGitHubToken } from './SkillRegistry';
 export { discoverPlaybooks } from './PlaybookDiscovery';
 export type { DiscoveredPlaybook } from './PlaybookDiscovery';

--- a/packages/services/test/services/CollectionsService.test.ts
+++ b/packages/services/test/services/CollectionsService.test.ts
@@ -268,7 +268,7 @@ describe('CollectionsService', () => {
         expect(list.some((c) => c.name === 'community.docker' && c.version === '3.4.5')).toBe(true);
     });
 
-    it('forceRefresh catches failure when ansible-doc JSON is invalid', async () => {
+    it('forceRefresh handles invalid ansible-doc JSON gracefully', async () => {
         runToolMock.mockImplementation((toolName: string) => {
             if (toolName === 'ade') {
                 return { exitCode: 0, stdout: adeInspectStdout, stderr: '' };
@@ -280,7 +280,7 @@ describe('CollectionsService', () => {
         });
         const svc = CollectionsService.getInstance();
         await svc.forceRefresh();
-        expect(svc.isLoaded()).toBe(false);
+        expect(svc.isLoaded()).toBe(true);
         expect(svc.listCollectionNames()).toEqual([]);
     });
 

--- a/packages/services/test/services/SCMDocsCache.test.ts
+++ b/packages/services/test/services/SCMDocsCache.test.ts
@@ -1,0 +1,319 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const execFileMock = vi.hoisted(() => vi.fn());
+const execMock = vi.hoisted(() => vi.fn());
+
+vi.mock('child_process', () => ({
+    execFile: execFileMock,
+    exec: execMock,
+}));
+
+vi.mock('vscode', () => undefined);
+
+vi.mock('../../src/CommandService', () => ({
+    getCommandService: () => ({
+        getToolPath: vi.fn().mockResolvedValue('/usr/bin/ansible-doc'),
+    }),
+}));
+
+import { SCMDocsCache } from '../../src/SCMDocsCache';
+
+/**
+ * Builds a minimal metadata dump JSON for testing.
+ *
+ * @param namespace - Ansible collection namespace.
+ * @param name - Ansible collection name.
+ * @returns Stringified metadata dump JSON.
+ */
+function buildMetadataDump(namespace: string, name: string): string {
+    return JSON.stringify({
+        all: {
+            module: {
+                [`${namespace}.${name}.my_module`]: {
+                    doc: {
+                        collection: `${namespace}.${name}`,
+                        plugin_name: `${namespace}.${name}.my_module`,
+                        short_description: 'Test module',
+                        options: {
+                            param1: { type: 'str', description: 'A parameter' },
+                        },
+                    },
+                    examples: '- name: Example\n  my_module:',
+                    return: {
+                        result: { type: 'str', description: 'The result' },
+                    },
+                },
+            },
+            lookup: {
+                [`${namespace}.${name}.my_lookup`]: {
+                    doc: {
+                        collection: `${namespace}.${name}`,
+                        plugin_name: `${namespace}.${name}.my_lookup`,
+                        short_description: 'Test lookup',
+                    },
+                },
+            },
+        },
+    });
+}
+
+describe('SCMDocsCache', () => {
+    let tmpDir: string;
+    let cacheDir: string;
+
+    beforeEach(() => {
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'scm-docs-test-'));
+        cacheDir = path.join(os.homedir(), '.cache', 'ansible-environments', 'scm-docs');
+        SCMDocsCache._setInstance(undefined);
+        execFileMock.mockReset();
+    });
+
+    afterEach(() => {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+        // Clean up test cache files to avoid cross-test contamination
+        if (fs.existsSync(cacheDir)) {
+            for (const f of fs.readdirSync(cacheDir)) {
+                if (
+                    f.startsWith('test-org__') ||
+                    f.startsWith('inv-org__') ||
+                    f.startsWith('empty-org__')
+                ) {
+                    fs.unlinkSync(path.join(cacheDir, f));
+                }
+            }
+        }
+        SCMDocsCache._setInstance(undefined);
+    });
+
+    it('returns singleton instance', () => {
+        const a = SCMDocsCache.getInstance();
+        const b = SCMDocsCache.getInstance();
+        expect(a).toBe(b);
+    });
+
+    it('invalidate clears memory cache', () => {
+        const cache = SCMDocsCache.getInstance();
+        cache.invalidate('test-org', 'test-repo');
+        // Should not throw, just clears the key
+    });
+
+    it('returns null from getPluginTypes when clone fails', async () => {
+        execFileMock.mockImplementation(
+            (
+                _cmd: string,
+                _args: string[],
+                _opts: unknown,
+                cb: (err: Error | null, stdout: string, stderr: string) => void,
+            ) => {
+                cb(new Error('git clone failed'), '', 'fatal: repo not found');
+            },
+        );
+
+        const cache = SCMDocsCache.getInstance();
+        cache.setLogFunction(vi.fn());
+
+        const result = await cache.getPluginTypes('test-org', 'test-repo', 'test', 'col');
+        expect(result).toBeNull();
+    });
+
+    it('indexes plugins via shallow clone and ansible-doc', async () => {
+        let callCount = 0;
+        execFileMock.mockImplementation(
+            (
+                cmd: string,
+                args: string[],
+                _opts: unknown,
+                cb: (err: Error | null, stdout: string, stderr: string) => void,
+            ) => {
+                callCount++;
+                if (cmd === 'git' && args[0] === 'clone') {
+                    cb(null, '', '');
+                } else if (cmd === 'git' && args.includes('rev-parse')) {
+                    cb(null, 'abc1234def5678\n', '');
+                } else if (args.includes('--metadata-dump')) {
+                    cb(null, buildMetadataDump('test', 'col'), '');
+                } else {
+                    cb(new Error(`Unexpected command: ${cmd} ${args.join(' ')}`), '', '');
+                }
+            },
+        );
+
+        const cache = SCMDocsCache.getInstance();
+        cache.setLogFunction(vi.fn());
+
+        const pluginTypes = await cache.getPluginTypes('test-org', 'test-repo', 'test', 'col');
+
+        expect(pluginTypes).not.toBeNull();
+        expect(pluginTypes).toHaveProperty('module');
+        expect(pluginTypes).toHaveProperty('lookup');
+        expect((pluginTypes as Record<string, unknown[]>).module).toHaveLength(1);
+        expect((pluginTypes as Record<string, unknown[]>).lookup).toHaveLength(1);
+        expect(callCount).toBe(3);
+    });
+
+    it('returns plugin documentation for a specific plugin', async () => {
+        execFileMock.mockImplementation(
+            (
+                cmd: string,
+                args: string[],
+                _opts: unknown,
+                cb: (err: Error | null, stdout: string, stderr: string) => void,
+            ) => {
+                if (cmd === 'git' && args[0] === 'clone') {
+                    cb(null, '', '');
+                } else if (cmd === 'git' && args.includes('rev-parse')) {
+                    cb(null, 'abc1234def5678\n', '');
+                } else if (args.includes('--metadata-dump')) {
+                    cb(null, buildMetadataDump('test', 'col'), '');
+                } else {
+                    cb(new Error(`Unexpected: ${cmd}`), '', '');
+                }
+            },
+        );
+
+        const cache = SCMDocsCache.getInstance();
+        cache.setLogFunction(vi.fn());
+
+        const doc = await cache.getPluginDoc(
+            'test-org',
+            'test-repo',
+            'test',
+            'col',
+            'test.col.my_module',
+            'module',
+        );
+
+        expect(doc).not.toBeNull();
+        expect(doc?.doc?.short_description).toBe('Test module');
+        expect(doc?.examples).toContain('Example');
+        expect(doc?.return).toHaveProperty('result');
+    });
+
+    it('returns null for a non-existent plugin', async () => {
+        execFileMock.mockImplementation(
+            (
+                cmd: string,
+                args: string[],
+                _opts: unknown,
+                cb: (err: Error | null, stdout: string, stderr: string) => void,
+            ) => {
+                if (cmd === 'git' && args[0] === 'clone') {
+                    cb(null, '', '');
+                } else if (cmd === 'git' && args.includes('rev-parse')) {
+                    cb(null, 'abc1234def5678\n', '');
+                } else if (args.includes('--metadata-dump')) {
+                    cb(null, buildMetadataDump('test', 'col'), '');
+                } else {
+                    cb(new Error(`Unexpected: ${cmd}`), '', '');
+                }
+            },
+        );
+
+        const cache = SCMDocsCache.getInstance();
+        cache.setLogFunction(vi.fn());
+
+        const doc = await cache.getPluginDoc(
+            'test-org',
+            'test-repo',
+            'test',
+            'col',
+            'test.col.nonexistent',
+            'module',
+        );
+
+        expect(doc).toBeNull();
+    });
+
+    it('uses memory cache on second call', async () => {
+        let cloneCount = 0;
+        execFileMock.mockImplementation(
+            (
+                cmd: string,
+                args: string[],
+                _opts: unknown,
+                cb: (err: Error | null, stdout: string, stderr: string) => void,
+            ) => {
+                if (cmd === 'git' && args[0] === 'clone') {
+                    cloneCount++;
+                    cb(null, '', '');
+                } else if (cmd === 'git' && args.includes('rev-parse')) {
+                    cb(null, 'abc1234def5678\n', '');
+                } else if (args.includes('--metadata-dump')) {
+                    cb(null, buildMetadataDump('test', 'col'), '');
+                } else {
+                    cb(new Error(`Unexpected: ${cmd}`), '', '');
+                }
+            },
+        );
+
+        const cache = SCMDocsCache.getInstance();
+        cache.setLogFunction(vi.fn());
+
+        await cache.getPluginTypes('test-org', 'test-repo', 'test', 'col');
+        await cache.getPluginTypes('test-org', 'test-repo', 'test', 'col');
+
+        expect(cloneCount).toBe(1);
+    });
+
+    it('refetches after invalidate', async () => {
+        let cloneCount = 0;
+        execFileMock.mockImplementation(
+            (
+                cmd: string,
+                args: string[],
+                _opts: unknown,
+                cb: (err: Error | null, stdout: string, stderr: string) => void,
+            ) => {
+                if (cmd === 'git' && args[0] === 'clone') {
+                    cloneCount++;
+                    cb(null, '', '');
+                } else if (cmd === 'git' && args.includes('rev-parse')) {
+                    cb(null, `sha-${String(cloneCount)}aaaa\n`, '');
+                } else if (args.includes('--metadata-dump')) {
+                    cb(null, buildMetadataDump('inv', 'refetch'), '');
+                } else {
+                    cb(new Error(`Unexpected: ${cmd}`), '', '');
+                }
+            },
+        );
+
+        const cache = SCMDocsCache.getInstance();
+        cache.setLogFunction(vi.fn());
+
+        await cache.getPluginTypes('inv-org', 'inv-repo', 'inv', 'refetch');
+        cache.invalidate('inv-org', 'inv-repo');
+        await cache.getPluginTypes('inv-org', 'inv-repo', 'inv', 'refetch');
+
+        expect(cloneCount).toBe(2);
+    });
+
+    it('handles empty metadata dump', async () => {
+        execFileMock.mockImplementation(
+            (
+                cmd: string,
+                args: string[],
+                _opts: unknown,
+                cb: (err: Error | null, stdout: string, stderr: string) => void,
+            ) => {
+                if (cmd === 'git' && args[0] === 'clone') {
+                    cb(null, '', '');
+                } else if (cmd === 'git' && args.includes('rev-parse')) {
+                    cb(null, 'empty111222333\n', '');
+                } else if (args.includes('--metadata-dump')) {
+                    cb(null, '{"all": {}}', '');
+                } else {
+                    cb(new Error(`Unexpected: ${cmd}`), '', '');
+                }
+            },
+        );
+
+        const cache = SCMDocsCache.getInstance();
+        cache.setLogFunction(vi.fn());
+
+        const result = await cache.getPluginTypes('empty-org', 'empty-repo', 'empty', 'col');
+        expect(result).toEqual({});
+    });
+});

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -35,6 +35,7 @@ import {
 import {
     GalaxyCollectionCache,
     GalaxyDocsCache,
+    SCMDocsCache,
     CollectionsService,
     setLogFunction as setCollectionsLogFunction,
     DevToolsService,
@@ -615,6 +616,10 @@ export function activate(context: vscode.ExtensionContext) {
     const galaxyDocsCache = GalaxyDocsCache.getInstance();
     galaxyDocsCache.setExtensionContext(context);
 
+    // Initialize SCM docs cache for GitHub collection plugin browsing
+    const scmDocsCache = SCMDocsCache.getInstance();
+    scmDocsCache.setLogFunction(log);
+
     // Register Collections commands
     const collectionsRefreshCommand = vscode.commands.registerCommand(
         'ansibleDevToolsCollections.refresh',
@@ -1117,6 +1122,28 @@ export function activate(context: vscode.ExtensionContext) {
         },
     );
 
+    const showGitHubPluginDocCommand = vscode.commands.registerCommand(
+        'ansibleCollectionSources.showGitHubPluginDoc',
+        async (node?: Parameters<typeof collectionSourcesProvider.showGitHubPluginDoc>[0]) => {
+            if (!node) {
+                vscode.window.showWarningMessage('Select a GitHub plugin from the tree view.');
+                return;
+            }
+            await collectionSourcesProvider.showGitHubPluginDoc(node, context.extensionUri);
+        },
+    );
+
+    const refreshGitHubCollectionCommand = vscode.commands.registerCommand(
+        'ansibleCollectionSources.refreshGitHubCollection',
+        (node?: Parameters<typeof collectionSourcesProvider.refreshGitHubCollection>[0]) => {
+            if (!node) {
+                vscode.window.showWarningMessage('Select a GitHub collection from the tree view.');
+                return;
+            }
+            collectionSourcesProvider.refreshGitHubCollection(node);
+        },
+    );
+
     // Register Galaxy cache refresh command
     const galaxyCacheRefreshCommand = vscode.commands.registerCommand(
         'ansibleDevToolsCollections.refreshGalaxyCache',
@@ -1335,6 +1362,8 @@ export function activate(context: vscode.ExtensionContext) {
         installGalaxyCollectionCommand,
         showGalaxyPluginDocCommand,
         galaxyPluginAiSummaryCommand,
+        showGitHubPluginDocCommand,
+        refreshGitHubCollectionCommand,
         selectLlmModelCommand,
         showLlmStatusCommand,
     );

--- a/src/views/CollectionSourcesProvider.ts
+++ b/src/views/CollectionSourcesProvider.ts
@@ -3,11 +3,12 @@ import {
     GalaxyCollectionCache,
     GalaxyDocsCache,
     GitHubCollectionCache,
+    SCMDocsCache,
     buildCollectionSourcesOverviewPrompt,
     buildGalaxySourceSummaryPrompt,
     buildGithubOrgSourceSummaryPrompt,
 } from '@ansible/services';
-import type { GalaxyCollection, PluginInfo } from '@ansible/services';
+import type { GalaxyCollection, GitHubCollection, PluginInfo } from '@ansible/services';
 
 let extensionLog: (msg: string) => void = console.log;
 
@@ -64,7 +65,10 @@ type TreeNode =
     | CollectionSourceNode
     | GalaxyCollectionNode
     | GalaxyPluginTypeNode
-    | GalaxyPluginNode;
+    | GalaxyPluginNode
+    | GitHubCollectionNode
+    | GitHubPluginTypeNode
+    | GitHubPluginNode;
 
 /** Root-level node representing a collection source (Galaxy or GitHub org). */
 class CollectionSourceNode extends vscode.TreeItem {
@@ -81,12 +85,7 @@ class CollectionSourceNode extends vscode.TreeItem {
         public readonly galaxyFilterResultCount?: number,
     ) {
         const isGalaxy = source.type === 'galaxy';
-        super(
-            source.name,
-            isGalaxy
-                ? vscode.TreeItemCollapsibleState.Collapsed
-                : vscode.TreeItemCollapsibleState.None,
-        );
+        super(source.name, vscode.TreeItemCollapsibleState.Collapsed);
 
         this.iconPath = new vscode.ThemeIcon(isGalaxy ? 'globe' : 'github');
 
@@ -114,7 +113,7 @@ class CollectionSourceNode extends vscode.TreeItem {
                 ? 'collectionSourceGalaxyFiltered'
                 : 'collectionSourceGalaxy';
         } else {
-            this.contextValue = 'collectionSource';
+            this.contextValue = 'collectionSourceGitHub';
         }
     }
 }
@@ -190,6 +189,86 @@ class GalaxyPluginNode extends vscode.TreeItem {
     }
 }
 
+/** Tree node representing a single GitHub collection (expandable to plugin types). */
+class GitHubCollectionNode extends vscode.TreeItem {
+    public readonly nodeType = 'githubCollection' as const;
+
+    /** @param collection - GitHub collection metadata. */
+    constructor(public readonly collection: GitHubCollection) {
+        super(
+            `${collection.namespace}.${collection.name}`,
+            vscode.TreeItemCollapsibleState.Collapsed,
+        );
+        this.description = collection.version ? `v${collection.version}` : '';
+        this.iconPath = new vscode.ThemeIcon('library');
+        this.contextValue = 'githubCollection';
+
+        const tooltip = new vscode.MarkdownString();
+        tooltip.appendMarkdown(`**${collection.namespace}.${collection.name}**\n\n`);
+        if (collection.version) tooltip.appendMarkdown(`Version: ${collection.version}\n\n`);
+        tooltip.appendMarkdown(`Org: ${collection.org}\n\n`);
+        if (collection.description) tooltip.appendMarkdown(collection.description);
+        this.tooltip = tooltip;
+    }
+}
+
+/** Tree node grouping plugins by type within a GitHub collection. */
+class GitHubPluginTypeNode extends vscode.TreeItem {
+    public readonly nodeType = 'githubPluginType' as const;
+
+    /**
+     * @param pluginType - Plugin type name.
+     * @param plugins - Plugins of this type.
+     * @param collection - Parent GitHub collection.
+     */
+    constructor(
+        public readonly pluginType: string,
+        public readonly plugins: PluginInfo[],
+        public readonly collection: GitHubCollection,
+    ) {
+        super(pluginType, vscode.TreeItemCollapsibleState.Collapsed);
+        this.description = `(${String(plugins.length)})`;
+        this.iconPath = new vscode.ThemeIcon('symbol-folder');
+        this.contextValue = 'githubPluginType';
+    }
+}
+
+/** Leaf tree node representing a single GitHub-sourced plugin. */
+class GitHubPluginNode extends vscode.TreeItem {
+    public readonly nodeType = 'githubPlugin' as const;
+
+    /**
+     * @param plugin - Plugin info.
+     * @param pluginType - Plugin type name.
+     * @param collection - Parent GitHub collection.
+     */
+    constructor(
+        public readonly plugin: PluginInfo,
+        public readonly pluginType: string,
+        public readonly collection: GitHubCollection,
+    ) {
+        super(plugin.name, vscode.TreeItemCollapsibleState.None);
+        this.description = plugin.shortDescription;
+        this.iconPath = new vscode.ThemeIcon('sparkle');
+        this.contextValue = 'githubPlugin';
+
+        this.command = {
+            command: 'ansibleCollectionSources.showGitHubPluginDoc',
+            title: 'Show Plugin Documentation',
+            arguments: [this],
+        };
+    }
+}
+
+/**
+ * Extracts the repository name from a full GitHub repository URL or path.
+ * @param repository - Repository URL or path (e.g., "org/repo-name").
+ * @returns The repository name portion.
+ */
+function repoNameFrom(repository: string): string {
+    return repository.split('/').pop() ?? repository;
+}
+
 // ---------------------------------------------------------------------------
 // Provider
 // ---------------------------------------------------------------------------
@@ -202,6 +281,7 @@ export class CollectionSourcesProvider implements vscode.TreeDataProvider<TreeNo
     private _galaxyCache: GalaxyCollectionCache;
     private _galaxyDocsCache: GalaxyDocsCache;
     private _githubCache: GitHubCollectionCache;
+    private _scmDocsCache: SCMDocsCache;
     private _disposables: vscode.Disposable[] = [];
     private _galaxyFilter: string | undefined;
 
@@ -210,6 +290,7 @@ export class CollectionSourcesProvider implements vscode.TreeDataProvider<TreeNo
         this._galaxyCache = GalaxyCollectionCache.getInstance();
         this._galaxyDocsCache = GalaxyDocsCache.getInstance();
         this._githubCache = GitHubCollectionCache.getInstance();
+        this._scmDocsCache = SCMDocsCache.getInstance();
         this._githubCache.setLogFunction(extensionLog);
 
         this._disposables.push(
@@ -342,8 +423,11 @@ export class CollectionSourcesProvider implements vscode.TreeDataProvider<TreeNo
             return Promise.resolve(this._getRootNodes());
         }
 
-        if (element instanceof CollectionSourceNode && element.source.type === 'galaxy') {
-            return Promise.resolve(this._getGalaxyChildren());
+        if (element instanceof CollectionSourceNode) {
+            if (element.source.type === 'galaxy') {
+                return Promise.resolve(this._getGalaxyChildren());
+            }
+            return Promise.resolve(this._getGitHubChildren(element.source.id));
         }
 
         if (element instanceof GalaxyCollectionNode) {
@@ -354,6 +438,18 @@ export class CollectionSourcesProvider implements vscode.TreeDataProvider<TreeNo
             return Promise.resolve(
                 element.plugins.map(
                     (p) => new GalaxyPluginNode(p, element.pluginType, element.collection),
+                ),
+            );
+        }
+
+        if (element instanceof GitHubCollectionNode) {
+            return this._getGitHubCollectionChildren(element.collection);
+        }
+
+        if (element instanceof GitHubPluginTypeNode) {
+            return Promise.resolve(
+                element.plugins.map(
+                    (p) => new GitHubPluginNode(p, element.pluginType, element.collection),
                 ),
             );
         }
@@ -440,6 +536,49 @@ export class CollectionSourcesProvider implements vscode.TreeDataProvider<TreeNo
         return Object.entries(pluginTypes)
             .sort(([a], [b]) => a.localeCompare(b))
             .map(([type, plugins]) => new GalaxyPluginTypeNode(type, plugins, collection));
+    }
+
+    /**
+     * Returns GitHub collection nodes for an org.
+     * @param org - GitHub organization name.
+     * @returns Array of GitHub collection tree nodes.
+     */
+    private _getGitHubChildren(org: string): TreeNode[] {
+        return this._githubCache
+            .getCollections(org)
+            .slice()
+            .sort((a, b) => `${a.namespace}.${a.name}`.localeCompare(`${b.namespace}.${b.name}`))
+            .map((c) => new GitHubCollectionNode(c));
+    }
+
+    /**
+     * Expands a GitHub collection into plugin-type groupings via SCMDocsCache.
+     * @param collection - The GitHub collection to expand.
+     * @returns Array of plugin-type tree nodes, or an error placeholder on failure.
+     */
+    private async _getGitHubCollectionChildren(collection: GitHubCollection): Promise<TreeNode[]> {
+        const pluginTypes = await this._scmDocsCache.getPluginTypes(
+            collection.org,
+            repoNameFrom(collection.repository),
+            collection.namespace,
+            collection.name,
+        );
+
+        if (!pluginTypes) {
+            const errorNode = new vscode.TreeItem(
+                'Failed to load plugin documentation',
+                vscode.TreeItemCollapsibleState.None,
+            );
+            errorNode.iconPath = new vscode.ThemeIcon('warning');
+            errorNode.tooltip =
+                `Could not index ${collection.namespace}.${collection.name}. ` +
+                'Requires git and ansible-doc on PATH. Click to retry.';
+            return [errorNode as TreeNode];
+        }
+
+        return Object.entries(pluginTypes)
+            .sort(([a], [b]) => a.localeCompare(b))
+            .map(([type, plugins]) => new GitHubPluginTypeNode(type, plugins, collection));
     }
 
     // -------------------------------------------------------------------
@@ -656,6 +795,58 @@ export class CollectionSourcesProvider implements vscode.TreeDataProvider<TreeNo
                 const { PluginDocPanel } = await import('@src/panels/PluginDocPanel');
                 PluginDocPanel.showWithData(extensionUri, plugin.fullName, pluginType, data);
             },
+        );
+    }
+
+    /**
+     * Fetches GitHub collection plugin docs via SCMDocsCache and opens the PluginDoc webview.
+     * @param node - The GitHub plugin tree node.
+     * @param extensionUri - Extension URI for webview resource loading.
+     */
+    public async showGitHubPluginDoc(
+        node: GitHubPluginNode,
+        extensionUri: vscode.Uri,
+    ): Promise<void> {
+        const { collection, plugin, pluginType } = node;
+
+        await vscode.window.withProgress(
+            {
+                location: vscode.ProgressLocation.Window,
+                title: `Loading ${plugin.fullName}...`,
+            },
+            async () => {
+                const data = await this._scmDocsCache.getPluginDoc(
+                    collection.org,
+                    repoNameFrom(collection.repository),
+                    collection.namespace,
+                    collection.name,
+                    plugin.fullName,
+                    pluginType,
+                );
+
+                if (!data) {
+                    vscode.window.showWarningMessage(
+                        `Could not load documentation for ${plugin.fullName}`,
+                    );
+                    return;
+                }
+
+                const { PluginDocPanel } = await import('@src/panels/PluginDocPanel');
+                PluginDocPanel.showWithData(extensionUri, plugin.fullName, pluginType, data);
+            },
+        );
+    }
+
+    /**
+     * Invalidates and refreshes the SCM docs cache for a GitHub collection.
+     * @param node - The GitHub collection tree node.
+     */
+    public refreshGitHubCollection(node: GitHubCollectionNode): void {
+        const { collection } = node;
+        this._scmDocsCache.invalidate(collection.org, repoNameFrom(collection.repository));
+        this.refresh();
+        vscode.window.showInformationMessage(
+            `Refreshing plugin docs for ${collection.namespace}.${collection.name}...`,
         );
     }
 


### PR DESCRIPTION
## Summary
- Add browsable plugin documentation for collections in configured GitHub organizations via shallow clone + ansible-doc metadata-dump
- Introduces SCMDocsCache service, shared metadataDumpParser, MCP tool `get_scm_plugin_doc`, and expandable tree nodes in CollectionSourcesProvider

## Changes
- **ADR-013**: Documents the shallow clone + ansible-doc approach for SCM collection plugin documentation
- **SCMDocsCache** (`packages/services/src/SCMDocsCache.ts`): New service with memory + disk caching (7-day TTL), SHA-based invalidation, failure cooldown (5 min), access token scrubbing in error messages, and sorted `readdirSync` for consistent file selection
- **GIT_ASKPASS for auth**: Token-based auth uses a temporary `GIT_ASKPASS` script instead of embedding tokens in the clone URL, preventing exposure via process listings and `.git/config`
- **metadataDumpParser** (`packages/common/src/parsers/metadataDumpParser.ts`): Extracted shared metadata-dump parsing logic from CollectionsService into browser-safe `@ansible/common`; handles malformed JSON gracefully
- **CollectionSourcesProvider** (`src/views/CollectionSourcesProvider.ts`): GitHub SCM collection nodes are now expandable, showing plugin types and individual plugins; per-collection refresh command; builtin collections filtered; alphabetical sort; extracted `repoNameFrom` helper
- **MCP tool `get_scm_plugin_doc`** (`packages/mcp-server/src/tools.ts`, `handlers.ts`): New tool for agent access to SCM collection docs with `force_refresh` parameter for cache invalidation
- **Shared plugin doc rendering** (`handlers.ts`): Extracted `_formatPluginTypeList()` and `_formatPluginDoc()` helpers, eliminating verbatim duplication between Galaxy and SCM handlers
- **Invariant 7 compliance**: SCMDocsCache resolves `ansible-doc` via `CommandService.getToolPath()` instead of manual path configuration
- **Agent-native parity**: `list_source_collections` now surfaces repo name for GitHub sources so agents can invoke `get_scm_plugin_doc`
- **Tests**: Full coverage for metadataDumpParser, SCMDocsCache, and MCP handler integration

## Quality of life
- ADR-013: SCM Collection Plugin Documentation via Shallow Clone
- Shared `metadataDumpParser` reduces duplication across CollectionsService and SCMDocsCache

## Test plan
- [x] `npm exec eslint -- .` passes
- [x] `npm exec tsc -- -b` compiles cleanly
- [x] `npm exec vitest -- run` passes (726 tests, 45 files)