### PR TITLE
feat(core): add lightspeed standalone package skeleton

### DIFF
--- a/.agents/skills/pr-review/SKILL.md
+++ b/.agents/skills/pr-review/SKILL.md
@@ -37,108 +37,113 @@ comments block merge.
 - After pushing fixes, update the PR description to reflect the expanded scope
   (per the submit-pr skill).
 
-## Copilot review patterns
+## Copilot reviews as agent learning opportunities
 
-Copilot automated reviews surface recurring categories. Address these
-proactively before pushing to avoid review round-trips:
+Every Copilot comment on an agent-authored PR is a defect in our own
+review process. Copilot applies the same principles every time — if it
+found something, the agent's pre-submit self-review (see the
+`submit-pr` skill) should have found it first. Without tightening that
+loop, we will never ship a PR without comments.
 
-### Supply-chain security
+After fixing each Copilot finding, ask: *which principle from the
+submit-pr self-review should have caught this?* If one exists but
+didn't trigger, the principle needs to be clearer or the agent didn't
+apply it. If no principle covers it, add one — but frame it as a
+general evaluation criterion, not a specific instance. Adding "don't
+do X" only prevents X; strengthening a principle prevents the entire
+class of issues X belongs to.
 
-Pin GitHub Actions to commit SHAs instead of mutable tags (`@v1`). Mutable
-tags allow upstream changes to affect CI without review. Use a comment to
-note the original tag:
+## How Copilot evaluates code
 
-```yaml
-- uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-```
+Copilot reviews succeed because they apply a small number of universal
+evaluation criteria to every line of the diff. Understanding these
+criteria lets the agent anticipate findings rather than react to them.
 
-### Inaccurate documentation
+**Semantic truthfulness.** Every declaration is read as a contract.
+Copilot checks whether types, return values, error codes, version
+ranges, log levels, comments, and docstrings accurately describe what
+the code actually does. Any gap — a comment that says "all" when the
+code means "some", a return type that promises `T` but can produce
+`{}`, an error code that is empty — gets flagged.
 
-Documentation MUST accurately describe the actual behavior. If a workflow
-triggers on `pull_request` targeting `main`, don't document it as running
-on "every pull request". Be specific about triggers, branches, and conditions.
+**Information exposure.** Copilot asks "should this data be visible
+here?" for every piece of information that escapes internal scope:
+logged data, error messages, API responses, documentation examples.
+User content in info-level logs, credentials on CLI examples, internal
+paths in error messages — all get flagged because the reviewer assumes
+the minimum-exposure principle.
 
-### Markdown table formatting
+**Caller safety.** Copilot reads every public interface from the
+caller's perspective and asks "could this surprise me?" Nullable
+returns not reflected in the type, missing null guards on
+platform-provided arguments, unsafe casts, optional fields typed as
+required, hidden side effects (logging, I/O, global state) that the
+name or signature doesn't advertise — all get flagged because the
+reviewer assumes callers trust the type signature and expect no
+undisclosed behavior.
 
-Tables must use a single leading `|` on each line. Double leading `||` renders
-as an extra empty column. Validate table rendering before committing.
+**Drift between prose and code.** Any time a comment, docstring, ADR,
+README, or inline annotation co-exists with the code it describes,
+Copilot checks whether the prose is still true after the diff. Renamed
+functions with old docstrings, changed triggers with old workflow
+descriptions, removed features with lingering references — all flagged.
 
-### Inaccurate comments
+**Supply-chain mutability.** References to external resources (action
+tags, dependency versions, engine ranges) that can change without
+review get flagged. The reviewer assumes that anything not pinned to
+a specific immutable identifier is a vector for silent behavior change.
 
-Code comments and docstrings MUST accurately describe what the code does. If
-you rename a function, change behavior, or remove functionality, update all
-associated comments in the same commit.
+**Internal consistency.** Every module's exports, code paths, and
+naming conventions are checked against each other. If nine code paths
+use a registry lookup but the tenth hardcodes a value, or if one
+export capitalizes differently from its siblings, the reviewer flags
+the deviation because inconsistency signals copy-paste drift or an
+unfinished refactor.
 
-### Secrets in documentation
+**Adversarial input tracing.** Copilot constructs edge-case scenarios
+for public functions: what happens with an empty-but-not-falsy value,
+a field combination after partial deletion, a response that satisfies
+the HTTP status check but lacks expected fields? If the traced path
+fails silently, sends a vacuous request, or produces a return value
+that violates the declared type, the reviewer flags it. This catches
+bugs that defensive checks miss — code can look correct line-by-line
+and still break under a specific constructed input.
 
-Never show API keys, tokens, or credentials on command lines in docs or
-examples. Demonstrate env var usage instead. Shell history and process lists
-expose command-line arguments.
+**Inherited contract completeness.** When the diff extends a class or
+implements an interface, Copilot checks that the subclass honors the
+full runtime contract — not just compiler-required members but expected
+behaviors. An Error subclass without `name` or `message`, a Disposable
+without cleanup, a stream without backpressure handling — all get
+flagged because TypeScript enforces structure but runtime contracts
+include semantics the compiler cannot check.
 
-### Unused variables / imports (ESLint)
+**Dead weight.** Unused imports, unreachable branches, written-but-never-
+read variables, parameters accepted but ignored — anything the code
+pays for but doesn't use. The reviewer assumes dead code obscures intent
+and may mask bugs.
 
-Copilot often flags unused imports. With ESLint `no-unused-vars` enabled,
-these fail CI. Remove unused imports or prefix intentionally unused parameters
-with `_`. Prefer trimming the import list over disabling the rule.
+## Project-specific patterns
 
-### JSDoc completeness
+These are known project-specific applications of the principles above.
+They serve as a quick reference, not an exhaustive list — the principles
+above should catch novel issues these don't cover.
 
-ESLint enforces `jsdoc/require-param` and `jsdoc/require-returns`. Every
-exported function needs `@param` for each parameter and `@returns` for
-non-void return types. Add JSDoc proactively — Copilot flags missing
-annotations on nearly every PR.
-
-### Prettier formatting
-
-The project enforces single quotes (unless the string contains an
-apostrophe, in which case double quotes avoid `\'`), trailing commas,
-and consistent parenthesization. Run `npm exec eslint -- . --fix` before
-manual review. Generated files (`.content.ts`) must also pass prettier.
-
-### Import alias violations
-
-Use `@src/*` aliases for cross-boundary imports, not relative `../`
-paths that reach outside the current package. `no-restricted-imports`
-enforces this. Copilot flags violations that ESLint may also catch.
-
-### Command handler null guards
-
-VS Code commands invoked from the Command Palette may receive
-`undefined` arguments even if the `when` clause restricts menu
-visibility. Always guard `node` parameters in tree-view command
-handlers:
-
-```typescript
-if (!node) return;
-```
-
-### `appendText` vs `appendMarkdown`
-
-Use `appendText` for dynamic or external content in `MarkdownString`
-tooltips. `appendMarkdown` with user-controlled data risks formatting
-injection (e.g., unescaped `[`, `]`, backticks). Reserve
-`appendMarkdown` for static template text.
-
-### Runtime config guards
-
-If a feature is gated by a configuration setting in `package.json`
-`when` clauses, also guard the command handler at runtime. The
-Command Palette bypasses menu visibility — a user (or agent) can
-invoke the command even when the menu item is hidden.
-
-### Documentation and comment drift
-
-When renaming, refactoring, or changing behavior, update ALL comments,
-docstrings, and documentation in the same commit. Copilot flags
-stale comments on nearly every PR. This includes: JSDoc descriptions,
-inline comments, AGENTS.md, README.md, and ADRs.
-
-### Generated file hygiene
-
-After running codegen (`node scripts/generate-skill-content.mjs`), run
-`npm exec eslint -- .` on the full project. Prettier and
-typescript-eslint rules apply to generated `.content.ts` files. Quote
-style, line length, and formatting must match project conventions.
+- **GitHub Actions**: pin to commit SHAs with a tag comment
+  (`actions/checkout@SHA # v4`)
+- **JSDoc**: ESLint enforces `jsdoc/require-param` (with description)
+  and `jsdoc/require-returns` on exported functions
+- **Prettier**: single quotes, trailing commas; run
+  `npm exec eslint -- . --fix` before review
+- **Imports**: use `@src/*` aliases for cross-package imports, not
+  relative `../` paths; remove unused imports
+- **VS Code commands**: guard `node` parameters — Command Palette can
+  invoke commands with `undefined` args even when `when` hides the menu
+- **MarkdownString**: use `appendText` for dynamic content,
+  `appendMarkdown` for static template text only
+- **Runtime config guards**: if a feature is `when`-gated in
+  `package.json`, also guard the handler at runtime
+- **Generated files**: after codegen, lint the full project — generated
+  `.content.ts` files must pass prettier and typescript-eslint
 
 ## Workflow
 

--- a/.agents/skills/submit-pr/SKILL.md
+++ b/.agents/skills/submit-pr/SKILL.md
@@ -61,7 +61,75 @@ If violations are found:
 compilation and bundling. If testing interactively (e.g., reloading the
 extension), also run `npm run compile && npm run build` explicitly.
 
-### Step 3: Commit with conventional commits
+### Step 3: Self-review the diff
+
+**This step is mandatory.** Do not skip it. Do not combine it with
+Step 2. After CI passes, review the **full PR diff** — all commits
+since the branch diverged from the base branch, not just the last
+commit or unstaged changes:
+
+```bash
+git diff upstream/next...HEAD
+```
+
+Read every changed line against these questions. For each question,
+name at least one specific file and line you verified. If you cannot,
+you haven't actually reviewed the diff.
+
+1. **Does every statement mean what it says?** Check every type
+   signature, return value, error code, version range, log level,
+   comment, and docstring. If the code declares it, the runtime must
+   honor it on every path.
+
+2. **Does this expose more than it should?** Check every log call,
+   error message, and user-facing string. Does it contain user content,
+   credentials, or internal state? Could a caller or log reader learn
+   something they shouldn't?
+
+3. **Would a caller be surprised?** Read every public function from
+   the caller's perspective. Can it return a value the type doesn't
+   cover? Does it mutate an argument the caller owns? Does it throw
+   where the signature implies it won't? Does it have side effects
+   (logging, I/O, global state) that its name or signature doesn't
+   advertise? Does it behave differently from sibling functions in
+   the same file?
+
+4. **Is everything still true after this change?** Diff comments and
+   docstrings against the code they describe. Did you rename something
+   but leave the old name in prose? Did you change behavior but leave
+   an old description?
+
+5. **Are dependencies and versions pinned to intent?** Check every
+   version range, action tag, and engine constraint. Does each one
+   express what you actually mean — not tighter, not looser?
+
+6. **Is there dead weight?** Check for unused imports, unreachable
+   branches, written-but-never-read variables, parameters accepted
+   but ignored.
+
+7. **Is this internally and externally consistent?** Within each
+   module: do all code paths use the same patterns (e.g., registry
+   lookups vs hardcoded values)? Are exports named consistently
+   (capitalization, prefixes)? Across the repo: do tsconfig targets,
+   engine floors, and conventions match sibling packages?
+
+8. **Would a constructed scenario break this?** For each public
+   function, construct one realistic failure case: an edge-case
+   input, a specific field combination after deletion/filtering,
+   an empty-but-not-falsy value. Trace it through the code path.
+   If it fails silently, sends a vacuous request, or produces a
+   return value that violates the declared type, that's a finding.
+
+9. **Do inherited contracts hold?** When extending a class or
+   implementing an interface, check that the subclass honors the
+   full runtime contract — not just the compiler-required members,
+   but expected behaviors (Error needs name and message, Disposable
+   needs dispose, EventEmitter needs cleanup). TypeScript enforces
+   structure; runtime contracts include semantics.
+
+Only proceed to Step 4 after completing this review.
+
+### Step 4: Commit with conventional commits
 
 Use the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
 format:
@@ -106,7 +174,7 @@ Include an issue reference in the commit body or PR body:
 related: #<issue_number>
 ```
 
-### Step 4: Push and create the pull request
+### Step 5: Push and create the pull request
 
 **Labels are required.** The repository requires at least one of these
 labels: `breaking`, `chore`, `feat`, `fix`. Map the conventional commit

--- a/.sdlc/adrs/ADR-015-lightspeed-standalone-package.md
+++ b/.sdlc/adrs/ADR-015-lightspeed-standalone-package.md
@@ -1,0 +1,200 @@
+# ADR-015: Lightspeed as a Standalone Opt-In Package
+
+## Status
+
+Proposed
+
+## Date
+
+2026-06-18
+
+## Context
+
+Ansible Lightspeed (IBM watsonx Code Assistant integration) provides
+inline code suggestions, playbook/role generation, playbook/role
+explanation, and training data attribution. On the `main` branch it is
+deeply embedded in the extension root: ~158 files, ~30 k LOC, 67
+references in `extension.ts`, plus coupling into settings, telemetry,
+content creator helpers, and the Vite build graph. It was never designed
+to be removable.
+
+The `next` branch (`ansible-environments`) intentionally excluded
+Lightspeed during the rewrite and has a clean npm-workspace monorepo
+with well-isolated packages (`common`, `services`, `ui`,
+`language-server`, `mcp-server`).
+
+A business requirement now asks us to bring Lightspeed functionality
+to `next` **for a limited period** (a few months) while maintaining the
+ability to cleanly remove it afterward. This ADR records the
+architectural approach chosen.
+
+### Scoping decisions
+
+- **WCA only.** The multi-LLM provider system (Google Gemini, Red Hat
+  Custom / OpenAI-compatible) is not ported. Only the Watson Code
+  Assistant (WCA) backend is supported, which simplifies the provider
+  layer and eliminates the `@google/genai` dependency and API-key
+  management paths.
+- **Vue webviews ported as-is.** The `main` branch uses Vue + PrimeVue
+  for Lightspeed webviews; `next` uses React + `@ansible/ui` for
+  everything else. Rewriting ~25 Vue components in React for a
+  temporary feature is not justified. The existing Vue code is ported
+  into the package with a dedicated Vite build.
+- **Isolated test suites.** Unit tests (vitest) and E2E tests (WDIO)
+  live inside `packages/lightspeed/` with their own configs and
+  runners. They never appear in the core test runs.
+
+## Decision
+
+**We will port Lightspeed as an opt-in `packages/lightspeed` workspace
+package with WCA-only support, existing Vue webviews, and isolated test
+suites, designed for clean removal.**
+
+### Package boundary
+
+`packages/lightspeed/` (`@ansible/lightspeed`) owns:
+
+- All domain logic: WCA API client, OAuth, inline suggestions,
+  generation/explanation, training matches.
+- Types and interfaces (ported from `src/interfaces/lightspeed.ts` and
+  `src/definitions/lightspeed.ts` on `main`).
+- Vue webview panels with a package-local `vite.config.mts`.
+- Own vitest and WDIO test suites with fixtures and mock servers.
+
+The extension (`src/`) contains a thin registration shim
+(`src/features/lightspeed/register.ts`, target <200 LOC) that:
+
+1. Checks the `ansible.lightspeed.enabled` setting (default: `false`).
+2. If enabled, imports `@ansible/lightspeed` and calls `activate()`.
+3. Returns a `Disposable` for clean deactivation.
+
+### Settings
+
+The `ansible.lightspeed.*` namespace is preserved for backward
+compatibility. The `enabled` setting defaults to `false` on `next`,
+making Lightspeed fully opt-in.
+
+### Activation
+
+`package.json` contributes entries (commands, settings, auth provider,
+keybindings, menus) are grouped for easy identification and bulk
+removal.
+
+## Alternatives Considered
+
+### A1: Embed Lightspeed in `src/` like `main`
+
+Copy the Lightspeed code directly into the extension source tree,
+mirroring the `main` branch layout.
+
+**Pros:** Fastest initial port; no package boundary design needed.
+
+**Cons:** Recreates the tight coupling that makes removal painful on
+`main`. Touching `extension.ts`, settings, telemetry, and build config
+in ~10+ cross-cutting files. Removal would require careful refactoring
+rather than `rm -rf`.
+
+**Why not chosen:** Defeats the primary goal of easy removal.
+
+### A2: Separate VS Code extension
+
+Publish Lightspeed as a standalone VS Code extension that communicates
+with the main extension via the extension API.
+
+**Pros:** Cleanest possible isolation; removal is a marketplace
+unpublish.
+
+**Cons:** Adds publish/install overhead; cross-extension communication
+adds complexity and latency; settings split across two extensions
+confuses users; CI must build and test two artifacts.
+
+**Why not chosen:** Over-engineered for a temporary feature lasting a
+few months.
+
+### A3: Don't bring Lightspeed to `next`
+
+Keep Lightspeed on `main` only and let users who need it stay on
+`main`.
+
+**Pros:** Zero effort; `next` stays clean.
+
+**Cons:** Not viable given the business requirement.
+
+**Why not chosen:** Doesn't meet the requirement.
+
+## Consequences
+
+### Positive
+
+- **Clean removal path.** Deleting the package directory plus a handful
+  of registration lines removes Lightspeed completely. A documented
+  removal checklist makes this a mechanical task.
+- **Core test suite unaffected.** Root `npm test` and WDIO runs never
+  include Lightspeed tests.
+- **Opt-in activation.** Users who don't enable Lightspeed pay zero
+  activation cost.
+- **Established pattern.** Follows the same workspace package pattern
+  as `@ansible/mcp-server`.
+
+### Negative
+
+- **Two UI frameworks.** Vue (Lightspeed) and React (everything else)
+  coexist in the `.vsix`, increasing bundle size temporarily.
+- **Additional build tooling.** Vite remains in the workspace for
+  Lightspeed webviews alongside the esbuild pipeline.
+- **Temporary by design.** Knowing the package will be removed may
+  discourage investment in code quality or thorough review.
+- **Vue/Vite dependencies** are added to the workspace solely for
+  Lightspeed.
+
+### Neutral
+
+- The `@ansible/lightspeed` package accepts `vscode` as a peer
+  dependency, consistent with how `@ansible/language-server` handles
+  VS Code API access.
+
+## Implementation Notes
+
+The implementation plan is tracked in
+[`.sdlc/plans/lightspeed-standalone-package.md`](../plans/lightspeed-standalone-package.md).
+
+Key files and patterns:
+
+- **Package skeleton:** mirrors `packages/mcp-server/` (composite
+  `tsconfig.json`, `tsc -b` compilation, npm workspace `"*"` version).
+- **Root wiring:** add to `tsconfig.json` references and
+  `package.json` dependencies.
+- **Registration shim:** single `registerLightspeed(context)` call in
+  `src/extension.ts`, delegating to `@ansible/lightspeed`.
+
+### Removal checklist
+
+1. `rm -rf packages/lightspeed/`
+2. Remove `"@ansible/lightspeed"` from root `package.json` deps.
+3. Remove tsconfig reference.
+4. Remove optional root script aliases.
+5. Delete `src/features/lightspeed/` shim.
+6. Remove `registerLightspeed()` call from `extension.ts`.
+7. Remove `package.json` contributes entries (commands, settings, auth,
+   menus, keybindings).
+8. Remove lightspeed media files.
+9. Remove `.sdlc/plans/lightspeed-standalone-package.md`.
+10. Update ADR-015 status to `Deprecated`.
+11. `npm install && npm run compile && npm run build`.
+
+## Related Decisions
+
+- [ADR-001](ADR-001-service-based-architecture.md) — Service-Based
+  Architecture (established the package pattern this ADR builds on)
+- [ADR-004](ADR-004-intentional-exclusions-from-main.md) — Intentional
+  Feature Exclusions from `main` (Lightspeed was excluded; this ADR
+  partially reverses that decision for a limited period)
+- [ADR-011](ADR-011-package-architecture.md) — Package Architecture
+  (defines `@ansible/common` and `@ansible/services` that this package
+  depends on)
+
+## Revision History
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-06-18 | — | Initial proposal |

--- a/.sdlc/adrs/README.md
+++ b/.sdlc/adrs/README.md
@@ -36,11 +36,12 @@ Decisions under consideration — not yet accepted or implemented.
 | ADR | Title | Date |
 |-----|-------|------|
 | [ADR-003](ADR-003-ee-via-devcontainers.md) | Execution Environment Support via Dev Containers | 2026-05-26 |
+| [ADR-015](ADR-015-lightspeed-standalone-package.md) | Lightspeed as a Standalone Opt-In Package | 2026-06-18 |
 
 ## Creating New ADRs
 
 1. Copy the template from `../templates/adr.md`
-2. Use the next available number (currently ADR-014)
+2. Use the next available number (currently ADR-016)
 3. Include:
    - Status (Proposed → Accepted → Implemented)
    - Date

--- a/.sdlc/plans/lightspeed-standalone-package.md
+++ b/.sdlc/plans/lightspeed-standalone-package.md
@@ -1,0 +1,207 @@
+# Lightspeed Standalone Package — Implementation Plan
+
+Related: [ADR-015](../adrs/ADR-015-lightspeed-standalone-package.md)
+
+## Overview
+
+Port Lightspeed (WCA-only) from `main` to `next` as an isolated, opt-in
+`packages/lightspeed` workspace package with existing Vue webviews,
+designed for easy removal in a few months.
+
+## Architecture
+
+`packages/lightspeed/` owns all domain logic; `src/` contains only a
+thin registration shim.
+
+```
+packages/lightspeed/ (@ansible/lightspeed)
+├── src/
+│   ├── index.ts            # Public API barrel
+│   ├── definitions.ts      # Commands, URLs, constants
+│   ├── interfaces.ts       # Request/response types
+│   ├── api.ts              # WCA HTTP API client
+│   ├── errors.ts           # Error classes and registry
+│   ├── handleApiError.ts   # Error mapping
+│   ├── oauth/              # OAuth provider + user session
+│   ├── inline/             # Inline suggestion engine
+│   ├── generation/         # Playbook + role generation
+│   ├── explanation/        # Playbook + role explanation
+│   ├── contentMatches/     # Training matches panel
+│   ├── statusBar.ts        # Status bar integration
+│   └── utils/              # Shared utilities
+├── webviews/               # Vue webviews (ported as-is)
+├── test/
+│   ├── unit/               # Vitest unit tests
+│   ├── wdio/               # WDIO E2E tests + mock server
+│   └── fixtures/           # Test fixtures
+├── package.json
+├── tsconfig.json
+├── vitest.config.mts       # Package-local vitest config
+├── vite.config.mts         # Webview build config
+└── wdio.conf.ts            # Package-local WDIO config
+```
+
+### Boundary rules
+
+**Inside `packages/lightspeed/`:**
+
+- All domain logic (WCA API client, OAuth, inline suggestions,
+  generation, explanation, training matches)
+- Types and interfaces
+- Vue webview panels with a package-local Vite config
+- Own test suites (vitest + WDIO) with fixtures and mock servers
+- Settings schema constants
+
+**Inside `src/features/lightspeed/` (thin shim, <200 LOC):**
+
+- `register.ts` — single entry point called from `extension.ts`
+  - Checks `ansible.lightspeed.enabled` (default: `false`)
+  - If disabled, returns early (zero activation cost)
+  - If enabled, imports `@ansible/lightspeed` and calls `activate()`
+  - Returns a `Disposable` for clean deactivation
+- No business logic, no state, no direct API calls
+
+**Root `package.json` contributes:**
+
+- Lightspeed commands, settings, auth provider, activation events,
+  keybindings, menus
+- Grouped for easy identification and bulk removal
+
+### Package dependencies
+
+```
+@ansible/lightspeed → @ansible/services → @ansible/common
+```
+
+No dependency on `@ansible/ui` — Vue webviews are self-contained.
+
+External deps Lightspeed brings:
+
+- `vue`, `primevue`, `@primeuix/themes` — webview UI
+- `vite` — package-local webview build (devDependency)
+- `uuid` — OAuth session IDs
+- `marked` + `highlight.js` — explanation rendering
+
+### Settings namespace
+
+Keep `ansible.lightspeed.*` for backward compatibility. The `enabled`
+setting defaults to `false` on `next` (opt-in).
+
+### Test isolation
+
+- **Unit tests:** own `vitest.config.mts` inside the package, not in
+  root config. `npm test` at root never touches Lightspeed.
+- **WDIO tests:** own `wdio.conf.ts` and mock server. Root WDIO runs
+  are unaware of Lightspeed specs.
+- **Dedicated runners:**
+  - `npm run test -w packages/lightspeed` — unit tests
+  - `npm run test:wdio -w packages/lightspeed` — E2E tests
+
+## Scoping decisions
+
+### WCA only
+
+The multi-LLM provider system (Google Gemini, RH Custom /
+OpenAI-compatible) is **not ported**. Removed:
+
+- `ProviderManager`, provider base/factory
+- `GoogleProvider` + `@google/genai`
+- `RHCustomProvider` + `openaiCompatibleClient.ts`
+- `LlmProviderSettings`, secret storage for API keys
+- Provider management commands and settings panel
+- Deprecated settings (`provider`, `apiKey`, `modelName`)
+
+The API client talks directly to WCA; auth is OAuth-only.
+
+### Vue webviews kept as-is
+
+Rewriting ~25 Vue components in React for a temporary feature is not
+justified. Two UI frameworks coexist temporarily — both disappear when
+the package is deleted.
+
+## Implementation phases
+
+### Phase 0: ADR
+
+Write ADR-015 documenting the decision.
+
+### Phase 1: Package skeleton + types + WCA API client
+
+- Create `packages/lightspeed/` following mcp-server pattern
+- Port types/interfaces from `src/interfaces/lightspeed.ts` and
+  `src/definitions/lightspeed.ts`
+- Port WCA API client (`api.ts`, `handleApiError.ts`, `errors.ts`)
+- Wire into root build graph (tsconfig, workspace)
+- Commit this plan and ADR-015
+
+### Phase 2: WCA provider (simplified)
+
+- Port WCA-specific logic only — direct API client, no routing layer
+- Drop all BYOLLM code
+
+### Phase 3: OAuth + user session
+
+- Port `lightSpeedOAuthProvider.ts` and `lightspeedUser.ts`
+- Accept `vscode` as a peer dependency
+- Export `createAuthProvider()` factory
+
+### Phase 4: Inline suggestions
+
+- Port `inlineSuggestions.ts` and `ansibleContext.ts`
+- Port suggestion utilities
+- Export `InlineSuggestionsFeature` for the shim
+
+### Phase 5: Vue webviews + Vite build
+
+- Copy `webviews/lightspeed/` into `packages/lightspeed/webviews/`
+- Create package-local `vite.config.mts` for the 4 kept entry points
+  (playbook generation, role generation, explanation, training matches)
+- Port `webviewMessageHandlers.ts` and status bar logic
+- Drop LLM provider settings and explorer webviews
+
+### Phase 6: Extension shim + integration
+
+- Write `src/features/lightspeed/register.ts`
+- Wire into `extension.ts` with `registerLightspeed(context)`
+- Add `package.json` contributes entries
+- Default `ansible.lightspeed.enabled` to `false`
+
+### Phase 7: Tests as dedicated suite
+
+- Port unit tests into `packages/lightspeed/test/unit/`
+- Port WDIO tests + mock server into `packages/lightspeed/test/wdio/`
+- Port test fixtures
+- Create package-local vitest and WDIO configs
+- Validate isolation: root test runs unaffected
+
+## Removal checklist
+
+When Lightspeed is deprecated:
+
+1. `rm -rf packages/lightspeed/`
+2. Remove `"@ansible/lightspeed": "*"` from root `package.json` deps
+3. Remove `{ "path": "packages/lightspeed" }` from root `tsconfig.json`
+4. Remove `"test:lightspeed"` script alias from root `package.json`
+5. Delete `src/features/lightspeed/` shim
+6. Remove `registerLightspeed()` call from `src/extension.ts`
+7. Remove Lightspeed contributes from `package.json` (commands,
+   settings, auth, menus, keybindings)
+8. Remove lightspeed media files
+9. Remove this plan document
+10. Update ADR-015 status to `Deprecated`
+11. `npm install && npm run compile && npm run build`
+
+No changes needed to root `vitest.config.mts` or root WDIO config.
+No refactoring of core extension code required.
+
+## Key risks
+
+- **Two UI frameworks.** Vue + React coexist temporarily. Acceptable
+  for a feature with a planned removal date.
+- **OAuth coupling to VS Code API.** Package accepts `vscode` as a
+  peer dep, same pattern as `@ansible/language-server`.
+- **Content creator cross-dependency.** On `main`, content creator
+  reuses Lightspeed's `WebviewMessageHandlers`. Must not recreate this
+  coupling on `next`.
+- **Telemetry integration.** Package should export telemetry hooks the
+  extension subscribes to, not call telemetry directly.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
       ],
       "dependencies": {
         "@ansible/common": "*",
+        "@ansible/lightspeed": "*",
         "@ansible/mcp-server": "*",
         "@ansible/services": "*",
         "@ansible/ui": "*",
@@ -89,6 +90,10 @@
     },
     "node_modules/@ansible/language-server": {
       "resolved": "packages/language-server",
+      "link": true
+    },
+    "node_modules/@ansible/lightspeed": {
+      "resolved": "packages/lightspeed",
       "link": true
     },
     "node_modules/@ansible/mcp-server": {
@@ -16912,6 +16917,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/lightspeed": {
+      "name": "@ansible/lightspeed",
+      "version": "0.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "@ansible/services": "0.0.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "vscode": "*"
+      },
+      "peerDependenciesMeta": {
+        "vscode": {
+          "optional": true
+        }
       }
     },
     "packages/mcp-server": {

--- a/package.json
+++ b/package.json
@@ -948,7 +948,7 @@
         },
         "ansibleEnvironments.llm.configure": {
           "type": "null",
-          "markdownDescription": "[Select Provider & Model...](command:ansibleEnvironments.selectLlmModel) · [Show Status](command:ansibleEnvironments.showLlmStatus)",
+          "markdownDescription": "[Select Provider & Model...](command:ansibleEnvironments.selectLlmModel) \u00b7 [Show Status](command:ansibleEnvironments.showLlmStatus)",
           "order": 2
         },
         "ansibleEnvironments.llm.provider": {
@@ -1032,6 +1032,7 @@
   },
   "dependencies": {
     "@ansible/common": "*",
+    "@ansible/lightspeed": "*",
     "@ansible/services": "*",
     "@ansible/mcp-server": "*",
     "@ansible/ui": "*",

--- a/packages/lightspeed/package.json
+++ b/packages/lightspeed/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@ansible/lightspeed",
+  "version": "0.0.1",
+  "description": "Ansible Lightspeed (WCA) integration — temporary opt-in package",
+  "main": "./out/index.js",
+  "types": "./out/index.d.ts",
+  "license": "MIT",
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "scripts": {
+    "compile": "tsc -b",
+    "watch": "tsc -b -w",
+    "clean": "rimraf out"
+  },
+  "dependencies": {
+    "@ansible/services": "0.0.1"
+  },
+  "peerDependencies": {
+    "vscode": "*"
+  },
+  "peerDependenciesMeta": {
+    "vscode": {
+      "optional": true
+    }
+  }
+}

--- a/packages/lightspeed/src/api.ts
+++ b/packages/lightspeed/src/api.ts
@@ -1,0 +1,469 @@
+import type {
+    CompletionRequestParams,
+    CompletionResponseParams,
+    ContentMatchesRequestParams,
+    ContentMatchesResponseParams,
+    ExplanationRequestParams,
+    ExplanationResponseParams,
+    FeedbackRequestParams,
+    FeedbackResponseParams,
+    PlaybookGenerationRequestParams,
+    RoleGenerationRequestParams,
+    PlaybookGenerationResponseParams,
+    RoleGenerationResponseParams,
+    RoleExplanationRequestParams,
+} from './interfaces';
+import {
+    LIGHTSPEED_PLAYBOOK_EXPLANATION_URL,
+    LIGHTSPEED_PLAYBOOK_GENERATION_URL,
+    LIGHTSPEED_ROLE_GENERATION_URL,
+    LIGHTSPEED_ROLE_EXPLANATION_URL,
+    LIGHTSPEED_SUGGESTION_COMPLETION_URL,
+    LIGHTSPEED_SUGGESTION_CONTENT_MATCHES_URL,
+    LIGHTSPEED_SUGGESTION_FEEDBACK_URL,
+    LIGHTSPEED_API_TIMEOUT,
+    WCA_API_ENDPOINT_DEFAULT,
+} from './definitions';
+import {
+    formatErrorDetail,
+    HTTPError,
+    UNKNOWN_ERROR,
+    ERRORS_UNAUTHORIZED,
+    type IError,
+} from './errors';
+import { mapError } from './handleApiError';
+
+/**
+ * Returns an appropriate fetch implementation, preferring Electron's
+ * net.fetch when available (for proxy/certificate support in VS Code).
+ * @returns The fetch function to use for HTTP requests.
+ */
+export function getFetch(): typeof globalThis.fetch {
+    try {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const electron = require('electron') as
+            | { net?: { fetch?: typeof globalThis.fetch } }
+            | undefined;
+        const electronFetch = electron?.net?.fetch;
+        if (electronFetch) {
+            return electronFetch;
+        }
+    } catch {
+        // electron not available
+    }
+    return globalThis.fetch;
+}
+
+/**
+ * Abstraction over the consumer-provided auth/config hooks so the API
+ * client has no direct dependency on vscode or SettingsManager.
+ */
+export interface LightspeedApiConfig {
+    /** Retrieves the current OAuth access token, or undefined if not authenticated. */
+    getAccessToken(): Promise<string | undefined>;
+    /** Whether the user is currently authenticated. */
+    isAuthenticated(): Promise<boolean>;
+    /** Whether the user's organization opted out of telemetry. */
+    orgOptOutTelemetry(): Promise<boolean>;
+    /** The WCA API endpoint URL. */
+    getApiEndpoint(): string;
+    /** The VS Code extension version string. */
+    getExtensionVersion(): string;
+    /** Emit a log message at the given level. */
+    log(level: 'info' | 'debug' | 'error', message: string): void;
+    /** Show an informational message to the user. */
+    showInfo(message: string): void;
+    /** Show an error message to the user. */
+    showError(message: string): void;
+}
+
+/** WCA API client for all Lightspeed HTTP interactions. */
+export class LightspeedAPI {
+    private config: LightspeedApiConfig;
+
+    /**
+     * @param config - Consumer-provided auth and config hooks.
+     */
+    constructor(config: LightspeedApiConfig) {
+        this.config = config;
+    }
+
+    /**
+     * Builds the WCA API base URL from the configured endpoint.
+     * @returns The base URL including the `/api` path segment.
+     */
+    private getBaseUrl(): string {
+        const endpoint = this.config.getApiEndpoint() || WCA_API_ENDPOINT_DEFAULT;
+        const trimmed = endpoint.endsWith('/') ? endpoint.slice(0, -1) : endpoint;
+        return `${trimmed}/api`;
+    }
+
+    /**
+     * Sends an authenticated POST request to the WCA API.
+     * @param endpoint - The API path relative to the base URL.
+     * @param body - JSON-serialized request body.
+     * @returns The raw fetch Response.
+     */
+    private async lightspeedPost(endpoint: string, body: string): Promise<Response> {
+        const fetch = getFetch();
+
+        const authToken = await this.config.getAccessToken();
+        if (authToken === undefined) {
+            throw new Error('Ansible Lightspeed authentication failed.');
+        }
+
+        const headers: Record<string, string> = {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${authToken}`,
+        };
+
+        const baseUrl = this.getBaseUrl();
+
+        return await fetch(`${baseUrl}/${endpoint}`, {
+            method: 'POST',
+            signal: AbortSignal.timeout(LIGHTSPEED_API_TIMEOUT),
+            body,
+            headers,
+        });
+    }
+
+    /**
+     * Requests an inline code completion from WCA.
+     * @param inputData - Completion prompt and metadata.
+     * @returns The completion response, or undefined on failure.
+     */
+    public async completionRequest(
+        inputData: CompletionRequestParams,
+    ): Promise<CompletionResponseParams | undefined> {
+        this.config.log(
+            'debug',
+            `[ansible-lightspeed] Completion request sent for suggestionId=${String(inputData.suggestionId)}`,
+        );
+        try {
+            const requestData = {
+                ...inputData,
+                metadata: {
+                    ...inputData.metadata,
+                    ansibleExtensionVersion: this.config.getExtensionVersion(),
+                },
+            };
+            const response = await this.lightspeedPost(
+                LIGHTSPEED_SUGGESTION_COMPLETION_URL,
+                JSON.stringify(requestData),
+            );
+
+            if (response.status === 204) {
+                this.config.showInfo(
+                    `Ansible Lightspeed does not have a suggestion for this input. Try changing your prompt, or contact your administrator with Suggestion Id ${String(requestData.suggestionId)} for assistance.`,
+                );
+                return undefined;
+            }
+
+            interface CompletionApiResponse {
+                predictions?: unknown[];
+            }
+            const data = (await response.json()) as CompletionApiResponse;
+
+            if (!response.ok) {
+                throw new HTTPError(response, response.status, data);
+            }
+
+            if (!data.predictions || data.predictions.length === 0 || !data.predictions[0]) {
+                this.config.showInfo(
+                    `Ansible Lightspeed does not have a suggestion for this input. Try changing your prompt, or contact your administrator with Suggestion Id ${String(requestData.suggestionId)} for assistance.`,
+                );
+                return undefined;
+            }
+
+            const suggestionId =
+                'suggestionId' in (data as Record<string, unknown>)
+                    ? String((data as Record<string, unknown>).suggestionId)
+                    : String(requestData.suggestionId);
+
+            this.config.log(
+                'debug',
+                `[ansible-lightspeed] Completion response for suggestionId=${suggestionId}, predictions=${String(data.predictions.length)}`,
+            );
+            return {
+                predictions: data.predictions as string[],
+                suggestionId,
+                ...('model' in (data as Record<string, unknown>)
+                    ? { model: String((data as Record<string, unknown>).model) }
+                    : {}),
+            };
+        } catch (error) {
+            const mappedError: IError = mapError(error as Error);
+            this.config.showError(
+                `${mappedError.message ?? UNKNOWN_ERROR} ${formatErrorDetail(mappedError.detail)}`,
+            );
+            return undefined;
+        }
+    }
+
+    /**
+     * Sends user feedback (inline suggestion, thumbs up/down, etc.) to WCA.
+     * @param inputData - The feedback payload.
+     * @param showAuthErrorMessage - Whether to surface auth errors to the user.
+     * @param showInfoMessage - Whether to show a success/error toast.
+     * @returns The feedback response, or undefined on failure/skip.
+     */
+    public async feedbackRequest(
+        inputData: FeedbackRequestParams,
+        showAuthErrorMessage = false,
+        showInfoMessage = false,
+    ): Promise<FeedbackResponseParams | undefined> {
+        if (!(await this.config.isAuthenticated()) && !showAuthErrorMessage) {
+            return undefined;
+        }
+
+        const orgOptOutTelemetry = await this.config.orgOptOutTelemetry();
+
+        const sanitized = { ...inputData };
+        if (orgOptOutTelemetry) {
+            delete sanitized.inlineSuggestion;
+        }
+
+        const hasEventData = Object.keys(sanitized).some((k) => k !== 'model');
+        if (!hasEventData) {
+            return undefined;
+        }
+        const requestData = {
+            ...sanitized,
+            metadata: {
+                ansibleExtensionVersion: this.config.getExtensionVersion(),
+            },
+        };
+        this.config.log(
+            'debug',
+            `[ansible-lightspeed] Feedback request sent with ${String(Object.keys(requestData).length)} event types`,
+        );
+        try {
+            const response = await this.lightspeedPost(
+                LIGHTSPEED_SUGGESTION_FEEDBACK_URL,
+                JSON.stringify(requestData),
+            );
+
+            const data: unknown = await response.json();
+
+            if (!response.ok) {
+                throw new HTTPError(response, response.status, data as object);
+            }
+
+            if (showInfoMessage) {
+                this.config.showInfo('Thanks for your feedback!');
+            }
+
+            return data as FeedbackResponseParams;
+        } catch (error) {
+            const mappedError: IError = mapError(error as Error);
+            const errorMessage = `${mappedError.message ?? UNKNOWN_ERROR} ${formatErrorDetail(mappedError.detail)}`;
+            if (showInfoMessage) {
+                this.config.showError(errorMessage);
+            }
+            return undefined;
+        }
+    }
+
+    /**
+     * Fetches training content matches for the given suggestions.
+     * @param inputData - Suggestions to match against training data.
+     * @returns Matching content or an error descriptor.
+     */
+    public async contentMatchesRequest(
+        inputData: ContentMatchesRequestParams,
+    ): Promise<ContentMatchesResponseParams | IError> {
+        if (!(await this.config.isAuthenticated())) {
+            this.config.showError('User not authenticated to use Ansible Lightspeed.');
+            return ERRORS_UNAUTHORIZED;
+        }
+
+        try {
+            const requestData = {
+                ...inputData,
+                metadata: {
+                    ansibleExtensionVersion: this.config.getExtensionVersion(),
+                },
+            };
+
+            this.config.log(
+                'debug',
+                `[ansible-lightspeed] Content Match request sent for suggestionId=${requestData.suggestionId}, suggestions=${String(requestData.suggestions.length)}`,
+            );
+
+            const response = await this.lightspeedPost(
+                LIGHTSPEED_SUGGESTION_CONTENT_MATCHES_URL,
+                JSON.stringify(requestData),
+            );
+
+            const data: unknown = await response.json();
+
+            if (!response.ok) {
+                throw new HTTPError(response, response.status, data as object);
+            }
+
+            return data as ContentMatchesResponseParams;
+        } catch (error) {
+            const mappedError: IError = mapError(error as Error);
+            return mappedError;
+        }
+    }
+
+    /**
+     * Requests a natural-language explanation for a playbook.
+     * @param inputData - The playbook content to explain.
+     * @returns The explanation or an error descriptor.
+     */
+    public async explanationRequest(
+        inputData: ExplanationRequestParams,
+    ): Promise<ExplanationResponseParams | IError> {
+        try {
+            const requestData = {
+                ...inputData,
+                metadata: {
+                    ansibleExtensionVersion: this.config.getExtensionVersion(),
+                },
+            };
+
+            this.config.log(
+                'debug',
+                `[ansible-lightspeed] Playbook Explanation request sent for explanationId=${requestData.explanationId}`,
+            );
+
+            const response = await this.lightspeedPost(
+                LIGHTSPEED_PLAYBOOK_EXPLANATION_URL,
+                JSON.stringify(requestData),
+            );
+
+            const data: unknown = await response.json();
+
+            if (!response.ok) {
+                throw new HTTPError(response, response.status, data as object);
+            }
+
+            return data as ExplanationResponseParams;
+        } catch (error) {
+            const mappedError: IError = mapError(error as Error);
+            return mappedError;
+        }
+    }
+
+    /**
+     * Generates a playbook from a natural-language description.
+     * @param inputData - The generation prompt and options.
+     * @returns The generated playbook or an error descriptor.
+     */
+    public async playbookGenerationRequest(
+        inputData: PlaybookGenerationRequestParams,
+    ): Promise<PlaybookGenerationResponseParams | IError> {
+        try {
+            const requestData = {
+                ...inputData,
+                metadata: {
+                    ansibleExtensionVersion: this.config.getExtensionVersion(),
+                },
+            };
+
+            this.config.log(
+                'debug',
+                `[ansible-lightspeed] Playbook generation request sent for generationId=${requestData.generationId}`,
+            );
+
+            const response = await this.lightspeedPost(
+                LIGHTSPEED_PLAYBOOK_GENERATION_URL,
+                JSON.stringify(requestData),
+            );
+
+            const data: unknown = await response.json();
+
+            if (!response.ok) {
+                throw new HTTPError(response, response.status, data as object);
+            }
+
+            return data as PlaybookGenerationResponseParams;
+        } catch (error) {
+            const mappedError: IError = mapError(error as Error);
+            return mappedError;
+        }
+    }
+
+    /**
+     * Generates a role from a natural-language description.
+     * @param inputData - The generation prompt and options.
+     * @returns The generated role files or an error descriptor.
+     */
+    public async roleGenerationRequest(
+        inputData: RoleGenerationRequestParams,
+    ): Promise<RoleGenerationResponseParams | IError> {
+        try {
+            const requestData = {
+                ...inputData,
+                metadata: {
+                    ansibleExtensionVersion: this.config.getExtensionVersion(),
+                },
+            };
+            this.config.log(
+                'debug',
+                `[ansible-lightspeed] Role Generation request sent for generationId=${requestData.generationId}`,
+            );
+            const response = await this.lightspeedPost(
+                LIGHTSPEED_ROLE_GENERATION_URL,
+                JSON.stringify(requestData),
+            );
+
+            const data: unknown = await response.json();
+
+            if (!response.ok) {
+                throw new HTTPError(response, response.status, data as object);
+            }
+
+            const typed = data as RoleGenerationResponseParams;
+            if (typed.role && !typed.name) {
+                typed.name = typed.role;
+            }
+
+            return typed;
+        } catch (error) {
+            const mappedError: IError = mapError(error as Error);
+            return mappedError;
+        }
+    }
+
+    /**
+     * Requests a natural-language explanation for a role.
+     * @param inputData - The role files to explain.
+     * @returns The explanation or an error descriptor.
+     */
+    public async roleExplanationRequest(
+        inputData: RoleExplanationRequestParams,
+    ): Promise<ExplanationResponseParams | IError> {
+        try {
+            const requestData = {
+                ...inputData,
+                metadata: {
+                    ansibleExtensionVersion: this.config.getExtensionVersion(),
+                },
+            };
+
+            this.config.log(
+                'debug',
+                `[ansible-lightspeed] Role Explanation request sent for explanationId=${requestData.explanationId}`,
+            );
+
+            const response = await this.lightspeedPost(
+                LIGHTSPEED_ROLE_EXPLANATION_URL,
+                JSON.stringify(requestData),
+            );
+
+            const data: unknown = await response.json();
+
+            if (!response.ok) {
+                throw new HTTPError(response, response.status, data as object);
+            }
+
+            return data as ExplanationResponseParams;
+        } catch (error) {
+            const mappedError: IError = mapError(error as Error);
+            return mappedError;
+        }
+    }
+}

--- a/packages/lightspeed/src/definitions.ts
+++ b/packages/lightspeed/src/definitions.ts
@@ -1,0 +1,87 @@
+export enum UserAction {
+    ACCEPTED = 0,
+    REJECTED = 1,
+    IGNORED = 2,
+}
+
+export enum ThumbsUpDownAction {
+    UP = 0,
+    DOWN = 1,
+}
+
+export enum WizardGenerationActionType {
+    OPEN = 0,
+    CLOSE_CANCEL = 1,
+    TRANSITION = 2,
+    CLOSE_ACCEPT = 3,
+}
+
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export namespace LightspeedCommands {
+    export const LIGHTSPEED_AUTH_REQUEST = 'ansible.lightspeed.oauth';
+    export const LIGHTSPEED_SUGGESTION_COMMIT = 'ansible.lightspeed.inlineSuggest.accept';
+    export const LIGHTSPEED_SUGGESTION_HIDE = 'ansible.lightspeed.inlineSuggest.hide';
+    export const LIGHTSPEED_SUGGESTION_TRIGGER = 'ansible.lightspeed.inlineSuggest.trigger';
+    export const LIGHTSPEED_SUGGESTION_MARKER = 'ansible.lightspeed.inlineSuggest.marker';
+    export const LIGHTSPEED_STATUS_BAR_CLICK = 'ansible.lightspeed.statusBar.click';
+    export const LIGHTSPEED_FETCH_TRAINING_MATCHES = 'ansible.lightspeed.fetchTrainingMatches';
+    export const LIGHTSPEED_CLEAR_TRAINING_MATCHES = 'ansible.lightspeed.clearTrainingMatches';
+    export const LIGHTSPEED_PLAYBOOK_EXPLANATION = 'ansible.lightspeed.playbookExplanation';
+    export const LIGHTSPEED_PLAYBOOK_GENERATION = 'ansible.lightspeed.playbookGeneration';
+    export const LIGHTSPEED_ROLE_GENERATION = 'ansible.lightspeed.roleGeneration';
+    export const LIGHTSPEED_ROLE_EXPLANATION = 'ansible.lightspeed.roleExplanation';
+    export const LIGHTSPEED_SIGN_IN_WITH_REDHAT = 'ansible.lightspeed.signInWithRedHat';
+    export const LIGHTSPEED_SIGN_IN_WITH_LIGHTSPEED = 'ansible.lightspeed.signInWithLightspeed';
+    export const LIGHTSPEED_OPEN_TRIAL_PAGE = 'ansible.lightspeed.openTrialPage';
+    export const LIGHTSPEED_REFRESH_EXPLORER_VIEW = 'ansible.lightspeed.explorer.refresh';
+}
+
+const LIGHTSPEED_API_VERSION = 'v0';
+const LIGHTSPEED_API_VERSION_V1 = 'v1';
+
+export const LIGHTSPEED_PLAYBOOK_EXPLANATION_URL = `${LIGHTSPEED_API_VERSION}/ai/explanations/`;
+export const LIGHTSPEED_PLAYBOOK_GENERATION_URL = `${LIGHTSPEED_API_VERSION}/ai/generations/`;
+export const LIGHTSPEED_ROLE_GENERATION_URL = `${LIGHTSPEED_API_VERSION_V1}/ai/generations/role/`;
+export const LIGHTSPEED_ROLE_EXPLANATION_URL = `${LIGHTSPEED_API_VERSION_V1}/ai/explanations/role/`;
+export const LIGHTSPEED_SUGGESTION_COMPLETION_URL = `${LIGHTSPEED_API_VERSION}/ai/completions/`;
+export const LIGHTSPEED_SUGGESTION_FEEDBACK_URL = `${LIGHTSPEED_API_VERSION}/ai/feedback/`;
+export const LIGHTSPEED_SUGGESTION_CONTENT_MATCHES_URL = `${LIGHTSPEED_API_VERSION}/ai/contentmatches/`;
+export const LIGHTSPEED_ME_AUTH_URL = `/api/${LIGHTSPEED_API_VERSION}/me/`;
+export const LIGHTSPEED_MARKDOWN_ME_AUTH_URL = `/api/${LIGHTSPEED_API_VERSION}/me/summary/`;
+
+export const LIGHTSPEED_CLIENT_ID = 'Vu2gClkeR5qUJTUGHoFAePmBznd6RZjDdy5FW2wy';
+export const LIGHTSPEED_SERVICE_LOGIN_TIMEOUT = 120000;
+
+export const WCA_API_ENDPOINT_DEFAULT = 'https://c.ai.ansible.redhat.com';
+
+export const LIGHTSPEED_API_TIMEOUT = 28000;
+
+export type LIGHTSPEED_SUGGESTION_TYPE = 'SINGLE-TASK' | 'MULTI-TASK';
+
+export type LIGHTSPEED_USER_TYPE = 'Licensed' | 'Unlicensed' | 'Not logged in';
+export const LIGHTSPEED_STATUS_BAR_TEXT_DEFAULT = 'Lightspeed (Not logged in)';
+
+export const LIGHTSPEED_MODEL_DEFAULT = 'default';
+
+export const LIGHTSPEED_SUGGESTION_GHOST_TEXT_COMMENT =
+    '# Content suggestion provided by Ansible Lightspeed\n';
+
+export const tasksInPlaybookKeywords = [
+    /(?<!\S)tasks\s*:(?!\S)\s*$/,
+    /(?<!\S)block\s*:(?!\S)\s*$/,
+    /(?<!\S)rescue\s*:(?!\S)\s*$/,
+    /(?<!\S)always\s*:(?!\S)\s*$/,
+    /(?<!\S)pre_tasks\s*:(?!\S)\s*$/,
+    /(?<!\S)post_tasks\s*:(?!\S)\s*$/,
+    /(?<!\S)handlers\s*:(?!\S)\s*$/,
+];
+
+export const tasksFileKeywords = [
+    /(?<!\S)block\s*:(?!\S)\s*$/,
+    /(?<!\S)rescue\s*:(?!\S)\s*$/,
+    /(?<!\S)always\s*:(?!\S)\s*$/,
+];
+
+export const SINGLE_TASK_REGEX_EP =
+    /^(?<![\s-])(?<blank>\s*)(?<list>- \s*name\s*:\s*)(?<description>\S.*)(?<end>$)/;
+export const MULTI_TASK_REGEX_EP = /^\s*#\s*\S+.*$/;

--- a/packages/lightspeed/src/errors.ts
+++ b/packages/lightspeed/src/errors.ts
@@ -1,0 +1,439 @@
+import type {
+    ExplanationResponseParams,
+    PlaybookGenerationResponseParams,
+    RoleGenerationResponseParams,
+} from './interfaces';
+
+/** Structured error returned by the API client. */
+export interface IError {
+    code: string;
+    message?: string;
+    detail?: unknown;
+}
+
+export const UNKNOWN_ERROR = 'An unknown error occurred.';
+
+/**
+ * Formats an error detail value for display, avoiding `[object Object]`.
+ * @param detail - The detail value to format.
+ * @returns A human-readable string representation.
+ */
+export function formatErrorDetail(detail: unknown): string {
+    if (detail === undefined || detail === null) return '';
+    if (typeof detail === 'string') return detail;
+    if (typeof detail === 'object') return JSON.stringify(detail);
+    if (typeof detail === 'number' || typeof detail === 'boolean') {
+        return detail.toString();
+    }
+    if (typeof detail === 'bigint') return detail.toString();
+    if (typeof detail === 'symbol') return detail.toString();
+    if (typeof detail === 'function') {
+        return detail.name.length > 0 ? detail.name : 'function';
+    }
+    return 'unknown';
+}
+
+/**
+ * Type guard to distinguish IError from successful response types.
+ * @param response - A response or error object.
+ * @returns True if the response is an IError.
+ */
+export function isError(
+    response:
+        | ExplanationResponseParams
+        | PlaybookGenerationResponseParams
+        | RoleGenerationResponseParams
+        | IError,
+): response is IError {
+    return 'code' in response;
+}
+
+/** HTTP error with access to the response, status code, and parsed body. */
+export class HTTPError extends Error {
+    readonly response: Response;
+    readonly code: number;
+    readonly body: object;
+
+    /**
+     * @param response - The raw fetch Response.
+     * @param code - The HTTP status code.
+     * @param body - The parsed response body.
+     */
+    constructor(response: Response, code: number, body: object) {
+        super(`HTTP ${String(code)} from ${response.url}`);
+        this.name = 'HTTPError';
+        this.response = response;
+        this.code = code;
+        this.body = body;
+    }
+}
+
+/** A known/mapped API error with an optional custom check function. */
+class MappedError implements IError {
+    readonly code: string;
+    readonly message?: string;
+    readonly detail?: unknown;
+    readonly check: (err: HTTPError) => boolean;
+
+    /**
+     * @param code - Machine-readable error code.
+     * @param message - Human-readable error message.
+     * @param detail - Additional detail payload.
+     * @param check - Custom predicate to match this error against an HTTPError.
+     */
+    public constructor(
+        code: string,
+        message?: string,
+        detail?: unknown,
+        check?: (err: HTTPError) => boolean,
+    ) {
+        this.code = code;
+        this.message = message;
+        this.detail = detail;
+        if (check) {
+            this.check = check;
+        } else {
+            this.check = (err: HTTPError) => {
+                const responseErrorData = err.body as Record<string, unknown>;
+                const errCode = Object.prototype.hasOwnProperty.call(responseErrorData, 'code')
+                    ? String(responseErrorData.code)
+                    : 'unknown';
+                return this.code === errCode;
+            };
+        }
+    }
+
+    /**
+     * Returns a clone of this error with a new detail value.
+     * @param detail - The detail to attach.
+     * @returns A new MappedError with the given detail.
+     */
+    public withDetail(detail?: unknown): MappedError {
+        return new MappedError(this.code, this.message, detail, this.check);
+    }
+}
+
+/** Registry of known HTTP errors keyed by status code. */
+class ErrorRegistry {
+    private errors = new Map<number, MappedError[]>();
+
+    /**
+     * Registers a known error for a given HTTP status code.
+     * @param statusCode - The HTTP status code.
+     * @param error - The error definition.
+     */
+    public addError(statusCode: number, error: MappedError): void {
+        if (!this.errors.has(statusCode)) {
+            this.errors.set(statusCode, []);
+        }
+        this.errors.get(statusCode)?.push(error);
+    }
+
+    /**
+     * Looks up a known error matching the given HTTPError.
+     * @param err - The HTTP error to match.
+     * @returns The matching MappedError, or undefined.
+     */
+    public getError(err: HTTPError): MappedError | undefined {
+        if (!('response' in err)) {
+            return undefined;
+        }
+
+        const statusCode: number = err.response.status;
+        const errors = this.errors.get(statusCode);
+        if (!errors) {
+            return undefined;
+        }
+        const e = errors.find((el) => el.check(err));
+
+        if (e) {
+            const responseErrorData = err.body as Record<string, unknown>;
+
+            const message =
+                e.message ??
+                (Object.prototype.hasOwnProperty.call(responseErrorData, 'message')
+                    ? String(responseErrorData.message)
+                    : 'unknown');
+            const items = err.body as Record<string, unknown>;
+            const detail = Object.prototype.hasOwnProperty.call(items, 'detail')
+                ? items.detail
+                : undefined;
+
+            return new MappedError(e.code, message, this.prettyPrintDetail(detail), e.check);
+        }
+
+        return undefined;
+    }
+
+    /**
+     * Formats a detail value for user-facing display.
+     * @param detail - The detail payload.
+     * @returns Formatted string, or undefined if no detail.
+     */
+    public prettyPrintDetail(detail: unknown): string | undefined {
+        let pretty = '';
+        if (detail === undefined) {
+            return undefined;
+        } else if (typeof detail === 'string') {
+            pretty = detail;
+        } else if (Array.isArray(detail)) {
+            const items = detail as string[];
+            items.forEach((value: string, index: number) => {
+                pretty =
+                    pretty +
+                    '(' +
+                    String(index + 1) +
+                    ') ' +
+                    value +
+                    (index < items.length - 1 ? ' ' : '');
+            });
+        } else if (detail instanceof Object && detail.constructor === Object) {
+            const items = detail as Record<string, unknown>;
+            const keys: string[] = Object.keys(detail);
+            keys.forEach((key, index) => {
+                pretty =
+                    pretty + `${key}: ${String(items[key])}` + (index < keys.length - 1 ? ' ' : '');
+            });
+        }
+        return pretty;
+    }
+}
+
+export const ERRORS = new ErrorRegistry();
+
+export const ERRORS_UNAUTHORIZED = new MappedError(
+    'fallback__unauthorized',
+    'You are not authorized to access Ansible Lightspeed. Please contact your administrator.',
+);
+export const ERRORS_NOT_FOUND = new MappedError(
+    'fallback__not_found',
+    'The resource could not be found. Please try again later.',
+);
+export const ERRORS_TOO_MANY_REQUESTS = new MappedError(
+    'fallback__too_many_requests',
+    'Too many requests to Ansible Lightspeed. Please try again later.',
+);
+export const ERRORS_BAD_REQUEST = new MappedError(
+    'fallback__bad_request',
+    'Bad Request response. Please try again.',
+);
+export const ERRORS_UNKNOWN = new MappedError(
+    'fallback__unknown',
+    'An error occurred attempting to complete your request. Please try again later.',
+);
+export const ERRORS_CONNECTION_TIMEOUT = new MappedError(
+    'fallback__connection_timeout',
+    'Ansible Lightspeed connection timeout. Please try again later.',
+);
+export const ERRORS_CONNECTION_CANCELED_TIMEOUT = new MappedError(
+    'fallback__connection_canceled_timeout',
+    'Ansible Lightspeed connection was canceled because of a timeout. Please try again later.',
+);
+
+// 400 errors
+ERRORS.addError(
+    400,
+    new MappedError(
+        'error__wca_cloud_flare_rejection',
+        'Cloudflare rejected the request. Please contact your administrator.',
+    ),
+);
+ERRORS.addError(
+    400,
+    new MappedError(
+        'error__wca_hap_filter_rejection',
+        'Potentially harmful language was detected in your request. Please check your input and try again.',
+    ),
+);
+ERRORS.addError(
+    400,
+    new MappedError(
+        'error__preprocess_invalid_yaml',
+        'An error occurred pre-processing the inline suggestion due to invalid YAML. Please contact your administrator.',
+    ),
+);
+ERRORS.addError(400, new MappedError('error__feedback_validation'));
+ERRORS.addError(
+    400,
+    new MappedError(
+        'error__wca_inference_failure',
+        'IBM watsonx Code Assistant inference failed. Please check your input and try again.',
+    ),
+);
+ERRORS.addError(
+    400,
+    new MappedError(
+        'error__wca_validation_failure',
+        'IBM watsonx Code Assistant failed to validate the response from the model. Please check your input and try again.',
+    ),
+);
+
+// 403 errors
+ERRORS.addError(
+    403,
+    new MappedError(
+        'error__wca_invalid_model_id',
+        'IBM watsonx Code Assistant Model ID is invalid. Please contact your administrator.',
+    ),
+);
+ERRORS.addError(
+    403,
+    new MappedError(
+        'error__wca_key_not_found',
+        'Could not find an API Key for IBM watsonx Code Assistant. Please contact your administrator.',
+    ),
+);
+ERRORS.addError(
+    403,
+    new MappedError(
+        'error__no_default_model_id',
+        'Ansible Lightspeed does not have a model configured. Contact your Ansible administrator to configure a model, or specify a model in your Ansible extension settings under Lightspeed: Model Id Override.',
+    ),
+);
+ERRORS.addError(
+    403,
+    new MappedError(
+        'error__wca_model_id_not_found',
+        'Your organization does not have an IBM watsonx Code Assistant model configured. Contact your Red Hat organization administrator to configure a model, or specify a model in your Ansible extension settings under Lightspeed: Model Id Override.',
+    ),
+);
+ERRORS.addError(
+    403,
+    new MappedError(
+        'permission_denied__user_trial_expired',
+        'Your trial to the generative AI model has expired. Refer to your IBM Cloud Account to re-enable access to the IBM watsonx Code Assistant by moving to one of the paid plans.',
+    ),
+);
+ERRORS.addError(
+    403,
+    new MappedError(
+        'permission_denied__terms_of_use_not_accepted',
+        'You have not accepted the Terms of Use. Please accept them before proceeding.',
+    ),
+);
+ERRORS.addError(
+    403,
+    new MappedError(
+        'permission_denied__user_not_org_administrator',
+        'You are not an Administrator of the Organization.',
+    ),
+);
+ERRORS.addError(
+    403,
+    new MappedError(
+        'permission_denied__user_has_no_subscription',
+        'Your organization does not have a subscription. Please contact your administrator.',
+    ),
+);
+ERRORS.addError(
+    403,
+    new MappedError(
+        'permission_denied__org_not_ready_because_wca_not_configured',
+        'Contact your administrator to configure IBM watsonx Code Assistant model settings for your organization.',
+    ),
+);
+ERRORS.addError(
+    403,
+    new MappedError(
+        'permission_denied__user_with_no_seat',
+        "You don't have access to IBM watsonx Code Assistant. Please contact your administrator.",
+    ),
+);
+ERRORS.addError(
+    403,
+    new MappedError(
+        'permission_denied__can_apply_for_trial',
+        'Access denied but user can apply for a trial period.',
+    ),
+);
+ERRORS.addError(
+    403,
+    new MappedError(
+        'permission_denied__cloudfront',
+        'Something in your editor content has caused your inline suggestion request to be blocked. \n' +
+            'Please open a ticket with Red Hat support and include the content of your editor up to the \n' +
+            'line and column where you requested a suggestion.',
+        undefined,
+        (err: HTTPError) => {
+            const body: unknown = err.body;
+            let bodyContainsCloudFront = false;
+            let bodyContainsCloudFrontBlocked = false;
+            const headerContainsCloudFrontServer: boolean =
+                (err.response.headers.get('server') ?? '').toLowerCase() === 'cloudfront';
+            if (typeof body === 'string') {
+                bodyContainsCloudFront = (/cloudfront/.exec(body.toLowerCase())?.length ?? 0) > 0;
+                bodyContainsCloudFrontBlocked =
+                    (/blocked/.exec(body.toLowerCase())?.length ?? 0) > 0;
+            }
+            return (
+                bodyContainsCloudFront &&
+                bodyContainsCloudFrontBlocked &&
+                headerContainsCloudFrontServer
+            );
+        },
+    ),
+);
+
+// 404 errors
+ERRORS.addError(
+    404,
+    new MappedError(
+        'feature_not_available',
+        'The requested action is not available in your environment.',
+    ),
+);
+
+// 418 errors
+ERRORS.addError(
+    418,
+    new MappedError(
+        'error__wca_instance_deleted',
+        'IBM watsonx Code Assistant instance associated with your Model Id has been deleted. Please contact your administrator.',
+    ),
+);
+
+// 500 errors
+ERRORS.addError(
+    500,
+    new MappedError(
+        'internal_server',
+        'An error occurred attempting to complete your request. Please try again later.',
+    ),
+);
+ERRORS.addError(
+    500,
+    new MappedError(
+        'error__feedback_internal_server',
+        'An error occurred attempting to submit your feedback. Please try again later.',
+    ),
+);
+ERRORS.addError(
+    500,
+    new MappedError(
+        'error__wca_suggestion_correlation_failed',
+        'IBM watsonx Code Assistant request/response correlation failed. Please contact your administrator.',
+    ),
+);
+ERRORS.addError(
+    500,
+    new MappedError(
+        'error__wca_request_id_correlation_failed',
+        'IBM watsonx Code Assistant request/response correlation failed. Please contact your administrator.',
+    ),
+);
+
+// 503 errors
+ERRORS.addError(
+    503,
+    new MappedError(
+        'error__attribution_exception',
+        'An error occurred attempting to complete your request. Please try again later.',
+    ),
+);
+ERRORS.addError(
+    503,
+    new MappedError(
+        'service_unavailable',
+        'The IBM watsonx Code Assistant is unavailable. Please try again later.',
+    ),
+);

--- a/packages/lightspeed/src/handleApiError.ts
+++ b/packages/lightspeed/src/handleApiError.ts
@@ -1,0 +1,62 @@
+import {
+    ERRORS,
+    ERRORS_UNAUTHORIZED,
+    ERRORS_TOO_MANY_REQUESTS,
+    ERRORS_BAD_REQUEST,
+    ERRORS_UNKNOWN,
+    ERRORS_CONNECTION_CANCELED_TIMEOUT,
+    ERRORS_CONNECTION_TIMEOUT,
+    ERRORS_NOT_FOUND,
+    HTTPError,
+    type IError,
+} from './errors';
+
+/**
+ * Maps an HTTPError to a user-facing IError using the error registry.
+ * @param err - The HTTP error to map.
+ * @returns A structured error with code, message, and optional detail.
+ */
+function mapHttpError(err: HTTPError): IError {
+    const mappedError = ERRORS.getError(err);
+    if (mappedError) {
+        return mappedError;
+    }
+
+    const items = err.body as Record<string, unknown>;
+    const detail = Object.prototype.hasOwnProperty.call(items, 'detail') ? items.detail : undefined;
+    const status: number = err.response.status;
+    if (status === 400) {
+        return ERRORS_BAD_REQUEST.withDetail(ERRORS.prettyPrintDetail(detail));
+    }
+    if (status === 401 || status === 403) {
+        return ERRORS_UNAUTHORIZED.withDetail(ERRORS.prettyPrintDetail(detail));
+    }
+    if (status === 404) {
+        return ERRORS_NOT_FOUND.withDetail(ERRORS.prettyPrintDetail(detail));
+    }
+    if (status === 429) {
+        return ERRORS_TOO_MANY_REQUESTS.withDetail(ERRORS.prettyPrintDetail(detail));
+    }
+
+    return ERRORS_UNKNOWN.withDetail(ERRORS.prettyPrintDetail(detail));
+}
+
+/**
+ * Maps any Error to a user-facing IError, handling timeouts,
+ * cancellations, HTTP errors, and unknown failures.
+ * @param err - The error to map.
+ * @returns A structured error with code, message, and optional detail.
+ */
+export function mapError(err: Error): IError {
+    if (err.name === 'AbortError' || err.name === 'TimeoutError') {
+        return ERRORS_CONNECTION_TIMEOUT;
+    }
+    if (err.name === 'CanceledError') {
+        return ERRORS_CONNECTION_CANCELED_TIMEOUT;
+    }
+    if (err instanceof HTTPError) {
+        return mapHttpError(err);
+    }
+
+    return ERRORS_UNKNOWN;
+}

--- a/packages/lightspeed/src/index.ts
+++ b/packages/lightspeed/src/index.ts
@@ -1,0 +1,6 @@
+export * from './definitions';
+export * from './interfaces';
+export * from './errors';
+export { mapError } from './handleApiError';
+export { LightspeedAPI, getFetch } from './api';
+export type { LightspeedApiConfig } from './api';

--- a/packages/lightspeed/src/interfaces.ts
+++ b/packages/lightspeed/src/interfaces.ts
@@ -1,0 +1,257 @@
+import type { AuthenticationSession } from 'vscode';
+import type {
+    LIGHTSPEED_USER_TYPE,
+    WizardGenerationActionType,
+    ThumbsUpDownAction,
+    UserAction,
+} from './definitions';
+
+export interface LightspeedAuthSession extends AuthenticationSession {
+    rhOrgHasSubscription: boolean;
+    rhUserIsOrgAdmin: boolean;
+}
+
+export interface LightspeedUserDetails {
+    rhOrgHasSubscription: boolean;
+    rhUserIsOrgAdmin: boolean;
+    displayName: string;
+    displayNameWithUserType: string;
+    orgOptOutTelemetry: boolean;
+}
+
+export interface CompletionResponseParams {
+    predictions: string[];
+    model?: string;
+    suggestionId: string;
+}
+
+export interface MetadataParams {
+    documentUri: string;
+    ansibleFileType: IAnsibleFileType;
+    activityId: string;
+    additionalContext?: IAdditionalContext;
+}
+
+export interface CompletionRequestParams {
+    prompt: string;
+    suggestionId?: string;
+    metadata?: MetadataParams;
+    model?: string;
+}
+
+export interface FeedbackResponseParams {
+    message?: string;
+}
+
+export interface InlineSuggestionEvent {
+    latency?: number;
+    userActionTime?: number;
+    documentUri?: string;
+    action?: UserAction;
+    error?: string;
+    suggestionId?: string;
+    activityId?: string;
+}
+
+export interface PlaybookExplanationEvent {
+    explanationId?: string;
+}
+
+export interface PlaybookFeedbackEvent {
+    action: ThumbsUpDownAction;
+    explanationId?: string;
+    generationId?: string;
+}
+
+export interface PlaybookGenerationActionEvent {
+    wizardId: string;
+    action: WizardGenerationActionType;
+    fromPage?: number;
+    toPage?: number;
+}
+
+export interface RoleGenerationActionEvent {
+    wizardId: string;
+    action: WizardGenerationActionType;
+    fromPage?: number;
+    toPage?: number;
+}
+
+export interface RoleExplanationEvent {
+    explanationId?: string;
+}
+
+export interface RoleFeedbackEvent {
+    action: ThumbsUpDownAction;
+    explanationId?: string;
+    generationId?: string;
+}
+
+export interface FeedbackRequestParams {
+    inlineSuggestion?: InlineSuggestionEvent;
+    playbookExplanation?: PlaybookExplanationEvent;
+    playbookExplanationFeedback?: PlaybookFeedbackEvent;
+    playbookGenerationAction?: PlaybookGenerationActionEvent;
+    roleGenerationAction?: RoleGenerationActionEvent;
+    roleExplanation?: RoleExplanationEvent;
+    roleExplanationFeedback?: RoleFeedbackEvent;
+    playbookOutlineFeedback?: PlaybookFeedbackEvent;
+    model?: string;
+}
+
+export interface IDocumentTrackerFields {
+    activityId: string;
+    content: string;
+}
+
+export type IDocumentTracker = Record<string, IDocumentTrackerFields>;
+
+export interface ContentMatchesRequestParams {
+    suggestions: string[];
+    suggestionId: string;
+    model?: string;
+}
+
+export interface IContentMatchParams {
+    repo_name: string;
+    repo_url: string;
+    path: string;
+    license: string;
+    data_source_description: string;
+    score: number;
+}
+
+export interface IContentMatch {
+    contentmatch: IContentMatchParams[];
+}
+
+export interface ContentMatchesResponseParams {
+    contentmatches: IContentMatch[];
+}
+
+export interface ISuggestionDetails {
+    suggestion: string;
+    suggestionId: string;
+    isPlaybook: boolean;
+}
+
+export interface PlaybookGenerationRequestParams {
+    text: string;
+    outline?: string;
+    generationId: string;
+    createOutline: boolean;
+    wizardId?: string;
+}
+
+export interface RoleGenerationRequestParams {
+    name?: string;
+    text: string;
+    outline?: string;
+    generationId: string;
+    createOutline: boolean;
+    wizardId?: string;
+}
+
+export interface PlaybookGenerationResponseParams {
+    playbook: string;
+    outline?: string;
+    generationId: string;
+}
+
+export enum RoleFileType {
+    Default = 'default',
+    Task = 'task',
+    Playbook = 'playbook',
+    Handler = 'handler',
+}
+
+export interface GenerationListEntry {
+    path: string;
+    file_type: RoleFileType;
+    content: string;
+}
+
+export interface RoleGenerationResponseParams {
+    files: GenerationListEntry[];
+    outline?: string;
+    generationId: string;
+    name: string;
+    role?: string;
+}
+
+export interface RoleExplanationRequestParams {
+    files: GenerationListEntry[];
+    explanationId: string;
+    roleName: string;
+}
+
+export interface ExplanationRequestParams {
+    content: string;
+    explanationId: string;
+}
+
+export interface ExplanationResponseParams {
+    content: string;
+    format: string;
+    explanationId: string;
+}
+
+export type IAnsibleFileType = 'playbook' | 'tasks_in_role' | 'tasks' | 'other';
+
+export type VarType = 'defaults' | 'vars';
+
+export type IAnsibleFileTypes = Record<string, IAnsibleFileType>;
+
+export type IVarsContext = Record<string, string>;
+
+export type IIncludeVarsContext = Record<string, string>;
+
+export type IVarsFileContext = Record<string, string>;
+
+interface IRoleVarsContext {
+    defaults: IVarsFileContext;
+    vars: IVarsFileContext;
+}
+
+interface IRoleContext {
+    name?: string;
+    tasks?: string[];
+    roleVars?: IRoleVarsContext;
+    includeVars?: IIncludeVarsContext;
+}
+
+export type IRolesContext = Record<string, IRoleContext>;
+
+interface IStandaloneTaskContext {
+    includeVars?: IIncludeVarsContext;
+}
+
+export type IWorkspaceRolesContext = Record<string, IRolesContext>;
+
+interface IPlaybookContext {
+    varInfiles?: IVarsFileContext;
+    roles?: IRolesContext;
+    taskFileNames?: string[];
+    includeVars?: IIncludeVarsContext;
+}
+
+interface IAdditionalContext {
+    playbookContext?: IPlaybookContext;
+    roleContext?: IRoleContext;
+    standaloneTaskContext?: IStandaloneTaskContext;
+}
+
+export interface LightspeedSessionUserInfo {
+    userType?: LIGHTSPEED_USER_TYPE;
+    role?: string;
+    subscribed?: boolean;
+}
+
+export interface LightspeedSessionModelInfo {
+    model?: string;
+}
+
+export interface LightspeedSessionInfo {
+    userInfo?: LightspeedSessionUserInfo;
+    modelInfo?: LightspeedSessionModelInfo;
+}

--- a/packages/lightspeed/tsconfig.json
+++ b/packages/lightspeed/tsconfig.json
@@ -5,9 +5,6 @@
     "lib": ["ES2020"],
     "outDir": "out",
     "rootDir": "src",
-    "paths": {
-      "@src/*": ["./src/*"]
-    },
     "types": ["node"],
     "sourceMap": true,
     "strict": true,
@@ -20,17 +17,8 @@
     "declarationMap": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", ".vscode-test", "packages", "src/panels/webview-entry.tsx", "src/panels/bridges", "src/panels/webview.d.ts"],
-  "ts-node": {
-    "compilerOptions": {
-      "types": ["node", "mocha"]
-    }
-  },
+  "exclude": ["node_modules", "out", "test"],
   "references": [
-    { "path": "packages/common" },
-    { "path": "packages/services" },
-    { "path": "packages/language-server" },
-    { "path": "packages/mcp-server" },
-    { "path": "packages/lightspeed" }
+    { "path": "../services" }
   ]
 }


### PR DESCRIPTION
## Summary
- Add `@ansible/lightspeed` as an isolated workspace package for temporary
  WCA (Watson Code Assistant) integration on the `next` branch
- Designed for clean removal in a few months — see ADR-015 and the
  implementation plan for the full architecture and removal checklist

## Changes
- **ADR-015** (`.sdlc/adrs/ADR-015-lightspeed-standalone-package.md`):
  documents the decision to port Lightspeed as an opt-in standalone package
  with WCA-only support, existing Vue webviews, and isolated test suites
- **Implementation plan** (`.sdlc/plans/lightspeed-standalone-package.md`):
  7-phase roadmap covering package skeleton, OAuth, inline suggestions,
  webviews, extension shim, and test isolation — with a step-by-step
  removal checklist
- **Package skeleton** (`packages/lightspeed/`): `@ansible/lightspeed`
  workspace package with types, interfaces, WCA API client, error handling,
  wired into root tsconfig and package.json
- **Scoping**: WCA-only (no BYOLLM), Vue webviews kept as-is (no React
  rewrite), isolated test suites (not in root test runs)
- **Agent skill updates**: updated `pr-review` and `submit-pr` skills
  with Copilot evaluation criteria (semantic truthfulness, information
  exposure, caller safety, prose-code drift, supply-chain mutability,
  dead weight) so the agent anticipates novel issues

## Copilot review rounds
- Round 1 (10 comments): error codes, log levels, type contracts, engine
  range — all fixed, threads resolved
- Round 2 (6 comments): engine/tsconfig alignment, 204 before json(),
  debug log payload, parameter mutation, test coverage (explained as
  Phase 1 skeleton) — all fixed/addressed, threads resolved

## Test plan
- [x] `npm run ci` passes (compile + lint + test:coverage + build)
- [x] All 16 Copilot review comments addressed and threads resolved

related: ADR-015