### PR TITLE
chore: migrate github runners to ubuntu-26.04

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,7 +44,7 @@ env:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   lint:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -89,7 +89,7 @@ jobs:
           prek-version: ">=0.3.8"
 
   preflight:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     container:
       image: ghcr.io/ansible/ext-builder:latest
       env:
@@ -241,7 +241,7 @@ jobs:
       run:
         shell: ${{ matrix.shell || 'bash'}}
     # The type of runner that the job will run on
-    runs-on: ${{ matrix.os || 'ubuntu-24.04' }}
+    runs-on: ${{ matrix.os || 'ubuntu-26.04' }}
     outputs:
       can_release_to_npm: ${{ steps.package.outputs.can_release_to_npm }}
     permissions:
@@ -257,7 +257,7 @@ jobs:
         continue-on-error:
           - false
         os:
-          - ubuntu-24.04
+          - ubuntu-26.04
         task-name:
           - test
         name:
@@ -284,7 +284,7 @@ jobs:
           - name: test (linux-wdio)
             id: test-linux-wdio
             task-name: wdio
-            os: ubuntu-24.04
+            os: ubuntu-26.04
             env:
               SKIP_PODMAN: 1
               SKIP_DOCKER: 1
@@ -345,7 +345,7 @@ jobs:
         if: contains(matrix.name, 'wsl') && (matrix.runs-on || '') != 'self-hosted'
         uses: Vampire/setup-wsl@d1da7f2c0322a5ee4f24975344f67fc0f5baf364 # v7.0.0
         with:
-          distribution: Ubuntu-24.04
+          distribution: Ubuntu-26.04
           set-as-default: "true"
           # '-i' seems to be the only option that loads .bashrc file that we need
           # https://github.com/Vampire/setup-wsl/discussions/54
@@ -558,7 +558,7 @@ jobs:
           slack_webhook_url: ${{ secrets.DEVTOOLS_CI_SLACK_URL }}
 
   builder-image:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     needs: [preflight, lint]
     permissions:
       contents: read
@@ -585,7 +585,7 @@ jobs:
         run: ./tools/builder.sh ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' && '--push' || '' }}
 
   mcp-server-image:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     needs: [preflight, lint]
     permissions:
       contents: read
@@ -667,7 +667,7 @@ jobs:
       id-token: write # codecov
       pull-requests: read # slack report
 
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
 
     steps:
       - name: Checkout Source # needed by codecov uploader

--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   analyze:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,7 +14,7 @@ submodules:
   recursive: true
 
 build:
-  os: ubuntu-24.04
+  os: ubuntu-26.04
   tools:
     python: "3.13"
   jobs:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -22,7 +22,7 @@ vars:
   XVFB:
     # prefix to add to allow execution of test in headless machines (CI)
     # keep the space after log filename as it is needed.
-    sh: bash -c 'if [[ "$OSTYPE" == "linux-gnu"* ]] && command -v xvfb-run >/dev/null; then echo "$(command -v xvfb-run) --auto-servernum -e out/log/xvfb.log "; fi'
+    sh: node ./tools/xvfb-prefix.mts
 tasks:
   default:
     desc: Run most commands
@@ -149,7 +149,7 @@ tasks:
       # Retrieve possibly missing commits:
       - $(git rev-parse --is-shallow-repository) && git fetch --unshallow > /dev/null || true
       - git fetch --tags || git fetch --tags --force
-      - bash -c '. "${VIRTUAL_ENV}/bin/activate" && zensical build --strict'
+      - uvx zensical build --strict
       - defer: { task: finish }
   lint:
     desc: Lint the project

--- a/tools/xvfb-prefix.mts
+++ b/tools/xvfb-prefix.mts
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process";
+
+/** Prefix for headless Linux CI when xvfb-run is available (see Taskfile XVFB). */
+function main(): void {
+  if (process.platform !== "linux") {
+    return;
+  }
+
+  try {
+    const xvfbRun = execFileSync("which", ["xvfb-run"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    if (xvfbRun) {
+      // Trailing space is required when prepended to test commands.
+      process.stdout.write(`${xvfbRun} --auto-servernum -e out/log/xvfb.log `);
+    }
+  } catch {
+    // xvfb-run not installed
+  }
+}
+
+main();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Migrate CI/CD infrastructure from ubuntu-24.04 to ubuntu-26.04 across GitHub Actions workflows, Read the Docs, and local build configuration. Introduces a new Node-based xvfb-prefix script to conditionally enable headless X11 on Linux CI environments and simplifies zensical invocation using uvx.

- Updated GitHub Actions workflows (ci.yaml, stats.yml) to run on ubuntu-26.04
- Updated Read the Docs build OS configuration to ubuntu-26.04
- Added tools/xvfb-prefix.mts Node script for conditional xvfb-run prefixing on Linux
- Refactored Taskfile.yml to use the new xvfb-prefix script and uvx for zensical builds

<!-- end of auto-generated comment: release notes by coderabbit.ai -->