### PR TITLE
chore(ci): update CI workflow to use Windows runners and remove self-hosted cleanup steps

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -69,8 +69,14 @@ keytar
 knip
 lcovonly
 lextudio
+libasound
+libatk
 libgbm
+libnspr
+libnss
 libonig
+libxkbcommon
+libxshmfence
 libyaml
 lightspeed
 lineinfile
@@ -123,3 +129,4 @@ watsonx
 wdio
 whereis
 xunit
+zstd

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,7 @@ concurrency:
 env:
   # https://docs.github.com/en/actions/learn-github-actions/environment-variables
   # https://devblogs.microsoft.com/commandline/share-environment-vars-between-wsl-and-windows/
-  WSLENV: HOSTNAME:CI:FORCE_COLOR:GITHUB_ACTION:GITHUB_ACTION_PATH/p:GITHUB_ACTION_REPOSITORY:GITHUB_WORKFLOW:GITHUB_WORKSPACE/p:GITHUB_PATH/p:GITHUB_ENV/p:VIRTUAL_ENV/p:SKIP_PODMAN:SKIP_DOCKER:NODE_OPTIONS:MISE_ENV
+  WSLENV: HOSTNAME:CI:FORCE_COLOR:GITHUB_ACTION:GITHUB_ACTION_PATH/p:GITHUB_ACTION_REPOSITORY:GITHUB_WORKFLOW:GITHUB_WORKSPACE/p:GITHUB_PATH/p:GITHUB_ENV/p:GITHUB_OUTPUT/p:GITHUB_STATE/p:GITHUB_STEP_SUMMARY/p:VIRTUAL_ENV/p:SKIP_PODMAN:SKIP_DOCKER:NODE_OPTIONS:MISE_ENV
   # We define a hostname because otherwise the variable might not always be accessible on runners.
   HOSTNAME: gha
   # help pytest output be colored on GHA
@@ -292,48 +292,18 @@ jobs:
           - name: test (wsl)
             id: test-wsl
             task-name: test
-            os: wsl-runner
-            runs-on: self-hosted
+            os: windows-latest
+            shell: "wsl-bash {0}"
             env:
               SKIP_PODMAN: 1
               SKIP_DOCKER: 1
+            continue-on-error: true
     steps:
-      # Self-hosted runners retain root-owned files from rootless Podman
-      # (overlay storage under out/als/tmp/).  These files live inside a
-      # user-namespace so normal rm fails with EACCES and sudo is
-      # unavailable.  `podman unshare` re-enters the same namespace,
-      # letting us delete them before checkout touches the workspace.
-      - name: Remove Podman overlay files on self-hosted runner
-        if: matrix.runs-on == 'self-hosted'
-        run: |
-          target="${GITHUB_WORKSPACE}/out/als/tmp/home/.local/share/containers"
-          if [ -d "$target" ]; then
-            podman unshare rm -rf -- "$target" \
-              || buildah unshare rm -rf -- "$target" \
-              || echo "::warning::Could not remove $target — checkout may fail"
-          fi
-
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0 # we need tags for dynamic versioning
           fetch-tags: true # needed for dynamic versioning
           show-progress: false
-          clean: ${{ (matrix.runs-on || '') != 'self-hosted' }}
-
-      - name: Clean workspace on self-hosted runner
-        if: matrix.runs-on == 'self-hosted'
-        run: |
-          set -euxo pipefail
-          # Rootless Podman overlays under .cache/containers/ use user
-          # namespace remapping; remove them with podman or sudo.
-          if [ -d .cache/containers ]; then
-            podman unshare rm -rf -- .cache/containers 2>/dev/null \
-              || sudo rm -rf -- .cache/containers \
-              || true
-          fi
-          sudo find . -not -user "$(id -u)" -delete 2>/dev/null || true
-          git reset --hard HEAD
-          git clean -ffdx -e out/als/tmp/
 
       - name: Run setup steps (composite action)
         uses: ./.github/actions/setup
@@ -342,7 +312,7 @@ jobs:
 
       # https://github.com/marketplace/actions/setup-wsl
       - name: Activate WSL
-        if: contains(matrix.name, 'wsl') && (matrix.runs-on || '') != 'self-hosted'
+        if: contains(matrix.name, 'wsl')
         uses: Vampire/setup-wsl@d1da7f2c0322a5ee4f24975344f67fc0f5baf364 # v7.0.0
         with:
           distribution: Ubuntu-24.04
@@ -372,6 +342,16 @@ jobs:
             gpg
             gpg-agent
             jq
+            libasound2t64
+            libatk-bridge2.0-0t64
+            libatk1.0-0t64
+            libgbm1
+            libgtk-3-0t64
+            libnspr4
+            libnss3
+            libsecret-1-0
+            libxkbcommon0
+            libxshmfence1
             make
             python3-dev
             python3-full
@@ -380,7 +360,73 @@ jobs:
             tar
             unzip
             xvfb
+            zstd
           # asdf nodejs plugin requires: dirmngr gpg curl gawk
+
+      - name: Cache WSL bootstrap
+        if: contains(matrix.name, 'wsl')
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        id: wsl-cache
+        with:
+          path: .cache/wsl-bootstrap
+          key: wsl-bootstrap-v2-${{ hashFiles('.config/mise.toml', 'pnpm-lock.yaml') }}
+
+      - name: Bootstrap tools inside WSL
+        if: contains(matrix.name, 'wsl')
+        run: |
+          set -euxo pipefail
+
+          # Cache lives on the Windows filesystem (actions/cache can
+          # reach it); we tar WSL-side tools from/to there.
+          CACHE_TAR="$GITHUB_WORKSPACE/.cache/wsl-bootstrap/wsl-tools.tar.zst"
+
+          if [ -f "$CACHE_TAR" ]; then
+            echo "::group::Restoring cached WSL tools"
+            tar xf "$CACHE_TAR" -C /
+            echo "::endgroup::"
+          else
+            echo "::group::Installing mise and tools from scratch"
+            curl -fsSL https://mise.run | sh
+            export PATH="$HOME/.local/bin:$PATH"
+            mise settings set experimental true
+            mise trust
+            mise install
+            mise reshim
+            echo "::endgroup::"
+          fi
+
+          # GITHUB_PATH doesn't work for WSL paths (runner is on the
+          # Windows side), so persist PATH via .bashrc which is loaded
+          # by every step (wsl-shell-command uses bash -i).
+          SHIMS="$HOME/.local/share/mise/shims"
+          export PATH="$HOME/.local/bin:$SHIMS:$PATH"
+          echo "export PATH=\"$HOME/.local/bin:$SHIMS:\$PATH\"" >> ~/.bashrc
+          mise reshim
+
+      - name: Save WSL bootstrap cache
+        if: contains(matrix.name, 'wsl') && steps.wsl-cache.outputs.cache-hit != 'true'
+        run: |
+          set -euxo pipefail
+          CACHE_TAR="$GITHUB_WORKSPACE/.cache/wsl-bootstrap/wsl-tools.tar.zst"
+          mkdir -p "$(dirname "$CACHE_TAR")"
+          tar cf "$CACHE_TAR" --zstd \
+            "$HOME/.local/bin/mise" \
+            "$HOME/.local/share/mise" \
+            2>/dev/null || true
+
+      - name: Copy source to native WSL filesystem
+        if: contains(matrix.name, 'wsl')
+        run: |
+          set -euxo pipefail
+          WSL_SRC="$HOME/workspace"
+          mkdir -p "$WSL_SRC"
+          tar cf - --exclude=.git --exclude=node_modules \
+            -C "$GITHUB_WORKSPACE" . | tar xf - -C "$WSL_SRC"
+          echo "gitdir: $GITHUB_WORKSPACE/.git" > "$WSL_SRC/.git"
+          echo "cd $WSL_SRC" >> ~/.bashrc
+
+          cd "$WSL_SRC"
+          pnpm install --frozen-lockfile
 
       # Workaround for: https://github.com/actions/runner/issues/1864
       - name: Ensure HOME is defined
@@ -503,9 +549,17 @@ jobs:
           # Reduce artifact size by removing cached test data
           rm -rf out/e2e/tmp/home/.cache || true
 
+      - name: Copy WSL test artifacts to Windows filesystem
+        if: ${{ always() && contains(matrix.name, 'wsl') }}
+        run: |
+          set -euxo pipefail
+          if [ -d out ]; then
+            tar cf - --dereference out | tar xf - -C "$GITHUB_WORKSPACE"
+          fi
+
       - name: Upload test logs and reports as logs-${{ steps.setup.outputs.OS_VERSION }}-${{ matrix.task-name }}.zip
-        # git-leaks not support on Windows
-        if: ${{ !cancelled() && runner.os != 'Windows'}}
+        # git-leaks not support on Windows (except WSL which runs Linux)
+        if: ${{ !cancelled() && (runner.os != 'Windows' || contains(matrix.name, 'wsl')) }}
         uses: ansible/actions/upload-artifact@main
         with:
           name: logs-${{ steps.setup.outputs.OS_VERSION }}-${{ matrix.id }}-${{ github.run_attempt }}.zip


### PR DESCRIPTION
This commit modifies the CI workflow by changing the runner for the 'test (wsl)' job from a self-hosted WSL runner to 'windows-latest'. It also removes unnecessary cleanup steps related to self-hosted runners, streamlining the workflow for better performance and reliability. The condition for activating WSL has been adjusted accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Merge branch 'main' into remove-self-hosted-wsl-runner migrates the WSL CI test job from self-hosted WSL runners to GitHub-managed `windows-latest`, removing self-hosted-specific cleanup/guard logic. It simplifies WSL activation, bootstraps WSL toolchains with cached setup, installs dependencies inside WSL, and copies artifacts back to Windows for reporting.

- Switch `test (wsl)` runner from self-hosted WSL to `windows-latest` using a `wsl-bash` shell
- Remove self-hosted-dependent checkout `clean:` behavior and Podman overlay/workspace cleanup steps
- Simplify WSL activation to trigger when the matrix name contains `wsl`; extend WSL `additional-packages` with `*-t64` libs and adjust `WSLENV`
- Add cached WSL bootstrap/tooling steps, persist PATH via `.bashrc`, copy the repo into native WSL at `$HOME/workspace`, and run `pnpm install` inside WSL
- Copy WSL test outputs back to `$GITHUB_WORKSPACE` and broaden log/report upload conditions to Windows `wsl` matrices
- Expand `.config/dictionary.txt` `lib*` entries and add `zstd`
  

