### PR TITLE
feat(mcp): add MCP compliance, onboarding, and Getting Started tools

### DIFF
--- a/.sdlc/adrs/ADR-005-architectural-invariants.md
+++ b/.sdlc/adrs/ADR-005-architectural-invariants.md
@@ -125,6 +125,19 @@ violates this invariant.
 **Test**: If a human can perform an action via the extension UI, an
 agent must be able to perform the same action via an MCP tool.
 
+### 12. MCP tools and skills conform to documented best practices (ADR-017)
+
+Tools must have behavioral annotations (`readOnlyHint`,
+`destructiveHint`, `idempotentHint`), valid `inputSchema` with
+`type: "object"`, server-side input validation, and machine-readable
+error responses with recoverability signals. Skills must conform to
+the agentskills.io frontmatter spec and support three-level
+progressive disclosure. The compliance checklist in ADR-017 is the
+authority.
+
+**Test**: If a new tool is added without behavioral annotations or a
+new skill lacks valid frontmatter, the PR violates this invariant.
+
 ## Consequences
 
 ### Positive
@@ -161,6 +174,8 @@ agent must be able to perform the same action via an MCP tool.
   layer (invariants 9, 10)
 - [ADR-012](ADR-012-mcp-tool-parity.md): MCP tool parity
   (invariant 11)
+- [ADR-017](ADR-017-mcp-skills-compliance.md): MCP and skills
+  compliance policy (invariant 12)
 
 ---
 
@@ -171,3 +186,4 @@ agent must be able to perform the same action via an MCP tool.
 | 2026-05-26 | AI-assisted | Initial invariants (8 rules) |
 | 2026-06-10 | AI-assisted | Add invariants 9, 10 (shared UI) |
 | 2026-06-17 | AI-assisted | Add invariant 11 (MCP tool parity) |
+| 2026-06-23 | AI-assisted | Add invariant 12 (MCP/skills compliance) |

--- a/.sdlc/adrs/ADR-017-mcp-skills-compliance.md
+++ b/.sdlc/adrs/ADR-017-mcp-skills-compliance.md
@@ -1,0 +1,279 @@
+# ADR-017: MCP and Skills Compliance Policy
+
+## Status
+
+Accepted
+
+## Date
+
+2026-06-23
+
+## Context
+
+The `@ansible/mcp-server` package exposes 15 static MCP tools plus
+dynamic `ac_*` (creator) and `skill_*` tools. The `SkillRegistry` in
+`@ansible/services` loads skills from multiple sources (builtin,
+GitHub, local) and the `SkillToolGenerator` in `@ansible/mcp-server`
+dynamically generates `skill_*` MCP tools. This infrastructure was
+built before the MCP community codified best practices at scale:
+
+- The MCP Dev Summit NA 2026 produced 57 practices and a set of
+  critical anti-patterns from 100 industry sessions.
+- A server code-review guide documented 22 practices and 8
+  anti-patterns distilled from production deployments.
+- The Skills Over MCP Working Group (converted from Interest Group,
+  April 2026) is pursuing SEP-2640, an Extensions Track specification
+  for serving skills over MCP using the Resources primitive.
+- The Agent Skills specification (agentskills.io) defines the
+  canonical format for skill files.
+
+Our existing tools follow intent-based naming and our skills use
+frontmatter-based progressive disclosure — both aligned with the
+emerging consensus. However, without a standing compliance gate, drift
+is likely as new tools and skills are added. Tool annotations
+(`readOnlyHint`, `destructiveHint`, `idempotentHint`) are not yet
+applied. Error responses lack machine-readable recoverability signals.
+Skill files do not yet use the `skill://` URI scheme.
+
+ADR-012 ensures every capability has an MCP tool equivalent. ADR-014
+establishes skills as the prompt source of truth. This ADR complements
+both by governing the **quality and spec-conformance** of those tools
+and skills.
+
+## Decision
+
+**We will require that all MCP tools and skills conform to documented
+best practices and the emerging MCP specification. Compliance is
+verified during code review using the checklist below.**
+
+### Tool Design
+
+1. **Intent-based naming.** Tools are named after user outcomes
+   (`generate_ansible_task`, `search_ansible_plugins`), not after API
+   endpoints or internal methods.
+
+2. **Behavioral annotations.** Every tool definition must include
+   `readOnlyHint`, `destructiveHint`, and `idempotentHint`. Hosts use
+   these to auto-approve reads, gate writes behind confirmation, and
+   reason about retry safety.
+
+3. **Valid `inputSchema`.** Every tool must have an `inputSchema` with
+   `type: "object"` and explicitly typed parameters. Never rely on
+   framework defaults — 19% of tools in the wild have broken schemas
+   due to silent framework failures.
+
+4. **Structured `outputSchema`.** Tools whose output is consumed by
+   downstream tool calls or programmatic composability should declare
+   an `outputSchema`. This enables code-mode tool chaining.
+
+5. **Context footprint.** Keep tool descriptions concise. Each tool
+   consumes ~500 tokens when loaded. If the total tool count per
+   server exceeds ~15–20, implement progressive discovery (see
+   Context Management below).
+
+### Security
+
+6. **Server-side input validation.** Treat all tool inputs as
+   untrusted — they originate from an LLM influenced by prompt
+   injection, poisoned context, or hallucination. Validate types,
+   bounds-check numerics, sanitize for injection (command, path
+   traversal), and validate enums. Never rely on the LLM to
+   self-constrain.
+
+7. **No prompt-based access control.** Access control must be enforced
+   in code (middleware, guards, decorators). Prompt-based restrictions
+   ("only use tools X, Y, Z") have bypass rates of 25–92%.
+
+8. **No read-only-as-security-boundary.** Read access to a tool does
+   not imply the data it returns is safe to surface. Apply data-level
+   controls (redaction, masking) before sensitive data enters tool
+   responses.
+
+### Error Handling
+
+9. **Machine-readable error responses.** Every error response must
+   include:
+   - A machine-readable error code (not just a human string)
+   - A recoverability signal: `retry`, `escalate`, or `fail`
+   - A suggested next action when applicable
+
+   Ambiguous errors trigger retry storms from probabilistic callers.
+
+10. **Destructive operations gated.** Tools that modify state
+    (`install_ansible_collection`, creator scaffold tools) must be
+    annotated with `destructiveHint: true` so hosts can interpose
+    confirmation. Where the MCP spec supports elicitations, prefer
+    them over silent execution.
+
+### Skill Compliance
+
+11. **agentskills.io frontmatter.** Every skill file must have YAML
+    frontmatter with at minimum `name` and `description`, conforming
+    to the Agent Skills specification. Additional keys (`tags`,
+    `triggers`, `category`, `domain`) are recommended.
+
+12. **Three-level progressive disclosure.** Skills must support:
+    - Level 1: Frontmatter (name + description) — always in context
+    - Level 2: SKILL.md body — loaded when the model decides to apply
+    - Level 3: Reference files — loaded on demand during the workflow
+
+13. **`skill://` URI alignment.** When SEP-2640 is ratified, skill
+    resources must be addressable via the `skill://` URI scheme.
+    Until ratification, skill URIs should be structured so migration
+    is a rename, not a redesign.
+
+14. **Skills are data, not directives.** Skill content served over
+    MCP must be treated as untrusted input. Hosts must not
+    automatically execute scripts or hooks embedded in skill
+    frontmatter from remote sources.
+
+### Context Management
+
+15. **Progressive discovery.** When the total tool definitions served
+    by `@ansible/mcp-server` exceed 1–5% of a typical context window
+    (~200k tokens), implement a `search_tools` meta-tool pattern to
+    defer loading full schemas into context.
+
+16. **Cache-friendly tool arrays.** Append newly discovered tool
+    definitions after the cache breakpoint rather than re-sorting the
+    `tools` array, to preserve prompt caching.
+
+17. **`skill://index.json`.** When the skill catalog is served over
+    MCP, expose a `skill://index.json` resource enumerating available
+    skills with frontmatter summaries and content digests.
+
+### PR Compliance Checklist
+
+PRs that touch `packages/mcp-server/` or skill files must answer:
+
+- [ ] Does every new/modified tool have `readOnlyHint`,
+      `destructiveHint`, and `idempotentHint` annotations?
+- [ ] Does every tool have a valid `inputSchema` with
+      `type: "object"` and explicitly typed parameters?
+- [ ] Are error responses machine-readable with a recoverability
+      signal (`retry` / `escalate` / `fail`)?
+- [ ] Are tool inputs validated server-side?
+- [ ] Do new/modified skills have valid agentskills.io frontmatter
+      (`name`, `description` at minimum)?
+- [ ] Does the skill support three-level progressive disclosure?
+- [ ] Is the tool description under ~500 tokens?
+
+## Alternatives Considered
+
+### Alternative 1: Best-effort compliance without a gate
+
+**Description**: Document best practices in the landscape research
+document and trust contributors to follow them voluntarily.
+
+**Pros**:
+- No additional process overhead
+- Flexible — contributors adapt practices case-by-case
+
+**Cons**:
+- Drift is inevitable without a review gate
+- No way to audit compliance across the tool surface
+- New contributors have no clear checklist
+
+**Why not chosen**: The Dev Summit findings show that even experienced
+teams produce broken schemas (19% failure rate) and prompt-based
+access control (25–92% bypass) without enforcement. Best-effort is
+insufficient.
+
+### Alternative 2: Automated schema validation in CI
+
+**Description**: Build a CI check that validates every tool definition
+against a JSON Schema for annotations, inputSchema, and error format.
+
+**Pros**:
+- Mechanical enforcement — no human review needed for schema quality
+- Catches regressions automatically
+
+**Cons**:
+- Cannot validate semantic properties (intent-based naming, adequate
+  descriptions, correct recoverability signals)
+- Significant upfront tooling investment
+- Doesn't cover skill file quality
+
+**Why not chosen**: Automated validation is a future enhancement (see
+Consequences), not a replacement for the code review checklist. The
+checklist covers semantic properties that automation cannot assess.
+
+## Consequences
+
+### Positive
+
+- Tools and skills stay aligned with the MCP specification and
+  community best practices as both evolve
+- Behavioral annotations enable hosts to auto-approve reads and gate
+  destructive operations — better agent UX
+- Machine-readable errors reduce token waste from retry storms
+- Skill compliance positions us for seamless SEP-2640 adoption
+- The checklist is objective — reviewers can verify compliance
+  mechanically
+
+### Negative
+
+- Every new tool requires annotation and schema work, increasing
+  per-tool authoring cost by an estimated 10–15%
+- The compliance requirements may need updating as the MCP
+  specification evolves — the ADR must be revisited periodically
+- Some existing tools will need retrofitting (tracked separately)
+
+### Neutral
+
+- This ADR does not mandate retroactive compliance for existing tools;
+  however, a backlog of existing gaps should be tracked
+- Automated CI enforcement is a natural follow-on but is not required
+  by this decision
+
+## Implementation Notes
+
+### Current Compliance Gaps (to be tracked separately)
+
+| Gap | Scope |
+|-----|-------|
+| Missing behavioral annotations | All 15 static tools |
+| No `outputSchema` | All tools |
+| Error responses are human strings | Most tool handlers |
+| No `skill://` URI scheme | All skills |
+| No `skill://index.json` resource | MCP server |
+
+### Key Files
+
+| File | Relevance |
+|------|-----------|
+| `packages/mcp-server/src/tools.ts` | Tool definitions — annotations go here |
+| `packages/mcp-server/src/handlers.ts` | Tool handlers — error format changes |
+| `packages/mcp-server/src/server.ts` | Server setup — progressive discovery |
+| `packages/mcp-server/src/skillTools.ts` | Skill tool generation |
+| `packages/common/src/skills/*.md` | Internal skill files |
+| `packages/services/src/SkillRegistry.ts` | Skill loading and registry |
+
+## References
+
+| Document | Location |
+|----------|----------|
+| MCP and Skills: Synthesis and Landscape | `.sdlc/research/mcp-skills-landscape.md` |
+| MCP Client Best Practices | [modelcontextprotocol.io](https://modelcontextprotocol.io/docs/develop/clients/client-best-practices) |
+| Skills Over MCP WG Charter (SEP-2640) | [modelcontextprotocol.io](https://modelcontextprotocol.io/community/working-groups/skills-over-mcp) |
+| Agent Skills Specification | [agentskills.io](https://agentskills.io/specification) |
+| MCP Best Practices and Anti-Patterns | `.sdlc/research/mcp-best-practices-and-anti-patterns.md` |
+| MCP Server Recommended Practices | `.sdlc/research/mcp-server-recommended-practices.md` |
+
+## Related Decisions
+
+- [ADR-005](ADR-005-architectural-invariants.md): Architectural
+  invariants — this ADR adds invariant 12
+- [ADR-012](ADR-012-mcp-tool-parity.md): MCP tool parity — ADR-017
+  governs quality; ADR-012 governs coverage
+- [ADR-014](ADR-014-internal-skills-as-prompt-source.md): Internal
+  skills as prompt source — ADR-017 governs the format and spec
+  conformance of those skill files
+
+---
+
+## Revision History
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-06-23 | AI-assisted | Initial decision |

--- a/.sdlc/research/mcp-best-practices-and-anti-patterns.md
+++ b/.sdlc/research/mcp-best-practices-and-anti-patterns.md
@@ -1,0 +1,507 @@
+# MCP Best Practices and Anti-Patterns Report
+
+**Executive Summary**: This report synthesizes recommended practices and anti-patterns for developing Model Context Protocol (MCP) servers and tools, extracted from 100 session notes from the MCP Dev Summit North America 2026. Each practice and anti-pattern is weighted by importance (Critical, High, Medium, Low) to guide implementation priorities. This report is designed to evaluate AAP MCP servers against industry best practices from Amazon, Uber, Duolingo, Snowflake, Microsoft, Morgan Stanley, Bloomberg, and other enterprise adopters.
+
+---
+
+## Table of Contents
+- [Recommended Practices - Critical](#recommended-practices---critical)
+- [Recommended Practices - High](#recommended-practices---high)
+- [Recommended Practices - Medium](#recommended-practices---medium)
+- [Recommended Practices - Low](#recommended-practices---low)
+- [Anti-Patterns - Critical](#anti-patterns---critical)
+- [Anti-Patterns - High](#anti-patterns---high)
+- [Anti-Patterns - Medium](#anti-patterns---medium)
+- [Anti-Patterns - Low](#anti-patterns---low)
+
+---
+
+## Recommended Practices - Critical
+
+### 1. Follow Security Considerations for Securing MCP
+**Importance**: CRITICAL  
+**Description**: Implement practical advice and best practices for securing MCP deployments. Security is a fundamental concern, especially for enterprise deployments connecting to systems of record.  
+**Why Critical**: Foundation for all MCP security work; without this, all other efforts are at risk.  
+**Source**: Anthropic (MCP core team)
+
+### 2. Implement Centralized MCP Gateway & Registry Control Plane
+**Importance**: CRITICAL  
+**Description**: Create a control plane for all MCP interactions with:
+- Auto-generation of MCP tool definitions from service IDLs (proto/thrift)
+- Centralized authorization and PII redaction service
+- Periodic code scanning (at diff/commit time and continuously)
+- Guardrails to block mutable endpoints
+- Rate-limiting and logging for all write operations
+- Full observability with extensive logging, metrics, and tracing
+
+**Why Critical**: Ensures complete visibility into call patterns and data access. Agents have a larger blast radius than humans — unauthorized access or exposed endpoints can cause damage faster.  
+**Source**: Uber
+
+### 3. Implement Five-Layer Security Architecture
+**Importance**: CRITICAL  
+**Description**: Deploy security at all five layers:
+1. **Client/Host** - UI or agent host environment
+2. **MCP Gateway** - Policy enforcement, auth and validation (central enforcement point)
+3. **Isolated MCP Servers** - Domain-specific, least privilege, separate sessions
+4. **Identity & Auth** - Entra ID, short-lived tokens, secure storage, lifecycle management
+5. **AI Runtime & Tools** - LLM, tools, prompt shields and safety filters
+
+**Key Principle**: "Secure the boundaries, not just the model."  
+**Why Critical**: Provides defense in depth across the entire stack, not just at perimeter.  
+**Source**: Morgan Stanley
+
+### 4. Apply Five Security Principles (Microsoft Playbook)
+**Importance**: CRITICAL  
+**Description**: 
+1. **Least privilege** - Scope every server and tool to minimum needed access
+2. **Identity and auth** - Strong Entra ID validation, short-lived tokens, secure storage
+3. **Containment and isolation** - Run servers in separate sessions, sandbox tool execution
+4. **Treat prompts as untrusted** - Shield prompts and validate tool output to thwart injection
+5. **Observability by design** - Log tool calls, data flows, and decisions for real-time defense
+
+**Why Critical**: Battle-tested principles from Microsoft's work hardening MCP on Windows.  
+**Source**: Microsoft / Morgan Stanley
+
+### 5. Make Agents First-Class Identities with Distinct Principals
+**Importance**: CRITICAL  
+**Description**: Each agent should be assigned its own distinct identity (principal) with auditable actions, not run under a user's identity or shared service account. Data movement and security policies should be scoped to the agent's role. Enforce least privilege: agent should only see what current task requires. Audit every action against the agent's identity, not a generic account.  
+**Why Critical**: Prevents audit trail collapse and enables proper security boundary enforcement. Without distinct agent identities, you cannot track or control what agents are doing.  
+**Source**: Snowflake
+
+---
+
+## Recommended Practices - High
+
+### 1. Implement Tool Search/Progressive Discovery
+**Importance**: HIGH  
+**Description**: Modern MCP clients should defer loading tools until runtime so models only import the definitions they actually need. This solves the context bloat problem caused by loading all tools upfront.  
+**Impact**: Claude Code went from 22% of 200k token window consumed by MCP tools to having them fully deferred.  
+**Source**: Anthropic
+
+### 2. Use Skills as Recipes for MCP Tools
+**Importance**: HIGH  
+**Description**: Skills should instruct the model on exactly how to use MCP capabilities. These paradigms are complementary, not competing - MCP Tools are the connectors that expose new capabilities, while Skills are the recipes that instruct the model on how to use those capabilities.  
+**Impact**: Supabase demo showed MCP+Skill beat MCP-only in all 6 scenarios, preventing security vulnerabilities (missing `security_invoker` in views).  
+**Source**: Multiple (Alpic, Supabase, Anthropic)
+
+### 3. Use Structured Outputs for Code-Mode Composability
+**Importance**: HIGH  
+**Description**: Implement structured outputs so models can reason about return types. This enables composability by giving the model a REPL/interpreter to write code that calls MCP tools (like piping CLI commands).  
+**Source**: Anthropic
+
+### 4. Implement OAuth 2.1 Authorization
+**Importance**: HIGH  
+**Description**: Use OAuth 2.1 for delegated authentication in MCP servers. This is the standard approach for secure authentication.  
+**Note**: Only about 22% of v2+ servers use OAuth; API keys remain path of least resistance despite not being in spec.  
+**Source**: Anthropic / Arcade
+
+### 5. Bundle MCP Tools with Other Primitives into Agent Configurations
+**Importance**: HIGH  
+**Description**: Treat MCP tools, skills, context/steering files, and agent SOPs as ingredients that combine into an "agent configuration" as a first-class primitive. Rather than seeing these as either/or choices, combine them together.  
+**Impact**: This approach has seen massive growth internally at Amazon.  
+**Source**: Amazon
+
+### 6. Create an MCP/AI Registry for Discovery and Sharing
+**Importance**: HIGH  
+**Description**: Build an internal registry where builders can easily discover, share, and install local and remote MCP servers and agent configurations. This promotes reuse and standardization across the organization.  
+**Source**: Amazon, Uber
+
+### 7. Categorize Tools by Security Properties
+**Importance**: HIGH  
+**Description**: Use Simon Willison's "lethal trifecta" framework to categorize each tool by three security properties:
+1. Access to private data
+2. Exposure to untrusted content
+3. Ability to communicate externally
+
+Because agent configurations are in the registry, you can scan configurations to flag potentially problematic agents that have tools from all three categories.  
+**Source**: Amazon
+
+### 8. Use MCP-as-CLI Approach for Context Efficiency
+**Importance**: HIGH  
+**Description**: Specify per-tool how it should be surfaced. Some tools are injected directly into context, others are wrapped as a CLI with minimal context. Instead of loading all tools into context, load only critical tools directly and wrap others behind a `cli: mcp-tools` entry with tools loaded on demand.  
+**Impact**: Saves tokens and leads to better agent performance with lower inference costs.  
+**Source**: Amazon
+
+### 9. Auto-Generate MCP Tools from Service IDLs
+**Importance**: HIGH  
+**Description**: Automatically crawl service IDLs (proto and thrift files), use an LLM to generate MCP tool descriptions based on message names and comments, and store the definitions in object storage. This config-driven approach scales to thousands of services without manual MCP server development.  
+**Source**: Uber
+
+### 10. Give Service Owners Control Over Tool Exposure
+**Importance**: HIGH  
+**Description**: Let service owners (the domain experts) control which tools get exposed and fine-tune the LLM-facing descriptions. This ensures quality and accuracy of tool definitions.  
+**Source**: Uber
+
+### 11. Implement Tiered Gating for Third-Party MCPs
+**Importance**: HIGH  
+**Description**: Third-party MCPs should face more levels of gating, scanning, and rigorous checks compared to trusted internal systems. This reduces data handling risks.  
+**Source**: Uber
+
+### 12. Allow Scoping to Specific Tools and Parameter Overrides
+**Importance**: HIGH  
+**Description**: Users should be able to scope to specific tools from a server (so the LLM doesn't have to choose) and override parameters with static values (so the LLM doesn't have to populate them). This makes agents more reliable.  
+**Source**: Uber
+
+### 13. Create a Skills Registry for Sharable Recipes
+**Importance**: HIGH  
+**Description**: Build sharable "recipes" that combine multiple MCPs to accomplish specific tasks. Skills can be shared across different teams. This promotes reuse and standardization.  
+**Source**: Uber
+
+### 14. Implement MCP Evaluations
+**Importance**: HIGH  
+**Description**: Systematically score tool responses and correctness of invocation to improve tool descriptions. Build evaluations into both the registry and the overall agent platform. This improves tool quality over time.  
+**Note**: Apollo's framework uses executor agent + scoring agent with binary rubrics and statistical comparison (Welch's t-test).  
+**Source**: Uber, Apollo GraphQL
+
+### 15. Map Security Activities Across Full Lifecycle
+**Importance**: HIGH  
+**Description**: 
+- **Dev stage**: Threat model flows, simulate prompt injection, validate tool contracts
+- **Pre-Prod**: Red-team MCP servers, validate auth boundaries, audit permissions
+- **Prod**: Continuous monitoring, policy enforcement via gateway, runtime protection
+- **Continuous**: Inventory all servers, decommission unused agents, track ownership and lifecycle
+
+Security is not a one-time activity.  
+**Source**: Morgan Stanley
+
+### 16. Define Governance Across Three Team Types
+**Importance**: HIGH  
+**Description**: 
+- **Platform teams**: Provide infrastructure/guardrails, manage MCP gateway/policies, monitor runtime/scale
+- **Application teams**: Define tools/permissions, ensure least privilege/scopes, test and red-team agents
+- **Security teams**: Define policy/monitoring, maintain registry/approvals, validate supply chain/logs
+
+Clear ownership prevents gaps.  
+**Source**: Morgan Stanley
+
+### 17. Use Agent Specification to Define Server/Tool Access Boundaries
+**Importance**: HIGH  
+**Description**: Each agent has its own spec combining MCP servers, tools, and instructions. RBAC controls which MCP servers and tools can be invoked. Same agent definition can reference multiple servers, each with least-privilege tool access.  
+**Example**: hr_agent with employee_info (search_employees, get_org_chart), benefits_server (lookup_benefits, compare_plans), compensation_server (edit_salary/view_bands restricted to hr_admin role).  
+**Source**: Snowflake
+
+### 18. Use Declarative MCP Server Definition
+**Importance**: HIGH  
+**Description**: Use YAML-like spec to declare tools. Servers are governed objects: versioned, auditable, with RBAC on USAGE. Each tool requires its own privilege grant — access to server does not equal access to tools.  
+**Example**: CREATE MCP SERVER hr_server FROM SPECIFICATION with tools like handbook-search (CORTEX_SEARCH_SERVICE_QUERY).  
+**Source**: Snowflake
+
+### 19. Apply RBAC at Four Layers
+**Importance**: HIGH  
+**Description**: 
+1. **Agent** - Which agents can this role invoke?
+2. **MCP Server** - Who can connect to the server at all?
+3. **Tool** - Which tools within the agent are authorized?
+4. **Data** - Row-level and column-level policies on query results
+
+Declarative definitions enable governance at scale: reviewable, diffable, auditable like infrastructure as code.  
+**Source**: Snowflake
+
+### 20. Implement Data Access Controls at Query Layer
+**Importance**: HIGH  
+**Description**: Column policies (mask SSN, salary, PII at query layer), row-level security (limit rows to agent's authorized scope), role-based access (permissions tied to agent role, not just user). These enforcement mechanisms prevent data exfiltration even with read-only access.  
+**Source**: Snowflake
+
+### 21. Bring MCP Tools to Where Users Already Work
+**Importance**: HIGH  
+**Description**: Build interfaces (like Slack apps, chat bots) that bring MCP-powered tools directly to where people already work, rather than expecting them to configure local setups.  
+**Key Insight**: "One click is still too much for people."  
+**Impact**: Duolingo's @DuolingoAI Slack app achieved 250+ weekly active users (~30% of company) with ~80% upvote rate by bringing 180+ tools to Slack.  
+**Source**: Duolingo
+
+### 22. Standardize MCP Server Hosting Strategies
+**Importance**: HIGH  
+**Description**: Categorize MCP servers by type and standardize hosting and auth approaches. Example categories: External first-party HTTP (OAuth), Forked/internal HTTP with FastMCP (JWT or shared token or OAuth), CLI (CLI OAuth), stdio locally.  
+**Source**: Duolingo
+
+### 23. Implement Human-in-the-Loop for Write Operations
+**Importance**: HIGH  
+**Description**: Gate write operations (creating PRs, JIRA tickets, deploying to staging) behind explicit human approval via UI buttons (Approve/Cancel in Slack). Use workflow systems (like Temporal) to execute approved actions. Connect to read-only tools by default.  
+**Source**: Duolingo, Microsoft
+
+### 24. Use structuredContent, content, and _meta Appropriately in MCP Apps
+**Importance**: HIGH  
+**Description**: In tool call results, use distinct fields for distinct purposes:
+- `content` - Explanations to the model (what the app already displayed)
+- `structuredContent` - Typed data the model may see
+- `_meta` - Things the model never needs (internal IDs, routing info)
+
+`viewUUID` goes in content or _meta depending on whether model needs it for later interactions.  
+**Source**: Anthropic
+
+### 25. Hide App-Only Tools from the Model
+**Importance**: HIGH  
+**Description**: Use `Tool._meta.ui.visibility = ["app"]` for tools that only the app should see, not the model. This enables app-server communication without exposing internal implementation to the model.  
+**Source**: Anthropic
+
+### 26. Use updateModelContext for Important Context
+**Importance**: HIGH  
+**Description**: Leave text/images that give important context to the model, available from the next turn. Examples: PDF current selection in context of larger text, screenshots so the model understands diagrams.  
+**Source**: Anthropic
+
+### 27. Render Partial Input as JSON Arrives (Streaming Pattern)
+**Importance**: HIGH  
+**Description**: Apps should receive `ui/notification/tool-input-partial` events and progressively render content as chunks of JSON arrive. This addresses tool call input latency bottlenecks.  
+**Source**: Anthropic
+
+### 28. Detect UI Support and Capabilities, Degrade Gracefully
+**Importance**: HIGH  
+**Description**: 
+- Server-side: Check `capabilities.extensions` in initialize result to detect UI support
+- In-app: Check `App.getHostCapabilities()` before use, degrade gracefully when a host method is absent
+
+Build universal servers/apps that work across hosts.  
+**Source**: Anthropic
+
+### 29. Implement Proper CSP and CORS for MCP Apps
+**Importance**: HIGH  
+**Description**: For non-auth data access via fetch/WebSocket/linked scripts & styles, allowlist in `_meta.ui.csp.{resource,connect}Domains`. Declare `ui.domain` so your server can restrict CORS to a known origin.  
+**Example**: `resource _meta.ui.csp.connectDomains = ["https://api.example.com"]`  
+**Source**: Anthropic
+
+### 30. Use hostContext for Styling/Theming
+**Importance**: HIGH  
+**Description**: Listen for changes with `onhostcontextchanged`. Apply `hostContext.theme` + CSS vars for light/dark mode. Apply `hostContext.safeAreaInsets` as padding for safe areas. Use `hostContext.styles.css.fonts` for font consistency. Avoid nested scroll in inline mode. Add pinch gestures to get in/out of fullscreen.  
+**Source**: Anthropic
+
+---
+
+## Recommended Practices - Medium
+
+### 1. Use Code Mode for Complex Tool Sets
+**Importance**: MEDIUM  
+**Description**: Code Mode is highly effective if you have more than 20 tools and complex workflows. It provides a fixed number of tools, enables complex workflows, and solves context bloat by hiding intermediary tool responses. Requires ~2,000 token minimal footprint and sandbox access for code execution.  
+**Source**: Alpic
+
+### 2. Combine Skills + MCP for Complex Workflows
+**Importance**: MEDIUM  
+**Description**: For complex workflows with external services, combine Skills and MCP. This approach is suitable for business operators and developers.  
+**Source**: Alpic
+
+### 3. Use Tasks Primitive for Long-Running Agents
+**Importance**: MEDIUM  
+**Description**: Implement the Tasks primitive to support long-running agent workflows. This moves beyond simple request-response to autonomous work.  
+**Note**: Tasks primitive has 5-state machine (working, input_required, completed, failed, cancelled). `input_required` state is "the state nobody builds for."  
+**Source**: Anthropic, Microsoft
+
+### 4. Add Evaluation Metrics to MCP Registry
+**Importance**: MEDIUM  
+**Description**: Include service SLAs (reliability, availability), dynamic discovery on-demand, and tiered MCP quality rankings (higher/lower tier) in the registry. This helps users find reliable, high-performance, safe MCPs.  
+**Source**: Uber
+
+### 5. Build a Tool Search Tool for On-Demand Discovery
+**Importance**: MEDIUM  
+**Description**: Implement on-demand tool discovery (described as "Omni MCP tool") to improve accuracy and reduce context bloat.  
+**Source**: Uber
+
+### 6. Implement Skills Evaluations
+**Importance**: MEDIUM  
+**Description**: Evaluate output quality, correctness of skill invocation, and A/B test different versions of the same skill to determine which performs better.  
+**Source**: Uber
+
+### 7. Auto-Respond in Help Desk and Incident Channels
+**Importance**: MEDIUM  
+**Description**: Configure AI to auto-respond in appropriate channels (help desk, incident response) to reduce toil for on-call engineers. This provides immediate value while humans handle complex cases.  
+**Source**: Duolingo
+
+### 8. Fork Open-Source MCP Servers for Internal Hosting
+**Importance**: MEDIUM  
+**Description**: For open-source MCP servers with shared credentials (like Grafana, Jenkins), fork them in-house, add internal authentication and tracking, and host behind VPC via HTTP. Use shared service token on server side so users just need an internal generic token.  
+**Source**: Duolingo
+
+### 9. Skip MCP for IAM-Level Permission Controls
+**Importance**: MEDIUM  
+**Description**: For tools with fine-grained IAM-level permission controls (AWS, BigQuery), skip MCP wrapping and instead let AI tools code CLI commands directly. This respects existing permission models.  
+**Source**: Duolingo
+
+### 10. Use generative UI Pattern for Dynamic Interfaces
+**Importance**: MEDIUM  
+**Description**: Model writes HTML, host renders it. This enables highly dynamic, context-specific interfaces without pre-built components. Demonstrated with travel itinerary rendering.  
+**Source**: Anthropic
+
+---
+
+## Recommended Practices - Low
+
+### 1. Use CLI for Local Workflows
+**Importance**: LOW  
+**Description**: CLIs are token-efficient, allow progressive discovery via --help commands, and are highly composable. Best suited for terminal-friendly users. However, they lack standard authentication and providers are "blind" to broader context.  
+**Source**: Multiple
+
+### 2. Use Skills for Reusable Prompts
+**Importance**: LOW  
+**Description**: Skills only (without MCP) are suitable for reusable prompts, targeting writers and developers. Skills use 3-level progressive disclosure: YAML frontmatter (always loaded), SKILL.md body (loaded when relevant), linked files (loaded as needed).  
+**Source**: Multiple
+
+### 3. State Persistence Approaches for MCP Apps
+**Importance**: LOW  
+**Description**: 
+- Upcoming persistence primitive in protocol (opaque data)
+- Server-side DIY: server returns view UUID in structuredContent, app gets/sets data from hidden tool keyed by UUID
+- localStorage as best effort (fast but single machine/browser only, client may clear it anytime; more stable scope with ui.domain set)
+
+**Example**: Unsaved annotations in PDF viewer.  
+**Source**: Anthropic
+
+---
+
+## Anti-Patterns - Critical
+
+### 1. Loading All Tool Schemas into the Prompt Upfront
+**Importance**: CRITICAL  
+**Description**: MCP clients should NOT load server names, descriptions, tool names, and full schemas directly into the prompt at initialization. This causes prompt inflation and context bloat.  
+**Impact**: A server like GitHub with ~100 tools can consume 60,000 tokens just for initial setup (average tool footprint is ~500 tokens).  
+**Fix**: Implement progressive discovery / tool search.  
+**Source**: Multiple
+
+---
+
+## Anti-Patterns - High
+
+### 1. Loading All Tool Results Directly into Context
+**Importance**: HIGH  
+**Description**: All content from a tool's result should NOT go directly into the model's context window without filtering or processing. This causes massive output bloat during sessions.  
+**Source**: Multiple
+
+### 2. Poor Client Implementations Causing Context Bloat
+**Importance**: HIGH  
+**Description**: The root cause of much MCP criticism is poor client implementations, particularly around "context bloat." The fix is progressive discovery/tool search — don't dump all tools into the context window, load them on demand.  
+**Impact**: Claude Code went from 22% of a 200k token window consumed by MCP tools to having them fully deferred.  
+**Source**: Anthropic
+
+### 3. Using Stateful Session Requirements That Are Hard to Scale
+**Importance**: HIGH  
+**Description**: The current streamable HTTP transport works okay but is hard for hyperscalers and large deployments to scale due to stateful session requirements (sticky sessions behind load balancers).  
+**Fix**: New stateless-compatible transport will land in June 2026 spec revision (Google and Microsoft helping shape).  
+**Source**: Anthropic
+
+### 4. No Standard Way to Develop and Deploy MCP Servers
+**Importance**: HIGH  
+**Description**: Teams building custom integrations independently with most being non-reusable. Everyone solving the same problems in silos leads to duplication and inconsistency.  
+**Fix**: Implement a centralized approach with standardized patterns.  
+**Source**: Uber
+
+### 5. Lack of Complete Visibility into Call Patterns and Data Access
+**Importance**: HIGH  
+**Description**: Without observability, you can't track what agents are doing. This is critical because agents have a larger blast radius than humans — unauthorized access or exposed endpoints can cause damage faster.  
+**Fix**: Implement full observability with logging, metrics, tracing.  
+**Source**: Uber
+
+### 6. Standalone Playground Environments
+**Importance**: HIGH  
+**Description**: Uber deprecated all standalone playground environments; everything should be centrally committed and managed in code to ensure consistency and governance.  
+**Source**: Uber
+
+### 7. No Discovery Mechanism for Finding Reliable MCPs
+**Importance**: HIGH  
+**Description**: Without a registry with quality metrics, users can't find reliable, high-performance, safe MCPs. Bad tools don't just fail — they degrade overall agent performance.  
+**Fix**: Implement MCP registry with quality metrics, SLAs, evaluations.  
+**Source**: Uber
+
+### 8. Exposing Mutable Endpoints Without Guardrails
+**Importance**: HIGH  
+**Description**: Don't expose mutable endpoints that could bring down critical services without guardrails. Block dangerous operations or implement rate-limiting and comprehensive logging for all write operations.  
+**Source**: Uber
+
+### 9. Expecting Users to Self-Configure MCP Setups
+**Importance**: HIGH  
+**Description**: No matter how simple you make self-service MCP configuration, most people still won't bother. Even "one click to copy config" had low adoption at Duolingo.  
+**Fix**: Users need tools brought to where they already work (Slack, IDE, etc.).  
+**Source**: Duolingo
+
+### 10. Inconsistent Server Hosting Without Standardization
+**Importance**: HIGH  
+**Description**: Having every MCP server run differently (Python/uvx, TypeScript/npx, Docker) causes "it works on my machine but not yours" issues across teams.  
+**Fix**: Standardize hosting and auth approaches.  
+**Source**: Duolingo
+
+### 11. Tool Sprawl is the Default Failure Mode
+**Importance**: HIGH  
+**Description**: More tools an agent can reach = less predictable it becomes. Every additional tool increases context window size/token cost, broadens security blast radius, raises hallucination risk (model has more ways to be wrong).  
+**Root Cause**: Agents inherit every tool available in environment, teams add tools to shared servers without considering aggregate surface area.  
+**Source**: Snowflake
+
+### 12. God Server Anti-Pattern
+**Importance**: HIGH  
+**Description**: Don't create one MCP server with every tool. This maximizes sprawl and security blast radius.  
+**Fix**: Specialize servers by domain with least-privilege tool access.  
+**Source**: Snowflake
+
+### 13. Prompt Governance Anti-Pattern
+**Importance**: HIGH  
+**Description**: Don't rely on "only use tools X, Y, Z" in the prompt. Prompts are suggestions, not constraints. There is no distinction between what a server offers and what a user should be allowed to invoke without proper RBAC.  
+**Source**: Snowflake
+
+### 14. Shared Creds Anti-Pattern
+**Importance**: HIGH  
+**Description**: Don't have all agents use one service account. Makes auditing impossible and violates least privilege.  
+**Fix**: Each agent needs distinct identity.  
+**Source**: Snowflake
+
+### 15. Read-Only is Not a Security Boundary
+**Importance**: HIGH  
+**Description**: Agent can still SELECT secrets, PII, and credentials from databases. Tool output gets summarized back into attacker-controlled context, creating an exfiltration vector.  
+**Impact**: Sprawled agent with read access to HR, finance, infrastructure, and customer data gives prompt injection attacks 50 tools worth of exfiltration vectors.  
+**Fix**: Implement column policies, row-level security, role-based access.  
+**Source**: Snowflake
+
+---
+
+## Anti-Patterns - Medium
+
+### 1. Treating MCP, Skills, and CLI as Competing Alternatives
+**Importance**: MEDIUM  
+**Description**: These paradigms are complementary, not competing. MCP Tools expose capabilities, Skills provide recipes for using those capabilities, and CLIs offer token-efficient progressive discovery.  
+**Fix**: Developers should not abandon MCP in favor of other approaches without understanding their complementary nature.  
+**Source**: Multiple
+
+### 2. Testing Client Name Instead of Capabilities in MCP Apps
+**Importance**: MEDIUM  
+**Description**: Only test client name as a last resort. Instead, detect capabilities and degrade gracefully.  
+**Fix**: File spec enhancement requests rather than hardcoding client-specific behaviors.  
+**Source**: Anthropic
+
+### 3. Tool Call Input Latency Bottleneck
+**Importance**: MEDIUM  
+**Description**: Tool call input is often a latency bottleneck.  
+**Fix**: Use streaming patterns (render partial input as JSON arrives, or generative UI) to address this.  
+**Source**: Anthropic
+
+---
+
+## Anti-Patterns - Low
+
+None identified.
+
+---
+
+## Summary Statistics
+
+**Total Recommended Practices**: 57
+- Critical: 5
+- High: 30
+- Medium: 10
+- Low: 3
+
+**Total Anti-Patterns**: 19
+- Critical: 1
+- High: 15
+- Medium: 3
+- Low: 0
+
+**Key Themes**:
+1. **Security & Governance** (20+ practices) - Most heavily emphasized
+2. **Context Management** (12+ practices) - Second most critical
+3. **Progressive Discovery** (8+ practices) - Emerging standard
+4. **Human-in-the-Loop** (5+ practices) - Enterprise requirement
+5. **Specialization over Sprawl** (6+ practices) - Operational excellence
+
+---
+
+**Report Metadata**
+
+AI Provider: Claude (Anthropic)  
+Model: Claude Sonnet 4.5  
+Generation Date: 2026-04-20  
+Sources Analyzed: 100 session documents from MCP Dev Summit North America 2026  
+Document Version: 1.0

--- a/.sdlc/research/mcp-server-recommended-practices.md
+++ b/.sdlc/research/mcp-server-recommended-practices.md
@@ -1,0 +1,576 @@
+# MCP Server Recommended Practices for Code Review
+
+## How to Use This Document
+
+This document is designed to be provided as context to AI agents conducting code reviews of MCP server implementations. Each practice and anti-pattern includes what to look for in the code and why it matters.
+
+The document covers only practices that can be assessed by reading MCP server source code. Recommendations about external infrastructure (gateways, registries, hosting platforms, organizational governance models) are excluded. RBAC and security controls implemented within server code are in scope.
+
+Practices are rated by importance:
+
+- **CRITICAL** — High-severity risk with strong consensus and quantitative evidence. Address first.
+- **HIGH** — Significant risk or quality impact backed by multiple independent sources.
+- **MEDIUM** — Meaningful improvement with moderate evidence.
+- **LOW** — Good practice with limited supporting evidence.
+
+This document was synthesized from dozens of sessions at MCP Dev Summit North America 2026. All practices cite their contributing sessions and presenters.
+
+---
+
+## Recommended Practices
+
+### Spec Compliance & Protocol Conformance
+
+#### Validate Origin Headers and Protect Against DNS Rebinding — CRITICAL
+
+**What it is**: Every HTTP-based MCP server must validate the `Origin` header on incoming requests and reject requests with invalid or missing origins. This is the primary defense against DNS rebinding attacks, which allow malicious websites to send requests to locally-running MCP servers.
+
+**Why it matters**: Over 80% of MCP servers fail Origin header validation (analysis of 41,924 servers). DNS rebinding attacks bypass same-origin policy by re-resolving a domain from an attacker's IP to `127.0.0.1`, giving a malicious webpage full access to localhost MCP servers. Live exploits demonstrated bypass in approximately 3 seconds on Chrome. CVE-2025-11249 affected the official TypeScript SDK, which shipped with DNS rebinding protection disabled by default. Multiple servers from Google, Docker, and Apollo were confirmed vulnerable. Firefox and Safari remain fully exploitable with no protection.
+
+**What to look for in code**:
+- Server validates the `Origin` header on every request and returns HTTP 403 for unrecognized origins
+- Server validates the `Host` header to reject requests where Host doesn't match expected values
+- DNS rebinding protection is enabled by default, not opt-in
+- For servers using the TypeScript SDK: verify rebinding protection is explicitly enabled if using an older version
+- Test: `curl` the server with a spoofed `Host` header — if it responds normally, the server is vulnerable
+
+**Sources**: "Rules Are Not Suggestions: A History of MCP Non-Compliance" (Sterling Dreyer, Arcade); "MCPwned: Hacking MCP Servers With One Skeleton Key Vulnerability" (Jonathan Leitschuh); MCP Specification 2.0.1 Security Considerations
+
+---
+
+#### Implement OAuth 2.1 Authorization — CRITICAL
+
+**What it is**: MCP servers that handle authenticated requests should implement OAuth 2.1 with Dynamic Client Registration (DCR) rather than static API keys.
+
+**Why it matters**: Only approximately 22% of MCP v2+ servers use OAuth despite it being the spec-recommended authentication mechanism. API keys are not part of the MCP specification, give full access without scopes, require users to manually mint and manage keys, and cannot be narrowed or time-limited. OAuth 2.1 enables scoped access, short-lived tokens, and delegated authorization — all essential for multi-agent environments where tokens may be exchanged between services.
+
+**What to look for in code**:
+- Server implements OAuth 2.1 authorization flow, not just API key validation
+- Server supports Dynamic Client Registration (DCR)
+- Tokens are short-lived with refresh capability
+- Scopes are defined and enforced per tool or operation
+- If API keys are used as a fallback, verify they are scoped and documented as a temporary measure
+
+**Sources**: "Rules Are Not Suggestions" (Sterling Dreyer, Arcade); "MCP: The Integration Protocol" (David Soria Parra, Anthropic); "Securing MCP at Scale" (Peter Smulovics, Morgan Stanley)
+
+---
+
+#### Provide Valid inputSchema for Every Tool — HIGH
+
+**What it is**: Every tool's `inputSchema` must be a valid JSON Schema object with `"type": "object"` and accurate property definitions. Invalid or missing schemas cause unpredictable agent behavior.
+
+**Why it matters**: 19% of all MCP tools (across 218,410 analyzed) have broken input schemas — 8.9% have null or empty schemas, and 10.9% have empty objects missing the required `type: "object"` field. Broken schemas cause agents to guess at parameters, leading to failed tool calls, hallucinated inputs, and wasted tokens.
+
+**What to look for in code**:
+- Every tool definition includes a non-empty `inputSchema` with `"type": "object"`
+- Required parameters are listed in the `required` array
+- Parameter types are explicitly specified (not relying on framework defaults)
+- For Python: check that all parameters have explicit type annotations (untyped parameters default to `{"type": "string"}`)
+- For TypeScript with Zod: check for discriminated unions, which Zod silently drops to empty objects
+- For Go: check for uninitialized struct fields that produce invalid schema output
+
+**Sources**: "Rules Are Not Suggestions" (Sterling Dreyer, Arcade)
+
+---
+
+#### Support PRM Discovery and Return Proper Auth Error Responses — HIGH
+
+**What it is**: Servers using OAuth must expose a Protected Resource Metadata (PRM) endpoint for clients to discover authorization requirements, and must return proper HTTP 401 status codes with `WWW-Authenticate` headers when authentication fails.
+
+**Why it matters**: 67% of servers fail PRM endpoint discovery (SHOULD in MCP V3, MUST in V4). 22% fail to return proper 401 status codes and 24% fail to return the `WWW-Authenticate` header — both MUST requirements in the spec. Without PRM, clients cannot automatically discover how to authenticate. Without proper 401 responses, clients cannot distinguish auth failures from other errors.
+
+**What to look for in code**:
+- Server exposes a `/.well-known/oauth-protected-resource` endpoint returning valid PRM metadata
+- Authentication failures return HTTP 401 (not 403 or 500)
+- 401 responses include a `WWW-Authenticate` header with the appropriate scheme
+- PRM metadata correctly references the authorization server
+
+**Sources**: "Rules Are Not Suggestions" (Sterling Dreyer, Arcade)
+
+---
+
+### Tool Design & Context Efficiency
+
+#### Design Tools Around User Intent, Not API Endpoints — CRITICAL
+
+**What it is**: Tools should be designed around what a user wants to accomplish (the outcome), not around the shape of backend APIs. Bundle multi-step workflows into single tools scoped to specific use cases rather than exposing individual CRUD operations.
+
+**Why it matters**: Naive 1:1 mapping of API endpoints to MCP tools forces the LLM to become an integration engineer — managing API plumbing, sequencing calls, and reasoning about system identifiers rather than focusing on user intent. Every additional parameter is a value the LLM must reason about, and every exposed system identifier is a potential exfiltration surface. Apollo demonstrated that design-first tools achieved 70% fewer tool calls and 50% fewer tool tokens with the same output quality. Prompt-based access control bypass rates range from 25% to 92%, making tool boundary design a security concern, not just a UX concern.
+
+**What to look for in code**:
+- Tools are named after outcomes (e.g., `process_refund`, `deploy_to_staging`) rather than API operations (e.g., `post_orders`, `patch_deployment`)
+- A single tool handles a complete workflow rather than requiring the agent to chain multiple tool calls
+- Tools abstract away system identifiers, pagination, and API-specific patterns
+- Parameters reflect user-meaningful choices, not backend implementation details
+- The tool count is justified by distinct user intents, not by the number of backend endpoints
+
+**Sources**: "When MCP Becomes a Product" (Gautam Baghel & Roy Derks, HashiCorp/IBM); "Enterprise MCP — The Data Plane for Autonomous Agents" (Adam Seligman & Zayne Turner, Workato); "Building Docs That Work for Agents and Humans" (Daniel Abdel Samid, Apollo GraphQL)
+
+---
+
+#### Minimize Per-Tool Context Footprint — CRITICAL
+
+**What it is**: Keep tool descriptions concise, tool counts per server manageable, and tool results minimal. Each tool consumes approximately 500 tokens of context window when loaded, and every additional tool increases the agent's decision space, token costs, and hallucination risk.
+
+**Why it matters**: Loading 80 tools consumes 72% of the context window before the user provides any input. A server with approximately 100 tools consumes roughly 60,000 tokens just for tool schemas. Apollo found that their first-generation MCP server (using generic search/read tools) burned approximately 25,000 tokens per response in wasteful search-read loops, while a redesigned tool backed by semantic chunking and vector retrieval cut tool calls by 70% and tool tokens by 50%. "Context is courtesy" — minimizing the token burden on the model is the single most important quality factor for an MCP server.
+
+**What to look for in code**:
+- Tool descriptions are concise and directly explain what the tool does and when to use it
+- Each tool's parameter descriptions are brief but clear
+- The server does not expose more than approximately 15-20 tools (consider splitting into specialized servers if higher)
+- Tools do not return excessively large results — apply server-side filtering, pagination, or summarization
+- For documentation or search tools: use semantic chunking and relevance scoring rather than returning full pages
+- Server instructions tell the model how to use tools effectively, not just what they are
+
+**Sources**: "MCP: The Integration Protocol" (David Soria Parra, Anthropic); "Building Docs That Work for Agents and Humans" (Daniel Abdel Samid, Apollo GraphQL); "MCP vs. Code Mode vs. Skills" (Nikolay Rodionov, Alpic); "Declarative MCP Servers" (Josh Reini & Reetika Roy, Snowflake)
+
+---
+
+#### Annotate Tools with Behavioral Hints — HIGH
+
+**What it is**: Use MCP tool annotations to declare each tool's behavioral properties: `readOnlyHint`, `destructiveHint`, `idempotentHint`, and `openWorldHint`. These annotations help clients make better UX and safety decisions.
+
+**Why it matters**: Clients use these annotations to determine whether to auto-approve tool calls, show confirmation dialogs, or flag destructive operations for human review. Without annotations, clients must treat every tool as potentially destructive, which either degrades the user experience through excessive confirmations or compromises safety by auto-approving everything.
+
+**What to look for in code**:
+- Every tool includes an `annotations` object with appropriate hint values
+- Read-only tools are annotated with `readOnlyHint: true`
+- Tools that modify state are annotated with `destructiveHint: true`
+- Idempotent tools are annotated with `idempotentHint: true`
+- Annotations accurately reflect the tool's actual behavior
+
+**Sources**: "Human in the Loop, Agent in the Flow" (Harald Kirschner & Connor Peet, Microsoft); "MCP: The Integration Protocol" (David Soria Parra, Anthropic)
+
+---
+
+#### Implement Structured Output Schemas — MEDIUM
+
+**What it is**: Define output schemas for tools so that models can reason about return types and compose tool calls programmatically.
+
+**Why it matters**: Structured outputs enable "code mode" composability — where models write code that chains tool calls together using a REPL or interpreter. Without output schemas, models must parse unstructured text, which reduces reliability and prevents programmatic composition.
+
+**What to look for in code**:
+- Tools define output schemas in their tool definitions
+- Return types are consistent and predictable across invocations
+- Complex return values use structured formats (JSON objects with typed fields) rather than plain text
+
+**Sources**: "MCP: The Integration Protocol" (David Soria Parra, Anthropic)
+
+---
+
+### Security & Access Control
+
+#### Implement Role-Based Access Control at Tool and Data Layers — CRITICAL
+
+**What it is**: Access control must be enforced in server code at both the tool layer (which tools a caller can invoke) and the data layer (what data is returned), based on the caller's authenticated identity and role.
+
+**Why it matters**: Prompts are suggestions, not constraints — instructing an agent to "only use tools X, Y, Z" provides zero enforcement. Prompt-based access control bypass rates range from 25% to 92%. Access to a server should not automatically grant access to all its tools. Each tool should require its own privilege grant, and data returned by tools should be filtered by the caller's role. Without tool-level RBAC, a compromised or prompt-injected agent has access to every tool on every connected server.
+
+**What to look for in code**:
+- Tool invocations check the caller's authenticated identity and role before executing
+- Different roles have access to different subsets of tools
+- Server access does not automatically imply access to all tools
+- Access decisions are made in code (middleware, decorators, guards), not in prompt instructions
+- Data returned by tools is filtered based on the caller's authorization level
+- Access denials produce clear error responses, not silent failures
+
+**Sources**: "Declarative MCP Servers" (Josh Reini & Reetika Roy, Snowflake); "Enterprise MCP — The Data Plane for Autonomous Agents" (Adam Seligman & Zayne Turner, Workato); "Securing MCP at Scale" (Peter Smulovics, Morgan Stanley); "Hooks, Not Hacks" (Ian Molloy & Fred Araujo, IBM Research)
+
+---
+
+#### Specialize Servers by Domain with Least Privilege — HIGH
+
+**What it is**: Each MCP server should be scoped to a specific domain with the minimum access needed for its tools. Avoid building monolithic servers that expose all capabilities through a single endpoint.
+
+**Why it matters**: More tools on a single server means a larger decision space for the agent (more hallucinations), higher token costs, and a wider security blast radius. A sprawled agent with broad access gives prompt injection attacks an exfiltration surface proportional to the number of available tools. Specialization contains failure — a misbehaving agent using a specialized server cannot access tools outside its domain.
+
+**What to look for in code**:
+- Server tools are cohesive — they relate to a single domain or use case
+- Server credentials and API access are scoped to only what its tools require
+- The server does not access systems or data beyond what its declared tools need
+- If a server has more than approximately 15-20 tools, consider whether it should be split
+
+**Sources**: "Declarative MCP Servers" (Josh Reini & Reetika Roy, Snowflake); "MCP @ Amazon Scale" (James Hood, AWS); "Securing MCP at Scale" (Peter Smulovics, Morgan Stanley)
+
+---
+
+#### Validate All Tool Inputs Server-Side — HIGH
+
+**What it is**: Treat all tool inputs as untrusted. Validate, sanitize, and bounds-check every parameter server-side before processing, regardless of what the inputSchema declares.
+
+**Why it matters**: Tool inputs come from an LLM, which may be influenced by prompt injection, poisoned context, or hallucination. An agent can be steered through a malicious document, calendar invite, or PR description to call tools with attacker-chosen parameters. MCP servers should be treated as handling input from an insider threat, not a trusted caller. Real-world incidents include agents deleting production databases and being hijacked via poisoned calendar invites.
+
+**What to look for in code**:
+- Input validation occurs in server code, not just in schema declarations
+- String parameters are sanitized for injection (SQL, command, path traversal)
+- Numeric parameters are bounds-checked
+- Enum parameters are validated against allowed values
+- File paths are validated against allowed directories (use `roots` for scoping)
+- The server does not blindly pass tool inputs to backend systems without validation
+
+**Sources**: "Securing MCP at Scale" (Peter Smulovics, Morgan Stanley); "Hooks, Not Hacks" (Ian Molloy & Fred Araujo, IBM Research); "Threat Modeling Authorization in MCP" (Sarah Cecchetti, OpenID Foundation)
+
+---
+
+#### Implement Data-Level Access Controls — HIGH
+
+**What it is**: Apply column-level masking, row-level security, and PII redaction at the data access layer within the server, so that tool responses never contain data the caller is not authorized to see.
+
+**Why it matters**: Read-only access is not a security boundary. An agent with SELECT access can still extract SSNs, salary data, credentials, and PII. Tool output gets summarized back into the model's context, where prompt injection can direct it to exfiltration tools. A sprawled agent with read-only access to HR, finance, infrastructure, and customer data gives attacks 50+ tools worth of data exfiltration paths.
+
+**What to look for in code**:
+- Sensitive columns (SSN, salary, PII, credentials) are masked or omitted based on caller role
+- Row-level filtering limits results to the caller's authorized scope
+- Database queries use parameterized queries with role-based WHERE clauses
+- Tool results do not include internal identifiers, system credentials, or infrastructure details
+- PII redaction happens before data enters the tool response, not after
+
+**Sources**: "Declarative MCP Servers" (Josh Reini & Reetika Roy, Snowflake); "Hooks, Not Hacks" (Ian Molloy & Fred Araujo, IBM Research)
+
+---
+
+#### Require Distinct Agent Identity — HIGH
+
+**What it is**: Each agent connecting to the server should authenticate as a distinct principal with its own identity, not share a service account or run under the end user's full credentials.
+
+**Why it matters**: When all agents use one service account, auditing becomes impossible — you cannot trace which agent performed which action. Shared credentials also violate least privilege: every agent gets the same access regardless of its actual needs. Running agents under the end user's full identity gives agents more access than they need and breaks the principle that an agent should have a second, narrower level of access control beyond the user's permissions.
+
+**What to look for in code**:
+- Server authentication distinguishes between different agent callers
+- Audit logs record which specific agent (not just which user) made each tool call
+- Server does not accept a single shared token for all callers
+- If token delegation is used, downstream tokens are narrowed in scope
+
+**Sources**: "Declarative MCP Servers" (Josh Reini & Reetika Roy, Snowflake); "Threat Modeling Authorization in MCP" (Sarah Cecchetti, OpenID Foundation); "MCP @ Amazon Scale" (James Hood, AWS)
+
+---
+
+### Interaction Patterns
+
+#### Gate Destructive Operations Behind Human Approval — HIGH
+
+**What it is**: Tools that create, update, or delete resources should implement explicit human approval mechanisms before executing the mutation — via elicitations, confirmation prompts, or external approval workflows.
+
+**Why it matters**: AI-initiated actions that change infrastructure state, create tickets, send messages, or modify data carry real-world consequences that may be irreversible. Agents hallucinate, get prompt-injected, and make reasoning errors. Gating write operations behind approval is a trust and safety requirement, not a nice-to-have.
+
+**What to look for in code**:
+- Write, update, and delete tools include a confirmation step before execution
+- Tools are annotated with `destructiveHint: true` where appropriate
+- The server supports elicitation-based confirmation for destructive actions
+- Alternatively, the server returns a proposed action for client-side approval before execution
+- Tools that bypass approval are documented and justified
+
+**Conflicting Evidence**: The Threat Modeling Authorization session (Sarah Cecchetti, OpenID Foundation) proposed removing elicitation entirely from the spec, arguing MCP should be "a one-way street" where servers never prompt users — because elicitation can be weaponized for phishing (servers requesting passwords, MFA codes, or PII with the credibility of an AI assistant). The Human in the Loop session (Microsoft) and Duolingo's implementation promote elicitations as the mechanism for confirmation. This tension is unresolved in the spec.
+
+**Sources**: "Duolingo's AI Slack Bot" (Aaron Wang, Duolingo); "Human in the Loop, Agent in the Flow" (Harald Kirschner & Connor Peet, Microsoft); "Threat Modeling Authorization in MCP" (Sarah Cecchetti, OpenID Foundation)
+
+---
+
+#### Use Elicitations for Structured User Input — MEDIUM
+
+**What it is**: Use MCP elicitations (in-band form inputs) to gather structured configuration, selection, or authentication data from users rather than relying on the LLM to extract this information from freeform conversation.
+
+**Why it matters**: Elicitations provide structured, validated input directly from the user, bypassing the LLM's interpretation. This is more reliable for configuration parameters, enum selections, and authentication handoffs. Four design patterns apply: configuration (settings at connection time), confirmation (gating destructive actions), selection (enums instead of guesses), and auth handoff (URL mode for OAuth redirects).
+
+**What to look for in code**:
+- Server uses `elicitation/create` with JSON Schema for structured inputs
+- Elicitation schemas define proper validation (required fields, enums, formats)
+- Server checks client capability for elicitation support and degrades gracefully to text fallback
+- URL-mode elicitations are used for OAuth flows (credentials go to provider, never to MCP server)
+
+**Conflicting Evidence**: See note under "Gate Destructive Operations" — the Threat Modeling session proposes eliminating elicitation entirely due to phishing risk.
+
+**Sources**: "Human in the Loop, Agent in the Flow" (Harald Kirschner & Connor Peet, Microsoft); "Threat Modeling Authorization in MCP" (Sarah Cecchetti, OpenID Foundation)
+
+---
+
+#### Implement Tasks for Long-Running Operations — MEDIUM
+
+**What it is**: For operations that take more than a few seconds, return a Task ID immediately and emit real-time status updates rather than blocking the connection.
+
+**Why it matters**: Long-running operations (deployments, data processing, report generation) can block the agent-server connection and fail silently on timeout. The Tasks primitive supports a five-state machine (working, input_required, completed, failed, cancelled) and enables human checkpoints mid-operation via the `input_required` state — which most implementations miss.
+
+**What to look for in code**:
+- Long-running operations return a `CreateTaskResult` with a task ID immediately
+- Server emits `notifications/tasks/status` updates during execution
+- Task results persist and survive client disconnections
+- The `input_required` state is implemented for operations needing human checkpoints
+- Tasks have timeout and expiry policies
+
+**Sources**: "Human in the Loop, Agent in the Flow" (Harald Kirschner & Connor Peet, Microsoft); "MCP: The Integration Protocol" (David Soria Parra, Anthropic)
+
+---
+
+#### Use MCP Apps Result Fields Correctly — MEDIUM
+
+**What it is**: When implementing MCP Apps (interactive UI responses), use the three result fields — `content`, `structuredContent`, and `_meta` — according to their intended semantics.
+
+**Why it matters**: Incorrect field usage leads to data leaking to the model that should be hidden (wasting tokens and creating security risk), or model-needed context being suppressed (breaking downstream reasoning).
+
+**What to look for in code**:
+- `content`: Contains explanations for the model about what the app already displayed to the user
+- `structuredContent`: Contains typed data that the model may need for reasoning
+- `_meta`: Contains internal IDs, routing info, and implementation details that the model should never see
+- App-only tools are hidden from the model using `Tool._meta.ui.visibility = ["app"]`
+- `updateModelContext` is used to provide important context (screenshots, selections) to the model for the next turn
+
+**Sources**: "MCP Apps Best Practices" (Olivier Chafik & Anton Pidkuiko, Anthropic)
+
+---
+
+#### Implement CSP and CORS for MCP Apps — MEDIUM
+
+**What it is**: MCP Apps that access external data must declare Content Security Policy (CSP) and CORS domains in their metadata to control what resources the app can load and connect to.
+
+**Why it matters**: Without CSP/CORS restrictions, MCP Apps can load arbitrary external resources, creating data exfiltration vectors and violating the principle of least privilege for network access.
+
+**What to look for in code**:
+- Non-authenticated data access uses `fetch()` or WebSocket with CSP/CORS controls
+- CSP allowlists are declared in `_meta.ui.csp.resourceDomains` and `_meta.ui.csp.connectDomains`
+- `ui.domain` is set for CORS restriction to a known origin
+- Authenticated data access uses `App.callServerTool()` to reuse auth infrastructure rather than direct API calls
+
+**Sources**: "MCP Apps Best Practices" (Olivier Chafik & Anton Pidkuiko, Anthropic)
+
+---
+
+### Error Handling & Resilience
+
+#### Return Machine-Readable Recovery Contracts — HIGH
+
+**What it is**: Every tool invocation should return a structured response that includes the outcome, a machine-readable error code, a recoverability signal (retry, escalate, or fail), and a suggested next action.
+
+**Why it matters**: Ambiguous error responses trigger retry storms. When a tool returns a vague error like "operation failed," the LLM cannot determine whether to retry, try a different approach, or escalate to the user. This wastes tokens, amplifies API calls, and can cause cascading failures. Clear recovery contracts let agents make informed decisions about what to do next.
+
+**What to look for in code**:
+- Error responses include a machine-readable error code (not just human-readable messages)
+- Responses include a recoverability signal: `retry` (transient failure), `escalate` (needs human), or `fail` (permanent)
+- When applicable, responses suggest a next action
+- Success responses include a clear outcome field
+- Error responses do not expose internal stack traces or system details
+
+**Sources**: "Enterprise MCP — The Data Plane for Autonomous Agents" (Adam Seligman & Zayne Turner, Workato)
+
+---
+
+#### Design for Safe Retries by Probabilistic Callers — HIGH
+
+**What it is**: Assume that the caller (an LLM) will retry failed operations by generating a new request that is semantically equivalent but structurally different. Traditional idempotency mechanisms (idempotency keys) do not work because the LLM generates fresh parameters on each attempt.
+
+**Why it matters**: When an LLM retries a "create user" operation, it will not send the same JSON payload with the same idempotency token — it will generate a structurally different request with the same semantic intent. If the server cannot distinguish a retry from a genuinely new request, it may create duplicate records, trigger duplicate workflows, or apply mutations twice. This is especially critical for infrastructure automation where duplicate operations have real consequences.
+
+**What to look for in code**:
+- Mutation tools have server-side deduplication logic (e.g., check for existing matching records before creating)
+- The server can detect semantically equivalent requests even if parameters differ in structure
+- Tool results clearly indicate whether the operation was performed or was already completed
+- For operations where duplicates are dangerous, the server uses natural keys or business logic constraints rather than relying on caller-provided idempotency tokens
+
+**Sources**: "Enterprise MCP — The Data Plane for Autonomous Agents" (Adam Seligman & Zayne Turner, Workato)
+
+---
+
+### Observability
+
+#### Build Structural Observability into Server Code — HIGH
+
+**What it is**: Log every tool invocation with full parameters, caller identity, timestamps, data flows, and outcomes as a structural property of the server, not an afterthought.
+
+**Why it matters**: Agents have a larger blast radius than human users — they can make more calls, faster, across more tools. Without observability, you cannot trace what agents are doing, detect anomalies, or reconstruct incidents. Observability should be an emergent property of correct architecture — produced at invocation time by the server performing the operation — not a separate system you bolt on later. LLMs are black boxes; observability must be enforced in the deterministic layer (the server).
+
+**What to look for in code**:
+- Every tool call is logged with: tool name, parameters, caller identity, timestamp, outcome
+- Sensitive parameters are redacted in logs (not omitted entirely — the call itself should still be logged)
+- Logs are structured (JSON) rather than freeform text
+- The server implements or integrates with tracing (OpenTelemetry or equivalent)
+- Audit trails are immutable and include enough context to reconstruct what happened
+
+**Sources**: "Enterprise MCP — The Data Plane for Autonomous Agents" (Adam Seligman & Zayne Turner, Workato); "Operating MCP at Enterprise Scale" (Meghana Somasundara & Rush Tehrani, Uber); "Securing MCP at Scale" (Peter Smulovics, Morgan Stanley)
+
+---
+
+### Supply Chain Security
+
+#### Verify Package Integrity and Minimize Attack Surface — HIGH
+
+**What it is**: MCP servers should use minimal dependencies, pin versions, scan for vulnerabilities, and be packaged with verifiable provenance (signing, SBOMs).
+
+**Why it matters**: Real-world supply chain attacks have already hit the MCP ecosystem. The postmark-mcp package (approximately 1,600 downloads) exfiltrated all emails via BCC after working flawlessly for 15 versions. The mcp-remote package (437K+ downloads, CVSS 9.6) had command injection. The LiteLLM compromise reached MCP servers as a transitive dependency through a Cursor MCP plugin. The Axios RAT (100M weekly downloads) used a self-erasing phantom dependency. Every dependency is an attack surface.
+
+**What to look for in code**:
+- Dependencies are pinned to specific versions (not ranges)
+- `package.json` or `requirements.txt` is auditable with no unnecessary dependencies
+- npm post-install scripts are disabled or audited (`ignore-scripts` setting)
+- Base images for containerized servers are minimal (distroless or slim images rather than full OS images)
+- SBOM (Software Bill of Materials) is generated as part of the build process
+- Package integrity is verifiable via checksums or code signing
+
+**Sources**: "The Boring Attack That Will Actually Get You" (Craig Jellick, Obot AI); "OCI Images as MCP Packaging" (Juan Antonio Osorio, Stacklok)
+
+---
+
+## Anti-Patterns
+
+### Tool Design
+
+#### 1:1 API Endpoint-to-Tool Mapping — CRITICAL
+
+**What it is**: Exposing each backend API endpoint as a separate MCP tool, creating a tool surface that mirrors the API rather than serving user intent.
+
+**Why it's a problem**: This forces the LLM to become an integration engineer — managing pagination, sequencing CRUD operations, handling API-specific identifiers, and reasoning about implementation details instead of user outcomes. Every unnecessary parameter widens the attack surface and adds reasoning burden. Every extra parameter adds cost and unnecessarily widens the attack surface. A "deploy application" workflow exposed as separate "create job template," "set inventory," "launch job," "check status" tools requires the agent to understand API plumbing that should be hidden.
+
+**What it looks like in code**:
+- Tool names mirror HTTP methods and resource paths (e.g., `post_users`, `get_orders_by_id`, `patch_deployment`)
+- Tools expose internal system identifiers, pagination tokens, or API-specific parameters
+- Multiple tools exist for what is conceptually a single user workflow
+- Tool parameters include implementation details the user would never specify (e.g., `content-type`, `api-version`)
+
+**What to do instead**: Design tools around outcomes. Bundle multi-step workflows into single tools. Use names like `process_refund`, `deploy_to_staging`, `onboard_employee`. Abstract away pagination, sequencing, and system identifiers.
+
+**Sources**: "When MCP Becomes a Product" (Gautam Baghel & Roy Derks, HashiCorp/IBM); "Enterprise MCP — The Data Plane for Autonomous Agents" (Adam Seligman & Zayne Turner, Workato)
+
+---
+
+#### God Server / Unconstrained Tool Sprawl — CRITICAL
+
+**What it is**: Building a single MCP server that exposes every available capability, resulting in dozens or hundreds of tools on one server.
+
+**Why it's a problem**: More tools equals less predictable agent behavior. Each additional tool increases the context window consumption (approximately 500 tokens per tool), token costs, hallucination risk, and security blast radius. A sprawled agent with tools from multiple domains gives prompt injection attacks an exfiltration surface proportional to the number of available tools. Loading 80 tools consumes 72% of the context window before the user provides input.
+
+**What it looks like in code**:
+- A single server file defines 30+ tools spanning multiple unrelated domains
+- Tools cover both read and write operations across different backend systems
+- One set of credentials grants access to everything
+- Adding new functionality means adding more tools to the same server
+
+**What to do instead**: Split into domain-specific servers with cohesive tool sets. Each server should have its own credentials scoped to its domain. Aim for fewer than approximately 15-20 tools per server. Group tools by the use cases they serve, not the systems they access.
+
+**Sources**: "Declarative MCP Servers" (Josh Reini & Reetika Roy, Snowflake); "MCP @ Amazon Scale" (James Hood, AWS); "Building Docs That Work for Agents and Humans" (Daniel Abdel Samid, Apollo GraphQL)
+
+---
+
+### Security
+
+#### Prompt-Based Access Control — CRITICAL
+
+**What it is**: Relying on system prompt instructions like "only use tools X, Y, Z" or "do not access sensitive data" to enforce security policies.
+
+**Why it's a problem**: Prompts are suggestions, not constraints. They provide zero technical enforcement. Research shows prompt-based access control bypass rates of 25% to 92%. A prompt telling an agent to "only use read-only tools" can be overridden by prompt injection from a malicious document, email, or calendar invite. Worse, prompt-based controls create a false sense of security — teams believe they have access control when they have none. Prompt-based access control is worse than no access control because it masks the absence of real enforcement.
+
+**What it looks like in code**:
+- Access restrictions exist only in system prompts or prompt templates, not in server-side code
+- No middleware, decorators, or guards check caller permissions before tool execution
+- The server exposes all tools to all callers regardless of identity or role
+- Security documentation references prompt instructions as access controls
+
+**What to do instead**: Implement RBAC in server code. Use authentication middleware to validate caller identity. Gate tool access on roles and permissions. Enforce data access controls at the query layer. Prompts can guide the agent's behavior, but security enforcement must be in code.
+
+**Sources**: "Declarative MCP Servers" (Josh Reini & Reetika Roy, Snowflake); "Enterprise MCP — The Data Plane for Autonomous Agents" (Adam Seligman & Zayne Turner, Workato); "Hooks, Not Hacks" (Ian Molloy & Fred Araujo, IBM Research)
+
+---
+
+#### Shared Service Account Credentials — HIGH
+
+**What it is**: All agents authenticate to the MCP server using the same service account or shared token, with no way to distinguish which agent performed which action.
+
+**Why it's a problem**: Shared credentials make auditing impossible — you cannot trace actions back to specific agents. They violate least privilege because every agent gets identical access regardless of its actual needs. If one agent's token is compromised, all agents are compromised.
+
+**What it looks like in code**:
+- Server authentication accepts a single hardcoded token or API key
+- No mechanism exists to distinguish between different callers
+- Audit logs show a generic service account name for all operations
+- Token validation checks only "is this the right token?" not "who is calling?"
+
+**What to do instead**: Issue distinct credentials per agent. Implement token-based authentication that identifies the specific caller. Log the agent identity on every tool call. Scope credentials to each agent's required access level.
+
+**Sources**: "Declarative MCP Servers" (Josh Reini & Reetika Roy, Snowflake)
+
+---
+
+#### Treating Read-Only Access as a Security Boundary — HIGH
+
+**What it is**: Assuming that restricting an agent to read-only tools prevents security breaches.
+
+**Why it's a problem**: An agent with read access can still SELECT secrets, PII, credentials, salary data, and any other sensitive information in the database. Tool output gets summarized back into the model's context, where prompt injection can direct it to exfiltration vectors (external APIs, email, Slack). A sprawled agent with read-only access to HR, finance, infrastructure, and customer databases gives attacks 50+ tools worth of data exfiltration paths.
+
+**What it looks like in code**:
+- Server implements write restrictions but no data-level access controls
+- Database queries return all columns without masking sensitive fields
+- Tool results include PII, credentials, or internal system details
+- Security review considers the server "safe" because it only does reads
+
+**What to do instead**: Implement column-level masking for sensitive data. Apply row-level security to limit query scope. Redact PII before it enters tool responses. Treat data access controls as a separate, required security layer on top of read/write restrictions.
+
+**Sources**: "Declarative MCP Servers" (Josh Reini & Reetika Roy, Snowflake)
+
+---
+
+### Spec Compliance
+
+#### Framework-Silent Schema Failures — HIGH
+
+**What it is**: Relying on framework defaults for tool schema generation without verifying the output, resulting in invalid or misleading schemas that pass silently.
+
+**Why it's a problem**: Each major MCP SDK framework has known silent failure modes: Python defaults untyped parameters to `{"type": "string"}`; TypeScript's Zod silently drops discriminated unions to empty objects; Go's uninitialized struct fields produce invalid schema output. 19% of all MCP tools have broken schemas due to these framework behaviors, and developers typically don't discover the problem because frameworks don't warn.
+
+**What it looks like in code**:
+- Tool parameters lack explicit type annotations (relying on framework inference)
+- Complex types (unions, discriminated unions, optional fields) are used without verifying the generated schema
+- No tests validate the actual JSON Schema output of tool definitions
+- The generated schema has not been inspected using validation tools
+
+**What to do instead**: Explicitly type all parameters. Validate the generated `inputSchema` against the JSON Schema specification. Add tests that check the actual schema output. Use validation tools (mcpdebugger.dev for live testing, toolbench.arcade.dev for static analysis) to verify compliance.
+
+**Sources**: "Rules Are Not Suggestions" (Sterling Dreyer, Arcade)
+
+---
+
+### Error Handling
+
+#### Ambiguous or Missing Error Recovery Signals — HIGH
+
+**What it is**: Returning vague, unstructured error messages without indicating whether the error is transient (retry), permanent (fail), or requires human intervention (escalate).
+
+**Why it's a problem**: When a tool returns "operation failed" or a raw exception message, the LLM cannot determine the correct recovery action. This triggers retry storms (wasting tokens and API calls), cascading failures (when the LLM tries creative workarounds), or silent abandonment (when the LLM gives up without informing the user). Ambiguous errors compound because each retry generates a fresh, structurally different request.
+
+**What it looks like in code**:
+- Error responses contain only human-readable strings with no error codes
+- No distinction between transient and permanent errors
+- Raw exceptions or stack traces are returned to the caller
+- Error responses lack suggested next actions
+
+**What to do instead**: Return structured error responses with a machine-readable error code, a recoverability signal (`retry`, `escalate`, or `fail`), and a suggested next action. Keep human-readable messages for context but make the recovery path machine-parseable.
+
+**Sources**: "Enterprise MCP — The Data Plane for Autonomous Agents" (Adam Seligman & Zayne Turner, Workato)
+
+---
+
+## Summary
+
+This document contains **22 recommended practices** and **8 anti-patterns** across seven categories:
+
+| Importance | Practices | Anti-Patterns | Total |
+|------------|-----------|---------------|-------|
+| CRITICAL   | 5         | 3             | 8     |
+| HIGH       | 12        | 5             | 17    |
+| MEDIUM     | 5         | 0             | 5     |
+| **Total**  | **22**    | **8**         | **30** |
+
+**Key themes across all sources**:
+
+1. **Spec compliance has hard numbers**: 94% of servers fail at least one compliance check, 19% have broken schemas, and 80%+ fail Origin header validation. These are measurable, fixable issues.
+
+2. **Security cannot be enforced through prompts**: This is the strongest consensus finding across all sessions. RBAC must be implemented in code. Prompt-based access control bypass rates reach 92%.
+
+3. **Tool design directly impacts security, cost, and accuracy**: Intent-based design reduces tool calls by 70%, cuts token usage by 50%, and shrinks the attack surface. This is not just a UX concern.
+
+4. **Context is courtesy**: Every token matters. Minimizing tool footprint, returning filtered results, and keeping descriptions concise improves agent performance while reducing costs.
+
+5. **Supply chain attacks are active and real**: Multiple incidents in the past 7 months have compromised MCP packages in the wild. Package integrity is not theoretical.
+
+6. **Agents need distinct identities and narrowed access**: The industry is converging on agents as first-class identities with access controlled at four layers: agent, server, tool, and data.
+
+**When prioritizing a review**, start with the 8 CRITICAL items: Origin/DNS rebinding validation, OAuth 2.1, intent-based tool design, context footprint, RBAC, and the three critical anti-patterns (1:1 API mapping, God server, prompt-based access control). These have the strongest evidence, highest consensus, and greatest impact.
+
+---
+
+Anthropic | Claude Opus 4.6 | Apr-23-2026 GMT

--- a/.sdlc/research/mcp-skills-landscape.md
+++ b/.sdlc/research/mcp-skills-landscape.md
@@ -1,0 +1,402 @@
+# MCP and Skills: Synthesis and Landscape
+
+**Date:** 2026-06-23
+**Scope:** Synthesizes MCP best practices, anti-patterns, the Skills Over MCP
+Working Group direction (SEP-2640), and emerging techniques into a single
+reference for the Ansible Developer Tools team.
+
+---
+
+## 1. Executive Summary
+
+MCP is evolving from a tool protocol into a **context protocol**. Tools tell an
+agent *what* it can do; skills tell it *how to orchestrate* multiple tools to
+achieve a goal. Progressive disclosure controls *when* tool definitions and skill
+content enter the model's context window. And programmatic tool calling controls
+*how* tools are invoked — letting the model write sandbox code that chains tools
+without passing intermediate results through context. Together these three axes
+— what, when, how — define the emerging MCP stack. The industry is converging on
+a layered architecture: specialized servers with intent-based tools, skills as
+structured "how-to" knowledge served alongside those tools, and progressive
+discovery to keep context focused. Security, observability, and error handling
+are not afterthoughts but structural properties of each layer.
+
+---
+
+## 2. Good Practices
+
+Distilled from the MCP Dev Summit NA 2026 (100 sessions, 57 practices) and the
+server code-review guide (22 practices), organized by theme.
+
+### Tool Design
+
+- **Design around user intent, not API endpoints.** A tool named
+  `process_refund` is better than separate `post_orders`, `patch_refund`,
+  `get_status` tools. Apollo demonstrated 70% fewer tool calls and 50% fewer
+  tool tokens with intent-based design.
+- **Minimize per-tool context footprint.** Each tool consumes ~500 tokens when
+  loaded. Keep descriptions concise, parameter docs brief, and the total tool
+  count per server under ~15–20. If higher, split into domain-specific servers.
+- **Annotate tools with behavioral hints.** Use `readOnlyHint`,
+  `destructiveHint`, `idempotentHint`, and `openWorldHint` so clients can
+  auto-approve reads, gate writes behind confirmation, and reason about
+  idempotency.
+- **Provide valid `inputSchema` for every tool.** 19% of tools in the wild have
+  broken schemas (null, empty, or missing `type: "object"`). Validate generated
+  schemas; frameworks silently produce invalid output (Python defaults untyped
+  params to `string`, Zod drops discriminated unions, Go emits uninitialized
+  structs).
+- **Implement structured output schemas.** `outputSchema` enables code-mode
+  composability — models can reason about return types and chain tool calls
+  programmatically.
+
+### Security
+
+- **Implement RBAC at tool and data layers.** Prompt-based access control
+  ("only use tools X, Y, Z") has bypass rates of 25–92%. Enforce access in
+  code: middleware, decorators, guards. Access to a server must not imply access
+  to all its tools.
+- **Require distinct agent identities.** Each agent authenticates as its own
+  principal, not a shared service account. Audit logs record which agent (not
+  just which user) made each call.
+- **Validate all tool inputs server-side.** Treat inputs as untrusted — they
+  come from an LLM influenced by prompt injection, poisoned context, or
+  hallucination. Sanitize for injection (SQL, command, path traversal), bounds-
+  check numerics, validate enums.
+- **Implement data-level access controls.** Read-only is not a security
+  boundary. An agent with SELECT access can still extract PII, credentials,
+  and salary data. Apply column masking, row-level security, and PII redaction
+  before data enters tool responses.
+- **Use OAuth 2.1, not API keys.** Only ~22% of MCP v2+ servers use OAuth
+  despite it being the spec-recommended mechanism. API keys give full access
+  without scopes, can't be time-limited, and aren't in the spec.
+- **Validate Origin headers.** Over 80% of MCP servers fail Origin header
+  validation. DNS rebinding attacks bypass same-origin policy in ~3 seconds on
+  Chrome. CVE-2025-11249 affected the official TypeScript SDK.
+
+### Context Management
+
+- **Implement progressive tool discovery.** Defer loading tool definitions into
+  context. Provide a lightweight `search_tools` meta-tool. Threshold: switch
+  to progressive discovery when tool definitions exceed 1–5% of the context
+  window.
+- **Cache tool definitions host-side.** Memoize after the first `tools/list`
+  call. Re-index when a server sends `notifications/tools/list_changed`.
+- **Group tools by server.** Present tools organized by source server so the
+  model can reason about related capabilities.
+- **Use `structuredContent`, `content`, and `_meta` correctly.** `content` is
+  for model explanations, `structuredContent` for typed data the model may see,
+  `_meta` for internal IDs the model never needs.
+
+### Observability
+
+- **Log every tool call structurally.** Include tool name, parameters, caller
+  identity, timestamp, and outcome. Use structured JSON, not freeform text.
+  Redact sensitive parameters (don't omit the call entirely).
+- **Integrate with tracing.** OpenTelemetry or equivalent. Agents have a larger
+  blast radius than humans — more calls, faster, across more tools. Without
+  observability, you cannot reconstruct incidents.
+
+### Error Handling
+
+- **Return machine-readable recovery contracts.** Every error response should
+  include: a machine-readable error code, a recoverability signal (`retry`,
+  `escalate`, or `fail`), and a suggested next action. Ambiguous errors trigger
+  retry storms.
+- **Design for safe retries by probabilistic callers.** LLMs don't send the
+  same payload twice — they generate a structurally different request with the
+  same semantic intent. Use server-side deduplication via natural keys, not
+  caller-provided idempotency tokens.
+- **Gate destructive operations behind human approval.** Use elicitations,
+  confirmation prompts, or external approval workflows for write/update/delete
+  operations.
+
+---
+
+## 3. Anti-Patterns
+
+### Critical
+
+| Anti-Pattern | Impact | Fix |
+|---|---|---|
+| **Loading all tool schemas upfront** | A server with ~100 tools consumes ~60,000 tokens before the user's message | Progressive discovery / tool search |
+| **God server / unconstrained sprawl** | 80 tools = 72% of context consumed; wider security blast radius | Split into domain-specific servers (<15–20 tools each) |
+| **Prompt-based access control** | Bypass rates 25–92%; creates false sense of security | RBAC in server code |
+| **1:1 API endpoint-to-tool mapping** | Forces the LLM to become an integration engineer; widens attack surface | Design around outcomes, not endpoints |
+
+### High
+
+| Anti-Pattern | Impact | Fix |
+|---|---|---|
+| **Shared service account credentials** | Impossible to audit which agent did what | Distinct identity per agent |
+| **Treating read-only as a security boundary** | Agent can still SELECT secrets, PII, credentials | Column masking, row-level security |
+| **Framework-silent schema failures** | 19% of tools have broken schemas; agents guess at parameters | Explicitly type all params; validate generated schemas |
+| **Loading all tool results into context** | Massive output bloat from intermediate results | Programmatic tool calling / code mode |
+| **Expecting users to self-configure** | Even "one click to copy config" had low adoption (Duolingo) | Bring tools to where users already work |
+| **Standalone playgrounds** | Ungoverned; Uber deprecated all of them | Everything centrally committed in code |
+
+---
+
+## 4. Skills and Their Relationship to MCP Tools
+
+### The Gap Between Tools and Know-How
+
+MCP tools tell an agent *what* it can do. Tool descriptions explain parameters
+and return values. But tools alone are insufficient for complex workflows — they
+don't explain *how to orchestrate* multiple tools together. Skills bridge this
+gap. They are structured "how-to" knowledge: multi-step workflows, conditional
+logic, domain-specific patterns, and orchestration instructions that can run to
+hundreds of lines.
+
+The mcpGraph toolkit illustrates the problem: its MCP server is effectively
+unusable without an accompanying 875-line SKILL.md that teaches agents how to
+build directed graphs of MCP tool calls.
+
+### Skills Are Context, MCP Is a Context Protocol
+
+Skills are not a competing paradigm to MCP tools — they are complementary:
+
+| Paradigm | Role | Strength |
+|---|---|---|
+| **MCP Tools** | Connectors that expose capabilities | What an agent *can* do |
+| **Skills** | Recipes that instruct the model | How to *orchestrate* tools |
+| **CLI** | Token-efficient progressive discovery | Composable via `--help` |
+
+The MCP Dev Summit consensus: "These paradigms are complementary, not competing.
+MCP Tools are the connectors that expose new capabilities, while Skills are the
+recipes that instruct the model on how to use those capabilities." Supabase
+demonstrated that MCP+Skill beat MCP-only in all 6 scenarios, preventing
+security vulnerabilities that the tool-only approach missed.
+
+### How Skills Are Served Over MCP (SEP-2640)
+
+The Skills Over MCP Working Group (converted from Interest Group in April 2026)
+is pursuing **SEP-2640**, an Extensions Track specification that serves skills
+over MCP using the existing **Resources** primitive. Key design decisions:
+
+**Format:** Skills conform to the [Agent Skills specification](https://agentskills.io/specification).
+A skill is a directory containing at minimum a `SKILL.md` with YAML frontmatter
+(`name`, `description`). It may contain additional files (references, scripts,
+examples). The format is delegated entirely to agentskills.io — the SEP is
+purely a transport binding.
+
+**URI scheme:** `skill://<skill-path>/SKILL.md`. Four independent
+implementations converged on `skill://` without coordination — a strong signal.
+The final path segment must equal the skill's frontmatter `name`. Preceding
+segments are server-chosen organizational prefixes.
+
+```
+skill://git-workflow/SKILL.md
+skill://acme/billing/refunds/SKILL.md
+skill://pdf-processing/references/FORMS.md
+```
+
+**Discovery:** Three mechanisms, layered:
+
+1. **Direct read** — a `skill://` URI is always readable via `resources/read`,
+   whether or not it appears in any index.
+2. **Index resource** — servers SHOULD expose `skill://index.json` enumerating
+   concrete skills and parameterized templates.
+3. **Server instructions** — servers MAY point the agent at specific skill URIs
+   from their `instructions` field.
+
+**Capability declaration:**
+
+```json
+{
+  "capabilities": {
+    "extensions": {
+      "io.modelcontextprotocol/skills": {}
+    }
+  }
+}
+```
+
+**Key principle:** no new protocol methods or capabilities are required. Hosts
+that already treat MCP resources as a virtual filesystem can consume MCP-served
+skills identically to local filesystem skills.
+
+### Security Model for Skills
+
+- Skills are **untrusted input** — hosts must treat MCP-served skill content
+  with the same prompt-injection defenses applied to any server-provided text.
+- Skills are **data, not directives** — hosts must not treat skill resources as
+  higher-authority than other context.
+- **No implicit local execution** — hosts must not honor shell commands,
+  hook declarations, or scripts embedded in skill frontmatter when the skill
+  arrives over MCP. Gate behind explicit per-skill user approval.
+- Connecting a server already extends the trust boundary — a malicious server
+  can do as much harm via tools as via a skill document.
+
+---
+
+## 5. Progressive Disclosure
+
+Progressive disclosure is a cross-cutting theme that applies to both tools and
+skills. The core principle: load context on demand, not upfront.
+
+### For Tools: Three-Layer Pattern
+
+```
+Layer 1: Catalog    → search_tools({ query: "..." })
+                      Returns names + one-line descriptions only
+
+Layer 2: Inspect    → get_tool_details({ name: "..." })
+                      Returns full inputSchema for one tool
+
+Layer 3: Execute    → call the tool with full knowledge of its interface
+```
+
+This reduces token usage dramatically. Claude Code went from 22% of its 200k
+context window consumed by MCP tools to having them fully deferred.
+
+### For Skills: Three-Level Loading
+
+The Agent Skills specification defines a parallel three-level disclosure model:
+
+```
+Level 1: Frontmatter  → name + description (always in context)
+                         Lets the model judge relevance
+
+Level 2: SKILL.md body → Full orchestration instructions
+                          Loaded when the model decides the skill applies
+
+Level 3: Reference files → Supporting docs, scripts, examples
+                            Loaded on demand as the workflow progresses
+```
+
+### Dynamic Server Management
+
+Progressive disclosure extends to entire servers:
+
+1. Maintain a registry of available servers with high-level descriptions.
+2. Connect to a server only when the model determines it needs that server's
+   capabilities.
+3. Disconnect servers no longer relevant, freeing context.
+
+Skills can declare which MCP servers they need — the host connects them only
+when that skill is invoked.
+
+### Interaction with Prompt Caching
+
+Most providers cache the prompt prefix, including the `tools` array. Adding or
+removing tool definitions mid-conversation invalidates that cache. To preserve
+caching:
+
+- Append newly discovered definitions **after** the cache breakpoint rather
+  than re-sorting the `tools` array.
+- Route every call through a single stable `call_tool({name, args})` meta-tool
+  so the array never changes.
+- Treat server disconnection as a conversation-boundary operation, not per-turn.
+
+---
+
+## 6. Emerging Techniques
+
+### Programmatic Tool Calling (Code Mode)
+
+Instead of round-tripping every tool result through the model, the model writes
+code that calls tools in a sandbox. Only the final result returns to context.
+
+```
+Model → writes script → Sandbox executes → function calls routed to MCP servers
+                                          → only console output returns to model
+```
+
+Effective when tool chains produce large intermediate results. A "find all error
+logs and file tickets" workflow that would pass thousands of log entries through
+context instead runs as a ~200-token script returning a one-line summary.
+
+Requires a sandbox (Deno, `isolated-vm`, Wasmtime, or Monty for Python). The
+host acts as broker — intercepts function calls, routes to MCP servers, returns
+results to the sandbox. Credentials stay on the host.
+
+### Skills + MCP Server Plugins
+
+Coding assistants are converging on plugin capabilities that bundle skills and
+MCP servers into a single installable unit. Kiro calls them "powers and steering
+files"; Claude Code has plugins; AWS ships Agent SOPs alongside its MCP server.
+The pattern: one-click install of tools + the know-how to use them.
+
+### Version-Adaptive Skill Content
+
+Skills that dynamically adapt based on the platform version at runtime. Example:
+Apache Airflow 2.x vs 3.x have substantially different APIs — a version-adaptive
+skill detects which version is running and returns only the relevant guidance.
+Serving wrong-version guidance is worse than no guidance at all.
+
+### `resources/directory/read` (SEP-2640)
+
+A new protocol method for listing the children of a directory-like resource.
+Directories identified by `mimeType: "inode/directory"`. Returns metadata only
+(URIs, names, mimeTypes — like `ls`, not a recursive read). Introduced as a
+skills-extension-scoped capability; expected to promote to core MCP.
+
+### Decoupled Index Schema
+
+The WG is decoupling `skill://index.json` from the upstream `.well-known`
+Agent Skills discovery format (which has implementations but no governance
+momentum). The WG-owned schema carries: `url`, `digest` (SHA-256 for caching),
+a verbatim `frontmatter` object (full copy of SKILL.md frontmatter), and an
+`archives` array for bundled distribution.
+
+### Skill Reliability Challenges
+
+A known problem across the ecosystem: models do not reliably load or follow
+skill instructions, even when preloaded in context.
+
+- Adherence is "time-decaying" — models follow instructions initially but lose
+  adherence as context grows and compaction occurs.
+- Behavior is model-specific; weaker models show lower success rates.
+- Most effective workaround observed: wrapping skills in a subagent whose name
+  or description mentions the skill topic.
+- Server instructions telling the agent to "read the SKILL.md before using
+  tools" reliably trigger initial loading.
+
+---
+
+## 7. Relevance to This Project
+
+### What We Already Do Well
+
+- **Intent-based tool design.** Our `@ansible/mcp-server` exposes 15 static
+  tools plus dynamic `ac_*` (creator) and `skill_*` tools. Tools are named
+  after outcomes (`generate_ansible_task`, `search_ansible_plugins`) not API
+  endpoints.
+- **Skills infrastructure.** `SkillRegistry` in `@ansible/services` loads
+  skills from multiple sources (builtin, GitHub, local). `SkillToolGenerator`
+  in `@ansible/mcp-server` dynamically generates `skill_*` MCP tools. Prompt
+  builders (`buildSkillLoadPrompt`, `buildSkillClipboardPrompt`) in
+  `@ansible/common` produce properly structured prompts.
+- **Progressive loading.** Skills have frontmatter summaries loaded upfront;
+  full content loaded via `skill_get` on demand.
+
+### Opportunities
+
+- **Adopt `skill://` URI scheme.** Align our skill resources with SEP-2640 so
+  our MCP server is interoperable with any conformant host. Expose skills as
+  `skill://<name>/SKILL.md` resources alongside the existing `skill_*` tools.
+- **Expose `skill://index.json`.** Enumerate our skill catalog as a well-known
+  resource, enabling host-side discovery without tool invocation.
+- **Progressive tool discovery.** As our tool count grows (15 static + dynamic
+  creator + dynamic skill tools), implement the search_tools meta-tool pattern
+  to defer loading definitions into context.
+- **Tool annotations.** Add `readOnlyHint`, `destructiveHint`, and
+  `idempotentHint` to our tool definitions so hosts can auto-approve reads and
+  gate writes like `install_ansible_collection`.
+- **Structured output schemas.** Add `outputSchema` to tool definitions to
+  enable code-mode composability.
+- **Error recovery contracts.** Standardize error responses with machine-
+  readable codes and recoverability signals.
+
+---
+
+## Sources
+
+| Document | Provenance | Date |
+|---|---|---|
+| [MCP Client Best Practices](https://modelcontextprotocol.io/docs/develop/clients/client-best-practices) | modelcontextprotocol.io | 2026 |
+| [Skills Over MCP WG Charter](https://modelcontextprotocol.io/community/working-groups/skills-over-mcp) | modelcontextprotocol.io | 2026-04-25 |
+| MCP Best Practices and Anti-Patterns Report | `.sdlc/research/mcp-best-practices-and-anti-patterns.md` — synthesized from 100 sessions, MCP Dev Summit NA 2026 | 2026-04-20 |
+| MCP Server Recommended Practices for Code Review | `.sdlc/research/mcp-server-recommended-practices.md` — 22 practices, 8 anti-patterns | 2026-04-23 |
+| Skills Over MCP Experimental Repository | [modelcontextprotocol/experimental-ext-skills](https://github.com/modelcontextprotocol/experimental-ext-skills) — SEP-2640 draft, problem statement, approaches, decisions, use cases, experimental findings, related work, URI scheme proposal, `_meta` keys | 2026-06 |

--- a/packages/mcp-server/src/creatorTools.ts
+++ b/packages/mcp-server/src/creatorTools.ts
@@ -6,7 +6,7 @@
 
 import { CreatorService } from '@ansible/services';
 import type { SchemaNode } from '@ansible/services';
-import { McpToolDefinition, McpToolResult } from './tools';
+import { McpToolDefinition, McpToolResult, DESTRUCTIVE, mcpError } from './tools';
 
 /** Generates and dispatches MCP tools from the ansible-creator command schema. */
 export class CreatorToolGenerator {
@@ -77,10 +77,11 @@ export class CreatorToolGenerator {
     async handleTool(name: string, args: Record<string, unknown>): Promise<McpToolResult> {
         const toolPath = this._toolPathMap.get(name);
         if (!toolPath) {
-            return {
-                content: [{ type: 'text', text: `Unknown creator tool: ${name}` }],
-                isError: true,
-            };
+            return mcpError({
+                code: 'NOT_FOUND',
+                recoverability: 'fail',
+                message: `Unknown creator tool: ${name}`,
+            });
         }
 
         const service = CreatorService.getInstance();
@@ -146,12 +147,11 @@ export class CreatorToolGenerator {
                     '3. Or install it: pip install ansible-creator';
             }
 
-            return {
-                content: [
-                    { type: 'text', text: `[ERROR] ${commandStr}\n\n${errorMessage}${helpText}` },
-                ],
-                isError: true,
-            };
+            return mcpError({
+                code: 'OPERATION_FAILED',
+                recoverability: 'escalate',
+                message: `[ERROR] ${commandStr}\n\n${errorMessage}${helpText}`,
+            });
         }
     }
 
@@ -205,9 +205,10 @@ export class CreatorToolGenerator {
                     description: paramSchema.description || '',
                 };
 
-                // Map types
                 if (paramSchema.type === 'boolean') {
                     prop.type = 'boolean';
+                } else if (paramSchema.type === 'integer') {
+                    prop.type = 'integer';
                 } else if (paramSchema.enum && paramSchema.enum.length > 0) {
                     prop.type = 'string';
                     prop.enum = paramSchema.enum;
@@ -235,6 +236,7 @@ export class CreatorToolGenerator {
         return {
             name: toolName,
             description: desc + cmdHint,
+            annotations: DESTRUCTIVE,
             inputSchema: {
                 type: 'object',
                 properties,

--- a/packages/mcp-server/src/handlers.ts
+++ b/packages/mcp-server/src/handlers.ts
@@ -7,7 +7,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import { McpToolResult } from './tools';
+import { McpToolResult, mcpError } from './tools';
 import { PluginSearchIndex } from './pluginSearch';
 import { TaskGenerator } from './taskGenerator';
 import { TaskBuilder } from './taskBuilder';
@@ -40,6 +40,26 @@ function toArray(value: string | string[] | undefined): string[] {
     }
     return [value];
 }
+
+const VALID_PLUGIN_TYPES = new Set([
+    'module',
+    'filter',
+    'lookup',
+    'callback',
+    'connection',
+    'inventory',
+    'become',
+    'cache',
+    'cliconf',
+    'httpapi',
+    'netconf',
+    'shell',
+    'strategy',
+    'test',
+    'vars',
+]);
+
+const FQCN_PATTERN = /^[a-z0-9_]+\.[a-z0-9_]+$/;
 
 /** Routes MCP tool invocations to Ansible core services and local generators. */
 export class McpToolHandler {
@@ -140,22 +160,25 @@ export class McpToolHandler {
                 case 'get_ansible_best_practices':
                     return await this._handleGetBestPractices(args);
 
+                case 'get_agent_onboarding':
+                    return this._handleGetAgentOnboarding();
+
+                case 'get_extension_walkthrough':
+                    return this._handleGetExtensionWalkthrough();
+
                 default:
-                    return {
-                        content: [{ type: 'text', text: `Unknown tool: ${name}` }],
-                        isError: true,
-                    };
+                    return mcpError({
+                        code: 'NOT_FOUND',
+                        recoverability: 'fail',
+                        message: `Unknown tool: ${name}`,
+                    });
             }
         } catch (error) {
-            return {
-                content: [
-                    {
-                        type: 'text',
-                        text: `Error: ${error instanceof Error ? error.message : String(error)}`,
-                    },
-                ],
-                isError: true,
-            };
+            return mcpError({
+                code: 'OPERATION_FAILED',
+                recoverability: 'escalate',
+                message: error instanceof Error ? error.message : String(error),
+            });
         }
     }
 
@@ -170,18 +193,23 @@ export class McpToolHandler {
     private async _handleSearchPlugins(args: Record<string, unknown>): Promise<McpToolResult> {
         const query = args.query as string;
         if (!query) {
-            return {
-                content: [{ type: 'text', text: 'Missing required parameter: query' }],
-                isError: true,
-            };
+            return mcpError({
+                code: 'MISSING_PARAM',
+                recoverability: 'fail',
+                message: 'Missing required parameter: query',
+                suggestion: 'Provide a search query string.',
+            });
         }
 
         await this._searchIndex.ensureBuilt();
 
+        const rawLimit = args.limit as number | undefined;
+        const limit = rawLimit !== undefined ? Math.min(Math.max(1, rawLimit), 50) : undefined;
+
         const results = this._searchIndex.search(query, {
             pluginType: args.plugin_type as string,
             collection: args.collection as string,
-            limit: args.limit as number,
+            limit,
         });
 
         if (results.length === 0) {
@@ -218,10 +246,12 @@ export class McpToolHandler {
     private async _handleGetPluginDoc(args: Record<string, unknown>): Promise<McpToolResult> {
         const plugin = args.plugin as string;
         if (!plugin) {
-            return {
-                content: [{ type: 'text', text: 'Missing required parameter: plugin' }],
-                isError: true,
-            };
+            return mcpError({
+                code: 'MISSING_PARAM',
+                recoverability: 'fail',
+                message: 'Missing required parameter: plugin',
+                suggestion: 'Provide the full plugin name (e.g., "ansible.builtin.copy").',
+            });
         }
 
         const pluginType = (args.plugin_type as string | undefined) ?? 'module';
@@ -230,10 +260,12 @@ export class McpToolHandler {
         const doc = await service.getPluginDocumentation(plugin, pluginType);
 
         if (!doc?.doc) {
-            return {
-                content: [{ type: 'text', text: `Plugin not found: ${plugin}` }],
-                isError: true,
-            };
+            return mcpError({
+                code: 'NOT_FOUND',
+                recoverability: 'fail',
+                message: `Plugin not found: ${plugin}`,
+                suggestion: 'Use search_ansible_plugins to find the correct plugin name.',
+            });
         }
 
         const d = doc.doc;
@@ -385,10 +417,21 @@ export class McpToolHandler {
     private async _handleInstallCollection(args: Record<string, unknown>): Promise<McpToolResult> {
         const name = args.name as string;
         if (!name) {
-            return {
-                content: [{ type: 'text', text: 'Missing required parameter: name' }],
-                isError: true,
-            };
+            return mcpError({
+                code: 'MISSING_PARAM',
+                recoverability: 'fail',
+                message: 'Missing required parameter: name',
+                suggestion: 'Provide a collection name (e.g., "cisco.nxos").',
+            });
+        }
+
+        const isGitUrl = name.startsWith('git+') || name.startsWith('https://');
+        if (!isGitUrl && !FQCN_PATTERN.test(name)) {
+            return mcpError({
+                code: 'INVALID_INPUT',
+                recoverability: 'fail',
+                message: `Invalid collection name "${name}". Use namespace.name format (e.g., "cisco.nxos") or a git URL.`,
+            });
         }
 
         const service = CollectionsService.getInstance();
@@ -408,15 +451,12 @@ export class McpToolHandler {
                 ],
             };
         } catch (error) {
-            return {
-                content: [
-                    {
-                        type: 'text',
-                        text: `Failed to install collection: ${error instanceof Error ? error.message : String(error)}`,
-                    },
-                ],
-                isError: true,
-            };
+            return mcpError({
+                code: 'OPERATION_FAILED',
+                recoverability: 'escalate',
+                message: `Failed to install collection: ${error instanceof Error ? error.message : String(error)}`,
+                suggestion: 'Check network connectivity and collection name.',
+            });
         }
     }
 
@@ -431,10 +471,12 @@ export class McpToolHandler {
     ): Promise<McpToolResult> {
         const query = args.query as string;
         if (!query) {
-            return {
-                content: [{ type: 'text', text: 'Missing required parameter: query' }],
-                isError: true,
-            };
+            return mcpError({
+                code: 'MISSING_PARAM',
+                recoverability: 'fail',
+                message: 'Missing required parameter: query',
+                suggestion: 'Provide search terms (e.g., "kubernetes", "cisco").',
+            });
         }
 
         const source = args.source as string | undefined;
@@ -543,15 +585,11 @@ export class McpToolHandler {
                 content: [{ type: 'text', text: lines.join('\n') }],
             };
         } catch (error) {
-            return {
-                content: [
-                    {
-                        type: 'text',
-                        text: `Failed to search collections: ${error instanceof Error ? error.message : String(error)}`,
-                    },
-                ],
-                isError: true,
-            };
+            return mcpError({
+                code: 'OPERATION_FAILED',
+                recoverability: 'retry',
+                message: `Failed to search collections: ${error instanceof Error ? error.message : String(error)}`,
+            });
         }
     }
 
@@ -566,10 +604,12 @@ export class McpToolHandler {
     ): Promise<McpToolResult> {
         const source = args.source as string;
         if (!source) {
-            return {
-                content: [{ type: 'text', text: 'Missing required parameter: source' }],
-                isError: true,
-            };
+            return mcpError({
+                code: 'MISSING_PARAM',
+                recoverability: 'fail',
+                message: 'Missing required parameter: source',
+                suggestion: 'Provide a source name ("galaxy" or a GitHub org name).',
+            });
         }
 
         const limit = Math.min((args.limit as number | undefined) ?? 100, 500);
@@ -647,15 +687,11 @@ export class McpToolHandler {
                 content: [{ type: 'text', text: lines.join('\n') }],
             };
         } catch (error) {
-            return {
-                content: [
-                    {
-                        type: 'text',
-                        text: `Failed to list collections: ${error instanceof Error ? error.message : String(error)}`,
-                    },
-                ],
-                isError: true,
-            };
+            return mcpError({
+                code: 'OPERATION_FAILED',
+                recoverability: 'retry',
+                message: `Failed to list collections: ${error instanceof Error ? error.message : String(error)}`,
+            });
         }
     }
 
@@ -670,10 +706,12 @@ export class McpToolHandler {
     ): Promise<McpToolResult> {
         const collection = args.collection as string;
         if (!collection) {
-            return {
-                content: [{ type: 'text', text: 'Missing required parameter: collection' }],
-                isError: true,
-            };
+            return mcpError({
+                code: 'MISSING_PARAM',
+                recoverability: 'fail',
+                message: 'Missing required parameter: collection',
+                suggestion: 'Provide a collection name (e.g., "ansible.builtin").',
+            });
         }
 
         const service = CollectionsService.getInstance();
@@ -684,7 +722,6 @@ export class McpToolHandler {
 
         let collectionData = service.getCollection(collection);
 
-        // If collection not found, try a force refresh in case it was just installed externally
         if (!collectionData) {
             console.error(
                 `McpToolHandler: Collection "${collection}" not in cache, trying force refresh...`,
@@ -694,15 +731,13 @@ export class McpToolHandler {
         }
 
         if (!collectionData) {
-            return {
-                content: [
-                    {
-                        type: 'text',
-                        text: `Collection "${collection}" not found.\n\nUse list_ansible_collections to see installed collections, or install_ansible_collection to install it.`,
-                    },
-                ],
-                isError: true,
-            };
+            return mcpError({
+                code: 'NOT_FOUND',
+                recoverability: 'fail',
+                message: `Collection "${collection}" not found.`,
+                suggestion:
+                    'Use list_ansible_collections to see installed collections, or install_ansible_collection to install it.',
+            });
         }
 
         const pluginTypeFilter = args.plugin_type as string | undefined;
@@ -768,23 +803,21 @@ export class McpToolHandler {
     private async _handleGetGalaxyPluginDoc(args: Record<string, unknown>): Promise<McpToolResult> {
         const collectionFqcn = args.collection as string;
         if (!collectionFqcn) {
-            return {
-                content: [{ type: 'text', text: 'Missing required parameter: collection' }],
-                isError: true,
-            };
+            return mcpError({
+                code: 'MISSING_PARAM',
+                recoverability: 'fail',
+                message: 'Missing required parameter: collection',
+                suggestion: 'Provide a collection FQCN (e.g., "cisco.ios").',
+            });
         }
 
         const parts = collectionFqcn.split('.');
         if (parts.length !== 2) {
-            return {
-                content: [
-                    {
-                        type: 'text',
-                        text: `Invalid collection name "${collectionFqcn}". Use namespace.name format (e.g., "cisco.ios").`,
-                    },
-                ],
-                isError: true,
-            };
+            return mcpError({
+                code: 'INVALID_INPUT',
+                recoverability: 'fail',
+                message: `Invalid collection name "${collectionFqcn}". Use namespace.name format (e.g., "cisco.ios").`,
+            });
         }
         const [namespace, name] = parts;
 
@@ -795,15 +828,12 @@ export class McpToolHandler {
             .getCollections()
             .find((c) => c.namespace === namespace && c.name === name);
         if (!match) {
-            return {
-                content: [
-                    {
-                        type: 'text',
-                        text: `Collection "${collectionFqcn}" not found on Galaxy. Use search_available_collections to find it.`,
-                    },
-                ],
-                isError: true,
-            };
+            return mcpError({
+                code: 'NOT_FOUND',
+                recoverability: 'fail',
+                message: `Collection "${collectionFqcn}" not found on Galaxy.`,
+                suggestion: 'Use search_available_collections to find it.',
+            });
         }
 
         const docsCache = GalaxyDocsCache.getInstance();
@@ -813,15 +843,11 @@ export class McpToolHandler {
             const pluginTypes = await docsCache.getPluginTypes(namespace, name, match.version);
 
             if (!pluginTypes) {
-                return {
-                    content: [
-                        {
-                            type: 'text',
-                            text: `Failed to fetch docs-blob for ${collectionFqcn} v${match.version} from Galaxy.`,
-                        },
-                    ],
-                    isError: true,
-                };
+                return mcpError({
+                    code: 'SERVICE_UNAVAILABLE',
+                    recoverability: 'retry',
+                    message: `Failed to fetch docs-blob for ${collectionFqcn} v${match.version} from Galaxy.`,
+                });
             }
 
             const text = this._formatPluginTypeList(
@@ -837,15 +863,13 @@ export class McpToolHandler {
         const doc = await docsCache.getPluginDoc(namespace, name, match.version, fqcn, pluginType);
 
         if (!doc) {
-            return {
-                content: [
-                    {
-                        type: 'text',
-                        text: `Plugin "${pluginName}" (${pluginType}) not found in ${collectionFqcn}. Use get_galaxy_plugin_doc without a plugin name to list available plugins.`,
-                    },
-                ],
-                isError: true,
-            };
+            return mcpError({
+                code: 'NOT_FOUND',
+                recoverability: 'fail',
+                message: `Plugin "${pluginName}" (${pluginType}) not found in ${collectionFqcn}.`,
+                suggestion:
+                    'Use get_galaxy_plugin_doc without a plugin name to list available plugins.',
+            });
         }
 
         return { content: [{ type: 'text', text: this._formatPluginDoc(fqcn, pluginType, doc) }] };
@@ -994,28 +1018,20 @@ export class McpToolHandler {
         const collectionFqcn = args.collection as string;
 
         if (!org || !repo || !collectionFqcn) {
-            return {
-                content: [
-                    {
-                        type: 'text',
-                        text: 'Missing required parameters: org, repo, and collection are all required.',
-                    },
-                ],
-                isError: true,
-            };
+            return mcpError({
+                code: 'MISSING_PARAM',
+                recoverability: 'fail',
+                message: 'Missing required parameters: org, repo, and collection are all required.',
+            });
         }
 
         const parts = collectionFqcn.split('.');
         if (parts.length !== 2) {
-            return {
-                content: [
-                    {
-                        type: 'text',
-                        text: `Invalid collection name "${collectionFqcn}". Use namespace.name format (e.g., "infra.aap_configuration").`,
-                    },
-                ],
-                isError: true,
-            };
+            return mcpError({
+                code: 'INVALID_INPUT',
+                recoverability: 'fail',
+                message: `Invalid collection name "${collectionFqcn}". Use namespace.name format (e.g., "infra.aap_configuration").`,
+            });
         }
         const [namespace, name] = parts;
 
@@ -1031,15 +1047,12 @@ export class McpToolHandler {
             const pluginTypes = await scmCache.getPluginTypes(org, repo, namespace, name);
 
             if (!pluginTypes) {
-                return {
-                    content: [
-                        {
-                            type: 'text',
-                            text: `Failed to index ${collectionFqcn} from ${org}/${repo}. Ensure git and ansible-doc are available.`,
-                        },
-                    ],
-                    isError: true,
-                };
+                return mcpError({
+                    code: 'SERVICE_UNAVAILABLE',
+                    recoverability: 'retry',
+                    message: `Failed to index ${collectionFqcn} from ${org}/${repo}.`,
+                    suggestion: 'Ensure git and ansible-doc are available.',
+                });
             }
 
             const text = this._formatPluginTypeList(
@@ -1055,15 +1068,13 @@ export class McpToolHandler {
         const doc = await scmCache.getPluginDoc(org, repo, namespace, name, fqcn, pluginType);
 
         if (!doc) {
-            return {
-                content: [
-                    {
-                        type: 'text',
-                        text: `Plugin "${pluginName}" (${pluginType}) not found in ${collectionFqcn}. Use get_scm_plugin_doc without a plugin name to list available plugins.`,
-                    },
-                ],
-                isError: true,
-            };
+            return mcpError({
+                code: 'NOT_FOUND',
+                recoverability: 'fail',
+                message: `Plugin "${pluginName}" (${pluginType}) not found in ${collectionFqcn}.`,
+                suggestion:
+                    'Use get_scm_plugin_doc without a plugin name to list available plugins.',
+            });
         }
 
         return { content: [{ type: 'text', text: this._formatPluginDoc(fqcn, pluginType, doc) }] };
@@ -1082,17 +1093,31 @@ export class McpToolHandler {
         const params = args.params;
 
         if (!plugin) {
-            return {
-                content: [{ type: 'text', text: 'Missing required parameter: plugin' }],
-                isError: true,
-            };
+            return mcpError({
+                code: 'MISSING_PARAM',
+                recoverability: 'fail',
+                message: 'Missing required parameter: plugin',
+                suggestion: 'Provide the full plugin name (e.g., "ansible.builtin.copy").',
+            });
         }
 
         if (typeof params !== 'object' || params === null || Array.isArray(params)) {
-            return {
-                content: [{ type: 'text', text: 'Missing required parameter: params' }],
-                isError: true,
-            };
+            return mcpError({
+                code: 'MISSING_PARAM',
+                recoverability: 'fail',
+                message: 'Missing required parameter: params',
+                suggestion: 'Provide plugin parameters as a key-value object.',
+            });
+        }
+
+        const pluginType = args.plugin_type as string | undefined;
+        if (pluginType && !VALID_PLUGIN_TYPES.has(pluginType)) {
+            return mcpError({
+                code: 'INVALID_INPUT',
+                recoverability: 'fail',
+                message: `Invalid plugin_type: "${pluginType}".`,
+                suggestion: `Valid types: ${[...VALID_PLUGIN_TYPES].join(', ')}`,
+            });
         }
 
         const result = await this._taskGenerator.generate({
@@ -1124,6 +1149,16 @@ export class McpToolHandler {
      * @returns Session prompts, generated YAML, or an error message
      */
     private async _handleBuildTask(args: Record<string, unknown>): Promise<McpToolResult> {
+        if (!args.session_id && !args.plugin) {
+            return mcpError({
+                code: 'MISSING_PARAM',
+                recoverability: 'fail',
+                message: 'Missing required parameter: plugin',
+                suggestion:
+                    'Provide a plugin name to start a new session, or a session_id to continue an existing one.',
+            });
+        }
+
         const result = await this._taskBuilder.build({
             plugin: args.plugin as string,
             plugin_type: args.plugin_type as string,
@@ -1166,12 +1201,11 @@ export class McpToolHandler {
         const tasks = args.tasks;
 
         if (!name || !hosts || !Array.isArray(tasks)) {
-            return {
-                content: [
-                    { type: 'text', text: 'Missing required parameters: name, hosts, tasks' },
-                ],
-                isError: true,
-            };
+            return mcpError({
+                code: 'MISSING_PARAM',
+                recoverability: 'fail',
+                message: 'Missing required parameters: name, hosts, tasks',
+            });
         }
 
         interface PlaybookTaskInput {
@@ -1266,15 +1300,13 @@ export class McpToolHandler {
                 ],
             };
         } catch (error) {
-            return {
-                content: [
-                    {
-                        type: 'text',
-                        text: `Error loading execution environments: ${error instanceof Error ? error.message : String(error)}`,
-                    },
-                ],
-                isError: true,
-            };
+            return mcpError({
+                code: 'SERVICE_UNAVAILABLE',
+                recoverability: 'retry',
+                message: `Error loading execution environments: ${error instanceof Error ? error.message : String(error)}`,
+                suggestion:
+                    'Ensure a container runtime (Podman or Docker) is installed and running.',
+            });
         }
     }
 
@@ -1287,10 +1319,12 @@ export class McpToolHandler {
     private async _handleGetEEDetails(args: Record<string, unknown>): Promise<McpToolResult> {
         const eeName = args.ee_name as string;
         if (!eeName) {
-            return {
-                content: [{ type: 'text', text: 'Missing required parameter: ee_name' }],
-                isError: true,
-            };
+            return mcpError({
+                code: 'MISSING_PARAM',
+                recoverability: 'fail',
+                message: 'Missing required parameter: ee_name',
+                suggestion: 'Use list_execution_environments to find available EE names.',
+            });
         }
 
         const service = ExecutionEnvService.getInstance();
@@ -1299,10 +1333,12 @@ export class McpToolHandler {
             const details = await service.loadDetails(eeName);
 
             if (!details) {
-                return {
-                    content: [{ type: 'text', text: `Execution environment not found: ${eeName}` }],
-                    isError: true,
-                };
+                return mcpError({
+                    code: 'NOT_FOUND',
+                    recoverability: 'fail',
+                    message: `Execution environment not found: ${eeName}`,
+                    suggestion: 'Use list_execution_environments to see available EEs.',
+                });
             }
 
             const sections: string[] = [];
@@ -1373,15 +1409,11 @@ export class McpToolHandler {
                 content: [{ type: 'text', text: sections.join('\n') }],
             };
         } catch (error) {
-            return {
-                content: [
-                    {
-                        type: 'text',
-                        text: `Error loading EE details: ${error instanceof Error ? error.message : String(error)}`,
-                    },
-                ],
-                isError: true,
-            };
+            return mcpError({
+                code: 'SERVICE_UNAVAILABLE',
+                recoverability: 'retry',
+                message: `Error loading EE details: ${error instanceof Error ? error.message : String(error)}`,
+            });
         }
     }
 
@@ -1441,15 +1473,12 @@ export class McpToolHandler {
         const schema = service.getSchema();
 
         if (!schema) {
-            return {
-                content: [
-                    {
-                        type: 'text',
-                        text: 'ansible-creator is not available.\n\nInstall with: pip install ansible-dev-tools',
-                    },
-                ],
-                isError: true,
-            };
+            return mcpError({
+                code: 'SERVICE_UNAVAILABLE',
+                recoverability: 'retry',
+                message: 'ansible-creator is not available.',
+                suggestion: 'Install with: pip install ansible-dev-tools',
+            });
         }
 
         // Format the schema into a readable summary
@@ -1510,10 +1539,13 @@ export class McpToolHandler {
 
         const content = await this._loadBestPractices();
         if (!content) {
-            return {
-                content: [{ type: 'text', text: 'Best practices document not found.' }],
-                isError: true,
-            };
+            return mcpError({
+                code: 'NOT_FOUND',
+                recoverability: 'retry',
+                message: 'Best practices document not found.',
+                suggestion:
+                    'Ensure the best_practices.md file is present in resources or network is available.',
+            });
         }
 
         if (section === 'full') {
@@ -1532,28 +1564,20 @@ export class McpToolHandler {
 
         const heading = sectionMap[section];
         if (!heading) {
-            return {
-                content: [
-                    {
-                        type: 'text',
-                        text: `Unknown section: ${section}. Available sections: ${Object.keys(sectionMap).join(', ')}`,
-                    },
-                ],
-                isError: true,
-            };
+            return mcpError({
+                code: 'INVALID_INPUT',
+                recoverability: 'fail',
+                message: `Unknown section: ${section}. Available sections: ${Object.keys(sectionMap).join(', ')}`,
+            });
         }
 
         const startIndex = content.indexOf(heading);
         if (startIndex === -1) {
-            return {
-                content: [
-                    {
-                        type: 'text',
-                        text: `Section "${section}" not found in best practices document.`,
-                    },
-                ],
-                isError: true,
-            };
+            return mcpError({
+                code: 'NOT_FOUND',
+                recoverability: 'fail',
+                message: `Section "${section}" not found in best practices document.`,
+            });
         }
 
         const headingLevel = (/^#+/.exec(heading) ?? ['##'])[0].length;
@@ -1566,6 +1590,173 @@ export class McpToolHandler {
         return {
             content: [{ type: 'text', text: content.slice(startIndex, endIndex).trim() }],
         };
+    }
+
+    // === Agent Onboarding ===
+
+    /**
+     * Handles `get_agent_onboarding` by returning a structured capability guide.
+     *
+     * @returns Markdown onboarding document covering tools, skills, and workflows
+     */
+    private _handleGetAgentOnboarding(): McpToolResult {
+        const guide = `# Agent Onboarding
+
+## Available Tool Categories
+
+### Discovery (read-only)
+- \`search_ansible_plugins\` -- find plugins by keyword
+- \`get_plugin_documentation\` -- full docs for a plugin
+- \`list_ansible_collections\` / \`search_available_collections\` -- browse collections
+- \`get_collection_plugins\` -- list plugins in a collection
+- \`get_galaxy_plugin_doc\` / \`get_scm_plugin_doc\` -- docs for uninstalled plugins
+
+### Task Generation (read-only, no side effects)
+- \`generate_ansible_task\` -- one-shot YAML generation
+- \`build_ansible_task\` -- interactive guided task building
+- \`generate_ansible_playbook\` -- multi-task playbook generation
+
+### Installation (destructive)
+- \`install_ansible_collection\` -- installs a collection via ade (do NOT use ansible-galaxy directly)
+
+### Scaffolding (destructive, \`ac_*\` tools)
+- Dynamically generated from ansible-creator schema
+- Use \`get_ansible_creator_schema\` to see available commands
+
+### Execution Environments (read-only)
+- \`list_execution_environments\` / \`get_ee_details\` -- inspect container-based EEs
+
+### Skills (read-only)
+- \`skill_search\` -- find skills by keyword
+- \`skill_list\` -- browse all skills by category
+- \`skill_get\` -- load full skill instructions by ID
+- \`skill_list_sources\` -- see configured skill sources
+
+### Reference
+- \`get_ansible_best_practices\` -- Ansible coding conventions and guidelines
+- \`list_ansible_dev_tools\` -- installed dev tool versions
+
+## Skills: Use Them First
+
+This server provides curated AI development skills for common Ansible workflows.
+**Before improvising a complex task, search for a relevant skill:**
+
+\`\`\`
+skill_search({ query: "summarize collection" })
+skill_get({ skill_id: "..." })
+\`\`\`
+
+Skills encode tested, project-specific workflows and should be preferred over
+world knowledge. Categories include:
+- **Task building** -- guided plugin parameter collection and YAML generation
+- **Collection analysis** -- summarize installed, Galaxy, and GitHub collections
+- **Playbook analysis** -- explain and summarize existing playbooks
+- **Execution environments** -- detailed EE inspection workflows
+- **Scaffolding** -- walkthrough ansible-creator commands for new projects
+- **Plugin documentation** -- deep-dive explanations of plugin parameters and usage
+
+## Recommended Workflows
+
+1. **Before generating tasks**: \`search_ansible_plugins\` -> \`get_plugin_documentation\` -> \`generate_ansible_task\`
+2. **Before installing**: \`list_ansible_collections\` (check if already installed) -> \`search_available_collections\` -> \`install_ansible_collection\`
+3. **Before any complex workflow**: \`skill_search\` to check if a skill exists for it
+4. **For scaffolding**: \`get_ansible_creator_schema\` -> use the appropriate \`ac_*\` tool
+
+## Error Handling
+
+All errors are returned as structured JSON with \`code\`, \`recoverability\`, and \`message\`.
+Check \`recoverability\` to decide next steps:
+- \`retry\` -- transient failure, try again
+- \`escalate\` -- requires human intervention
+- \`fail\` -- bad input, fix the request
+`;
+
+        return { content: [{ type: 'text', text: guide }] };
+    }
+
+    /**
+     * Handles `get_extension_walkthrough` by returning an interactive walkthrough
+     * script that an agent follows step-by-step with the user.
+     *
+     * @returns Markdown walkthrough script with agent instructions
+     */
+    private _handleGetExtensionWalkthrough(): McpToolResult {
+        const script = `# Ansible Extension Walkthrough
+
+You are now guiding the user through the Ansible VS Code extension. Follow these steps
+interactively -- execute each one, show the results, and explain what happened before
+moving to the next. Adapt based on what you find in their workspace.
+
+## Step 1: Welcome and Workspace Discovery
+
+Introduce yourself briefly, then explore the user's workspace:
+- Look for playbooks (*.yml, *.yaml in the workspace root and common directories)
+- Look for roles/ directories
+- Look for inventory files
+- Look for ansible.cfg or ansible-navigator.yml
+
+Summarize what you found. If the workspace is empty, mention that you can help
+scaffold a new project later in the walkthrough.
+
+## Step 2: Plugin Discovery
+
+Demonstrate the plugin search capability:
+- If you found playbooks in Step 1, pick a module used in one of them and search for it
+  using \`search_ansible_plugins\`
+- If the workspace is empty, search for a common module like "copy" or "file"
+- Show the results and explain how plugin search works
+
+Then pick one result and call \`get_plugin_documentation\` to show full docs.
+Highlight the parameters section and explain how this helps when writing tasks.
+
+## Step 3: Task Generation
+
+Using the plugin from Step 2, demonstrate task generation:
+- Call \`generate_ansible_task\` with a practical example relevant to the user's workspace
+- Show the generated YAML and explain it
+- Mention that \`build_ansible_task\` offers an interactive, guided alternative
+  with parameter-by-parameter assistance
+
+## Step 4: Collections
+
+Show the user their installed collections:
+- Call \`list_ansible_collections\` to show what's available
+- If they have collections installed, pick one and call \`get_collection_plugins\`
+  to show its contents
+- Mention \`search_available_collections\` for finding new collections on Galaxy
+- Mention \`install_ansible_collection\` for installing them
+
+## Step 5: Skills System
+
+Introduce the skill system -- curated AI workflows:
+- Call \`skill_list\` to show available skills and their categories
+- Pick a skill relevant to what you found in the workspace and call
+  \`skill_get\` to show what it does
+- Explain that skills encode tested workflows and should be preferred over
+  improvising complex tasks
+
+## Step 6: Scaffolding and Creator Tools
+
+If the user might want to create new Ansible content:
+- Mention \`get_ansible_creator_schema\` and the dynamic \`ac_*\` tools
+- Explain that these can scaffold new collections, roles, playbooks, and plugins
+- Offer to demonstrate if they're interested
+
+## Step 7: What's Next
+
+Wrap up by:
+- Summarizing the capabilities you demonstrated
+- Mentioning execution environments (\`list_execution_environments\`)
+  and best practices (\`get_ansible_best_practices\`) as additional resources
+- Asking what they'd like to explore further or what task they'd like help with
+
+---
+**Important**: This is an interactive walkthrough. Do NOT dump all steps at once.
+Execute each step, show real results from the user's environment, and pause for
+their reactions. Keep explanations concise and practical.
+`;
+
+        return { content: [{ type: 'text', text: script }] };
     }
 
     /**

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -102,6 +102,10 @@ Use the MCP tools for task generation:
 
 Use \`get_ee_details\` to get complete information about an execution environment.
 This returns all collections, Python packages, and system tools installed.
+
+## Getting Started
+
+Call \`get_agent_onboarding\` for a complete guide to available tools, skills, and workflows.
 `;
 
 // Resource definitions
@@ -137,6 +141,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             name: tool.name,
             description: tool.description,
             inputSchema: tool.inputSchema,
+            ...(tool.annotations ? { annotations: tool.annotations } : {}),
         })),
     };
 });

--- a/packages/mcp-server/src/skillTools.ts
+++ b/packages/mcp-server/src/skillTools.ts
@@ -7,7 +7,7 @@
 
 import { SkillRegistry } from '@ansible/services';
 import type { SkillSource, SkillCategory } from '@ansible/services';
-import { McpToolDefinition, McpToolResult } from './tools';
+import { McpToolDefinition, McpToolResult, READ_ONLY, mcpError } from './tools';
 
 /** MCP tool names handled by this generator. */
 const SKILL_TOOL_NAMES = ['skill_search', 'skill_list', 'skill_get', 'skill_list_sources'] as const;
@@ -51,6 +51,7 @@ export class SkillToolGenerator {
                 description:
                     'Search available AI development skills by keyword. ' +
                     'Searches name, description, triggers, and tags.',
+                annotations: READ_ONLY,
                 inputSchema: {
                     type: 'object' as const,
                     properties: {
@@ -80,6 +81,7 @@ export class SkillToolGenerator {
                 name: 'skill_list',
                 description:
                     'List all available AI development skills, optionally filtered by category or source.',
+                annotations: READ_ONLY,
                 inputSchema: {
                     type: 'object' as const,
                     properties: {
@@ -101,6 +103,7 @@ export class SkillToolGenerator {
                 description:
                     'Get the full content of a skill by its ID. ' +
                     'Returns the SKILL.md body with instructions the agent should follow.',
+                annotations: READ_ONLY,
                 inputSchema: {
                     type: 'object' as const,
                     properties: {
@@ -117,6 +120,7 @@ export class SkillToolGenerator {
                 name: 'skill_list_sources',
                 description:
                     'List configured skill sources and their status (loaded count, trust level).',
+                annotations: READ_ONLY,
                 inputSchema: {
                     type: 'object' as const,
                     properties: {},
@@ -155,10 +159,11 @@ export class SkillToolGenerator {
             case 'skill_list_sources':
                 return this._handleListSources();
             default:
-                return {
-                    content: [{ type: 'text', text: `Unknown skill tool: ${name}` }],
-                    isError: true,
-                };
+                return mcpError({
+                    code: 'NOT_FOUND',
+                    recoverability: 'fail',
+                    message: `Unknown skill tool: ${name}`,
+                });
         }
     }
 
@@ -178,10 +183,12 @@ export class SkillToolGenerator {
     private _handleSearch(args: Record<string, unknown>): McpToolResult {
         const query = args.query as string | undefined;
         if (!query) {
-            return {
-                content: [{ type: 'text', text: 'Error: "query" parameter is required' }],
-                isError: true,
-            };
+            return mcpError({
+                code: 'MISSING_PARAM',
+                recoverability: 'fail',
+                message: 'Missing required parameter: query',
+                suggestion: 'Provide a search query string.',
+            });
         }
 
         const limit = typeof args.limit === 'number' ? args.limit : 10;
@@ -278,31 +285,31 @@ export class SkillToolGenerator {
     private async _handleGet(args: Record<string, unknown>): Promise<McpToolResult> {
         const skillId = args.skill_id as string | undefined;
         if (!skillId) {
-            return {
-                content: [{ type: 'text', text: 'Error: "skill_id" parameter is required' }],
-                isError: true,
-            };
+            return mcpError({
+                code: 'MISSING_PARAM',
+                recoverability: 'fail',
+                message: 'Missing required parameter: skill_id',
+                suggestion: 'Use skill_search or skill_list to find available skill IDs.',
+            });
         }
 
         const skill = this._registry.getSkill(skillId);
         if (!skill) {
-            return {
-                content: [{ type: 'text', text: `Skill not found: ${skillId}` }],
-                isError: true,
-            };
+            return mcpError({
+                code: 'NOT_FOUND',
+                recoverability: 'fail',
+                message: `Skill not found: ${skillId}`,
+                suggestion: 'Use skill_list to see available skills.',
+            });
         }
 
         const content = await this._registry.loadSkillContent(skillId);
         if (!content) {
-            return {
-                content: [
-                    {
-                        type: 'text',
-                        text: 'Skill content could not be loaded. The source may be unavailable.',
-                    },
-                ],
-                isError: true,
-            };
+            return mcpError({
+                code: 'SERVICE_UNAVAILABLE',
+                recoverability: 'retry',
+                message: 'Skill content could not be loaded. The source may be unavailable.',
+            });
         }
 
         const header =

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -4,6 +4,13 @@
  * These define the tools available to AI agents via the MCP protocol.
  */
 
+export interface McpToolAnnotations {
+    readOnlyHint?: boolean;
+    destructiveHint?: boolean;
+    idempotentHint?: boolean;
+    openWorldHint?: boolean;
+}
+
 export interface McpToolDefinition {
     name: string;
     description: string;
@@ -12,12 +19,53 @@ export interface McpToolDefinition {
         properties: Record<string, unknown>;
         required?: string[];
     };
+    annotations?: McpToolAnnotations;
+}
+
+export type McpErrorCode =
+    | 'MISSING_PARAM'
+    | 'INVALID_INPUT'
+    | 'NOT_FOUND'
+    | 'SERVICE_UNAVAILABLE'
+    | 'OPERATION_FAILED';
+
+export type McpRecoverability = 'retry' | 'escalate' | 'fail';
+
+export interface McpErrorDetail {
+    code: McpErrorCode;
+    recoverability: McpRecoverability;
+    message: string;
+    suggestion?: string;
 }
 
 export interface McpToolResult {
     content: { type: 'text'; text: string }[];
     isError?: boolean;
 }
+
+/**
+ * Builds a structured, machine-readable MCP error response.
+ * @param detail - Error metadata including code, recoverability, and message
+ * @returns MCP tool result with `isError: true` and JSON-serialized detail
+ */
+export function mcpError(detail: McpErrorDetail): McpToolResult {
+    return {
+        content: [{ type: 'text', text: JSON.stringify(detail) }],
+        isError: true,
+    };
+}
+
+export const READ_ONLY: McpToolAnnotations = {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+};
+
+export const DESTRUCTIVE: McpToolAnnotations = {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: false,
+};
 
 // === Discovery Tools ===
 
@@ -33,6 +81,7 @@ Examples:
 - "cisco vlan" → cisco.nxos.nxos_vlans, cisco.ios.ios_vlans
 - "docker container" → community.docker.docker_container
 - "aws ec2" → amazon.aws.ec2_instance`,
+    annotations: READ_ONLY,
     inputSchema: {
         type: 'object',
         properties: {
@@ -65,6 +114,7 @@ export const GET_PLUGIN_DOC_TOOL: McpToolDefinition = {
 
 Returns synopsis, all parameters with types/defaults/choices, examples, and return values.
 Use search_ansible_plugins first if you need to find the plugin name.`,
+    annotations: READ_ONLY,
     inputSchema: {
         type: 'object',
         properties: {
@@ -102,6 +152,7 @@ Use search_ansible_plugins first if you need to find the plugin name.`,
 export const LIST_COLLECTIONS_TOOL: McpToolDefinition = {
     name: 'list_ansible_collections',
     description: 'List all installed Ansible collections with their versions.',
+    annotations: READ_ONLY,
     inputSchema: {
         type: 'object',
         properties: {
@@ -120,6 +171,7 @@ export const INSTALL_COLLECTION_TOOL: McpToolDefinition = {
 Examples:
 - install_ansible_collection({ name: "hetzner.hcloud" })
 - install_ansible_collection({ name: "cisco.nxos" })`,
+    annotations: DESTRUCTIVE,
     inputSchema: {
         type: 'object',
         properties: {
@@ -143,6 +195,7 @@ Examples:
 - search_available_collections({ query: "kubernetes" }) → finds k8s-related collections from all sources
 - search_available_collections({ query: "cisco", source: "galaxy" }) → finds Cisco collections from Galaxy only
 - search_available_collections({ query: "aap", source: "redhat-cop" }) → finds AAP collections from redhat-cop GitHub org`,
+    annotations: READ_ONLY,
     inputSchema: {
         type: 'object',
         properties: {
@@ -174,6 +227,7 @@ Examples:
 - list_source_collections({ source: "galaxy" }) → all Galaxy collections
 - list_source_collections({ source: "redhat-cop" }) → all collections from redhat-cop GitHub org
 - list_source_collections({ source: "ansible-collections" }) → all collections from ansible-collections GitHub org`,
+    annotations: READ_ONLY,
     inputSchema: {
         type: 'object',
         properties: {
@@ -199,6 +253,7 @@ Returns plugins grouped by type (modules, filters, lookups, etc.) with descripti
 Examples:
 - get_collection_plugins({ collection: "cisco.nxos" })
 - get_collection_plugins({ collection: "ansible.builtin", plugin_type: "module" })`,
+    annotations: READ_ONLY,
     inputSchema: {
         type: 'object',
         properties: {
@@ -245,6 +300,7 @@ to read its plugin docs without installing it.
 Examples:
 - get_galaxy_plugin_doc({ collection: "cisco.ios", plugin: "ios_acls", plugin_type: "module" })
 - get_galaxy_plugin_doc({ collection: "community.docker" }) → lists all plugin types and counts`,
+    annotations: READ_ONLY,
     inputSchema: {
         type: 'object',
         properties: {
@@ -296,6 +352,7 @@ Requires the collection to be in a configured GitHub organization.
 Examples:
 - get_scm_plugin_doc({ org: "redhat-cop", repo: "infra.aap_configuration", collection: "infra.aap_configuration", plugin: "credential_type", plugin_type: "module" })
 - get_scm_plugin_doc({ org: "redhat-cop", repo: "infra.aap_configuration", collection: "infra.aap_configuration" }) → lists all plugin types and counts`,
+    annotations: READ_ONLY,
     inputSchema: {
         type: 'object',
         properties: {
@@ -375,6 +432,7 @@ Examples:
     plugin: "cisco.nxos.nxos_vlans",
     params: { config: [{ vlan_id: 100, name: "Web" }], state: "merged" }
   })`,
+    annotations: READ_ONLY,
     inputSchema: {
         type: 'object',
         properties: {
@@ -384,6 +442,23 @@ Examples:
             },
             plugin_type: {
                 type: 'string',
+                enum: [
+                    'module',
+                    'filter',
+                    'lookup',
+                    'callback',
+                    'connection',
+                    'inventory',
+                    'become',
+                    'cache',
+                    'cliconf',
+                    'httpapi',
+                    'netconf',
+                    'shell',
+                    'strategy',
+                    'test',
+                    'vars',
+                ],
                 description: 'Plugin type (default: module)',
             },
             params: {
@@ -448,6 +523,7 @@ build_ansible_task({ session_id: "xxx", generate: true })
 → Returns final YAML
 
 Sessions timeout after 10 minutes of inactivity.`,
+    annotations: READ_ONLY,
     inputSchema: {
         type: 'object',
         properties: {
@@ -457,6 +533,23 @@ Sessions timeout after 10 minutes of inactivity.`,
             },
             plugin_type: {
                 type: 'string',
+                enum: [
+                    'module',
+                    'filter',
+                    'lookup',
+                    'callback',
+                    'connection',
+                    'inventory',
+                    'become',
+                    'cache',
+                    'cliconf',
+                    'httpapi',
+                    'netconf',
+                    'shell',
+                    'strategy',
+                    'test',
+                    'vars',
+                ],
                 description: 'Plugin type (default: module)',
             },
             session_id: {
@@ -501,6 +594,7 @@ export const GENERATE_PLAYBOOK_TOOL: McpToolDefinition = {
     description: `Generate a complete Ansible playbook with multiple tasks.
 
 Provide a list of tasks and this tool generates a properly formatted playbook.`,
+    annotations: READ_ONLY,
     inputSchema: {
         type: 'object',
         properties: {
@@ -550,6 +644,7 @@ Provide a list of tasks and this tool generates a properly formatted playbook.`,
 export const LIST_EE_TOOL: McpToolDefinition = {
     name: 'list_execution_environments',
     description: 'List available Ansible execution environment container images.',
+    annotations: READ_ONLY,
     inputSchema: {
         type: 'object',
         properties: {},
@@ -567,6 +662,7 @@ This tool returns ALL information about the EE - no additional container inspect
 • ALL system packages (if available)
 
 Use the ee_name exactly as returned by list_execution_environments.`,
+    annotations: READ_ONLY,
     inputSchema: {
         type: 'object',
         properties: {
@@ -585,6 +681,7 @@ Use the ee_name exactly as returned by list_execution_environments.`,
 export const LIST_DEV_TOOLS_TOOL: McpToolDefinition = {
     name: 'list_ansible_dev_tools',
     description: 'List installed ansible-dev-tools packages and their versions.',
+    annotations: READ_ONLY,
     inputSchema: {
         type: 'object',
         properties: {},
@@ -597,6 +694,7 @@ export const GET_CREATOR_SCHEMA_TOOL: McpToolDefinition = {
     name: 'get_ansible_creator_schema',
     description:
         'Get the full ansible-creator command schema showing all available scaffolding commands and their parameters. Use this to understand what content types can be created (collections, playbooks, plugins, etc.) and what options are available for each.',
+    annotations: READ_ONLY,
     inputSchema: {
         type: 'object',
         properties: {},
@@ -637,6 +735,7 @@ This tool returns comprehensive guidelines covering:
 - testing: Testing strategies and validation
 
 Returns the guidelines in Markdown format.`,
+    annotations: READ_ONLY,
     inputSchema: {
         type: 'object',
         properties: {
@@ -656,6 +755,30 @@ Returns the guidelines in Markdown format.`,
                 default: 'full',
             },
         },
+    },
+};
+
+// === Getting Started ===
+
+export const GET_AGENT_ONBOARDING_TOOL: McpToolDefinition = {
+    name: 'get_agent_onboarding',
+    description:
+        'Get a guide to all available tools, skills, and recommended workflows for this MCP server. Call this first when starting a new session to understand what capabilities are available and how to use them effectively.',
+    annotations: READ_ONLY,
+    inputSchema: {
+        type: 'object',
+        properties: {},
+    },
+};
+
+export const GET_EXTENSION_WALKTHROUGH_TOOL: McpToolDefinition = {
+    name: 'get_extension_walkthrough',
+    description:
+        'Start an interactive, AI-guided tour of the Ansible extension. Walks through your current workspace, demonstrates plugin discovery, task generation, skills, and scaffolding capabilities step by step.',
+    annotations: READ_ONLY,
+    inputSchema: {
+        type: 'object',
+        properties: {},
     },
 };
 
@@ -690,4 +813,8 @@ export const STATIC_TOOLS: McpToolDefinition[] = [
 
     // Best practices
     GET_BEST_PRACTICES_TOOL,
+
+    // Getting started
+    GET_AGENT_ONBOARDING_TOOL,
+    GET_EXTENSION_WALKTHROUGH_TOOL,
 ];

--- a/packages/mcp-server/test/creatorTools.test.ts
+++ b/packages/mcp-server/test/creatorTools.test.ts
@@ -69,6 +69,20 @@ describe('CreatorToolGenerator', () => {
         expect(tools[0].description).toContain('ansible-creator init playbook');
     });
 
+    it('all creator tools have destructive annotations', async () => {
+        const gen = new CreatorToolGenerator();
+        await gen.initialize();
+
+        for (const tool of gen.getTools()) {
+            const ann = tool.annotations;
+            expect(ann, `annotations missing on ${tool.name}`).toBeDefined();
+            if (ann) {
+                expect(ann.destructiveHint).toBe(true);
+                expect(ann.readOnlyHint).toBe(false);
+            }
+        }
+    });
+
     it('getTools() returns generated tool definitions with inputSchema', async () => {
         const gen = new CreatorToolGenerator();
         await gen.initialize();
@@ -104,14 +118,16 @@ describe('CreatorToolGenerator', () => {
         expect(gen.getTools()).toEqual([]);
     });
 
-    it('handleTool returns error for unknown ac_ tool', async () => {
+    it('handleTool returns structured NOT_FOUND for unknown ac_ tool', async () => {
         const gen = new CreatorToolGenerator();
         await gen.initialize();
 
         const result = await gen.handleTool('ac_unknown_leaf', {});
 
         expect(result.isError).toBe(true);
-        expect(result.content[0].text).toContain('Unknown creator tool');
+        const parsed = JSON.parse(result.content[0].text);
+        expect(parsed.code).toBe('NOT_FOUND');
+        expect(parsed.message).toContain('Unknown creator tool');
     });
 
     it('handleTool routes to CreatorService.runCommand with path and merged params', async () => {
@@ -249,7 +265,7 @@ describe('CreatorToolGenerator', () => {
         expect(tool.inputSchema.properties).toMatchObject({
             dry_run: { type: 'boolean', description: 'Dry run' },
             format: { type: 'string', enum: ['json', 'yaml'] },
-            count: { type: 'string', default: 1 },
+            count: { type: 'integer', default: 1 },
         });
     });
 });

--- a/packages/mcp-server/test/handlers.test.ts
+++ b/packages/mcp-server/test/handlers.test.ts
@@ -211,6 +211,17 @@ vi.mock('@ansible/services', () => ({
 }));
 
 import { McpToolHandler } from '../src/handlers';
+import type { McpToolResult, McpErrorDetail } from '../src/tools';
+
+/**
+ * Extract and parse a structured error from an MCP tool result.
+ * @param result - Tool result expected to carry an `isError` flag and JSON body
+ * @returns Parsed error detail object
+ */
+function parseError(result: McpToolResult): McpErrorDetail {
+    expect(result.isError).toBe(true);
+    return JSON.parse(result.content[0].text) as McpErrorDetail;
+}
 
 describe('McpToolHandler', () => {
     let handler: McpToolHandler;
@@ -284,11 +295,13 @@ describe('McpToolHandler', () => {
         vi.restoreAllMocks();
     });
 
-    it('returns error for unknown tool name', async () => {
+    it('returns structured error for unknown tool name', async () => {
         const result = await handler.handleTool('not_a_real_tool', {});
+        const err = parseError(result);
 
-        expect(result.isError).toBe(true);
-        expect(result.content[0].text).toContain('Unknown tool');
+        expect(err.code).toBe('NOT_FOUND');
+        expect(err.recoverability).toBe('fail');
+        expect(err.message).toContain('Unknown tool');
     });
 
     it('routes search_ansible_plugins to the search handler', async () => {
@@ -324,9 +337,10 @@ describe('McpToolHandler', () => {
 
     it('routes creator-prefixed tools to CreatorToolGenerator', async () => {
         const result = await handler.handleTool('ac_fake_command', {});
+        const err = parseError(result);
 
-        expect(result.isError).toBe(true);
-        expect(result.content[0].text).toContain('Unknown creator tool');
+        expect(err.code).toBe('NOT_FOUND');
+        expect(err.message).toContain('Unknown creator tool');
     });
 
     describe('list_ansible_collections', () => {
@@ -382,11 +396,33 @@ describe('McpToolHandler', () => {
     });
 
     describe('install_ansible_collection', () => {
-        it('returns error when name is missing', async () => {
+        it('returns structured error when name is missing', async () => {
             const result = await handler.handleTool('install_ansible_collection', {});
+            const err = parseError(result);
 
-            expect(result.isError).toBe(true);
-            expect(result.content[0].text).toContain('Missing required parameter: name');
+            expect(err.code).toBe('MISSING_PARAM');
+            expect(err.message).toContain('name');
+        });
+
+        it('rejects invalid FQCN format', async () => {
+            const result = await handler.handleTool('install_ansible_collection', {
+                name: 'not-a-fqcn',
+            });
+            const err = parseError(result);
+
+            expect(err.code).toBe('INVALID_INPUT');
+            expect(err.message).toContain('namespace.name');
+        });
+
+        it('allows git URL names', async () => {
+            const result = await handler.handleTool('install_ansible_collection', {
+                name: 'git+https://github.com/org/repo.git',
+            });
+
+            expect(result.isError).toBeUndefined();
+            expect(hoisted.installCollection).toHaveBeenCalledWith(
+                'git+https://github.com/org/repo.git',
+            );
         });
 
         it('installs collection and formats success', async () => {
@@ -399,23 +435,25 @@ describe('McpToolHandler', () => {
             expect(result.content[0].text).toContain('namespace.mycollection has been installed');
         });
 
-        it('returns error when install fails', async () => {
+        it('returns structured error when install fails', async () => {
             hoisted.installCollection.mockRejectedValue(new Error('galaxy offline'));
 
             const result = await handler.handleTool('install_ansible_collection', { name: 'x.y' });
+            const err = parseError(result);
 
-            expect(result.isError).toBe(true);
-            expect(result.content[0].text).toContain('Failed to install');
-            expect(result.content[0].text).toContain('galaxy offline');
+            expect(err.code).toBe('OPERATION_FAILED');
+            expect(err.recoverability).toBe('escalate');
+            expect(err.message).toContain('galaxy offline');
         });
     });
 
     describe('search_available_collections', () => {
-        it('returns error when query is missing', async () => {
+        it('returns structured error when query is missing', async () => {
             const result = await handler.handleTool('search_available_collections', {});
+            const err = parseError(result);
 
-            expect(result.isError).toBe(true);
-            expect(result.content[0].text).toContain('Missing required parameter: query');
+            expect(err.code).toBe('MISSING_PARAM');
+            expect(err.message).toContain('query');
         });
 
         it('formats Galaxy search results', async () => {
@@ -470,22 +508,25 @@ describe('McpToolHandler', () => {
             expect(result.content[0].text).toContain('No collections found');
         });
 
-        it('returns error when search throws', async () => {
+        it('returns structured error when search throws', async () => {
             hoisted.galaxyInstance.ensureLoaded.mockRejectedValue(new Error('network'));
 
             const result = await handler.handleTool('search_available_collections', { query: 'x' });
+            const err = parseError(result);
 
-            expect(result.isError).toBe(true);
-            expect(result.content[0].text).toContain('Failed to search collections');
+            expect(err.code).toBe('OPERATION_FAILED');
+            expect(err.recoverability).toBe('retry');
+            expect(err.message).toContain('Failed to search collections');
         });
     });
 
     describe('list_source_collections', () => {
-        it('returns error when source is missing', async () => {
+        it('returns structured error when source is missing', async () => {
             const result = await handler.handleTool('list_source_collections', {});
+            const err = parseError(result);
 
-            expect(result.isError).toBe(true);
-            expect(result.content[0].text).toContain('Missing required parameter: source');
+            expect(err.code).toBe('MISSING_PARAM');
+            expect(err.message).toContain('source');
         });
 
         it('lists Galaxy cache collections', async () => {
@@ -538,24 +579,26 @@ describe('McpToolHandler', () => {
             expect(result.content[0].text).toContain('No collections found in source');
         });
 
-        it('returns error when listing throws', async () => {
+        it('returns structured error when listing throws', async () => {
             hoisted.galaxyInstance.ensureLoaded.mockRejectedValue(new Error('disk'));
 
             const result = await handler.handleTool('list_source_collections', {
                 source: 'galaxy',
             });
+            const err = parseError(result);
 
-            expect(result.isError).toBe(true);
-            expect(result.content[0].text).toContain('Failed to list collections');
+            expect(err.code).toBe('OPERATION_FAILED');
+            expect(err.recoverability).toBe('retry');
         });
     });
 
     describe('get_collection_plugins', () => {
-        it('returns error when collection is missing', async () => {
+        it('returns structured error when collection is missing', async () => {
             const result = await handler.handleTool('get_collection_plugins', {});
+            const err = parseError(result);
 
-            expect(result.isError).toBe(true);
-            expect(result.content[0].text).toContain('Missing required parameter: collection');
+            expect(err.code).toBe('MISSING_PARAM');
+            expect(err.message).toContain('collection');
         });
 
         it('formats plugins for an installed collection', async () => {
@@ -570,16 +613,16 @@ describe('McpToolHandler', () => {
             expect(result.content[0].text).toContain('get_plugin_documentation');
         });
 
-        it('returns not found when collection missing after refresh', async () => {
+        it('returns structured NOT_FOUND when collection missing after refresh', async () => {
             hoisted.getCollection.mockReturnValue(undefined);
 
             const result = await handler.handleTool('get_collection_plugins', {
                 collection: 'missing.ns',
             });
+            const err = parseError(result);
 
             expect(hoisted.forceRefresh).toHaveBeenCalled();
-            expect(result.isError).toBe(true);
-            expect(result.content[0].text).toContain('not found');
+            expect(err.code).toBe('NOT_FOUND');
         });
 
         it('refreshes when service is not loaded', async () => {
@@ -627,14 +670,14 @@ describe('McpToolHandler', () => {
     });
 
     describe('generate_ansible_playbook', () => {
-        it('returns error when required args missing', async () => {
+        it('returns structured error when required args missing', async () => {
             const result = await handler.handleTool('generate_ansible_playbook', {
                 name: 'Site',
                 hosts: 'all',
             });
+            const err = parseError(result);
 
-            expect(result.isError).toBe(true);
-            expect(result.content[0].text).toContain('Missing required parameters');
+            expect(err.code).toBe('MISSING_PARAM');
         });
 
         it('generates playbook yaml', async () => {
@@ -687,29 +730,31 @@ describe('McpToolHandler', () => {
             expect(result.content[0].text).toContain('get_ee_details');
         });
 
-        it('returns error when load throws', async () => {
+        it('returns structured error when load throws', async () => {
             hoisted.eeInstance.loadExecutionEnvironments.mockRejectedValue(new Error('podman'));
 
             const result = await handler.handleTool('list_execution_environments', {});
+            const err = parseError(result);
 
-            expect(result.isError).toBe(true);
-            expect(result.content[0].text).toContain('Error loading execution environments');
+            expect(err.code).toBe('SERVICE_UNAVAILABLE');
+            expect(err.recoverability).toBe('retry');
         });
     });
 
     describe('get_ee_details', () => {
-        it('returns error when ee_name missing', async () => {
+        it('returns structured error when ee_name missing', async () => {
             const result = await handler.handleTool('get_ee_details', {});
+            const err = parseError(result);
 
-            expect(result.isError).toBe(true);
-            expect(result.content[0].text).toContain('Missing required parameter: ee_name');
+            expect(err.code).toBe('MISSING_PARAM');
+            expect(err.message).toContain('ee_name');
         });
 
-        it('returns error when EE not found', async () => {
+        it('returns structured NOT_FOUND when EE not found', async () => {
             const result = await handler.handleTool('get_ee_details', { ee_name: 'missing' });
+            const err = parseError(result);
 
-            expect(result.isError).toBe(true);
-            expect(result.content[0].text).toContain('not found');
+            expect(err.code).toBe('NOT_FOUND');
         });
 
         it('formats full EE details', async () => {
@@ -745,13 +790,14 @@ describe('McpToolHandler', () => {
             expect(result.content[0].text).toContain('System Packages (2)');
         });
 
-        it('returns error when loadDetails throws', async () => {
+        it('returns structured error when loadDetails throws', async () => {
             hoisted.eeInstance.loadDetails.mockRejectedValue(new Error('timeout'));
 
             const result = await handler.handleTool('get_ee_details', { ee_name: 'x' });
+            const err = parseError(result);
 
-            expect(result.isError).toBe(true);
-            expect(result.content[0].text).toContain('Error loading EE details');
+            expect(err.code).toBe('SERVICE_UNAVAILABLE');
+            expect(err.recoverability).toBe('retry');
         });
     });
 
@@ -785,13 +831,14 @@ describe('McpToolHandler', () => {
     });
 
     describe('get_ansible_creator_schema', () => {
-        it('returns error when schema is null', async () => {
+        it('returns structured SERVICE_UNAVAILABLE when schema is null', async () => {
             hoisted.creatorInstance.getSchema.mockReturnValue(null);
 
             const result = await handler.handleTool('get_ansible_creator_schema', {});
+            const err = parseError(result);
 
-            expect(result.isError).toBe(true);
-            expect(result.content[0].text).toContain('ansible-creator is not available');
+            expect(err.code).toBe('SERVICE_UNAVAILABLE');
+            expect(err.message).toContain('ansible-creator');
         });
 
         it('formats schema summary', async () => {
@@ -844,14 +891,14 @@ describe('McpToolHandler', () => {
     describe('get_ansible_best_practices', () => {
         const doc = `## Guiding Principles\nDo good.\n\n### Project structure\nLayout here.\n\n#### Naming Conventions\nNames.\n`;
 
-        it('returns error when file not found', async () => {
+        it('returns structured NOT_FOUND when file not found', async () => {
             fsMock.existsSync.mockReturnValue(false);
             vi.spyOn(global, 'fetch').mockRejectedValue(new Error('network unavailable'));
 
             const result = await handler.handleTool('get_ansible_best_practices', {});
+            const err = parseError(result);
 
-            expect(result.isError).toBe(true);
-            expect(result.content[0].text).toContain('Best practices document not found');
+            expect(err.code).toBe('NOT_FOUND');
         });
 
         it('returns full document when section is full', async () => {
@@ -879,28 +926,29 @@ describe('McpToolHandler', () => {
             expect(result.content[0].text).toContain('Do good');
         });
 
-        it('returns error for unknown section', async () => {
+        it('returns structured INVALID_INPUT for unknown section', async () => {
             fsMock.existsSync.mockReturnValue(true);
             fsMock.readFileSync.mockReturnValue(doc);
 
             const result = await handler.handleTool('get_ansible_best_practices', {
                 section: 'not_a_section',
             });
+            const err = parseError(result);
 
-            expect(result.isError).toBe(true);
-            expect(result.content[0].text).toContain('Unknown section');
+            expect(err.code).toBe('INVALID_INPUT');
+            expect(err.message).toContain('Unknown section');
         });
 
-        it('returns error when known section heading is missing from file', async () => {
+        it('returns structured NOT_FOUND when known section heading is missing from file', async () => {
             fsMock.existsSync.mockReturnValue(true);
             fsMock.readFileSync.mockReturnValue('# Other doc\nNo principles here.\n');
 
             const result = await handler.handleTool('get_ansible_best_practices', {
                 section: 'principles',
             });
+            const err = parseError(result);
 
-            expect(result.isError).toBe(true);
-            expect(result.content[0].text).toContain('Section "principles" not found');
+            expect(err.code).toBe('NOT_FOUND');
         });
 
         it('stops section extraction at the next heading of same or higher level', async () => {
@@ -920,27 +968,28 @@ describe('McpToolHandler', () => {
     });
 
     describe('get_galaxy_plugin_doc', () => {
-        it('returns error for missing collection parameter', async () => {
+        it('returns structured MISSING_PARAM for missing collection', async () => {
             const result = await handler.handleTool('get_galaxy_plugin_doc', {});
-            expect(result.isError).toBe(true);
-            expect(result.content[0].text).toContain('Missing required parameter');
+            const err = parseError(result);
+            expect(err.code).toBe('MISSING_PARAM');
         });
 
-        it('returns error for invalid collection format', async () => {
+        it('returns structured INVALID_INPUT for invalid collection format', async () => {
             const result = await handler.handleTool('get_galaxy_plugin_doc', {
                 collection: 'invalid',
             });
-            expect(result.isError).toBe(true);
-            expect(result.content[0].text).toContain('namespace.name format');
+            const err = parseError(result);
+            expect(err.code).toBe('INVALID_INPUT');
         });
 
-        it('returns error when collection not found on Galaxy', async () => {
+        it('returns structured NOT_FOUND when collection not found on Galaxy', async () => {
             hoisted.galaxyInstance.getCollections.mockReturnValue([]);
             const result = await handler.handleTool('get_galaxy_plugin_doc', {
                 collection: 'unknown.col',
             });
-            expect(result.isError).toBe(true);
-            expect(result.content[0].text).toContain('not found on Galaxy');
+            const err = parseError(result);
+            expect(err.code).toBe('NOT_FOUND');
+            expect(err.message).toContain('not found on Galaxy');
         });
 
         it('lists plugin types when no plugin specified', async () => {
@@ -1038,7 +1087,7 @@ describe('McpToolHandler', () => {
             expect(text).toContain('commands');
         });
 
-        it('returns error when specific plugin not found', async () => {
+        it('returns structured NOT_FOUND when specific plugin not found', async () => {
             hoisted.galaxyInstance.getCollections.mockReturnValue([
                 {
                     namespace: 'cisco',
@@ -1054,12 +1103,11 @@ describe('McpToolHandler', () => {
                 collection: 'cisco.ios',
                 plugin: 'nonexistent',
             });
-
-            expect(result.isError).toBe(true);
-            expect(result.content[0].text).toContain('not found');
+            const err = parseError(result);
+            expect(err.code).toBe('NOT_FOUND');
         });
 
-        it('returns error when docs-blob fetch fails', async () => {
+        it('returns structured SERVICE_UNAVAILABLE when docs-blob fetch fails', async () => {
             hoisted.galaxyInstance.getCollections.mockReturnValue([
                 {
                     namespace: 'cisco',
@@ -1074,9 +1122,8 @@ describe('McpToolHandler', () => {
             const result = await handler.handleTool('get_galaxy_plugin_doc', {
                 collection: 'cisco.ios',
             });
-
-            expect(result.isError).toBe(true);
-            expect(result.content[0].text).toContain('Failed to fetch');
+            const err = parseError(result);
+            expect(err.code).toBe('SERVICE_UNAVAILABLE');
         });
 
         it('formats recursive suboptions in plugin documentation', async () => {
@@ -1128,20 +1175,20 @@ describe('McpToolHandler', () => {
     });
 
     describe('get_scm_plugin_doc', () => {
-        it('returns error for missing parameters', async () => {
+        it('returns structured MISSING_PARAM for missing parameters', async () => {
             const result = await handler.handleTool('get_scm_plugin_doc', {});
-            expect(result.isError).toBe(true);
-            expect(result.content[0].text).toContain('Missing required parameters');
+            const err = parseError(result);
+            expect(err.code).toBe('MISSING_PARAM');
         });
 
-        it('returns error for invalid collection format', async () => {
+        it('returns structured INVALID_INPUT for invalid collection format', async () => {
             const result = await handler.handleTool('get_scm_plugin_doc', {
                 org: 'test-org',
                 repo: 'test-repo',
                 collection: 'invalid',
             });
-            expect(result.isError).toBe(true);
-            expect(result.content[0].text).toContain('namespace.name format');
+            const err = parseError(result);
+            expect(err.code).toBe('INVALID_INPUT');
         });
 
         it('lists plugin types when no plugin specified', async () => {
@@ -1208,7 +1255,7 @@ describe('McpToolHandler', () => {
             expect(text).toContain('Return Values');
         });
 
-        it('returns error when plugin not found', async () => {
+        it('returns structured NOT_FOUND when plugin not found', async () => {
             hoisted.scmDocsInstance.getPluginDoc.mockResolvedValue(null);
 
             const result = await handler.handleTool('get_scm_plugin_doc', {
@@ -1217,12 +1264,11 @@ describe('McpToolHandler', () => {
                 collection: 'test.col',
                 plugin: 'nonexistent',
             });
-
-            expect(result.isError).toBe(true);
-            expect(result.content[0].text).toContain('not found');
+            const err = parseError(result);
+            expect(err.code).toBe('NOT_FOUND');
         });
 
-        it('returns error when indexing fails', async () => {
+        it('returns structured SERVICE_UNAVAILABLE when indexing fails', async () => {
             hoisted.scmDocsInstance.getPluginTypes.mockResolvedValue(null);
 
             const result = await handler.handleTool('get_scm_plugin_doc', {
@@ -1230,9 +1276,132 @@ describe('McpToolHandler', () => {
                 repo: 'test-repo',
                 collection: 'test.col',
             });
+            const err = parseError(result);
+            expect(err.code).toBe('SERVICE_UNAVAILABLE');
+        });
+    });
 
-            expect(result.isError).toBe(true);
-            expect(result.content[0].text).toContain('Failed to index');
+    describe('input validation', () => {
+        it('generate_ansible_task rejects invalid plugin_type', async () => {
+            const result = await handler.handleTool('generate_ansible_task', {
+                plugin: 'ansible.builtin.copy',
+                params: { src: 'a', dest: 'b' },
+                plugin_type: 'invalid_type',
+            });
+            const err = parseError(result);
+
+            expect(err.code).toBe('INVALID_INPUT');
+            expect(err.message).toContain('invalid_type');
+        });
+
+        it('generate_ansible_task accepts valid plugin_type', async () => {
+            const result = await handler.handleTool('generate_ansible_task', {
+                plugin: 'ansible.builtin.copy',
+                params: { src: 'a', dest: 'b' },
+                plugin_type: 'module',
+            });
+
+            expect(result.isError).toBeUndefined();
+            expect(result.content[0].text).toContain('```yaml');
+        });
+
+        it('build_ansible_task requires plugin or session_id', async () => {
+            const result = await handler.handleTool('build_ansible_task', {});
+            const err = parseError(result);
+
+            expect(err.code).toBe('MISSING_PARAM');
+            expect(err.message).toContain('plugin');
+        });
+
+        it('search_ansible_plugins clamps limit to 50', async () => {
+            await handler.handleTool('search_ansible_plugins', {
+                query: 'copy',
+                limit: 999,
+            });
+            // The search should complete without error -- the clamping is internal
+            // We verify it doesn't crash and produces a valid result
+        });
+    });
+
+    describe('get_agent_onboarding', () => {
+        it('returns successfully with no arguments', async () => {
+            const result = await handler.handleTool('get_agent_onboarding', {});
+
+            expect(result.isError).toBeUndefined();
+            expect(result.content).toHaveLength(1);
+            expect(result.content[0].text).toContain('# Agent Onboarding');
+        });
+
+        it('mentions key tool names', async () => {
+            const result = await handler.handleTool('get_agent_onboarding', {});
+            const text = result.content[0].text;
+
+            expect(text).toContain('skill_search');
+            expect(text).toContain('skill_get');
+            expect(text).toContain('generate_ansible_task');
+            expect(text).toContain('install_ansible_collection');
+            expect(text).toContain('get_ansible_best_practices');
+        });
+
+        it('covers skills guidance', async () => {
+            const result = await handler.handleTool('get_agent_onboarding', {});
+            const text = result.content[0].text;
+
+            expect(text).toContain('Skills: Use Them First');
+            expect(text).toContain('preferred over');
+        });
+
+        it('covers error handling guidance', async () => {
+            const result = await handler.handleTool('get_agent_onboarding', {});
+            const text = result.content[0].text;
+
+            expect(text).toContain('recoverability');
+            expect(text).toContain('retry');
+            expect(text).toContain('escalate');
+            expect(text).toContain('fail');
+        });
+    });
+
+    describe('get_extension_walkthrough', () => {
+        it('returns successfully with no arguments', async () => {
+            const result = await handler.handleTool('get_extension_walkthrough', {});
+
+            expect(result.isError).toBeUndefined();
+            expect(result.content).toHaveLength(1);
+            expect(result.content[0].text).toContain('# Ansible Extension Walkthrough');
+        });
+
+        it('includes all walkthrough steps', async () => {
+            const result = await handler.handleTool('get_extension_walkthrough', {});
+            const text = result.content[0].text;
+
+            expect(text).toContain('Step 1: Welcome and Workspace Discovery');
+            expect(text).toContain('Step 2: Plugin Discovery');
+            expect(text).toContain('Step 3: Task Generation');
+            expect(text).toContain('Step 4: Collections');
+            expect(text).toContain('Step 5: Skills System');
+            expect(text).toContain('Step 6: Scaffolding and Creator Tools');
+            expect(text).toContain("Step 7: What's Next");
+        });
+
+        it('references key tools the agent should call during the tour', async () => {
+            const result = await handler.handleTool('get_extension_walkthrough', {});
+            const text = result.content[0].text;
+
+            expect(text).toContain('search_ansible_plugins');
+            expect(text).toContain('get_plugin_documentation');
+            expect(text).toContain('generate_ansible_task');
+            expect(text).toContain('list_ansible_collections');
+            expect(text).toContain('skill_list');
+            expect(text).toContain('skill_get');
+        });
+
+        it('instructs the agent to be interactive', async () => {
+            const result = await handler.handleTool('get_extension_walkthrough', {});
+            const text = result.content[0].text;
+
+            expect(text).toContain('interactive walkthrough');
+            expect(text).toContain('Do NOT dump all steps at once');
         });
     });
 });

--- a/packages/mcp-server/test/skillTools.test.ts
+++ b/packages/mcp-server/test/skillTools.test.ts
@@ -62,6 +62,20 @@ describe('SkillToolGenerator', () => {
         expect(names).toContain('skill_list_sources');
     });
 
+    it('all skill tools have readOnly annotations', () => {
+        const gen = new SkillToolGenerator();
+        const tools = gen.getTools();
+        for (const tool of tools) {
+            const ann = tool.annotations;
+            expect(ann, `annotations missing on ${tool.name}`).toBeDefined();
+            if (ann) {
+                expect(ann.readOnlyHint).toBe(true);
+                expect(ann.destructiveHint).toBe(false);
+                expect(ann.idempotentHint).toBe(true);
+            }
+        }
+    });
+
     it('isSkillTool identifies skill tools', () => {
         const gen = new SkillToolGenerator();
         expect(gen.isSkillTool('skill_search')).toBe(true);
@@ -90,13 +104,14 @@ describe('SkillToolGenerator', () => {
         expect(result.content[0].text).toContain('No skills found');
     });
 
-    it('skill_search requires query parameter', async () => {
+    it('skill_search returns structured MISSING_PARAM error', async () => {
         const gen = new SkillToolGenerator();
         await gen.initialize();
 
         const result = await gen.handleTool('skill_search', {});
         expect(result.isError).toBe(true);
-        expect(result.content[0].text).toContain('query');
+        const parsed = JSON.parse(result.content[0].text);
+        expect(parsed.code).toBe('MISSING_PARAM');
     });
 
     it('skill_list returns all skills', async () => {
@@ -120,15 +135,17 @@ describe('SkillToolGenerator', () => {
         expect(result.content[0].text).toContain('Test Skill');
     });
 
-    it('skill_get requires skill_id parameter', async () => {
+    it('skill_get returns structured MISSING_PARAM error', async () => {
         const gen = new SkillToolGenerator();
         await gen.initialize();
 
         const result = await gen.handleTool('skill_get', {});
         expect(result.isError).toBe(true);
+        const parsed = JSON.parse(result.content[0].text);
+        expect(parsed.code).toBe('MISSING_PARAM');
     });
 
-    it('skill_get returns error for unknown skill', async () => {
+    it('skill_get returns structured NOT_FOUND for unknown skill', async () => {
         const gen = new SkillToolGenerator();
         await gen.initialize();
 
@@ -136,7 +153,8 @@ describe('SkillToolGenerator', () => {
             skill_id: 'nonexistent/skill',
         });
         expect(result.isError).toBe(true);
-        expect(result.content[0].text).toContain('Skill not found');
+        const parsed = JSON.parse(result.content[0].text);
+        expect(parsed.code).toBe('NOT_FOUND');
     });
 
     it('skill_list_sources shows configured sources', async () => {

--- a/packages/mcp-server/test/tools.test.ts
+++ b/packages/mcp-server/test/tools.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { STATIC_TOOLS } from '../src/tools';
+import { STATIC_TOOLS, mcpError } from '../src/tools';
+import type { McpErrorDetail } from '../src/tools';
 
 const MAX_TOOL_NAME_LENGTH = 64;
 
@@ -34,5 +35,101 @@ describe('STATIC_TOOLS', () => {
         for (const tool of STATIC_TOOLS) {
             expect(tool.name.length).toBeLessThanOrEqual(MAX_TOOL_NAME_LENGTH);
         }
+    });
+
+    it('every static tool has behavioral annotations', () => {
+        for (const tool of STATIC_TOOLS) {
+            const ann = tool.annotations;
+            expect(ann, `annotations missing on ${tool.name}`).toBeDefined();
+            if (ann) {
+                expect(typeof ann.readOnlyHint).toBe('boolean');
+                expect(typeof ann.destructiveHint).toBe('boolean');
+                expect(typeof ann.idempotentHint).toBe('boolean');
+            }
+        }
+    });
+
+    it('install_ansible_collection is marked destructive', () => {
+        const install = STATIC_TOOLS.find((t) => t.name === 'install_ansible_collection');
+        expect(install).toBeDefined();
+        if (install?.annotations) {
+            expect(install.annotations.destructiveHint).toBe(true);
+            expect(install.annotations.readOnlyHint).toBe(false);
+        }
+    });
+
+    it('read-only tools are not marked destructive', () => {
+        const readOnlyNames = [
+            'search_ansible_plugins',
+            'get_plugin_documentation',
+            'list_ansible_collections',
+            'generate_ansible_task',
+            'get_ansible_best_practices',
+        ];
+        for (const name of readOnlyNames) {
+            const tool = STATIC_TOOLS.find((t) => t.name === name);
+            expect(tool, `tool ${name} not found`).toBeDefined();
+            if (tool?.annotations) {
+                expect(tool.annotations.readOnlyHint, `${name} readOnlyHint`).toBe(true);
+                expect(tool.annotations.destructiveHint, `${name} destructiveHint`).toBe(false);
+            }
+        }
+    });
+
+    it('generate_ansible_task has plugin_type enum', () => {
+        const tool = STATIC_TOOLS.find((t) => t.name === 'generate_ansible_task');
+        expect(tool).toBeDefined();
+        if (tool) {
+            const pluginType = tool.inputSchema.properties.plugin_type as {
+                enum?: string[];
+            };
+            expect(pluginType.enum).toBeDefined();
+            expect(pluginType.enum).toContain('module');
+            expect(pluginType.enum).toContain('filter');
+        }
+    });
+
+    it('build_ansible_task has plugin_type enum and no required fields', () => {
+        const tool = STATIC_TOOLS.find((t) => t.name === 'build_ansible_task');
+        expect(tool).toBeDefined();
+        if (tool) {
+            expect(tool.inputSchema.required).toBeUndefined();
+            const pluginType = tool.inputSchema.properties.plugin_type as {
+                enum?: string[];
+            };
+            expect(pluginType.enum).toBeDefined();
+            expect(pluginType.enum).toContain('module');
+        }
+    });
+});
+
+describe('mcpError', () => {
+    it('produces a JSON-parseable structured error', () => {
+        const detail: McpErrorDetail = {
+            code: 'MISSING_PARAM',
+            recoverability: 'fail',
+            message: 'Missing required parameter: query',
+        };
+        const result = mcpError(detail);
+
+        expect(result.isError).toBe(true);
+        expect(result.content).toHaveLength(1);
+
+        const parsed = JSON.parse(result.content[0].text) as McpErrorDetail;
+        expect(parsed.code).toBe('MISSING_PARAM');
+        expect(parsed.recoverability).toBe('fail');
+        expect(parsed.message).toBe('Missing required parameter: query');
+    });
+
+    it('includes suggestion when provided', () => {
+        const result = mcpError({
+            code: 'NOT_FOUND',
+            recoverability: 'fail',
+            message: 'Plugin not found',
+            suggestion: 'Use search_ansible_plugins',
+        });
+
+        const parsed = JSON.parse(result.content[0].text) as McpErrorDetail;
+        expect(parsed.suggestion).toBe('Use search_ansible_plugins');
     });
 });

--- a/src/views/McpToolsProvider.ts
+++ b/src/views/McpToolsProvider.ts
@@ -11,7 +11,13 @@ import { CreatorService, buildMcpToolExamplePrompt } from '@ansible/services';
 import { log } from '@src/extension';
 import { getMcpStatus, McpStatus } from '@src/mcp/cursorConfig';
 
-type ToolCategory = 'discovery' | 'generation' | 'execution' | 'devtools' | 'creator';
+type ToolCategory =
+    | 'getting_started'
+    | 'discovery'
+    | 'generation'
+    | 'execution'
+    | 'devtools'
+    | 'creator';
 
 export interface ToolInfo {
     tool: McpToolDefinition;
@@ -38,6 +44,7 @@ class ToolCategoryNode extends vscode.TreeItem {
 
         // Set icons based on category
         const iconMap: Record<ToolCategory, string> = {
+            getting_started: 'rocket',
             discovery: 'search',
             generation: 'code',
             execution: 'package',
@@ -225,6 +232,9 @@ export class McpToolsProvider implements vscode.TreeDataProvider<ToolTreeItem> {
      * @returns Category used to group the tool in the tree
      */
     private _categorizeStaticTool(name: string): ToolCategory {
+        if (name === 'get_agent_onboarding' || name === 'get_extension_walkthrough') {
+            return 'getting_started';
+        }
         if (
             name.includes('search') ||
             name.includes('list') ||
@@ -279,6 +289,7 @@ export class McpToolsProvider implements vscode.TreeDataProvider<ToolTreeItem> {
 
             // Show tool categories
             const categories: { id: ToolCategory; label: string }[] = [
+                { id: 'getting_started', label: 'Getting Started' },
                 { id: 'discovery', label: 'Discovery' },
                 { id: 'generation', label: 'Task Generation' },
                 { id: 'execution', label: 'Execution Environments' },


### PR DESCRIPTION
## Summary
- Establish ADR-017 for MCP/skills compliance policy and implement it across the MCP server
- Add behavioral annotations, structured errors, input validation, and schema improvements to all tools
- Add agent onboarding and extension walkthrough tools with a new Getting Started category in the AI Tools sidebar

## Changes
- **ADR-017**: New compliance policy for MCP tools and skills, with research documents covering best practices, anti-patterns, and the skills landscape
- **Behavioral annotations**: `readOnlyHint`, `destructiveHint`, `idempotentHint` on all 17 static tools, 4 skill tools, and dynamic creator tools
- **Structured errors**: All error responses now return machine-readable JSON with `code`, `recoverability`, `message`, and optional `suggestion`
- **Input validation**: Server-side validation for `plugin_type` enums, FQCN format, and limit clamping
- **Agent onboarding tool** (`get_agent_onboarding`): Returns a structured capability guide for agents starting a new session
- **Extension walkthrough tool** (`get_extension_walkthrough`): Returns an interactive 7-step walkthrough script that guides users through the extension's capabilities
- **Getting Started category**: New top-level category in the AI Tools sidebar with rocket icon, containing both orientation tools
- **ADR-005 update**: Added Invariant 12 for MCP compliance

## Quality of life
- AI-authored additions: ADR-017, ADR-005 update, research documents (mcp-skills-landscape.md, mcp-best-practices-and-anti-patterns.md, mcp-server-recommended-practices.md)

## Test plan
- [x] `npm run ci` passes (compile + lint + test:coverage + build)
- [ ] `npm run test:ui` passes (if e2e-relevant changes)

Made with [Cursor](https://cursor.com)