### PR TITLE
chore(docs): harden developer experience and onboarding

### DIFF
--- a/.agents/skills/onboard/SKILL.md
+++ b/.agents/skills/onboard/SKILL.md
@@ -1,0 +1,212 @@
+---
+name: onboard
+description: >
+  Walk a new developer through the project architecture, ADRs,
+  development workflows, and codebase structure. Use when the user says
+  "onboard me", "walk me through the project", "I'm new here", "help me
+  get started", "show me the architecture", or any variant of asking for
+  an orientation to the ansible-environments codebase.
+argument-hint: "[--quick] [--topic architecture|workflows|adrs|skills]"
+user-invocable: true
+metadata:
+  author: ansible-environments team
+  version: 1.0.0
+---
+
+# Developer Onboarding
+
+Guide a new developer through the project step by step. This is an
+**interactive** skill — present each section, pause for questions, and
+adapt depth based on the developer's experience.
+
+## Workflow
+
+Run through these sections in order. After each section, ask if the
+developer has questions before proceeding.
+
+If the user passes `--quick`, give a condensed overview (one paragraph
+per section, skip the deep dives). If `--topic <topic>` is given, jump
+directly to that section.
+
+### Section 1: Project Overview
+
+Read and present `CONTRIBUTING.md` (prerequisites, setup, daily
+workflow). Confirm the developer has:
+
+- Node.js 22+ and npm 10+
+- VS Code installed
+- The repo cloned and `npm ci` completed
+
+Then run:
+
+```bash
+npm run compile && npm run build
+```
+
+Verify both succeed. If not, troubleshoot before continuing.
+
+### Section 2: Architecture
+
+Read and present `AGENTS.md`, focusing on:
+
+1. **Package architecture** — explain the five packages and their
+   dependency rules:
+   - `@ansible/common` — browser-safe, zero Node.js dependencies
+   - `@ansible/services` — Node.js services, conditional `vscode` require
+   - `@ansible/language-server` — LSP server
+   - `@ansible/mcp-server` — standalone MCP server for AI agents
+   - `@ansible/ui` — shared React webview components
+
+2. **Extension host** (`src/`) — panels, views, services, features
+
+3. **The nine architectural invariants** — read each one aloud. These
+   are non-negotiable and the most important thing for a new developer
+   to internalize.
+
+Point to `AGENTS.md` for the full reference.
+
+### Section 3: Architecture Decision Records
+
+Read `.sdlc/adrs/README.md` to list all ADRs. Walk through the key
+ones in this order:
+
+| ADR | Why it matters for onboarding |
+|-----|-------------------------------|
+| ADR-001 | Foundational: why we have a service layer separate from VS Code |
+| ADR-011 | Package split: `@ansible/common` vs `@ansible/services` |
+| ADR-005 | The invariants — explains *why* each rule exists |
+| ADR-006 | esbuild bundler — how the build works |
+| ADR-014 | Internal skills — how AI prompts are managed |
+| ADR-012 | MCP tool parity — every UI feature needs an MCP tool |
+
+For each ADR, summarize the **Decision** and **Consequences** sections.
+Don't read them verbatim — explain them conversationally.
+
+Skip ADRs that are `Proposed` or `Deprecated` unless the developer asks.
+
+### Section 4: Development Workflows
+
+Walk through the daily development loop:
+
+1. **Branching** — read the `branching-strategy` skill. Key point:
+   `next` is the active branch, `main` is frozen, never merge between
+   them. All feature branches come from `upstream/next`.
+
+2. **Edit → Check → Iterate cycle**:
+   ```bash
+   npm run check    # compile + lint + test (fast feedback)
+   ```
+
+3. **Before committing**:
+   ```bash
+   npm run ci       # compile + lint + test:coverage + build
+   ```
+   This mirrors CI. Do not push if it fails.
+
+4. **Submitting a PR** — point to the `submit-pr` skill. Key points:
+   - Conventional Commits with project scopes
+   - Labels required (`breaking`, `chore`, `feat`, `fix`)
+   - Target `next`, never `main`
+   - Single commit, draft until CI green
+
+5. **Handling PR review** — point to the `pr-review` skill. Key points:
+   - Reply to every comment with explanation + commit hash
+   - Resolve threads explicitly
+   - Common Copilot patterns to watch for
+
+6. **Testing the extension locally**:
+   ```bash
+   npm run package           # package VSIX only
+   npm run package:install   # package + install into VS Code
+   ```
+   After `package:install`, reload VS Code to activate the updated
+   extension. Press `F5` for a lighter-weight Extension Development
+   Host (uses the dev build without packaging).
+
+### Section 5: Internal Skills and AI Integration
+
+Explain the dual-consumption model for AI prompts:
+
+1. **Internal skills** live in `packages/common/src/skills/*.md` as
+   markdown with YAML frontmatter.
+2. **Codegen** produces `.content.ts` sidecars (`node scripts/generate-skill-content.mjs`).
+3. **Prompt builders** in `packages/common/src/prompts/` import
+   `.content` files and append dynamic context.
+4. **MCP agents** discover skills via `skill_list` / `skill_get` tools
+   through the `SkillRegistry` `builtin` source.
+
+Point to ADR-014 for the full rationale.
+
+### Section 6: Key Services Tour
+
+Briefly explain the major services — what each one does, not how it
+works internally:
+
+| Service | What it does |
+|---------|-------------|
+| `CollectionsService` | Plugin doc cache, collection discovery |
+| `CommandService` | Runs CLI tools from the active Python env |
+| `CreatorService` | Scaffolds content via `ansible-creator` |
+| `ExecutionEnvService` | EE image listing and inspection |
+| `SkillRegistry` | AI skill discovery and indexing |
+| `EECache` / `EnvironmentCache` | Caching layers for EE and env data |
+| `SCMDocsCache` | Plugin docs from Git repos (shallow clone) |
+
+Point to `packages/services/src/` for the implementations.
+
+### Section 7: Testing
+
+Explain the test structure:
+
+- **Unit tests** (`vitest`) — in `packages/*/test/` and `test/unit/`
+- **Integration tests** — `test/integration/` (requires VS Code test runner)
+- **UI tests** (`wdio`) — `test/ui/` (requires display server)
+- **Coverage thresholds** — 85% statements, 75% branches, 85%
+  functions, 85% lines (enforced by `npm run test:coverage`)
+
+Show how to run tests:
+
+```bash
+npm test              # quick unit tests
+npm run test:coverage # with thresholds (matches CI)
+npm run test:ui       # e2e (requires display)
+```
+
+### Section 8: Common Pitfalls
+
+Read the "Common pitfalls" table from `CONTRIBUTING.md` and walk
+through each one. These are the mistakes that have caused the most
+rework historically:
+
+- Wrong Node version (ESLint 10 needs Node 20+)
+- Stale bundles after changes
+- Partial lint (single file vs full project)
+- Forgetting skill codegen after editing `.md` files
+- CI vs local environment mismatch
+
+### Section 9: Available Agent Skills
+
+List all skills in `.agents/skills/` with a one-line description of
+when to use each:
+
+| Skill | When to use |
+|-------|-------------|
+| `onboard` | First-time project orientation (you are here) |
+| `submit-pr` | Creating a pull request |
+| `pr-review` | Responding to review comments |
+| `write-adr` | Architectural decisions |
+| `manage-todos` | Project work item tracking |
+| `branching-strategy` | Branch questions (next vs main) |
+| `review-contributor-pr` | Reviewing external contributions |
+
+### Wrap-up
+
+Ask the developer:
+
+1. Do you have questions about any section?
+2. Is there a specific area of the codebase you want to explore first?
+3. Do you have a task or issue to start working on?
+
+If they have a task, suggest the appropriate workflow (e.g.,
+`submit-pr` for a new feature, `write-adr` for an architectural
+change).

--- a/.agents/skills/pr-review/SKILL.md
+++ b/.agents/skills/pr-review/SKILL.md
@@ -81,6 +81,65 @@ Copilot often flags unused imports. With ESLint `no-unused-vars` enabled,
 these fail CI. Remove unused imports or prefix intentionally unused parameters
 with `_`. Prefer trimming the import list over disabling the rule.
 
+### JSDoc completeness
+
+ESLint enforces `jsdoc/require-param` and `jsdoc/require-returns`. Every
+exported function needs `@param` for each parameter and `@returns` for
+non-void return types. Add JSDoc proactively — Copilot flags missing
+annotations on nearly every PR.
+
+### Prettier formatting
+
+The project enforces single quotes (unless the string contains an
+apostrophe, in which case double quotes avoid `\'`), trailing commas,
+and consistent parenthesization. Run `npm exec eslint -- . --fix` before
+manual review. Generated files (`.content.ts`) must also pass prettier.
+
+### Import alias violations
+
+Use `@src/*` aliases for cross-boundary imports, not relative `../`
+paths that reach outside the current package. `no-restricted-imports`
+enforces this. Copilot flags violations that ESLint may also catch.
+
+### Command handler null guards
+
+VS Code commands invoked from the Command Palette may receive
+`undefined` arguments even if the `when` clause restricts menu
+visibility. Always guard `node` parameters in tree-view command
+handlers:
+
+```typescript
+if (!node) return;
+```
+
+### `appendText` vs `appendMarkdown`
+
+Use `appendText` for dynamic or external content in `MarkdownString`
+tooltips. `appendMarkdown` with user-controlled data risks formatting
+injection (e.g., unescaped `[`, `]`, backticks). Reserve
+`appendMarkdown` for static template text.
+
+### Runtime config guards
+
+If a feature is gated by a configuration setting in `package.json`
+`when` clauses, also guard the command handler at runtime. The
+Command Palette bypasses menu visibility — a user (or agent) can
+invoke the command even when the menu item is hidden.
+
+### Documentation and comment drift
+
+When renaming, refactoring, or changing behavior, update ALL comments,
+docstrings, and documentation in the same commit. Copilot flags
+stale comments on nearly every PR. This includes: JSDoc descriptions,
+inline comments, AGENTS.md, README.md, and ADRs.
+
+### Generated file hygiene
+
+After running codegen (`node scripts/generate-skill-content.mjs`), run
+`npm exec eslint -- .` on the full project. Prettier and
+typescript-eslint rules apply to generated `.content.ts` files. Quote
+style, line length, and formatting must match project conventions.
+
 ## Workflow
 
 1. **Ensure the PR branch is up to date with `next`.** Before reviewing or
@@ -118,12 +177,14 @@ gh run view RUN_ID --log-failed 2>&1 | tail -80
 
 Common CI failures and how to fix them:
 
-- **lint (eslint)**: Run `npm exec eslint -- . --fix` locally. Common issues:
-  unused imports, missing type annotations, inconsistent formatting.
-- **compile (tsc)**: Run `npm exec tsc -- -b` to check for type errors across all
-  packages. Fix type mismatches, missing imports, and `any` type leaks.
-- **unit tests (vitest)**: Run `npm exec vitest -- run` to reproduce. Update tests
-  when behavior changes.
+- **Any of lint / compile / test / build**: Run `npm run ci` locally to
+  reproduce the full CI pipeline. This is the fastest path to a fix.
+- **lint (eslint)**: Run `npm exec eslint -- . --fix` to auto-fix.
+  Common issues: unused imports, missing JSDoc, prettier formatting.
+- **compile (tsc)**: Run `npm run compile` (includes skill codegen).
+  Fix type mismatches, missing imports, and `any` type leaks.
+- **unit tests (vitest)**: Run `npm run test:coverage` to match CI
+  thresholds. Update tests when behavior changes.
 - **e2e tests (wdio)**: Run `npm run test:ui` to reproduce. These tests
   launch a real VS Code instance — check for timing issues and flaky
   selectors.

--- a/.agents/skills/submit-pr/SKILL.md
+++ b/.agents/skills/submit-pr/SKILL.md
@@ -33,22 +33,33 @@ Use a descriptive branch name (e.g., `feat/add-vault-commands`,
 If changes already exist on the current branch (e.g., from an in-progress
 session), cherry-pick or rebase them onto the new branch.
 
-### Step 2: Run lint and type checks
+### Step 2: Run the full CI check locally
 
 ```bash
-npm exec eslint -- .
-npm exec tsc -- -b
-npm exec vitest -- run
+npm run ci
 ```
+
+This single command runs skill codegen, TypeScript compilation, ESLint
+on the **entire project**, Vitest with coverage thresholds, and the
+esbuild production bundle. It mirrors what CI runs.
 
 **All checks must pass cleanly on all files** — not just the files you
 changed. If the branch has pre-existing violations (e.g., from an old base),
 rebase onto `upstream/next` first.
 
+**CRITICAL:** Run `npm run ci` as the **last step before committing**.
+Do not push if it fails. Do not claim quality gates passed without
+running this command. Partial lint (on changed files only) or skipping
+the build step has caused repeated CI failures.
+
 If violations are found:
 1. Run `npm exec eslint -- . --fix` to auto-fix what it can
 2. Manually fix remaining violations (type errors, test failures)
-3. Re-run until clean
+3. Re-run `npm run ci` until clean — do not shortcut with partial runs
+
+**Rebuild reminder:** After any code change, `npm run ci` handles
+compilation and bundling. If testing interactively (e.g., reloading the
+extension), also run `npm run compile && npm run build` explicitly.
 
 ### Step 3: Commit with conventional commits
 
@@ -118,9 +129,7 @@ gh pr create --base next --label "<type>" --title "conventional commit style tit
 - List each AI-generated artifact and its purpose
 
 ## Test plan
-- [ ] `npm exec eslint -- .` passes
-- [ ] `npm exec tsc -- -b` compiles cleanly
-- [ ] `npm exec vitest -- run` passes
+- [ ] `npm run ci` passes (compile + lint + test:coverage + build)
 - [ ] `npm run test:ui` passes (if e2e-relevant changes)
 
 related: #<issue_number>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,26 @@
 Read this file before touching code. It defines the architectural
 invariants and operational rules for the `next` branch.
 
+## New Developer Detection
+
+On your **first interaction** in this workspace, check whether the
+developer is new to the codebase:
+
+```bash
+git log --author="$(git config user.name)" --oneline next -- | head -1
+```
+
+If this returns empty (no commits on `next`), offer the `onboard`
+skill:
+
+> "It looks like this may be your first time working in this codebase.
+> Would you like me to walk you through the architecture, ADRs, and
+> development workflows? (Just say `/onboard` or skip to your task.)"
+
+Also offer onboarding if the developer asks orientation questions like
+"how does this work", "where is X", "what's the structure", or "I'm
+new here".
+
 ## Architectural Invariants
 
 These are non-negotiable. Violating any of them will break the system
@@ -67,10 +87,24 @@ See the `branching-strategy` skill for full details.
 
 Before committing:
 
-1. `npm exec tsc -- -b` — type check all packages
-2. `npm exec vitest -- run` — unit tests pass
-3. `npm exec eslint -- .` — no lint violations (when eslint config is available)
-4. Verify no architectural invariants (above) were violated
+1. `npm run ci` — **required before every commit/push**. Runs skill
+   codegen, TypeScript compilation, ESLint on the full project, Vitest
+   with coverage thresholds (85/75/85/85), and esbuild bundling. This
+   mirrors what CI runs. Do not push if it fails. Do not claim quality
+   gates passed without running this command.
+2. Verify no architectural invariants (above) were violated.
+
+For iterative development, `npm run check` (compile + lint + test
+without coverage thresholds or build) is acceptable. Switch to
+`npm run ci` before committing.
+
+### Rebuild after changes
+
+After **any** code change, run `npm run compile && npm run build`.
+The extension, MCP server, and language server all load from `dist/`
+(esbuild bundles) — stale bundles mask bugs. `npm run ci` includes
+both steps, but if you are testing interactively (e.g., reloading the
+extension window), rebuild explicitly.
 
 ## Commit Format
 
@@ -154,6 +188,7 @@ the closing `---` is the instruction text. Prompt builders call
 
 | Skill | When to use |
 |-------|-------------|
+| `onboard` | First-time developer orientation |
 | `submit-pr` | Creating a pull request |
 | `pr-review` | Responding to review comments |
 | `write-adr` | Architectural decisions (not bug fixes) |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,96 @@
+# Contributing to Ansible Environments
+
+## Prerequisites
+
+- **Node.js 22+** and **npm 10+** (ESLint 10 requires Node 20+)
+- **VS Code** (for extension development and debugging)
+- **Python 3.9+** (for Ansible tooling integration)
+
+## Setup
+
+```bash
+git clone git@github.com:cidrblock/ansible-environments.git
+cd ansible-environments
+git remote add upstream git@github.com:cidrblock/ansible-environments.git
+npm ci
+npm run compile
+npm run build
+```
+
+Use `npm ci` (not `npm install`) for reproducible dependency resolution.
+
+## Daily workflow
+
+1. Create a feature branch from `upstream/next`:
+   ```bash
+   git fetch upstream
+   git checkout -b feat/my-feature upstream/next
+   ```
+2. Make changes.
+3. Iterate with the fast check:
+   ```bash
+   npm run check    # compile + lint + test (no coverage thresholds)
+   ```
+4. Before committing, run the full CI mirror:
+   ```bash
+   npm run ci       # compile + lint + test:coverage + build
+   ```
+5. Commit, push, and open a PR targeting `next`.
+
+## Branching
+
+- **`next`** is the active development branch. All PRs target `next`.
+- **`main`** is frozen (legacy codebase). Never merge between them.
+- See the `branching-strategy` skill for details.
+
+## Project structure
+
+See [AGENTS.md](AGENTS.md) for architectural invariants and the full
+project layout. See the [ADR index](.sdlc/adrs/README.md) for design
+decisions.
+
+```
+packages/
+  common/           # @ansible/common — browser-safe types, prompts, utils
+  services/         # @ansible/services — Node.js service implementations
+  language-server/  # @ansible/language-server — LSP server
+  mcp-server/       # @ansible/mcp-server — standalone MCP server
+  ui/               # @ansible/ui — shared React webview components
+src/                # VS Code extension host (views, panels, commands)
+```
+
+## npm scripts reference
+
+| Script | What it does | When to use |
+|--------|-------------|-------------|
+| `npm run compile` | Skill codegen + `tsc -b` | After any code change |
+| `npm run build` | esbuild bundling | Before testing the extension or MCP server |
+| `npm run lint` | ESLint on the entire project | Check for lint violations |
+| `npm test` | Vitest (no coverage) | Quick test run |
+| `npm run test:coverage` | Vitest with coverage thresholds | Match CI thresholds (85/75/85/85) |
+| `npm run check` | compile + lint + test | Iterative development |
+| `npm run ci` | compile + lint + test:coverage + build | **Before every commit/push** |
+| `npm run watch` | `tsc -b --watch` | Continuous compilation during development |
+| `npm run watch:bundle` | esbuild watch mode | Continuous bundling during development |
+| `npm run package` | Package VSIX (no install) | Verify extension packaging works |
+| `npm run package:install` | Package VSIX and install into VS Code | Test the extension in your local VS Code |
+| `npm run test:ui` | WebDriverIO e2e tests | After UI/panel changes |
+
+## PR process
+
+- Follow [Conventional Commits](https://www.conventionalcommits.org).
+  Scopes: `core`, `ls`, `mcp`, `extension`, `views`, `panels`, `ci`, `docs`.
+- PRs require a label: `breaking`, `chore`, `feat`, or `fix`.
+- See the `submit-pr` skill for the full workflow.
+- See the `pr-review` skill for handling review feedback.
+
+## Common pitfalls
+
+| Pitfall | How to avoid |
+|---------|-------------|
+| **Node version too old** | ESLint 10 requires Node 20+. Use Node 22 LTS. |
+| **Stale bundles after changes** | Run `npm run compile && npm run build` or `npm run ci`. The extension and MCP server load from `dist/` — stale bundles mask bugs. |
+| **Partial lint** | Always lint the full project (`npm run lint`), not individual files. Cross-file issues (unused exports, import aliases) are invisible in single-file lint. |
+| **Forgetting skill codegen** | `npm run compile` includes codegen. If you edit a `.md` skill file, the `.content.ts` sidecar must be regenerated and committed together. |
+| **CI passes locally but fails remotely** | Ensure you run `npm run ci` (not just `npm run check`). Coverage thresholds and the esbuild build step catch additional failures. |
+| **Line ending issues** | `.gitattributes` enforces LF for skill files. If codegen produces different output on Windows, check `git config core.autocrlf`. |

--- a/README.md
+++ b/README.md
@@ -8,12 +8,15 @@ The extension uses a multi-package architecture with npm workspaces:
 
 ```
 packages/
-  core/           # @ansible/core — VS Code-independent service layer
-  mcp-server/     # @ansible/mcp-server — standalone MCP server
-src/              # Extension host (views, panels, commands)
+  common/           # @ansible/common — browser-safe types, prompts, utils, parsers
+  services/         # @ansible/services — Node.js service implementations
+  language-server/  # @ansible/language-server — LSP server
+  mcp-server/       # @ansible/mcp-server — standalone MCP server
+  ui/               # @ansible/ui — shared React webview components
+src/                # Extension host (views, panels, commands)
 ```
 
-`@ansible/core` contains all domain logic (collections, commands, creator, EE, caching) with no VS Code dependency. The MCP server and extension host both consume it, so the same code runs in VS Code and as a standalone CLI tool.
+`@ansible/common` contains browser-safe types, prompts, and utilities with no Node.js or VS Code dependency. `@ansible/services` contains Node.js service implementations. The MCP server and extension host both consume these packages, so the same logic runs in VS Code and as a standalone CLI tool.
 
 ## Features
 
@@ -173,10 +176,12 @@ node packages/mcp-server/out/server.js
 ### Setup
 
 ```bash
-npm install       # Install dependencies (workspaces resolve automatically)
-npm run compile   # Build all packages (tsc -b with project references)
-npm run watch     # Watch mode for development
+npm ci            # Install dependencies (reproducible lockfile resolution)
+npm run compile   # Skill codegen + tsc -b (all packages)
+npm run build     # esbuild bundling
 ```
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full onboarding guide.
 
 ### Running
 
@@ -187,17 +192,19 @@ Press `F5` to launch a VS Code Extension Development Host with the extension loa
 ```bash
 npm test              # Run unit tests (Vitest)
 npm run test:coverage # Run with coverage (thresholds enforced)
-npm run test:e2e      # Run e2e tests (WebDriverIO + VS Code)
+npm run test:ui       # Run e2e tests (WebDriverIO + VS Code)
+npm run ci            # Full CI mirror: compile + lint + test:coverage + build
 ```
 
 The test suite uses:
-- **Vitest** for unit tests across `core` and `mcp-server` packages
+- **Vitest** for unit tests across all packages
 - **WebDriverIO** with `wdio-vscode-service` for e2e tests against a real VS Code instance
 
 ### Building
 
 ```bash
-npm exec vsce -- package   # Package the extension as a VSIX
+npm run package             # Package the extension as a VSIX
+npm run package:install     # Package and install into VS Code for testing
 ```
 
 ### Alpha releases (VSIX on GitHub)

--- a/package.json
+++ b/package.json
@@ -986,7 +986,11 @@
     "lint": "eslint .",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
+    "check": "npm run compile && npm run lint && npm run test",
+    "ci": "npm run compile && npm run lint && npm run test:coverage && npm run build",
     "test:watch": "vitest",
+    "package": "vsce package --no-dependencies",
+    "package:install": "vsce package --no-dependencies && code --install-extension *.vsix --force && rm -f *.vsix",
     "test:integration": "tsc -p test/integration/tsconfig.json && vscode-test",
     "pretest:ui": "node scripts/install-test-extensions.mjs",
     "test:ui": "wdio run wdio.conf.ts"


### PR DESCRIPTION
## Summary
- Add `npm run ci` and `npm run check` scripts that mirror the CI pipeline locally, closing the gap between what CI runs and what developers run before push
- Create `CONTRIBUTING.md`, an interactive `onboard` agent skill, and update quality gates across AGENTS.md, submit-pr, and pr-review skills

## Changes
- **package.json**: Add `ci`, `check`, `package`, and `package:install` scripts
- **AGENTS.md**: Replace piecemeal quality gate commands with `npm run ci`, add rebuild-after-changes guidance, add new-developer detection with `onboard` skill offer
- **submit-pr skill**: Step 2 now uses `npm run ci` with explicit "do not claim passed without running" language
- **pr-review skill**: Add 8 Copilot pattern categories observed across PRs #2887-#2906 (JSDoc, Prettier, import aliases, command guards, appendText vs appendMarkdown, runtime config guards, documentation drift, generated file hygiene), update CI failure remediation to lead with `npm run ci`
- **CONTRIBUTING.md** (new): Prerequisites, setup, daily workflow, npm scripts reference table, branching pointers, common pitfalls
- **onboard skill** (new): 9-section interactive walkthrough of architecture, ADRs, workflows, services, testing, and pitfalls with `--quick` and `--topic` flags
- **README.md**: Fix stale `packages/core/` → `common/` + `services/`, `test:e2e` → `test:ui`, add `npm run ci` and `package:install`

## Quality of life
- AI-authored additions: `CONTRIBUTING.md`, `.agents/skills/onboard/SKILL.md`, AGENTS.md new-developer detection section
- All changes are documentation/tooling — no runtime code changes

## Test plan
- [x] `npm run ci` passes (compile + lint + test:coverage + build)
- [ ] `npm run test:ui` passes (no e2e-relevant changes)