### PR TITLE
fix: suppress repeated PET warning using globalState and Don't show again

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -109,7 +109,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
 
   // Initialize Python Environment Service early
   const pythonEnvService = PythonEnvironmentService.getInstance();
-  await pythonEnvService.initialize();
+  await pythonEnvService.initialize(context);
   context.subscriptions.push(pythonEnvService);
 
   // Initialize Terminal Service

--- a/src/services/PythonEnvironmentService.ts
+++ b/src/services/PythonEnvironmentService.ts
@@ -33,6 +33,7 @@ export class PythonEnvironmentService implements vscode.Disposable {
   private _pythonExtApi: PythonExtension | undefined;
   private _initialized: boolean = false;
   private _petWarningShown: boolean = false;
+  private _context: vscode.ExtensionContext | undefined;
   private _disposables: vscode.Disposable[] = [];
 
   private _onDidChangeEnvironment =
@@ -53,11 +54,17 @@ export class PythonEnvironmentService implements vscode.Disposable {
    * Initialize the service. Tries the Environments extension first; if PET
    * is missing falls back to the main Python extension's environments API.
    */
-  public async initialize(): Promise<boolean> {
+  public async initialize(
+    context?: vscode.ExtensionContext,
+  ): Promise<boolean> {
     if (this._initialized) {
       return (
         this._pythonEnvApi !== undefined || this._pythonExtApi !== undefined
       );
+    }
+
+    if (context) {
+      this._context = context;
     }
 
     console.log(
@@ -238,9 +245,15 @@ export class PythonEnvironmentService implements vscode.Disposable {
   // ---------------------------------------------------------------------------
 
   private _showPetWarning(): void {
-    if (this._petWarningShown) {
+    const alreadyShown = this._context
+      ? this._context.globalState.get<boolean>("ansible.petWarningShown") ===
+        true
+      : this._petWarningShown;
+
+    if (alreadyShown) {
       return;
     }
+
     this._petWarningShown = true;
 
     const useEnvsSetting = vscode.workspace
@@ -255,10 +268,16 @@ export class PythonEnvironmentService implements vscode.Disposable {
             ? " Disabling the Environments extension delegation may resolve hanging discovery."
             : ""),
         ...(useEnvsSetting ? ["Disable Environments Extension"] : []),
+        "Don't show again",
         "Learn More",
       )
       .then(async (selection) => {
-        if (selection === "Disable Environments Extension") {
+        if (selection === "Don't show again") {
+          await this._context?.globalState.update(
+            "ansible.petWarningShown",
+            true,
+          );
+        } else if (selection === "Disable Environments Extension") {
           await vscode.workspace
             .getConfiguration("python")
             .update(

--- a/src/services/PythonEnvironmentService.ts
+++ b/src/services/PythonEnvironmentService.ts
@@ -243,12 +243,14 @@ export class PythonEnvironmentService implements vscode.Disposable {
   // ---------------------------------------------------------------------------
 
   private _showPetWarning(): void {
-    const alreadyShown = this._context
-      ? this._context.globalState.get<boolean>("ansible.petWarningShown") ===
-        true
-      : this._petWarningShown;
+    if (this._petWarningShown) {
+      return;
+    }
 
-    if (alreadyShown) {
+    if (
+      this._context?.globalState.get<boolean>("ansible.petWarningShown") ===
+      true
+    ) {
       return;
     }
 
@@ -258,7 +260,7 @@ export class PythonEnvironmentService implements vscode.Disposable {
       .getConfiguration("python")
       .get<boolean>("useEnvironmentsExtension");
 
-    vscode.window
+    void vscode.window
       .showWarningMessage(
         "Python environment discovery is degraded (PET binary missing). " +
           "This commonly occurs in OpenVSX-based editors (Dev Spaces, VSCodium)." +

--- a/src/services/PythonEnvironmentService.ts
+++ b/src/services/PythonEnvironmentService.ts
@@ -54,9 +54,7 @@ export class PythonEnvironmentService implements vscode.Disposable {
    * Initialize the service. Tries the Environments extension first; if PET
    * is missing falls back to the main Python extension's environments API.
    */
-  public async initialize(
-    context?: vscode.ExtensionContext,
-  ): Promise<boolean> {
+  public async initialize(context?: vscode.ExtensionContext): Promise<boolean> {
     if (this._initialized) {
       return (
         this._pythonEnvApi !== undefined || this._pythonExtApi !== undefined

--- a/test/unit/services/PythonEnvironmentService.test.ts
+++ b/test/unit/services/PythonEnvironmentService.test.ts
@@ -315,7 +315,7 @@ describe("PythonEnvironmentService", function () {
       await new Promise((resolve) => setTimeout(resolve, 0));
 
       expect(
-        (ctx.globalState.update as ReturnType<typeof vi.fn>),
+        ctx.globalState.update as ReturnType<typeof vi.fn>,
       ).toHaveBeenCalledWith("ansible.petWarningShown", true);
     });
 
@@ -331,7 +331,7 @@ describe("PythonEnvironmentService", function () {
       await new Promise((resolve) => setTimeout(resolve, 0));
 
       expect(
-        (ctx.globalState.update as ReturnType<typeof vi.fn>),
+        ctx.globalState.update as ReturnType<typeof vi.fn>,
       ).not.toHaveBeenCalled();
     });
 

--- a/test/unit/services/PythonEnvironmentService.test.ts
+++ b/test/unit/services/PythonEnvironmentService.test.ts
@@ -19,6 +19,23 @@ describe("PythonEnvironmentService", function () {
   let mockExistsSync: ReturnType<typeof vi.fn>;
   let mockPythonExtApi: ReturnType<typeof vi.fn>;
 
+  const makeMockContext = (
+    globalStateOverrides: Record<string, unknown> = {},
+  ) => {
+    const store = new Map<string, unknown>(
+      Object.entries(globalStateOverrides),
+    );
+    return {
+      globalState: {
+        get: vi.fn((key: string) => store.get(key)),
+        update: vi.fn((key: string, value: unknown) => {
+          store.set(key, value);
+          return Promise.resolve();
+        }),
+      },
+    } as unknown as import("vscode").ExtensionContext;
+  };
+
   const resetSingleton = () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (PythonEnvironmentService as any)._instance = undefined;
@@ -175,9 +192,11 @@ describe("PythonEnvironmentService", function () {
       mockExistsSync.mockReturnValue(true);
 
       await service.initialize();
+      const callsAfterFirst = mockGetExtension.mock.calls.length;
       await service.initialize();
 
-      expect(mockGetExtension).toHaveBeenCalledTimes(1);
+      // Second call must not trigger any additional extension lookups
+      expect(mockGetExtension.mock.calls.length).toBe(callsAfterFirst);
     });
   });
 
@@ -234,6 +253,7 @@ describe("PythonEnvironmentService", function () {
 
       expect(mockShowWarningMessage).toHaveBeenCalledWith(
         expect.stringContaining("PET binary missing"),
+        "Don't show again",
         "Learn More",
       );
     });
@@ -263,6 +283,79 @@ describe("PythonEnvironmentService", function () {
       await new Promise((resolve) => setTimeout(resolve, 0));
 
       expect(mockOpenExternal).toHaveBeenCalled();
+    });
+  });
+
+  describe("initialize — PET warning globalState persistence", function () {
+    const makePetMissingEnv = () =>
+      mockGetExtension.mockImplementation((id: string) => {
+        if (id === PYTHON_ENVS_EXTENSION_ID) {
+          return {
+            isActive: true,
+            extensionPath: "/envs/ext/path",
+            exports: makeMockEnvsApi(),
+            activate: vi.fn(),
+          };
+        }
+        if (id === "ms-python.python") {
+          return { isActive: true, activate: vi.fn() };
+        }
+        return undefined;
+      });
+
+    it("should persist suppression to globalState when Don't show again clicked", async function () {
+      makePetMissingEnv();
+      mockExistsSync.mockReturnValue(false);
+      mockShowWarningMessage.mockResolvedValue("Don't show again");
+      mockPythonExtApi.mockResolvedValue(makeMockPythonExtApi());
+
+      const ctx = makeMockContext();
+      await service.initialize(ctx);
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(
+        (ctx.globalState.update as ReturnType<typeof vi.fn>),
+      ).toHaveBeenCalledWith("ansible.petWarningShown", true);
+    });
+
+    it("should not persist to globalState when warning dismissed without action", async function () {
+      makePetMissingEnv();
+      mockExistsSync.mockReturnValue(false);
+      mockShowWarningMessage.mockResolvedValue(undefined);
+      mockPythonExtApi.mockResolvedValue(makeMockPythonExtApi());
+
+      const ctx = makeMockContext();
+      await service.initialize(ctx);
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(
+        (ctx.globalState.update as ReturnType<typeof vi.fn>),
+      ).not.toHaveBeenCalled();
+    });
+
+    it("should not show warning when globalState already set", async function () {
+      makePetMissingEnv();
+      mockExistsSync.mockReturnValue(false);
+      mockPythonExtApi.mockResolvedValue(makeMockPythonExtApi());
+
+      const ctx = makeMockContext({ "ansible.petWarningShown": true });
+      await service.initialize(ctx);
+
+      expect(mockShowWarningMessage).not.toHaveBeenCalled();
+    });
+
+    it("should still fall back to Python extension even when warning suppressed", async function () {
+      makePetMissingEnv();
+      mockExistsSync.mockReturnValue(false);
+      mockPythonExtApi.mockResolvedValue(makeMockPythonExtApi());
+
+      const ctx = makeMockContext({ "ansible.petWarningShown": true });
+      const result = await service.initialize(ctx);
+
+      expect(result).toBe(true);
+      expect(service.hasFullApi()).toBe(false);
     });
   });
 

--- a/test/unit/services/PythonEnvironmentService.test.ts
+++ b/test/unit/services/PythonEnvironmentService.test.ts
@@ -332,7 +332,9 @@ describe("PythonEnvironmentService", function () {
         return undefined;
       });
       mockExistsSync.mockReturnValue(false);
-      mockShowWarningMessage.mockResolvedValue("Disable Environments Extension");
+      mockShowWarningMessage.mockResolvedValue(
+        "Disable Environments Extension",
+      );
       mockShowInformationMessage.mockResolvedValue(undefined);
       mockPythonExtApi.mockResolvedValue(makeMockPythonExtApi());
 
@@ -372,7 +374,9 @@ describe("PythonEnvironmentService", function () {
         return undefined;
       });
       mockExistsSync.mockReturnValue(false);
-      mockShowWarningMessage.mockResolvedValue("Disable Environments Extension");
+      mockShowWarningMessage.mockResolvedValue(
+        "Disable Environments Extension",
+      );
       mockShowInformationMessage.mockResolvedValue("Reload Now");
       mockPythonExtApi.mockResolvedValue(makeMockPythonExtApi());
 

--- a/test/unit/services/PythonEnvironmentService.test.ts
+++ b/test/unit/services/PythonEnvironmentService.test.ts
@@ -309,6 +309,7 @@ describe("PythonEnvironmentService", function () {
 
       // Reset initialized flag to allow a second initialize() call on the same
       // instance, keeping _petWarningShown=true to exercise the early-return path.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (service as any)._initialized = false;
       await service.initialize();
 

--- a/test/unit/services/PythonEnvironmentService.test.ts
+++ b/test/unit/services/PythonEnvironmentService.test.ts
@@ -284,6 +284,110 @@ describe("PythonEnvironmentService", function () {
 
       expect(mockOpenExternal).toHaveBeenCalled();
     });
+
+    it("should not show warning again if already shown in current session", async function () {
+      mockGetExtension.mockImplementation((id: string) => {
+        if (id === PYTHON_ENVS_EXTENSION_ID) {
+          return {
+            isActive: true,
+            extensionPath: "/ext/path",
+            exports: makeMockEnvsApi(),
+            activate: vi.fn(),
+          };
+        }
+        if (id === "ms-python.python") {
+          return { isActive: true, activate: vi.fn() };
+        }
+        return undefined;
+      });
+      mockExistsSync.mockReturnValue(false);
+      mockShowWarningMessage.mockResolvedValue(undefined);
+      mockPythonExtApi.mockResolvedValue(makeMockPythonExtApi());
+
+      await service.initialize();
+      expect(mockShowWarningMessage).toHaveBeenCalledTimes(1);
+
+      // Reset initialized flag to allow a second initialize() call on the same
+      // instance, keeping _petWarningShown=true to exercise the early-return path.
+      (service as any)._initialized = false;
+      await service.initialize();
+
+      expect(mockShowWarningMessage).toHaveBeenCalledTimes(1);
+    });
+
+    it("should disable environments extension when that button is selected", async function () {
+      mockGetExtension.mockImplementation((id: string) => {
+        if (id === PYTHON_ENVS_EXTENSION_ID) {
+          return {
+            isActive: true,
+            extensionPath: "/ext/path",
+            exports: makeMockEnvsApi(),
+            activate: vi.fn(),
+          };
+        }
+        if (id === "ms-python.python") {
+          return { isActive: true, activate: vi.fn() };
+        }
+        return undefined;
+      });
+      mockExistsSync.mockReturnValue(false);
+      mockShowWarningMessage.mockResolvedValue("Disable Environments Extension");
+      mockShowInformationMessage.mockResolvedValue(undefined);
+      mockPythonExtApi.mockResolvedValue(makeMockPythonExtApi());
+
+      const mockConfig = {
+        get: vi.fn().mockReturnValue(true),
+        update: vi.fn().mockResolvedValue(undefined),
+      };
+      mockGetConfiguration.mockReturnValue(mockConfig);
+
+      await service.initialize();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(mockConfig.update).toHaveBeenCalledWith(
+        "useEnvironmentsExtension",
+        false,
+        vscode.ConfigurationTarget.Global,
+      );
+      expect(mockShowInformationMessage).toHaveBeenCalledWith(
+        expect.stringContaining("Reload"),
+        "Reload Now",
+      );
+    });
+
+    it("should reload window when Reload Now selected after disabling environments extension", async function () {
+      mockGetExtension.mockImplementation((id: string) => {
+        if (id === PYTHON_ENVS_EXTENSION_ID) {
+          return {
+            isActive: true,
+            extensionPath: "/ext/path",
+            exports: makeMockEnvsApi(),
+            activate: vi.fn(),
+          };
+        }
+        if (id === "ms-python.python") {
+          return { isActive: true, activate: vi.fn() };
+        }
+        return undefined;
+      });
+      mockExistsSync.mockReturnValue(false);
+      mockShowWarningMessage.mockResolvedValue("Disable Environments Extension");
+      mockShowInformationMessage.mockResolvedValue("Reload Now");
+      mockPythonExtApi.mockResolvedValue(makeMockPythonExtApi());
+
+      const mockConfig = {
+        get: vi.fn().mockReturnValue(true),
+        update: vi.fn().mockResolvedValue(undefined),
+      };
+      mockGetConfiguration.mockReturnValue(mockConfig);
+
+      await service.initialize();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(mockExecuteCommand).toHaveBeenCalledWith(
+        "workbench.action.reloadWindow",
+      );
+    });
   });
 
   describe("initialize — PET warning globalState persistence", function () {

--- a/test/unit/services/PythonEnvironmentService.test.ts
+++ b/test/unit/services/PythonEnvironmentService.test.ts
@@ -196,7 +196,7 @@ describe("PythonEnvironmentService", function () {
       await service.initialize();
 
       // Second call must not trigger any additional extension lookups
-      expect(mockGetExtension.mock.calls.length).toBe(callsAfterFirst);
+      expect(mockGetExtension.mock.calls).toHaveLength(callsAfterFirst);
     });
   });
 
@@ -558,6 +558,44 @@ describe("PythonEnvironmentService", function () {
       expect(env).toBeDefined();
       expect(env?.execInfo.run.executable).toBe("/usr/bin/python3");
       expect(env?.version).toBe("3.11.5");
+    });
+
+    it("should return undefined and log when fallback resolveEnvironment throws", async function () {
+      const fallbackApi = makeMockPythonExtApi({
+        resolveEnvironment: vi
+          .fn()
+          .mockRejectedValue(new Error("resolve boom")),
+      });
+
+      mockGetExtension.mockImplementation((id: string) => {
+        if (id === PYTHON_ENVS_EXTENSION_ID) {
+          return {
+            isActive: true,
+            extensionPath: "/ext/path",
+            exports: makeMockEnvsApi(),
+            activate: vi.fn(),
+          };
+        }
+        if (id === "ms-python.python") {
+          return { isActive: true, activate: vi.fn() };
+        }
+        return undefined;
+      });
+      mockExistsSync.mockReturnValue(false);
+      mockShowWarningMessage.mockResolvedValue(undefined);
+      mockPythonExtApi.mockResolvedValue(fallbackApi);
+
+      const consoleErrorSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => undefined);
+
+      await service.initialize();
+      const env = await service.getEnvironment();
+
+      expect(env).toBeUndefined();
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Error getting environment (python ext)"),
+      );
     });
 
     it("should return undefined when fallback resolves to nothing", async function () {
@@ -935,6 +973,43 @@ describe("PythonEnvironmentService", function () {
       const result = await service.getEnvironments();
 
       expect(result).toEqual([]);
+    });
+
+    it("should return empty array and log when fallback resolveEnvironment throws", async function () {
+      const fallbackApi = makeMockPythonExtApi({
+        known: [{ id: "env-1", path: "/usr/bin/python3" }],
+        resolveEnvironment: vi.fn().mockRejectedValue(new Error("list boom")),
+      });
+
+      mockGetExtension.mockImplementation((id: string) => {
+        if (id === PYTHON_ENVS_EXTENSION_ID) {
+          return {
+            isActive: true,
+            extensionPath: "/ext/path",
+            exports: makeMockEnvsApi(),
+            activate: vi.fn(),
+          };
+        }
+        if (id === "ms-python.python") {
+          return { isActive: true, activate: vi.fn() };
+        }
+        return undefined;
+      });
+      mockExistsSync.mockReturnValue(false);
+      mockShowWarningMessage.mockResolvedValue(undefined);
+      mockPythonExtApi.mockResolvedValue(fallbackApi);
+
+      const consoleErrorSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => undefined);
+
+      await service.initialize();
+      const result = await service.getEnvironments();
+
+      expect(result).toEqual([]);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Error getting environments (python ext)"),
+      );
     });
 
     it("should call API getEnvironments with scope", async function () {


### PR DESCRIPTION
## Summary

On OpenVSX-based editors (VSCodium, Dev Spaces) the PET binary is absent from the `ms-python.vscode-python-envs` universal build, so the warning fired on every extension host restart. The `_petWarningShown` flag was in-memory and reset each time the extension host restarted.

- Pass `ExtensionContext` into `PythonEnvironmentService.initialize()` so the service can read/write `globalState`
- Replace the unconditional once-per-process suppression with an explicit **Don't show again** button that persists the decision to `globalState`; users who dismiss without clicking continue to see the warning on subsequent restarts until they actively choose to suppress it
- Add tests covering the new `globalState` path: persist on click, no persist on dismiss, suppress when already set

The root cause of #2792 is upstream - OpenVSX distributes a universal VSIX for `ms-python.vscode-python-envs` that omits the platform-specific `pet` binary. The extension already handles this correctly by falling back to `ms-python.python`. This change addresses the UX symptom: the repeated warning popup on every restart.

Relates to #2792

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Merge branch 'main' into gy/fix-pet-warning-globalstate: Persist PET-missing Python environment warning suppression across extension-host restarts by passing ExtensionContext into PythonEnvironmentService.initialize(). Persist warning suppression across restarts via ExtensionContext.globalState; “Don’t show again” writes ansible.petWarningShown, dismiss leaves it unset. Tests verify persistence, dismiss, and pre-set suppression.
- Pass context to pythonEnvService.initialize
- Persist/skip PET warning via globalState
- Add unit tests for persistence/dismiss/pre-set

Related: `#2792`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->