### PR TITLE
ci: bump GitHub Actions to Node 24 versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,10 @@ jobs:
         node-version: [20, 22]
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
@@ -51,9 +51,9 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -65,9 +65,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-and-test
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -83,9 +83,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-and-test
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -115,9 +115,9 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -130,9 +130,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-and-test
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -143,7 +143,7 @@ jobs:
         run: npm exec vsce -- package --no-dependencies
 
       - name: Upload VSIX
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: vsix
           path: "*.vsix"

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -20,9 +20,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -32,7 +32,7 @@ jobs:
       - name: Build docs
         run: npm run docs:build
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: docs/dist
 
@@ -44,4 +44,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/release-vsix.yml
+++ b/.github/workflows/release-vsix.yml
@@ -14,11 +14,11 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.release.tag_name }}
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/wsl2-ui.yml
+++ b/.github/workflows/wsl2-ui.yml
@@ -49,10 +49,10 @@ jobs:
     timeout-minutes: 20
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -93,7 +93,7 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       # ── WSL2 Fedora setup ─────────────────────────────────────────
       - name: Enable WSL2
@@ -106,7 +106,7 @@ jobs:
 
       - name: Cache WSL distro image
         id: wsl-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: C:\wsl-cache
           key: wsl-fedora-44-base-v1
@@ -192,7 +192,7 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       # ── WSL2 Fedora setup ─────────────────────────────────────────
       - name: Enable WSL2
@@ -205,7 +205,7 @@ jobs:
 
       - name: Cache WSL distro image
         id: wsl-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: C:\wsl-cache
           key: wsl-fedora-44-base-v1


### PR DESCRIPTION
## Summary
- Bump all GitHub Actions across all 4 workflows to Node 24-compatible versions, eliminating the Node 20 deprecation warnings

## Changes
| Action | Before | After | Workflows |
|--------|--------|-------|-----------|
| `actions/checkout` | `v5` | `v7` | all 4 |
| `actions/setup-node` | `v5` | `v6` | all 4 |
| `actions/cache` | `v4` | `v5` | wsl2-ui |
| `actions/upload-artifact` | `v5` | `v7` | ci |
| `actions/upload-pages-artifact` | `v3` | `v5` | docs-deploy |
| `actions/deploy-pages` | `v4` | `v5` | docs-deploy |

`codecov/codecov-action@v7` was already current and unchanged.

## Test plan
- [ ] CI workflow passes (this PR itself validates the action bumps)
- [ ] Docs deploy workflow passes on next push to `docs/`

Made with [Cursor](https://cursor.com)