### PR TITLE
chore: reduce chance of false positives from codecov gate

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -11,8 +11,22 @@ comment:
   after_n_builds: 3
 coverage:
   status:
-    patch: false
-    project: true
+    # Project coverage fluctuates across linux/macos/wsl uploads and on
+    # indirect changes to unrelated lines; relax this check so minor
+    # fluctuations do not block merges.
+    project:
+      default:
+        target: auto
+        threshold: 0.5%
+    # Enforce coverage only on lines changed in the pull request.
+    patch:
+      default:
+        target: auto
+        threshold: 0%
+    # Indirect coverage changes on untouched lines are noisy in multi-OS CI.
+    changes:
+      default:
+        enabled: false
 github_checks:
   annotations: true
 ignore:


### PR DESCRIPTION
## Summary
- Disable the `codecov/changes` status check, which fails on indirect coverage shifts on untouched lines
- Enable `codecov/patch` to enforce coverage on lines changed in the pull request
- Relax `codecov/project` with a 0.5% threshold so minor multi-OS upload variance does not block merges

## Test plan
- [ ] Confirm CI uploads coverage from linux, macos, and wsl as before
- [ ] Verify PR shows `codecov/patch` as the blocking check instead of failing on unrelated project coverage drops
- [ ] Confirm `codecov/changes` no longer appears as a failing status


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
chore: reduce codecov false positives—Updated Codecov gating to disable `codecov/changes`, enforce `codecov/patch` on PR-modified lines, and relax `codecov/project` with a 0.5% tolerance to avoid false failures from multi-OS coverage variance.
- Disable `codecov/changes` enforcement (changes off).
- Enable blocking `codecov/patch` for modified lines.
- Allow 0.5% tolerance for `codecov/project`.

Co-authored-by: Cursor <cursoragent@cursor.com>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->