### PR TITLE
feat(views): add plugin tooltips and AI sparkle for SCM plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -555,6 +555,11 @@
         "icon": "$(sparkle)"
       },
       {
+        "command": "ansibleCollectionSources.githubPluginAiSummary",
+        "title": "Describe with AI",
+        "icon": "$(sparkle)"
+      },
+      {
         "command": "ansibleCollectionSources.showGitHubPluginDoc",
         "title": "Show Plugin Documentation",
         "icon": "$(book)"
@@ -821,6 +826,11 @@
         {
           "command": "ansibleCollectionSources.galaxyPluginAiSummary",
           "when": "view == ansibleCollectionSources && viewItem == galaxyPlugin && config.ansibleEnvironments.enableAiFeatures",
+          "group": "inline@1"
+        },
+        {
+          "command": "ansibleCollectionSources.githubPluginAiSummary",
+          "when": "view == ansibleCollectionSources && viewItem == githubPlugin && config.ansibleEnvironments.enableAiFeatures",
           "group": "inline@1"
         }
       ]

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -78,6 +78,7 @@ export {
     buildCollectionSummaryPrompt,
     buildPluginExplanationPrompt,
     buildGalaxyPluginExplanationPrompt,
+    buildScmPluginExplanationPrompt,
     buildCollectionSourcesOverviewPrompt,
     buildGalaxySourceSummaryPrompt,
     buildGithubOrgSourceSummaryPrompt,

--- a/packages/common/src/prompts/collections.ts
+++ b/packages/common/src/prompts/collections.ts
@@ -77,6 +77,32 @@ Use the \`get_galaxy_plugin_doc\` MCP tool with collection="${collectionFqcn}", 
 4. Any gotchas or best practices`;
 }
 
+/**
+ * Build an AI prompt to describe an SCM-sourced plugin (GitHub).
+ *
+ * @param org - GitHub organization (e.g. "redhat-cop").
+ * @param repo - Repository name (e.g. "infra.aap_configuration").
+ * @param collectionFqcn - Collection namespace.name (e.g. "infra.aap_configuration").
+ * @param pluginName - Short plugin name (e.g. "credential_type").
+ * @param pluginType - Plugin type (module, lookup, filter, etc.).
+ * @returns Prompt instructing the AI to fetch and explain the SCM plugin.
+ */
+export function buildScmPluginExplanationPrompt(
+    org: string,
+    repo: string,
+    collectionFqcn: string,
+    pluginName: string,
+    pluginType: string,
+): string {
+    return `Explain the Ansible ${pluginType} plugin "${collectionFqcn}.${pluginName}" from the GitHub collection "${collectionFqcn}" (${org}/${repo}).
+
+Use the \`get_scm_plugin_doc\` MCP tool with org="${org}", repo="${repo}", collection="${collectionFqcn}", plugin="${pluginName}", and plugin_type="${pluginType}" to get the full documentation, then provide:
+1. What this plugin does in plain language
+2. The most important parameters and when to use them
+3. A practical example task showing common usage
+4. Any gotchas or best practices`;
+}
+
 /** Input for building a collection sources overview prompt. */
 export interface CollectionSourcesInput {
     galaxyCount: number;

--- a/packages/common/src/prompts/index.ts
+++ b/packages/common/src/prompts/index.ts
@@ -12,6 +12,7 @@ export {
     buildCollectionSummaryPrompt,
     buildPluginExplanationPrompt,
     buildGalaxyPluginExplanationPrompt,
+    buildScmPluginExplanationPrompt,
     buildCollectionSourcesOverviewPrompt,
     buildGalaxySourceSummaryPrompt,
     buildGithubOrgSourceSummaryPrompt,

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -24,6 +24,7 @@ export {
     buildCollectionSummaryPrompt,
     buildPluginExplanationPrompt,
     buildGalaxyPluginExplanationPrompt,
+    buildScmPluginExplanationPrompt,
     buildCollectionSourcesOverviewPrompt,
     buildGalaxySourceSummaryPrompt,
     buildGithubOrgSourceSummaryPrompt,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -46,6 +46,7 @@ import {
     buildCollectionSummaryPrompt,
     buildPluginExplanationPrompt,
     buildGalaxyPluginExplanationPrompt,
+    buildScmPluginExplanationPrompt,
     buildEESummaryPrompt,
     buildEEDetailPrompt,
     buildCreatorOverviewPrompt,
@@ -1108,12 +1109,50 @@ export function activate(context: vscode.ExtensionContext) {
             pluginType: string;
             collection: { namespace: string; name: string };
         }) => {
+            if (
+                !vscode.workspace
+                    .getConfiguration('ansibleEnvironments')
+                    .get<boolean>('enableAiFeatures', true)
+            ) {
+                return;
+            }
             if (!node) {
                 vscode.window.showWarningMessage('Select a Galaxy plugin from the tree view.');
                 return;
             }
             const collectionFqcn = `${node.collection.namespace}.${node.collection.name}`;
             const prompt = buildGalaxyPluginExplanationPrompt(
+                collectionFqcn,
+                node.plugin.name,
+                node.pluginType,
+            );
+            await openChatWithPrompt(prompt);
+        },
+    );
+
+    const githubPluginAiSummaryCommand = vscode.commands.registerCommand(
+        'ansibleCollectionSources.githubPluginAiSummary',
+        async (node?: {
+            plugin: { name: string; fullName: string };
+            pluginType: string;
+            collection: { namespace: string; name: string; org: string; repository: string };
+        }) => {
+            if (
+                !vscode.workspace
+                    .getConfiguration('ansibleEnvironments')
+                    .get<boolean>('enableAiFeatures', true)
+            ) {
+                return;
+            }
+            if (!node) {
+                vscode.window.showWarningMessage('Select a GitHub plugin from the tree view.');
+                return;
+            }
+            const collectionFqcn = `${node.collection.namespace}.${node.collection.name}`;
+            const repo = node.collection.repository.split('/').pop() ?? node.collection.repository;
+            const prompt = buildScmPluginExplanationPrompt(
+                node.collection.org,
+                repo,
                 collectionFqcn,
                 node.plugin.name,
                 node.pluginType,
@@ -1362,6 +1401,7 @@ export function activate(context: vscode.ExtensionContext) {
         installGalaxyCollectionCommand,
         showGalaxyPluginDocCommand,
         galaxyPluginAiSummaryCommand,
+        githubPluginAiSummaryCommand,
         showGitHubPluginDocCommand,
         refreshGitHubCollectionCommand,
         selectLlmModelCommand,

--- a/src/views/CollectionSourcesProvider.ts
+++ b/src/views/CollectionSourcesProvider.ts
@@ -181,6 +181,18 @@ class GalaxyPluginNode extends vscode.TreeItem {
         this.iconPath = new vscode.ThemeIcon('symbol-method');
         this.contextValue = 'galaxyPlugin';
 
+        const tooltip = new vscode.MarkdownString();
+        tooltip.appendMarkdown(`**`);
+        tooltip.appendText(plugin.fullName);
+        tooltip.appendMarkdown(`** *(${pluginType})*\n\n`);
+        if (plugin.shortDescription) {
+            tooltip.appendText(plugin.shortDescription);
+            tooltip.appendMarkdown('\n\n');
+        }
+        tooltip.appendMarkdown('Collection: ');
+        tooltip.appendText(`${collection.namespace}.${collection.name} v${collection.version}`);
+        this.tooltip = tooltip;
+
         this.command = {
             command: 'ansibleCollectionSources.showGalaxyPluginDoc',
             title: 'Show Plugin Documentation',
@@ -249,8 +261,22 @@ class GitHubPluginNode extends vscode.TreeItem {
     ) {
         super(plugin.name, vscode.TreeItemCollapsibleState.None);
         this.description = plugin.shortDescription;
-        this.iconPath = new vscode.ThemeIcon('sparkle');
+        this.iconPath = new vscode.ThemeIcon('symbol-method');
         this.contextValue = 'githubPlugin';
+
+        const tooltip = new vscode.MarkdownString();
+        tooltip.appendMarkdown(`**`);
+        tooltip.appendText(plugin.fullName);
+        tooltip.appendMarkdown(`** *(${pluginType})*\n\n`);
+        if (plugin.shortDescription) {
+            tooltip.appendText(plugin.shortDescription);
+            tooltip.appendMarkdown('\n\n');
+        }
+        tooltip.appendMarkdown('Collection: ');
+        tooltip.appendText(`${collection.namespace}.${collection.name} v${collection.version}`);
+        tooltip.appendMarkdown('\n\nSource: ');
+        tooltip.appendText(`${collection.org}/${repoNameFrom(collection.repository)}`);
+        this.tooltip = tooltip;
 
         this.command = {
             command: 'ansibleCollectionSources.showGitHubPluginDoc',


### PR DESCRIPTION
## Summary
- Add rich hover tooltips to plugin tree nodes (Galaxy and SCM) showing FQCN, type, description, and source
- Add the sparkle AI action button for SCM/GitHub plugins, matching the existing Galaxy pattern

## Changes
- **Plugin tooltips** (`CollectionSourcesProvider.ts`): Both `GalaxyPluginNode` and `GitHubPluginNode` now render a Markdown tooltip on hover with plugin FQCN, type, short description, collection version, and source (org/repo for SCM)
- **AI sparkle for SCM plugins** (`package.json`, `extension.ts`): New `githubPluginAiSummary` command with `$(sparkle)` inline icon, gated by `enableAiFeatures` setting. Opens an AI chat session using `get_scm_plugin_doc` to explain the plugin
- **`buildScmPluginExplanationPrompt`** (`packages/common/src/prompts/collections.ts`): New prompt that references `get_scm_plugin_doc` with org/repo/collection/plugin parameters
- **Exports**: New prompt exported from `@ansible/common` and `@ansible/services`

## Test plan
- [x] `npm run lint` (`eslint .`) passes
- [x] `npm exec tsc -- -b` compiles cleanly
- [x] `npm exec vitest -- run` passes (726 tests, 45 files)
- [x] `npm run build` (esbuild) bundles cleanly