### PR TITLE
chore: keep using ubuntu 24.04 on wsl

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -314,7 +314,7 @@ jobs:
         if: contains(matrix.name, 'wsl')
         uses: Vampire/setup-wsl@d1da7f2c0322a5ee4f24975344f67fc0f5baf364 # v7.0.0
         with:
-          distribution: Ubuntu-26.04
+          distribution: Ubuntu-24.04 # Ubuntu-26.04 not supported yet
           set-as-default: "true"
           # '-i' seems to be the only option that loads .bashrc file that we need
           # https://github.com/Vampire/setup-wsl/discussions/54


### PR DESCRIPTION
Fixes: #2912


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Preserve WSL on Ubuntu 24.04 while the broader infrastructure migrates to Ubuntu 26.04. This PR creates a targeted exception within the infrastructure migration effort, ensuring Windows Subsystem for Linux environments remain on a stable version.

- WSL distribution in CI workflow updated to use Ubuntu-24.04 instead of Ubuntu-26.04 for matrix entries containing `wsl`


Related: `#2912`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->