### PR TITLE
ci: add Codecov coverage uploads to CI workflows

### DIFF
--- a/.agents/skills/submit-pr/SKILL.md
+++ b/.agents/skills/submit-pr/SKILL.md
@@ -76,6 +76,27 @@ Read every changed line against these questions. For each question,
 name at least one specific file and line you verified. If you cannot,
 you haven't actually reviewed the diff.
 
+**Artifact-type sweep.** Before answering the questions below, list
+every distinct artifact type in the diff (e.g., TypeScript, YAML
+workflow, shell script, Dockerfile, JSON config). For each question,
+you must cite at least one file of *each* artifact type — not just
+TypeScript. If a question feels inapplicable to an artifact type,
+translate it:
+
+- "caller" in YAML means any action, job, or step that consumes
+  a declaration (e.g., `actions/checkout` consumes `permissions:`,
+  a downstream job consumes an output)
+- "type signature" in YAML means a key's implicit contract
+  (e.g., `permissions:` replaces defaults, not extends them;
+  `if:` expressions evaluate to boolean)
+- "constructed scenario" for shell means: what happens when
+  the command runs on a different shell (bash vs powershell),
+  a different OS (encoding, path separators), or with missing
+  input (empty files, failed prior steps)?
+- "dependencies pinned to intent" for actions means: does the
+  action tag, permissions scope, or `if:` condition express
+  exactly what you mean — not broader, not narrower?
+
 1. **Does every statement mean what it says?** Check every type
    signature, return value, error code, version range, log level,
    comment, and docstring. If the code declares it, the runtime must

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ concurrency:
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     strategy:
       matrix:
         node-version: [20, 22]
@@ -34,6 +37,16 @@ jobs:
 
       - name: Run tests with coverage
         run: npm run test:coverage
+
+      - name: Upload coverage to Codecov
+        if: ${{ always() && hashFiles('coverage/cobertura-coverage.xml') != '' }}
+        uses: codecov/codecov-action@v7
+        with:
+          files: ./coverage/cobertura-coverage.xml
+          flags: unit-node${{ matrix.node-version }}
+          disable_search: true
+          fail_ci_if_error: true
+          use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/wsl2-ui.yml
+++ b/.github/workflows/wsl2-ui.yml
@@ -187,6 +187,9 @@ jobs:
     runs-on: windows-2022
     continue-on-error: true
     timeout-minutes: 25
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
       - uses: actions/checkout@v5
@@ -259,6 +262,22 @@ jobs:
         shell: powershell
         run: |
           wsl -d ${{ env.WSL_DISTRO }} -u ci -- bash -c "cd ${{ env.WSL_CHECKOUT }} && npm run test:coverage"
+
+      - name: Copy coverage out of WSL
+        if: ${{ always() }}
+        shell: powershell
+        run: |
+          wsl -d ${{ env.WSL_DISTRO }} -u ci -- bash -c "if [ -f ${{ env.WSL_CHECKOUT }}/coverage/cobertura-coverage.xml ]; then mkdir -p /mnt/d/a/vscode-ansible/vscode-ansible/coverage && cp ${{ env.WSL_CHECKOUT }}/coverage/cobertura-coverage.xml /mnt/d/a/vscode-ansible/vscode-ansible/coverage/; fi"
+
+      - name: Upload coverage to Codecov
+        if: ${{ always() && hashFiles('coverage/cobertura-coverage.xml') != '' }}
+        uses: codecov/codecov-action@v7
+        with:
+          files: ./coverage/cobertura-coverage.xml
+          flags: wsl-fedora
+          disable_search: true
+          fail_ci_if_error: true
+          use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
 
       - name: Integration tests
         shell: powershell

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,18 @@
+codecov:
+  require_ci_to_pass: false
+  notify:
+    after_n_builds: 3
+    wait_for_ci: false
+comment:
+  layout: "condensed_header, condensed_files, condensed_footer"
+  hide_project_coverage: true
+  require_changes: "coverage_drop OR uncovered_patch"
+  after_n_builds: 3
+coverage:
+  status:
+    patch: false
+    project: true
+github_checks:
+  annotations: true
+ignore:
+  - ".agents/**"

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -35,7 +35,7 @@ export default defineConfig({
     test: {
         coverage: {
             provider: 'v8',
-            reporter: ['text', 'html', 'lcov'],
+            reporter: ['text', 'html', 'lcov', 'cobertura'],
             reportsDirectory: 'coverage',
             include: [
                 'packages/common/src/**/*.ts',


### PR DESCRIPTION
## Summary
- Add Codecov coverage reporting to the `next` branch CI, mirroring the pattern established on `main`
- Coverage is uploaded from 3 jobs using OIDC auth (tokenless) with per-job flags
- Strengthen the submit-pr skill's self-review to apply uniformly across artifact types

## Changes
- **`vitest.config.mts`**: Add `cobertura` reporter so vitest writes XML alongside lcov/html
- **`codecov.yml`** (new): Codecov config — project status enabled, patch disabled, `after_n_builds: 3`, `.agents/**` ignored
- **`.github/workflows/ci.yml`**: Add `contents: read` + `id-token: write` permissions and `codecov/codecov-action@v7` upload step to `build-and-test` job with `flags: unit-node{20,22}`
- **`.github/workflows/wsl2-ui.yml`**: Add permissions, WSL-native coverage copy to mounted Windows path (avoids PowerShell UTF-16 encoding), and Codecov upload with `flags: wsl-fedora`
- **`.agents/skills/submit-pr/SKILL.md`**: Add artifact-type sweep preamble to Step 3, forcing the agent to translate self-review principles across YAML, shell, and cross-platform artifacts — not just TypeScript

## Quality of life
- AI-authored addition: artifact-type sweep in submit-pr skill, based on learnings from Copilot review findings on this PR

## Test plan
- [ ] `build-and-test` job (Node 20 + 22) uploads cobertura XML to Codecov
- [ ] `wsl-unit-integration` job copies coverage out of WSL and uploads to Codecov
- [ ] Codecov posts PR status check and comment after 3 uploads
- [ ] Fork PRs gracefully skip OIDC (fall back to token-based, which will skip if no token)
- [x] `npm run ci` passes locally (compile + lint + test:coverage + build)
