### PR TITLE
docs(python-tools): add complete documentation for ADT ecosystem tools

### DIFF
--- a/.sdlc/adrs/ADR-016-docs-as-ecosystem-hub.md
+++ b/.sdlc/adrs/ADR-016-docs-as-ecosystem-hub.md
@@ -34,24 +34,25 @@ This framing has problems:
 ## Decision
 
 **The documentation site is titled "Ansible Developer Tools" and
-structured as an ecosystem hub covering all Ansible development
-tooling, not just the VS Code extension.**
+structured as the single, authoritative documentation source for all
+Ansible development tooling — not just the VS Code extension.**
 
 The site navigation is organized by capability area, not by artifact:
 
 - **Getting Started** — ecosystem overview, installation, configuration
 - **Python Tools** — ADT, ADE, ansible-lint, ansible-creator,
-  ansible-navigator (overview pages linking to each tool's own docs)
+  ansible-navigator, ansible-builder, molecule, tox-ansible,
+  ansible-sign (complete documentation for each tool)
 - **Editor Integration** — VS Code extension, Language Server, settings
 - **AI & Agents** — MCP server, connecting AI agents
 - **Development** — contributing, architecture, testing
 - **Reference** — commands, best practices
 - **Roadmap** — feature plans
 
-The Python Tools pages link to each tool's canonical documentation
-(Read the Docs, PyPI, GitHub) rather than duplicating it. The docs site
-provides integration context — how the tools work together and how they
-connect to the editor and AI agent layers.
+The Python Tools pages provide **complete coverage** of each tool:
+concepts, installation, CLI usage, configuration reference, and
+integration with the editor and AI agent layers. This site replaces
+the individual per-tool documentation sites as the canonical source.
 
 ## Alternatives Considered
 
@@ -96,13 +97,17 @@ own marketplace identity.
   support (Neovim, JetBrains) without restructuring.
 - **AI-era ready.** The MCP server and agent connectivity have a
   first-class home rather than being buried in extension features.
-- **Reduced duplication.** Python tool pages link to canonical docs
-  rather than rewriting them.
+- **Complete coverage.** All tool documentation lives in one place,
+  eliminating the need to cross-reference multiple Read the Docs sites.
+- **Consistent voice and structure.** A single documentation site
+  ensures consistent terminology, cross-linking, and editorial quality
+  across all tools.
 
 ### Negative
 
-- **Broader maintenance scope.** The site references tools maintained by
-  other teams. Links and descriptions can drift.
+- **Broader maintenance scope.** The site owns the documentation for
+  tools maintained by other teams. Content must be kept current as
+  upstream tools release new features.
 - **Naming ambiguity.** "Ansible Developer Tools" as a docs title could
   be confused with the `ansible-dev-tools` Python package. The site
   should make the distinction clear on the landing page.
@@ -130,3 +135,4 @@ own marketplace identity.
 | Date | Author | Change |
 |------|--------|--------|
 | 2026-06-22 | — | Initial record |
+| 2026-06-23 | — | Amended: site provides complete tool coverage, replacing per-tool docs sites as canonical source |

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -43,9 +43,54 @@ export default defineConfig({
                     label: 'Python Tools',
                     items: [
                         { slug: 'python-tools/overview' },
-                        { slug: 'python-tools/ansible-lint' },
-                        { slug: 'python-tools/ansible-creator' },
-                        { slug: 'python-tools/ansible-navigator' },
+                        { slug: 'python-tools/workflow' },
+                        {
+                            label: 'Scaffold',
+                            items: [
+                                { slug: 'python-tools/ansible-creator' },
+                                {
+                                    slug: 'python-tools/ansible-creator/reference',
+                                    badge: 'Reference',
+                                },
+                                { slug: 'python-tools/ansible-dev-environment' },
+                                {
+                                    slug: 'python-tools/ansible-dev-environment/reference',
+                                    badge: 'Reference',
+                                },
+                            ],
+                        },
+                        {
+                            label: 'Validate',
+                            items: [
+                                { slug: 'python-tools/ansible-lint' },
+                                {
+                                    slug: 'python-tools/ansible-lint/reference',
+                                    badge: 'Reference',
+                                },
+                                { slug: 'python-tools/molecule' },
+                                {
+                                    slug: 'python-tools/molecule/reference',
+                                    badge: 'Reference',
+                                },
+                                { slug: 'python-tools/tox-ansible' },
+                            ],
+                        },
+                        {
+                            label: 'Execute & Ship',
+                            items: [
+                                { slug: 'python-tools/ansible-navigator' },
+                                {
+                                    slug: 'python-tools/ansible-navigator/reference',
+                                    badge: 'Reference',
+                                },
+                                { slug: 'python-tools/ansible-builder' },
+                                {
+                                    slug: 'python-tools/ansible-builder/reference',
+                                    badge: 'Reference',
+                                },
+                                { slug: 'python-tools/ansible-sign' },
+                            ],
+                        },
                     ],
                 },
                 {

--- a/docs/src/content/docs/python-tools/ansible-builder.mdx
+++ b/docs/src/content/docs/python-tools/ansible-builder.mdx
@@ -1,0 +1,503 @@
+---
+title: ansible-builder
+description: Build execution environment container images from a declarative YAML definition.
+---
+
+ansible-builder automates the creation of execution environment (EE) container images. An execution environment packages `ansible-core`, `ansible-runner`, collections, Python dependencies, and system packages into a single container image — providing a consistent, reproducible Ansible control node for development, CI/CD, and production use with Ansible Automation Platform.
+
+Builder takes a declarative YAML definition file and produces a container image through a multi-stage build process, using Podman or Docker as the container runtime.
+
+## Installation
+
+```bash
+# Via the full suite (recommended)
+pip install ansible-dev-tools
+
+# Standalone
+pip install ansible-builder
+```
+
+Verify installation:
+
+```bash
+ansible-builder --version
+```
+
+## Core concepts
+
+### Execution environments
+
+An execution environment (EE) is a container image that serves as an Ansible control node. It contains everything needed to run Ansible automation:
+
+- Python interpreter
+- `ansible-core`
+- `ansible-runner`
+- Ansible collections
+- Python package dependencies
+- System package dependencies
+
+EEs ensure that playbooks run identically across development, CI/CD, and production — eliminating "works on my machine" problems.
+
+### The definition file
+
+An `execution-environment.yml` file declares what goes into the image. Builder reads this file and generates a Containerfile/Dockerfile, then builds the image.
+
+### Four-stage build process
+
+Builder creates EE images through four internal stages, each optimized for layer caching:
+
+1. **Base stage** — Pulls the base image, installs Python interpreter, pip, `ansible-core`, and `ansible-runner`
+2. **Galaxy stage** — Downloads collections from Galaxy, collects their Python and system dependency metadata
+3. **Builder stage** — Merges Python dependencies, downloads and builds Python wheels, downloads system packages
+4. **Final stage** — Integrates all stages, installs collections, system packages, and Python packages into the final image
+
+## EE definition file (v3)
+
+Version 3 is the current and recommended schema. It has seven top-level sections:
+
+```yaml
+---
+version: 3
+
+images:
+  base_image:
+    name: docker.io/redhat/ubi9:latest
+
+dependencies:
+  ansible_core:
+    package_pip: ansible-core==2.17.0
+  ansible_runner:
+    package_pip: ansible-runner
+  galaxy: requirements.yml
+  python:
+    - boto3>=1.26
+    - requests
+    - psutil
+  system: bindep.txt
+  python_interpreter:
+    package_system: python3.12
+    python_path: /usr/bin/python3.12
+  exclude:
+    python:
+      - docker
+    system:
+      - python3-Cython
+
+build_arg_defaults:
+  ANSIBLE_GALAXY_CLI_COLLECTION_OPTS: '--pre'
+  ANSIBLE_GALAXY_CLI_ROLE_OPTS: ''
+  PKGMGR_PRESERVE_CACHE: ''
+
+additional_build_files:
+  - src: files/ansible.cfg
+    dest: configs
+  - src: scripts/
+    dest: scripts
+
+additional_build_steps:
+  prepend_base:
+    - RUN echo "Base stage prep"
+  append_base:
+    - RUN echo "Base stage done"
+  prepend_galaxy:
+    - COPY _build/configs/ansible.cfg /etc/ansible/ansible.cfg
+  append_galaxy: []
+  prepend_builder: []
+  append_builder: []
+  prepend_final:
+    - RUN whoami
+  append_final:
+    - RUN echo "Build complete"
+
+options:
+  container_init:
+    cmd: ["bash"]
+    entrypoint: ["/opt/builder/bin/entrypoint", "dumb-init"]
+    package_pip: dumb-init==1.2.5
+  package_manager_path: /usr/bin/dnf
+  skip_ansible_check: false
+  relax_passwd_permissions: true
+  workdir: /runner
+  user: 1000
+  tags:
+    - my-ee:latest
+    - my-ee:1.0.0
+```
+
+### `version`
+
+Required. Must be `3`.
+
+### `images`
+
+Defines the base container image:
+
+```yaml
+images:
+  base_image:
+    name: docker.io/redhat/ubi9:latest
+    signature_original_name: registry.redhat.io/ubi9:latest  # for mirrored images
+```
+
+Use `host/namespace/container:tag` format. The `signature_original_name` field is for verifying signed images that have been mirrored to a different registry (Podman only).
+
+### `dependencies`
+
+Declares everything the EE needs beyond the base image:
+
+#### `ansible_core` and `ansible_runner`
+
+```yaml
+dependencies:
+  ansible_core:
+    package_pip: ansible-core==2.17.0
+  ansible_runner:
+    package_pip: ansible-runner>=2.4.0
+```
+
+Values are passed directly to pip — can be version pins, URLs, or package names.
+
+#### `galaxy` (collections)
+
+Three formats supported:
+
+```yaml
+# File reference
+dependencies:
+  galaxy: requirements.yml
+
+# Inline dict
+dependencies:
+  galaxy:
+    collections:
+      - name: community.general
+      - name: ansible.utils
+        version: "3.0.0"
+      - name: company.internal
+        source: https://galaxy.internal.company.com/
+
+# Inline string
+dependencies:
+  galaxy: |
+    collections:
+      - community.general
+      - ansible.utils
+```
+
+#### `python` (Python packages)
+
+```yaml
+# File reference
+dependencies:
+  python: requirements.txt
+
+# Inline list (PEP 508 format)
+dependencies:
+  python:
+    - boto3>=1.26
+    - requests
+    - jmespath
+    - pywinrm  # for Windows hosts
+```
+
+#### `system` (system packages)
+
+```yaml
+# File reference
+dependencies:
+  system: bindep.txt
+
+# Inline list (bindep format)
+dependencies:
+  system:
+    - gcc [compile]
+    - python3-devel [compile]
+    - libffi-devel [compile]
+    - iputils [platform:rpm]
+    - openssh-clients
+```
+
+Bindep format markers:
+
+| Marker | Meaning |
+|--------|---------|
+| `[compile]` | Needed only during build, not in final image |
+| `[platform:rpm]` | Platform selector |
+| `[epel]` | Enables EPEL repos before install |
+| (no marker) | Runtime requirement, installed into final image |
+
+#### `python_interpreter`
+
+Override the Python interpreter in the base image:
+
+```yaml
+dependencies:
+  python_interpreter:
+    package_system: python3.12
+    python_path: /usr/bin/python3.12
+```
+
+#### `exclude`
+
+Exclude specific dependencies discovered from collections:
+
+```yaml
+dependencies:
+  exclude:
+    python:
+      - docker
+      - podman
+    system:
+      - python3-Cython
+    all_from_collections:
+      - community.docker
+      - ~community\..+  # regex: exclude all community.* collection deps
+```
+
+The `~` prefix enables regex matching for collection names.
+
+### `build_arg_defaults`
+
+```yaml
+build_arg_defaults:
+  ANSIBLE_GALAXY_CLI_COLLECTION_OPTS: '--pre'
+  ANSIBLE_GALAXY_CLI_ROLE_OPTS: '--force'
+  PKGMGR_PRESERVE_CACHE: always
+```
+
+### `additional_build_files`
+
+Copy files into the build context for use in custom build steps:
+
+```yaml
+additional_build_files:
+  - src: files/ansible.cfg
+    dest: configs
+  - src: scripts/post-install.sh
+    dest: scripts
+```
+
+Files are placed under `_build/<dest>/` in the build context, accessible in build steps as `COPY _build/<dest>/<filename> /target/path`.
+
+### `additional_build_steps`
+
+Inject custom commands at eight hook points in the build process:
+
+| Hook | When it runs |
+|------|-------------|
+| `prepend_base` | Before base stage operations |
+| `append_base` | After base stage operations |
+| `prepend_galaxy` | Before collection download |
+| `append_galaxy` | After collection download |
+| `prepend_builder` | Before dependency builds |
+| `append_builder` | After dependency builds |
+| `prepend_final` | Before final assembly |
+| `append_final` | After final assembly |
+
+Do NOT use `USER` directives in build steps — use `options.user` instead.
+
+### `options`
+
+```yaml
+options:
+  container_init:
+    cmd: ["bash"]
+    entrypoint: ["/opt/builder/bin/entrypoint", "dumb-init"]
+    package_pip: dumb-init==1.2.5
+  package_manager_path: /usr/bin/dnf
+  skip_ansible_check: false
+  skip_pip_install: false
+  relax_passwd_permissions: true
+  workdir: /runner
+  user: 1000
+  tags:
+    - my-ee:latest
+```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `package_manager_path` | `/usr/bin/dnf` | System package manager (also supports `microdnf`) |
+| `skip_ansible_check` | `false` | Skip validation of ansible/runner installation |
+| `skip_pip_install` | `false` | Skip pip installation into base image |
+| `relax_passwd_permissions` | `true` | Grant GID 0 write to `/etc/passwd` |
+| `workdir` | `/runner` | Working directory in the image |
+| `user` | `1000` | User ID for the image |
+| `tags` | `["ansible-execution-env:latest"]` | Image tags |
+
+## CLI reference
+
+### `ansible-builder build`
+
+Build the container image (generates context + builds):
+
+```bash
+# Basic build
+ansible-builder build
+
+# Custom tag
+ansible-builder build --tag my-org/my-ee:latest
+
+# Multiple tags
+ansible-builder build --tag my-ee:latest --tag my-ee:1.0.0
+
+# Custom definition file
+ansible-builder build --file custom-ee.yml
+
+# Use Docker instead of Podman
+ansible-builder build --container-runtime docker
+
+# Pass build arguments
+ansible-builder build --build-arg HTTP_PROXY=http://proxy:8080
+
+# Prune dangling images after build
+ansible-builder build --prune-images
+
+# Verbose output
+ansible-builder build -v 3
+```
+
+**Options:**
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--tag, -t` | Image name/tag (repeatable) | `ansible-execution-env:latest` |
+| `--file, -f` | EE definition file path | `execution-environment.yml` |
+| `--context, -c` | Build context output directory | `context` |
+| `--container-runtime` | `podman` or `docker` | `podman` |
+| `--build-arg` | Build-time variables (repeatable) | — |
+| `--prune-images` | Remove dangling images after build | `false` |
+| `--squash` | Layer squash: `new`, `all`, `off` (Podman only) | `off` |
+| `--galaxy-keyring` | GPG keyring for collection signature verification | — |
+| `--container-policy` | Image validation: `ignore_all`, `system`, `signature_required` | — |
+| `--container-keyring` | GPG keyring for container image validation | — |
+| `-v, --verbosity` | Verbosity level (0-3) | `2` |
+
+### `ansible-builder create`
+
+Generate the build context and Containerfile without building:
+
+```bash
+# Generate only
+ansible-builder create
+
+# Inspect the generated Containerfile
+cat context/Containerfile
+```
+
+Useful for:
+- Reviewing what Builder will do before building
+- Generating artifacts to build on a different platform (CI/CD)
+- Customizing the Containerfile manually before building
+
+### `ansible-builder introspect`
+
+Inspect installed collections and report their dependencies:
+
+```bash
+# Introspect default collections path
+ansible-builder introspect /usr/share/ansible/collections
+
+# Clean and deduplicate output
+ansible-builder introspect --sanitize /path/to/collections
+
+# Write combined requirements to files
+ansible-builder introspect --sanitize \
+  --write-pip requirements.txt \
+  --write-bindep bindep.txt \
+  /path/to/collections
+
+# Merge with user requirements
+ansible-builder introspect --sanitize \
+  --user-pip my-requirements.txt \
+  --user-bindep my-bindep.txt \
+  /path/to/collections
+```
+
+This is primarily useful for collection authors to verify their declared dependencies.
+
+## Collection-level dependencies
+
+Collections declare their dependencies in `meta/execution-environment.yml`:
+
+```yaml
+# meta/execution-environment.yml
+dependencies:
+  python: requirements.txt
+  system: bindep.txt
+```
+
+Or directly via files in the collection root:
+- `requirements.txt` — Python dependencies
+- `bindep.txt` — System dependencies
+
+Builder automatically discovers and merges these during the Galaxy and Builder stages.
+
+## Container runtime integration
+
+| Feature | Podman | Docker |
+|---------|--------|--------|
+| Default runtime | Yes | No (use `--container-runtime docker`) |
+| Build file name | `Containerfile` | `Dockerfile` |
+| Image signature verification | Yes (`--container-policy`) | Not supported |
+| Layer squashing | Yes (`new`, `all`, `off`) | Not supported |
+| Build args | Yes | Yes |
+| Multi-tag support | Yes | Yes |
+
+### Image signature verification (Podman only)
+
+```bash
+ansible-builder build \
+  --container-policy signature_required \
+  --container-keyring /path/to/keyring.gpg
+```
+
+Policies:
+- `ignore_all` — No signature checks
+- `system` — Use system-level `policy.json`
+- `signature_required` — All referenced images must have valid signatures
+
+## Using the community-ansible-dev-tools image as a base
+
+The ADT container image works as an EE base with all tools pre-installed:
+
+```yaml
+---
+version: 3
+images:
+  base_image:
+    name: ghcr.io/ansible/community-ansible-dev-tools:latest
+dependencies:
+  galaxy: requirements.yml
+  python: requirements.txt
+options:
+  package_manager_path: /usr/bin/dnf5
+```
+
+## Editor integration
+
+The VS Code extension integrates with ansible-builder through:
+
+- **ansible-creator** scaffolding of EE projects (generating `execution-environment.yml` with CI/CD workflows)
+- **ansible-navigator's `:builder`** subcommand for building EEs from within the navigator TUI
+- **Image introspection** to display EE contents (collections, packages, versions) in the extension's views
+
+## Migrating from v1/v2
+
+Versions 1 and 2 of the definition schema are deprecated (as of ansible-builder 3.2) and will be removed in 3.3. Key migration steps:
+
+1. Set `version: 3`
+2. Move `build_arg_defaults.EE_BASE_IMAGE` to `images.base_image.name`
+3. Remove `build_arg_defaults.EE_BUILDER_IMAGE` (no longer needed)
+4. Update `additional_build_steps` keys from `prepend`/`append` to stage-specific hooks
+
+## Next steps
+
+Your execution environment is built. Secure it for production:
+
+- [Run playbooks in your new EE with ansible-navigator](/vscode-ansible/python-tools/ansible-navigator/) — use the image you just built
+- [Sign your project with ansible-sign](/vscode-ansible/python-tools/ansible-sign/) — protect the content from tampering before deploying to Automation Platform
+
+## Links
+
+- [PyPI: ansible-builder](https://pypi.org/project/ansible-builder/)
+- [GitHub: ansible/ansible-builder](https://github.com/ansible/ansible-builder)

--- a/docs/src/content/docs/python-tools/ansible-builder/reference.mdx
+++ b/docs/src/content/docs/python-tools/ansible-builder/reference.mdx
@@ -1,0 +1,494 @@
+---
+title: "ansible-builder: Reference"
+description: Complete v3 schema specification, CLI flags, bindep format, and introspect command reference for ansible-builder.
+---
+
+This page provides exhaustive reference material for ansible-builder. For an introduction and typical usage, see the [ansible-builder guide](/vscode-ansible/python-tools/ansible-builder/).
+
+## Prerequisites
+
+- **Platform**: Linux and macOS. Windows is not supported.
+- **Python**: 3.10 or newer.
+- **Container runtime**: Podman (preferred) or Docker must be installed and accessible.
+- **Base image**: Must be RPM-based (e.g., `ubi9`, `centos-stream`). Debian/Ubuntu base images are not officially supported.
+
+## CLI reference
+
+### `ansible-builder build`
+
+```text
+ansible-builder build [options]
+```
+
+| Flag | Short | Description | Default |
+|------|-------|-------------|---------|
+| `--tag` | `-t` | Image name:tag (repeatable for multiple tags) | `ansible-execution-env:latest` |
+| `--file` | `-f` | Path to EE definition file | `execution-environment.yml` |
+| `--context` | `-c` | Output directory for build context | `context` |
+| `--container-runtime` | | `podman` or `docker` | `podman` |
+| `--build-arg` | | Build-time variable (repeatable, format: `KEY=VALUE`) | — |
+| `--extra-build-cli-args` | | Raw args passed to container build command | — |
+| `--galaxy-keyring` | | GPG keyring for collection signature verification | — |
+| `--galaxy-ignore-signature-status-code` | | Status codes to ignore during verification | — |
+| `--galaxy-required-valid-signature-count` | | Required valid signature count | — |
+| `--container-policy` | | `ignore_all`, `system`, `signature_required` (Podman only) | — |
+| `--container-keyring` | | GPG keyring for container image validation (Podman only) | — |
+| `--prune-images` | | Remove dangling images after build | `false` |
+| `--squash` | | Layer squash: `new`, `all`, `off` (Podman only) | `off` |
+| `--no-cache` | | Do not use cache when building | `false` |
+| `--verbosity` | `-v` | Verbosity level (0-3, stackable: `-vvv`) | `2` |
+| `--help` | `-h` | Show help | — |
+
+### `ansible-builder create`
+
+```text
+ansible-builder create [options]
+```
+
+Generates build context and Containerfile/Dockerfile without building. Accepts all `build` flags except `--prune-images` and `--squash`.
+
+### `ansible-builder introspect`
+
+```text
+ansible-builder introspect [options] <folder>
+```
+
+| Argument/Flag | Description | Default |
+|---------------|-------------|---------|
+| `<folder>` | Collections path containing `ansible_collections/` | `/usr/share/ansible/collections` |
+| `--sanitize` | De-duplicate and clean output | — |
+| `--user-pip <file>` | Additional pip requirements to merge | — |
+| `--user-bindep <file>` | Additional bindep requirements to merge | — |
+| `--write-pip <file>` | Write combined pip requirements to file | — |
+| `--write-bindep <file>` | Write combined bindep requirements to file | — |
+| `--exclude-collection-reqs <file>` | File listing collections to exclude | — |
+| `--verbosity` | `-v` | Verbosity (0-3) | `2` |
+
+## EE definition v3 schema (complete field reference)
+
+### `version`
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `version` | `integer` | Yes (for v3) | Must be `3`. Defaults to `1` if omitted. |
+
+### `images`
+
+```yaml
+images:
+  base_image:
+    name: <string>                    # Required. Container image URI.
+    signature_original_name: <string> # Optional. Original name for mirrored/signed images.
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `images.base_image.name` | `string` | Yes | Container image in `host/namespace/image:tag` format |
+| `images.base_image.signature_original_name` | `string` | No | Original registry name for signature verification of mirrored images (Podman only) |
+
+### `dependencies`
+
+#### `dependencies.ansible_core`
+
+```yaml
+dependencies:
+  ansible_core:
+    package_pip: <string>  # pip specifier for ansible-core
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `package_pip` | `string` | No | Pip specifier: version pin (`ansible-core==2.17.0`), URL, git ref, or just `ansible-core` |
+
+#### `dependencies.ansible_runner`
+
+```yaml
+dependencies:
+  ansible_runner:
+    package_pip: <string>  # pip specifier for ansible-runner
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `package_pip` | `string` | No | Pip specifier for ansible-runner |
+
+#### `dependencies.galaxy`
+
+Three input formats:
+
+**File reference:**
+```yaml
+dependencies:
+  galaxy: requirements.yml
+```
+
+**Inline dict:**
+```yaml
+dependencies:
+  galaxy:
+    collections:
+      - name: community.general
+      - name: ansible.utils
+        version: "3.0.0"
+      - name: company.internal
+        source: https://galaxy.internal.com/
+    roles:
+      - name: geerlingguy.docker
+```
+
+**Inline string:**
+```yaml
+dependencies:
+  galaxy: |
+    collections:
+      - community.general
+      - ansible.utils
+```
+
+#### `dependencies.python`
+
+Two input formats:
+
+**File reference:**
+```yaml
+dependencies:
+  python: requirements.txt
+```
+
+**Inline list (PEP 508 format):**
+```yaml
+dependencies:
+  python:
+    - boto3>=1.26
+    - requests
+    - jmespath
+    - "pywinrm[credssp]"  # with extras
+```
+
+#### `dependencies.system`
+
+Two input formats:
+
+**File reference:**
+```yaml
+dependencies:
+  system: bindep.txt
+```
+
+**Inline list (bindep format):**
+```yaml
+dependencies:
+  system:
+    - gcc [compile]
+    - python3-devel [compile]
+    - libffi-devel [compile]
+    - iputils [platform:rpm]
+    - openssh-clients
+```
+
+#### `dependencies.python_interpreter`
+
+```yaml
+dependencies:
+  python_interpreter:
+    package_system: <string>  # System package name (e.g., python3.12)
+    python_path: <string>     # Interpreter path (e.g., /usr/bin/python3.12)
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `package_system` | `string` | No | System package name to install |
+| `python_path` | `string` | No | Full path to Python interpreter |
+
+#### `dependencies.exclude`
+
+```yaml
+dependencies:
+  exclude:
+    python: []              # Python packages to exclude
+    system: []              # System packages to exclude
+    all_from_collections: [] # Collections whose deps to exclude
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `python` | `list[string]` | Python package names (case-insensitive match) |
+| `system` | `list[string]` | System package names (case-insensitive match) |
+| `all_from_collections` | `list[string]` | Collection FQCNs; supports `~regex` prefix |
+
+**Regex matching:**
+
+```yaml
+dependencies:
+  exclude:
+    all_from_collections:
+      - community.docker             # exact match
+      - ~community\..+               # regex: all community.* collections
+      - ~ansible\.(netcommon|utils)   # regex: specific ansible.* collections
+```
+
+### `build_arg_defaults`
+
+```yaml
+build_arg_defaults:
+  ANSIBLE_GALAXY_CLI_COLLECTION_OPTS: <string>
+  ANSIBLE_GALAXY_CLI_ROLE_OPTS: <string>
+  PKGMGR_PRESERVE_CACHE: <string>
+```
+
+| Key | Description | Example |
+|-----|-------------|---------|
+| `ANSIBLE_GALAXY_CLI_COLLECTION_OPTS` | Extra args for `ansible-galaxy collection install` | `'--pre'` |
+| `ANSIBLE_GALAXY_CLI_ROLE_OPTS` | Extra args for `ansible-galaxy role install` | `'--force'` |
+| `PKGMGR_PRESERVE_CACHE` | Keep package manager cache | `always` or empty |
+
+### `additional_build_files`
+
+```yaml
+additional_build_files:
+  - src: <string>   # Source path (file, directory, or glob)
+    dest: <string>  # Destination subdirectory under _build/
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `src` | `string` | Yes | Source path relative to definition file (or absolute) |
+| `dest` | `string` | Yes | Destination subdirectory in build context under `_build/` |
+
+Files are accessible in build steps as `_build/<dest>/<filename>`.
+
+### `additional_build_steps`
+
+```yaml
+additional_build_steps:
+  prepend_base: <string or list>
+  append_base: <string or list>
+  prepend_galaxy: <string or list>
+  append_galaxy: <string or list>
+  prepend_builder: <string or list>
+  append_builder: <string or list>
+  prepend_final: <string or list>
+  append_final: <string or list>
+```
+
+Each field accepts either a multi-line string or a list of strings. Each entry is a Dockerfile/Containerfile instruction:
+
+```yaml
+# Multi-line string format
+additional_build_steps:
+  prepend_final: |
+    RUN whoami
+    RUN cat /etc/os-release
+    COPY _build/configs/app.cfg /etc/app.cfg
+
+# List format
+additional_build_steps:
+  append_final:
+    - RUN echo "Build complete"
+    - RUN rm -rf /tmp/*
+```
+
+**Important:** Do NOT use `USER` directives in build steps. Use `options.user` instead.
+
+### `options`
+
+```yaml
+options:
+  container_init:
+    cmd: <list[string]>
+    entrypoint: <list[string]>
+    package_pip: <string>
+  package_manager_path: <string>
+  skip_ansible_check: <boolean>
+  skip_pip_install: <boolean>
+  relax_passwd_permissions: <boolean>
+  workdir: <string>
+  user: <string or integer>
+  tags: <list[string]>
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `container_init.cmd` | `list[string]` | `["bash"]` | Container CMD |
+| `container_init.entrypoint` | `list[string]` | `["/opt/builder/bin/entrypoint", "dumb-init"]` | Container ENTRYPOINT |
+| `container_init.package_pip` | `string` | `dumb-init==1.2.5` | Init system pip package |
+| `package_manager_path` | `string` | `/usr/bin/dnf` | System package manager path |
+| `skip_ansible_check` | `boolean` | `false` | Skip ansible-core/runner validation |
+| `skip_pip_install` | `boolean` | `false` | Skip pip installation into base |
+| `relax_passwd_permissions` | `boolean` | `true` | Grant GID 0 write to `/etc/passwd` |
+| `workdir` | `string` | `/runner` | Container working directory |
+| `user` | `string\|integer` | `1000` | Container user (name or UID) |
+| `tags` | `list[string]` | `["ansible-execution-env:latest"]` | Image tags |
+
+## Bindep format reference
+
+Bindep (Binary Dependency) format specifies system packages with optional platform and profile markers:
+
+```text
+<package-name> [<markers>]
+```
+
+### Marker types
+
+| Marker | Syntax | Description |
+|--------|--------|-------------|
+| Platform | `[platform:rpm]`, `[platform:dpkg]` | Package manager selector |
+| Profile | `[compile]`, `[test]` | Build phase selector |
+| EPEL | `[epel]` | Enable EPEL before install |
+
+### Profile behavior in ansible-builder
+
+| Profile | Installed in | Description |
+|---------|-------------|-------------|
+| `[compile]` | Builder stage only | Build dependencies (gcc, -devel packages) |
+| (no marker) | Final stage | Runtime dependencies |
+| `[test]` | Not installed | Informational only |
+
+### Examples
+
+```text
+# Runtime dependencies (installed in final image)
+openssh-clients
+libpq
+openssl
+
+# Build dependencies (builder stage only, not in final image)
+gcc [compile]
+python3-devel [compile]
+libffi-devel [compile]
+postgresql-devel [compile]
+
+# Platform-specific
+iputils [platform:rpm]
+inetutils-ping [platform:dpkg]
+
+# EPEL packages
+python3-saml [epel]
+```
+
+## Build process details
+
+### Stage 1: Base
+
+1. `FROM` base image
+2. Run `prepend_base` steps
+3. Install Python interpreter (if `python_interpreter` specified)
+4. Install pip (if not `skip_pip_install`)
+5. Install `ansible-core` (from `dependencies.ansible_core`)
+6. Install `ansible-runner` (from `dependencies.ansible_runner`)
+7. Install `dumb-init` (from `options.container_init.package_pip`)
+8. Run `append_base` steps
+
+### Stage 2: Galaxy
+
+1. Run `prepend_galaxy` steps
+2. Copy `requirements.yml` into build context
+3. Run `ansible-galaxy collection install` (with `ANSIBLE_GALAXY_CLI_COLLECTION_OPTS`)
+4. Run `ansible-galaxy role install` (with `ANSIBLE_GALAXY_CLI_ROLE_OPTS`)
+5. Introspect installed collections for Python and system deps
+6. Run `append_galaxy` steps
+
+### Stage 3: Builder
+
+1. Run `prepend_builder` steps
+2. Merge Python deps: definition file + collection introspection - exclusions
+3. Merge system deps: definition file + collection introspection - exclusions
+4. Install system `[compile]` packages
+5. Build Python wheels
+6. Run `append_builder` steps
+
+### Stage 4: Final
+
+1. Run `prepend_final` steps
+2. Install collections from Galaxy stage
+3. Install runtime system packages (no `[compile]` marker)
+4. Install Python packages from built wheels
+5. Set `USER`, `WORKDIR`, `CMD`, `ENTRYPOINT`
+6. Run `append_final` steps
+
+### Generated build arg
+
+The Containerfile includes `EE_BASE_IMAGE` as a build argument, enabling runtime overrides:
+
+```bash
+ansible-builder build --build-arg EE_BASE_IMAGE=different-image:tag
+```
+
+## Squash modes (Podman only)
+
+| Mode | Behavior |
+|------|----------|
+| `off` | No squashing (default) |
+| `new` | Squash new layers only (base image layers preserved) |
+| `all` | Squash all layers into one |
+
+## Container policy (Podman only)
+
+| Policy | Behavior |
+|--------|----------|
+| `ignore_all` | No signature verification |
+| `system` | Use system `policy.json` |
+| `signature_required` | Generate `policy.json` requiring valid signatures for all images |
+
+With `signature_required`, Builder generates a policy file requiring signatures from `--container-keyring` for every image referenced in the definition.
+
+## Collection dependency metadata
+
+Collections declare dependencies for EE inclusion in:
+
+### `meta/execution-environment.yml`
+
+```yaml
+---
+dependencies:
+  python: requirements.txt
+  system: bindep.txt
+```
+
+### Direct files (fallback)
+
+- `requirements.txt` in collection root
+- `bindep.txt` in collection root
+
+### Auto-excluded packages
+
+Builder automatically excludes these from introspected Python dependencies:
+
+- `ansible-core`, `ansible`
+- `pytest`, `pytest-*`
+- `mock`, `unittest2`
+- `setuptools`, `pip`, `wheel`
+- Other test and build packages
+
+Override with `--user-pip` flag on the `introspect` command.
+
+## Build context and `.build_ignore`
+
+The build context directory (default: `context/`) receives generated files. If your EE definition references `additional_build_files`, those are copied into `context/_build/`.
+
+A `.build_ignore` file (similar to `.dockerignore`) can be placed in the context directory to exclude files. However, Builder regenerates the context on every `build`/`create` invocation, so `.build_ignore` is only useful for excluding files already in a persistent context directory — not for files generated by Builder itself.
+
+## Schema version comparison
+
+| Feature | v1 | v2 | v3 |
+|---------|----|----|-----|
+| `version` field | Optional (defaults to 1) | Required: `2` | Required: `3` |
+| Base image | `build_arg_defaults.EE_BASE_IMAGE` | `images.base_image.name` | `images.base_image.name` |
+| Builder image | `build_arg_defaults.EE_BUILDER_IMAGE` | `images.builder_image.name` | Removed |
+| Image signatures | No | Yes (Podman) | Yes (Podman) |
+| Inline dependencies | No | No | Yes |
+| Python interpreter | No | No | Yes |
+| Dependency exclusion | No | No | Yes (v3.1+) |
+| Build step hooks | 2 (`prepend`, `append`) | 2 (`prepend`, `append`) | 8 (per-stage) |
+| Additional build files | No | No | Yes |
+| Options section | No | No | Yes |
+| Status | Deprecated (3.2) | Deprecated (3.2) | Current |
+
+## Migration from v1/v2
+
+1. Set `version: 3`
+2. Move `build_arg_defaults.EE_BASE_IMAGE` → `images.base_image.name`
+3. Remove `build_arg_defaults.EE_BUILDER_IMAGE` (and `images.builder_image`)
+4. Move `additional_build_steps.prepend` → `additional_build_steps.prepend_final`
+5. Move `additional_build_steps.append` → `additional_build_steps.append_final`
+6. Move `ansible_config` → `additional_build_files` + `prepend_galaxy` COPY step

--- a/docs/src/content/docs/python-tools/ansible-creator.mdx
+++ b/docs/src/content/docs/python-tools/ansible-creator.mdx
@@ -1,12 +1,289 @@
 ---
 title: ansible-creator
-description: Scaffolding tool for generating Ansible collections, roles, playbook projects, and more.
+description: Scaffolding tool for generating Ansible collections, playbook projects, roles, plugins, and execution environments.
 ---
 
-ansible-creator generates scaffolding for Ansible content -- collections, roles, playbook projects, devfiles, execution environment definitions, and more. The VS Code extension integrates ansible-creator through dynamically generated forms driven by the CLI's schema.
+ansible-creator generates project scaffolding for Ansible content — collections, playbook projects, roles, plugins, execution environment definitions, devcontainers, and devfiles. It encodes community leading practices into templates so that new projects start with CI/CD, testing, linting, and proper directory structures out of the box.
 
-- [Documentation](https://ansible.readthedocs.io/projects/creator/)
-- [PyPI](https://pypi.org/project/ansible-creator/)
-- [GitHub](https://github.com/ansible/ansible-creator)
+The VS Code extension integrates ansible-creator through dynamically generated forms driven by the CLI's schema, making scaffolding accessible without memorizing CLI flags.
 
-Content coming soon. This page will cover how ansible-creator powers the scaffolding experience in the editor.
+## Installation
+
+```bash
+# Via the full suite (recommended)
+pip install ansible-dev-tools
+
+# Standalone
+pip install ansible-creator
+```
+
+Verify installation:
+
+```bash
+ansible-creator --version
+```
+
+## Core concepts
+
+### Project types
+
+ansible-creator can scaffold three types of projects:
+
+| Type | Command | What it creates |
+|------|---------|-----------------|
+| **Collection** | `ansible-creator init collection` | Full Ansible collection with plugins, roles, tests, molecule scenarios, CI, devcontainer |
+| **Playbook** | `ansible-creator init playbook` | Playbook project with inventory, playbooks, a playbook-adjacent collection, and CI |
+| **Execution Environment** | `ansible-creator init execution_env` | EE definition file with CI/CD workflow |
+
+### Resources and plugins
+
+Beyond full projects, ansible-creator can add individual components to existing projects:
+
+| Command | What it adds |
+|---------|--------------|
+| `ansible-creator add resource devcontainer` | `.devcontainer/` directory with Docker and Podman variants |
+| `ansible-creator add resource devfile` | `devfile.yaml` |
+| `ansible-creator add resource execution-environment` | Sample `execution-environment.yml` |
+| `ansible-creator add resource role` | Role scaffold to an existing collection |
+| `ansible-creator add resource play-argspec` | Playbook argspec examples |
+| `ansible-creator add resource ee-ci` | CI files (GitHub Actions or GitLab CI) |
+| `ansible-creator add plugin module` | Module plugin scaffold |
+| `ansible-creator add plugin filter` | Filter plugin scaffold |
+| `ansible-creator add plugin action` | Action plugin scaffold |
+| `ansible-creator add plugin lookup` | Lookup plugin scaffold |
+| `ansible-creator add plugin test` | Test plugin scaffold |
+
+## CLI reference
+
+### `ansible-creator init collection`
+
+Create a new Ansible collection with full project structure.
+
+```bash
+ansible-creator init collection mynamespace.mycollection /path/to/output
+```
+
+This generates approximately 100 files including:
+
+- `galaxy.yml`, `README.md`, `LICENSE`, `CHANGELOG.rst`
+- `plugins/` with directories for modules, filters, actions, lookups, tests, and utilities
+- Sample plugins (`sample_module.py`, `sample_filter.py`, etc.)
+- `roles/run/` with the standard role directory structure
+- `tests/` with integration tests and unit test placeholders
+- `extensions/molecule/` with integration test scenarios
+- `.devcontainer/` with Docker and Podman configurations
+- `.github/workflows/` with release and test workflows
+- `.vscode/extensions.json` recommending the Ansible extension
+- `pyproject.toml`, `.pre-commit-config.yaml`
+
+**Options:**
+
+| Flag | Description |
+|------|-------------|
+| `-o, --overwrite` | Overwrite existing files |
+| `-no, --no-overwrite` | Prevent overwriting |
+| `--json` | JSON output mode |
+| `-v, --verbosity` | Verbosity level (0-3, additive) |
+| `--log-file` | Log file path |
+| `--log-level` | Log level |
+
+### `ansible-creator init playbook`
+
+Create a new playbook project.
+
+```bash
+ansible-creator init playbook mynamespace.myproject /path/to/output
+```
+
+Generates:
+
+- `ansible.cfg`, `ansible-navigator.yml`
+- `site.yml`, `linux_playbook.yml`, `network_playbook.yml`
+- `inventory/` with `hosts.yml`, `group_vars/`, `host_vars/`
+- `collections/` with an embedded playbook-adjacent collection
+- `.devcontainer/`, `.github/workflows/`, `.vscode/extensions.json`
+- `devfile.yaml`
+
+### `ansible-creator init execution_env`
+
+Create an execution environment project.
+
+```bash
+ansible-creator init execution_env /path/to/output
+```
+
+Generates:
+
+- `execution-environment.yml`
+- `.github/workflows/ee-build.yml` (or `.gitlab-ci.yml`)
+- `.gitignore`, `README.md`
+
+**EE-specific options:**
+
+| Flag | Description |
+|------|-------------|
+| `--ee-base-image <image>` | Base container image |
+| `--ee-collections <fqcn[:version]>` | Collections to include (repeatable) |
+| `--ee-python-deps <pkg>` | Python dependencies (repeatable) |
+| `--ee-system-packages <pkg>` | System packages (repeatable) |
+| `--ee-config '<json>'` | Inline JSON configuration |
+| `--ee-config-file <path>` | YAML/JSON config file path |
+| `--scm-provider <github\|gitlab>` | CI provider (default: `github`) |
+
+### `ansible-creator add resource`
+
+Add a resource to an existing project.
+
+```bash
+# Add a devcontainer with upstream image
+ansible-creator add resource devcontainer /path/to/project --image upstream
+
+# Add a role to a collection
+ansible-creator add resource role my_role /path/to/collection
+
+# Add CI for an EE project targeting GitLab
+ansible-creator add resource ee-ci /path/to/project --scm-provider gitlab
+```
+
+The `--image` flag for devcontainer accepts: `auto`, `upstream` (community image), or `aap` (Red Hat subscription image).
+
+### `ansible-creator add plugin`
+
+Add a plugin to an existing collection.
+
+```bash
+# Add a module plugin
+ansible-creator add plugin module my_module /path/to/collection
+
+# Add a filter plugin
+ansible-creator add plugin filter my_filter /path/to/collection
+```
+
+Plugin types: `action`, `filter`, `lookup`, `module`, `test`
+
+## Execution environment configuration
+
+The `init execution_env` command supports rich configuration for EE projects through three input methods (combinable):
+
+### CLI flags
+
+```bash
+ansible-creator init execution_env /path/to/output \
+  --ee-base-image docker.io/redhat/ubi9:latest \
+  --ee-collections community.general \
+  --ee-collections ansible.utils:3.0.0 \
+  --ee-python-deps boto3 \
+  --ee-system-packages gcc
+```
+
+### Inline JSON
+
+```bash
+ansible-creator init execution_env /path/to/output \
+  --ee-config '{"base_image": "docker.io/redhat/ubi9:latest", "collections": [{"name": "community.general"}]}'
+```
+
+### Config file
+
+```bash
+ansible-creator init execution_env /path/to/output \
+  --ee-config-file ee-config.yml
+```
+
+Example `ee-config.yml`:
+
+```yaml
+name: my-custom-ee
+base_image: docker.io/redhat/ubi9:latest
+collections:
+  - name: community.general
+    version: "8.0.0"
+  - name: ansible.utils
+    source: https://galaxy.ansible.com
+galaxy_servers:
+  - id: automation_hub
+    url: https://console.redhat.com/api/automation-hub/
+    token_required: true
+    validate_certs: true
+scm_servers:
+  - id: github
+    hostname: github.com
+    token_env_var: GITHUB_TOKEN
+python_deps:
+  - boto3
+  - requests>=2.28
+system_packages:
+  - gcc
+  - python3-devel
+options:
+  package_manager_path: /usr/bin/dnf5
+additional_build_steps:
+  append_final:
+    - RUN echo "Custom step"
+```
+
+**Configuration keys:**
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `name` | string | EE name |
+| `base_image` | string | Base container image URL |
+| `collections` | array | Collection entries with `name`, `version`, `type`, `source` |
+| `galaxy_servers` | array | Galaxy server entries with `id`, `url`, `auth_url`, `token_required`, `validate_certs` |
+| `scm_servers` | array | SCM provider entries with `id`, `hostname`, `token_env_var` |
+| `python_deps` | array | Python package dependencies |
+| `system_packages` | array | System packages to install |
+| `options` | object | Build options (e.g., `package_manager_path`) |
+| `additional_build_steps` | object | Custom Dockerfile steps at phases: `prepend_base`, `append_base`, `prepend_galaxy`, `prepend_final`, `append_final` |
+| `additional_build_files` | array | Extra files for build context (`src`, `dest`) |
+| `ee_file_name` | string | Override default `execution-environment.yml` name |
+| `ansible_cfg` | string | Raw `ansible.cfg` content (overrides `galaxy_servers`) |
+
+## VS Code extension integration
+
+The VS Code extension provides a graphical interface to ansible-creator through the **Ansible Development Tools** panel in the activity bar. This integration:
+
+1. **Reads schemas dynamically** from the `adt server` REST API
+2. **Renders interactive forms** for each scaffolding type (collection, playbook, EE, devcontainer, devfile)
+3. **Validates input** before invoking the CLI
+4. **Streams output** to the VS Code output panel
+
+The extension also exposes ansible-creator capabilities through the MCP server, enabling AI agents to scaffold projects programmatically.
+
+### Accessing from VS Code
+
+1. Open the Ansible section in the VS Code activity bar
+2. Navigate to "Ansible Development Tools"
+3. Select the content type to scaffold
+4. Fill in the form fields
+5. Click "Create" to generate the project
+
+### MCP server tools
+
+The MCP server exposes these ansible-creator-powered tools:
+
+- `create_playbook_project` — Scaffold a new playbook project
+- `create_collection` — Scaffold a new collection
+- `create_execution_environment` — Generate an EE definition with schema validation
+
+## Shell completion
+
+Experimental tab completion is available via `argcomplete`:
+
+```bash
+pip install argcomplete --user
+activate-global-python-argcomplete --user
+```
+
+## Next steps
+
+Your project is scaffolded. Now start developing:
+
+- [Set up an isolated environment with ansible-dev-environment](/vscode-ansible/python-tools/ansible-dev-environment/) — install your collection in editable mode for active development
+- [Lint your content with ansible-lint](/vscode-ansible/python-tools/ansible-lint/) — validate against best practices as you write
+- [Test with Molecule](/vscode-ansible/python-tools/molecule/) — the scaffolded project includes Molecule scenarios ready to run
+
+## Links
+
+- [PyPI: ansible-creator](https://pypi.org/project/ansible-creator/)
+- [GitHub: ansible/ansible-creator](https://github.com/ansible/ansible-creator)

--- a/docs/src/content/docs/python-tools/ansible-creator/reference.mdx
+++ b/docs/src/content/docs/python-tools/ansible-creator/reference.mdx
@@ -1,0 +1,379 @@
+---
+title: "ansible-creator: Reference"
+description: Complete CLI reference, scaffolded file trees, and configuration schema for ansible-creator.
+---
+
+This page provides exhaustive reference material for ansible-creator. For an introduction and typical usage, see the [ansible-creator guide](/vscode-ansible/python-tools/ansible-creator/).
+
+## CLI reference
+
+### Global options
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--version` | | Show version and exit |
+| `--help` | `-h` | Show help and exit |
+| `--json` | | Output in JSON format |
+| `--no-ansi` | `--na` | Disable colored output |
+| `--log-file` | `--lf` | Log file path (default: `./ansible-creator.log`) |
+| `--log-level` | `--ll` | Log level: `notset`, `debug`, `info`, `warning`, `error`, `critical` |
+| `--log-append` | `--la` | Append to log file (default: `true`) |
+| `--verbosity` | `-v` | Verbosity (0-3, additive: `-vvv`) |
+
+### `ansible-creator init collection`
+
+```text
+ansible-creator init collection <namespace.name> <path>
+```
+
+**Positional arguments:**
+
+| Argument | Description |
+|----------|-------------|
+| `namespace.name` | Collection namespace and name in dotted format (e.g., `myorg.myapp`) |
+| `path` | Output directory for the collection |
+
+**Options (in addition to global options):**
+
+| Flag | Short | Description | Default |
+|------|-------|-------------|---------|
+| `--overwrite` | `-o` | Overwrite existing files | — |
+| `--no-overwrite` | `-no` | Prevent overwriting (error if files exist) | — |
+| `--force` | `-f` | Force re-initialization (deprecated, use `--overwrite`) | — |
+
+### `ansible-creator init playbook`
+
+```text
+ansible-creator init playbook <collection-name> <path>
+```
+
+**Positional arguments:**
+
+| Argument | Description |
+|----------|-------------|
+| `collection-name` | Name for the playbook-adjacent collection (e.g., `myorg.myproject`) |
+| `path` | Output directory for the playbook project |
+
+**Options:** Same subcommand-specific options as `init collection` (`--overwrite`, `--no-overwrite`, `--force`), plus all global options.
+
+### `ansible-creator init execution_env`
+
+```text
+ansible-creator init execution_env <path>
+```
+
+**Positional arguments:**
+
+| Argument | Description |
+|----------|-------------|
+| `path` | Output directory for the EE project |
+
+**Options (in addition to common options):**
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--ee-base-image <image>` | Base container image | — |
+| `--ee-collections <fqcn[:version]>` | Collections to include (repeatable) | — |
+| `--ee-python-deps <pkg>` | Python dependencies (repeatable) | — |
+| `--ee-system-packages <pkg>` | System packages (repeatable) | — |
+| `--ee-config '<json>'` | Inline JSON EE configuration | — |
+| `--ee-config-file <path>` | Path to YAML/JSON EE config file | — |
+| `--scm-provider <github\|gitlab>` | SCM provider for generated CI | `github` |
+
+### `ansible-creator add resource`
+
+```text
+ansible-creator add resource <type> <path> [options]
+```
+
+**Resource types:**
+
+| Type | Description | Additional options |
+|------|-------------|-------------------|
+| `devcontainer` | `.devcontainer/` directory | `--image <auto\|upstream\|aap>` |
+| `devfile` | `devfile.yaml` | — |
+| `execution-environment` | Sample `execution-environment.yml` | — |
+| `play-argspec` | Playbook argspec examples | — |
+| `role` | Role scaffold | Takes role name as additional positional arg |
+| `ee-ci` | CI workflow for EE builds | `--scm-provider <github\|gitlab>` |
+
+### `ansible-creator add plugin`
+
+```text
+ansible-creator add plugin <type> <name> <collection-path>
+```
+
+**Plugin types:** `action`, `filter`, `lookup`, `module`, `test`
+
+**Positional arguments:**
+
+| Argument | Description |
+|----------|-------------|
+| `type` | Plugin type |
+| `name` | Plugin name (will be used as filename and class name) |
+| `collection-path` | Path to the existing collection |
+
+## Scaffolded file trees
+
+### Collection (`init collection`)
+
+```text
+<namespace>.<name>/
+├── .devcontainer/
+│   ├── docker/
+│   │   └── devcontainer.json
+│   └── podman/
+│       └── devcontainer.json
+├── .github/
+│   └── workflows/
+│       ├── release.yml
+│       └── test.yml
+├── .vscode/
+│   └── extensions.json
+├── changelogs/
+│   └── config.yaml
+├── docs/
+├── extensions/
+│   ├── eda/
+│   │   └── rulebooks/
+│   └── molecule/
+│       └── integration/
+│           ├── molecule.yml
+│           ├── converge.yml
+│           └── verify.yml
+├── meta/
+│   └── runtime.yml
+├── plugins/
+│   ├── action/
+│   │   ├── __init__.py
+│   │   └── sample_action.py
+│   ├── cache/
+│   │   └── __init__.py
+│   ├── filter/
+│   │   ├── __init__.py
+│   │   └── sample_filter.py
+│   ├── inventory/
+│   │   └── __init__.py
+│   ├── lookup/
+│   │   ├── __init__.py
+│   │   └── sample_lookup.py
+│   ├── module_utils/
+│   │   └── __init__.py
+│   ├── modules/
+│   │   ├── __init__.py
+│   │   └── sample_module.py
+│   ├── plugin_utils/
+│   │   └── __init__.py
+│   ├── sub_plugins/
+│   │   └── __init__.py
+│   └── test/
+│       ├── __init__.py
+│       └── sample_test.py
+├── roles/
+│   └── run/
+│       ├── defaults/
+│       │   └── main.yml
+│       ├── files/
+│       ├── handlers/
+│       │   └── main.yml
+│       ├── meta/
+│       │   └── main.yml
+│       ├── tasks/
+│       │   └── main.yml
+│       ├── templates/
+│       ├── tests/
+│       │   ├── inventory
+│       │   └── test.yml
+│       └── vars/
+│           └── main.yml
+├── tests/
+│   ├── integration/
+│   │   └── targets/
+│   │       └── hello_world/
+│   │           └── tasks/
+│   │               └── main.yml
+│   └── unit/
+│       └── .keep
+├── .isort.cfg
+├── .pre-commit-config.yaml
+├── .prettierignore
+├── CHANGELOG.rst
+├── CODE_OF_CONDUCT.md
+├── CONTRIBUTING
+├── LICENSE
+├── README.md
+├── galaxy.yml
+├── pyproject.toml
+└── tox.ini
+```
+
+### Playbook project (`init playbook`)
+
+```text
+<project>/
+├── .devcontainer/
+│   ├── docker/
+│   │   └── devcontainer.json
+│   └── podman/
+│       └── devcontainer.json
+├── .github/
+│   ├── ansible-code-bot.yml
+│   └── workflows/
+│       └── tests.yml
+├── .vscode/
+│   └── extensions.json
+├── collections/
+│   └── ansible_collections/
+│       └── <namespace>/
+│           └── <name>/
+│               ├── roles/
+│               │   └── run/
+│               │       ├── defaults/main.yml
+│               │       ├── handlers/main.yml
+│               │       ├── meta/main.yml
+│               │       ├── tasks/main.yml
+│               │       └── vars/main.yml
+│               └── galaxy.yml
+├── inventory/
+│   ├── group_vars/
+│   │   ├── all.yml
+│   │   └── web_servers.yml
+│   ├── host_vars/
+│   │   ├── server1.yml
+│   │   ├── server2.yml
+│   │   ├── server3.yml
+│   │   ├── switch1.yml
+│   │   └── switch2.yml
+│   └── hosts.yml
+├── ansible.cfg
+├── ansible-navigator.yml
+├── devfile.yaml
+├── linux_playbook.yml
+├── network_playbook.yml
+└── site.yml
+```
+
+### Execution environment (`init execution_env`)
+
+```text
+<project>/
+├── .github/
+│   └── workflows/
+│       └── ee-build.yml       # or .gitlab-ci.yml with --scm-provider gitlab
+├── .gitignore
+├── README.md
+└── execution-environment.yml
+```
+
+## EE configuration schema
+
+The `--ee-config-file` option accepts a YAML or JSON file with the following schema:
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `name` | `string` | Execution environment name |
+| `base_image` | `string` | Base container image URL |
+| `collections` | `array` | Collection entries (see below) |
+| `galaxy_servers` | `array` | Galaxy server entries (see below) |
+| `scm_servers` | `array` | SCM provider entries (see below) |
+| `python_deps` | `array of string` | Python package dependencies |
+| `system_packages` | `array of string` | System packages to install |
+| `options` | `object` | Build options |
+| `additional_build_steps` | `object` | Custom Dockerfile steps |
+| `additional_build_files` | `array` | Extra files for build context |
+| `ee_file_name` | `string` | Override default filename |
+| `ansible_cfg` | `string` | Raw ansible.cfg content |
+
+### `collections` entries
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | `string` | Yes | FQCN (e.g., `community.general`) |
+| `version` | `string` | No | Version constraint |
+| `type` | `string` | No | Source type |
+| `source` | `string` | No | Custom Galaxy server URL |
+
+### `galaxy_servers` entries
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | `string` | Yes | Server identifier (used in ansible.cfg section name) |
+| `url` | `string` | Yes | Galaxy server URL |
+| `auth_url` | `string` | No | SSO authentication URL |
+| `token_required` | `boolean` | No | Whether authentication is required |
+| `validate_certs` | `boolean` | No | Validate TLS certificates |
+
+### `scm_servers` entries
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | `string` | Yes | Server identifier |
+| `hostname` | `string` | Yes | SCM hostname (e.g., `github.com`) |
+| `token_env_var` | `string` | Yes | Environment variable name containing the access token |
+
+### `options` fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `package_manager_path` | `string` | Path to package manager (e.g., `/usr/bin/dnf5`) |
+
+### `additional_build_steps` fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `prepend_base` | `string or array` | Commands before base stage |
+| `append_base` | `string or array` | Commands after base stage |
+| `prepend_galaxy` | `string or array` | Commands before galaxy stage |
+| `prepend_final` | `string or array` | Commands before final stage |
+| `append_final` | `string or array` | Commands after final stage |
+
+### `additional_build_files` entries
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `src` | `string` | Yes | Source path (relative or absolute) |
+| `dest` | `string` | Yes | Destination subdirectory in build context |
+
+## Scaffolded EE in CI/CD
+
+A scaffolded execution environment project integrates with CI for automated builds:
+
+```yaml
+# .github/workflows/build-ee.yml
+name: Build Execution Environment
+on:
+  push:
+    paths:
+      - 'execution-environment.yml'
+      - 'requirements.txt'
+      - 'bindep.txt'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: pip install ansible-builder
+      - run: ansible-builder build --tag my-ee:${{ github.sha }}
+      - run: podman push my-ee:${{ github.sha }} registry.example.com/my-ee:${{ github.sha }}
+```
+
+## `adt server` REST API endpoints
+
+The VS Code extension communicates with ansible-creator through these endpoints served by `adt server`:
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/metadata` | Server information |
+| POST | `/v1/creator/playbook` | Create playbook project (v1 API) |
+| POST | `/v1/creator/collection` | Create collection (v1 API) |
+| POST | `/v2/creator/playbook` | Create playbook project (v2 API) |
+| POST | `/v2/creator/collection` | Create collection (v2 API) |
+| POST | `/v2/creator/devfile` | Create devfile |
+| POST | `/v2/creator/ee_project` | Create execution environment project |
+| GET | `/v2/creator/capabilities` | Query available scaffolding types |
+| GET | `/v2/creator/schema` | Get JSON schema for scaffolding form |
+| POST | `/v2/creator/scaffold` | Run scaffolding (dynamic, schema-driven) |

--- a/docs/src/content/docs/python-tools/ansible-dev-environment.mdx
+++ b/docs/src/content/docs/python-tools/ansible-dev-environment.mdx
@@ -1,0 +1,210 @@
+---
+title: ansible-dev-environment
+description: A pip-like tool for installing and managing Ansible collections in isolated virtual environments.
+---
+
+ansible-dev-environment (ADE) provides pip-like install semantics for Ansible collections. It creates isolated virtual environments, resolves collection and Python dependencies, and supports editable installs for active development — making it the foundation for any local Ansible content development workflow.
+
+## Installation
+
+```bash
+# Via the full suite (recommended)
+pip install ansible-dev-tools
+
+# Standalone
+pip install ansible-dev-environment
+```
+
+After installation, the `ade` command is available:
+
+```bash
+ade --version
+```
+
+## Core concepts
+
+### Why not just pip and venv?
+
+Standard Python tooling has no awareness of Ansible collections. ADE bridges this gap:
+
+| Aspect | pip/venv | ADE |
+|--------|----------|-----|
+| Collection awareness | None | Understands `galaxy.yml`, FQCN namespaces, collection dependencies |
+| Dependency resolution | Python packages only | Resolves Python deps AND collection deps (`requirements.yml`) |
+| Editable installs | `pip install -e .` for Python packages | `ade install -e .` for Ansible collections via symlinks |
+| Isolation | Isolates Python packages | Three isolation modes for collection paths |
+| Test requirements | Manual `pip install -r test-requirements.txt` | Automatic with `ade install -e .[test]` |
+
+### Isolation modes
+
+ADE provides three levels of collection path isolation:
+
+| Mode | Behavior |
+|------|----------|
+| `cfg` (default) | Creates/updates `ansible.cfg` in the current directory with `collections_path = .` |
+| `restrictive` | Exits with error if collections are found in system locations (`~/.ansible/collections`, `/usr/share/ansible/collections`) |
+| `none` | No isolation (not recommended for development) |
+
+### Editable installs
+
+When developing a collection, `ade install -e .` symlinks the collection source into the virtual environment's `ansible_collections/` namespace. Changes to your source are immediately visible to Ansible, pytest, and other tools without reinstalling.
+
+### uv acceleration
+
+ADE automatically uses [uv](https://github.com/astral-sh/uv) when available for faster virtual environment creation and package installation. Disable with `--no-uv` or `SKIP_UV=1`.
+
+## CLI reference
+
+### `ade install`
+
+Install a collection and its dependencies into a virtual environment.
+
+```bash
+# Install the current collection in editable mode
+ade install -e .
+
+# Install with test dependencies
+ade install -e .[test]
+
+# Install from a requirements file
+ade install -r requirements.yml
+
+# Specify a custom venv location
+ade install -e . --venv /path/to/venv
+
+# Use a specific Python version
+ade install -e . --python python3.12
+
+# Choose isolation mode
+ade install -e . --im restrictive
+```
+
+**Options:**
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--venv <path>` | Target virtual environment directory | `.venv` |
+| `-e, --editable` | Install in editable mode (development) | — |
+| `-r, --requirement <file>` | Install from requirements file | — |
+| `-p, --python <version>` | Python interpreter (version, name, or path) | System default |
+| `--seed / --no-seed` | Install `ansible-dev-tools` into venv | `true` |
+| `--im, --isolation-mode` | Isolation mode: `restrictive`, `cfg`, `none` | `cfg` |
+| `--acv` | Ansible core version constraint | — |
+| `--uv / --no-uv` | Use uv package manager if available | `true` |
+| `--cpi` | Collection path isolation | — |
+| `--ssp` | System site packages | — |
+
+### `ade uninstall`
+
+Remove a collection from the virtual environment.
+
+```bash
+ade uninstall namespace.collection --venv .venv
+```
+
+### `ade list`
+
+List installed collections in the environment.
+
+```bash
+ade list --venv .venv
+```
+
+### `ade inspect`
+
+Inspect installed collections with detailed metadata.
+
+```bash
+ade inspect --venv .venv
+```
+
+### `ade check`
+
+Check installed collections for issues.
+
+```bash
+ade check --venv .venv
+```
+
+### `ade tree`
+
+Display the dependency tree for installed collections.
+
+```bash
+ade tree --venv .venv
+```
+
+### Global options
+
+| Flag | Description |
+|------|-------------|
+| `--ansi / --no-ansi` | Enable/disable colored output |
+| `--lf <path>` | Log file path |
+| `--ll <level>` | Log level: `notset`, `debug`, `info`, `warning`, `error`, `critical` |
+| `--la <true\|false>` | Append to log file |
+| `-v` | Verbose output |
+| `-V, --version` | Show version |
+
+## Typical workflow
+
+### New collection development
+
+```bash
+# Clone the collection repo
+git clone git@github.com:myorg/ansible-collection-myapp.git
+cd ansible-collection-myapp
+
+# Create an isolated environment with all dependencies
+ade install -e .[test] --venv .venv
+
+# Activate the environment
+source .venv/bin/activate
+
+# Develop — changes are immediately visible
+vim plugins/modules/my_module.py
+
+# Run tests directly
+pytest tests/unit/
+
+# View dependency tree
+ade tree --venv .venv
+
+# When done, deactivate
+deactivate
+```
+
+### Working with multiple collections
+
+```bash
+# Install from a requirements file
+ade install -r requirements.yml --venv .venv
+
+# List what's installed
+ade list --venv .venv
+```
+
+### Dependency processing
+
+When installing a collection, ADE automatically processes:
+
+- `requirements.txt` — Runtime Python dependencies
+- `test-requirements.txt` — Development/testing Python dependencies (with `[test]` extra)
+- `requirements.yml` — Collection dependencies (processed by `ansible-galaxy`)
+
+## Editor integration
+
+The VS Code extension uses ADE under the hood when managing Python environments for Ansible development. The extension's environment detection locates collections installed via ADE and provides full IntelliSense support for editable installs.
+
+When you configure a Python environment in the extension settings, ADE-managed virtual environments are automatically discovered and offered as options.
+
+## Next steps
+
+With your development environment set up, you're ready to scaffold content:
+
+- [Scaffold a new project with ansible-creator](/vscode-ansible/python-tools/ansible-creator/) — generate a collection, playbook project, or execution environment
+- [Validate your content with ansible-lint](/vscode-ansible/python-tools/ansible-lint/) — catch issues as you write
+
+## Links
+
+- [PyPI: ansible-dev-environment](https://pypi.org/project/ansible-dev-environment/)
+- [GitHub: ansible/ansible-dev-environment](https://github.com/ansible/ansible-dev-environment)

--- a/docs/src/content/docs/python-tools/ansible-dev-environment/reference.mdx
+++ b/docs/src/content/docs/python-tools/ansible-dev-environment/reference.mdx
@@ -1,0 +1,167 @@
+---
+title: "ansible-dev-environment: Reference"
+description: Complete CLI reference for all ade subcommands and options.
+---
+
+This page provides exhaustive reference material for ansible-dev-environment. For an introduction and typical usage, see the [ansible-dev-environment guide](/vscode-ansible/python-tools/ansible-dev-environment/).
+
+## Global options
+
+These options apply to all `ade` subcommands:
+
+| Flag | Short | Description | Default |
+|------|-------|-------------|---------|
+| `--ansi` | | Enable colored output | `true` |
+| `--no-ansi` | | Disable colored output | — |
+| `--lf <path>` | | Log file path | — |
+| `--ll <level>` | | Log level: `notset`, `debug`, `info`, `warning`, `error`, `critical` | `notset` |
+| `--la <true\|false>` | | Append to log file | `true` |
+| `--uv` | | Use uv package manager if available | `true` |
+| `--no-uv` | | Disable uv usage | — |
+| `--verbose` | `-v` | Verbose output | — |
+| `--version` | `-V` | Show version and exit | — |
+| `--help` | `-h` | Show help and exit | — |
+
+## `ade install`
+
+Install a collection and its dependencies into a virtual environment.
+
+```text
+ade install [options] [collection_specifier]
+```
+
+| Flag | Short | Description | Default |
+|------|-------|-------------|---------|
+| `--venv <path>` | | Target virtual environment directory | `.venv` |
+| `--editable` | `-e` | Install in editable mode (symlink) | — |
+| `--requirement <file>` | `-r` | Install from requirements file | — |
+| `--python <version>` | `-p` | Python interpreter (version number, name, or full path) | System default |
+| `--seed` | | Install `ansible-dev-tools` into venv | `true` |
+| `--no-seed` | | Skip `ansible-dev-tools` installation | — |
+| `--isolation-mode <mode>` | `--im` | Isolation mode: `cfg`, `restrictive`, `none` | `cfg` |
+| `--acv <constraint>` | | Ansible core version constraint (pip format) | — |
+| `--uv` | | Use uv for package operations | `true` |
+| `--no-uv` | | Disable uv | — |
+| `--cpi` | | Collection path isolation | — |
+| `--ssp` | | Enable system site packages | — |
+
+### Collection specifier format
+
+```bash
+# Current directory
+ade install -e .
+
+# Current directory with test extras
+ade install -e .[test]
+
+# Specific collection by FQCN
+ade install namespace.name
+
+# From requirements file
+ade install -r requirements.yml
+```
+
+### Isolation modes
+
+| Mode | Behavior |
+|------|----------|
+| `cfg` | Creates/updates `ansible.cfg` with `collections_path = .` in the current directory |
+| `restrictive` | Exits with error if collections exist in `~/.ansible/collections` or `/usr/share/ansible/collections` |
+| `none` | No collection path isolation |
+
+### Dependency resolution
+
+When installing a collection, `ade install` processes these files if present:
+
+| File | Purpose | When processed |
+|------|---------|----------------|
+| `requirements.txt` | Python runtime dependencies | Always |
+| `test-requirements.txt` | Python test/dev dependencies | With `[test]` extra |
+| `requirements.yml` | Collection dependencies | Always (via `ansible-galaxy`) |
+| `galaxy.yml` | Collection metadata and version | Always |
+
+## `ade uninstall`
+
+Remove a collection from the virtual environment.
+
+```text
+ade uninstall <namespace.name> [options]
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--venv <path>` | Target virtual environment | `.venv` |
+
+## `ade list`
+
+List installed collections.
+
+```text
+ade list [options]
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--venv <path>` | Target virtual environment | `.venv` |
+
+## `ade inspect`
+
+Inspect installed collections with detailed metadata.
+
+```text
+ade inspect [options]
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--venv <path>` | Target virtual environment | `.venv` |
+
+## `ade check`
+
+Check installed collections for issues (missing dependencies, version conflicts).
+
+```text
+ade check [options]
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--venv <path>` | Target virtual environment | `.venv` |
+
+## `ade tree`
+
+Display the dependency tree for installed collections.
+
+```text
+ade tree [options]
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--venv <path>` | Target virtual environment | `.venv` |
+
+## Environment variables
+
+| Variable | Description |
+|----------|-------------|
+| `SKIP_UV` | Set to `1` to disable uv acceleration |
+
+## How editable installs work
+
+When `ade install -e .` is used:
+
+1. ADE reads `galaxy.yml` to determine the collection namespace and name
+2. Creates the virtual environment (with uv if available)
+3. Installs `ansible-dev-tools` (unless `--no-seed`)
+4. Runs `ansible-galaxy collection build` to generate the collection tarball
+5. Runs `ansible-galaxy collection install` for collection dependencies from `requirements.yml`
+6. Creates a symlink from `<venv>/lib/python<ver>/site-packages/ansible_collections/<namespace>/<name>` to the source directory
+7. Installs Python dependencies from `requirements.txt`
+8. Installs test dependencies from `test-requirements.txt` (if `[test]` extra specified)
+
+The symlink means your source edits are immediately visible to:
+- `ansible-playbook` and `ansible` commands
+- `pytest` test runners
+- `ansible-lint`
+- `molecule`
+- Any tool using the venv's Python

--- a/docs/src/content/docs/python-tools/ansible-lint.mdx
+++ b/docs/src/content/docs/python-tools/ansible-lint.mdx
@@ -1,12 +1,463 @@
 ---
 title: ansible-lint
-description: Best practices checker for Ansible content -- playbooks, roles, and collections.
+description: Best practices checker for Ansible playbooks, roles, and collections with tiered profiles and autofix.
 ---
 
-ansible-lint checks playbooks, roles, and collections for practices and behavior that could be improved. It encodes community best practices as rules and integrates with the Language Server for real-time diagnostics in your editor.
+ansible-lint checks playbooks, roles, and collections for practices and behavior that could be improved. It encodes community best practices as rules organized into tiered profiles, supports automatic fixing of common issues, and integrates with the Language Server for real-time diagnostics in your editor.
 
-- [Documentation](https://ansible.readthedocs.io/projects/lint/)
-- [PyPI](https://pypi.org/project/ansible-lint/)
-- [GitHub](https://github.com/ansible/ansible-lint)
+The tool is opinionated by design — following the same philosophy as `black` and `prettier` — promoting content that reads like documentation, is production-ready, and provides consistent results.
 
-Content coming soon. This page will cover how ansible-lint integrates with the editor and CI workflows.
+## Installation
+
+```bash
+# Via the full suite (recommended)
+pip install ansible-dev-tools
+
+# Standalone
+pip install ansible-lint
+
+# With locked dependencies (Python 3.10+, in venv)
+pip install "ansible-lint[lock]"
+
+# Fedora/RHEL
+dnf install ansible-lint
+```
+
+Verify installation:
+
+```bash
+ansible-lint --version
+```
+
+## Core concepts
+
+### Profiles
+
+ansible-lint uses a tiered profile system where each level includes all rules from the level below. Choose a profile based on your content's intended audience:
+
+| Profile | Purpose | Use when |
+|---------|---------|----------|
+| `min` | Content is parseable | You just need syntax validation |
+| `basic` | Standard style and formatting | Writing internal playbooks |
+| `moderate` | Maintainability best practices | Team-shared content |
+| `safety` | Security and determinism | Production deployments |
+| `shared` | Galaxy/Automation Hub quality | Publishing to Galaxy |
+| `production` | AAP certified/validated standards | Enterprise content |
+
+Set a profile in your config file or via CLI:
+
+```bash
+ansible-lint --profile moderate
+```
+
+### Rules
+
+ansible-lint ships with 45+ rules, each with a unique string ID. Rules check for:
+
+- **Style**: naming conventions, YAML formatting, key ordering
+- **Best practices**: FQCN usage, handler patterns, idempotency
+- **Security**: file permissions, password logging, prompts
+- **Compatibility**: deprecated modules, bare variables, free-form syntax
+- **Metadata**: galaxy.yml completeness, changelog presence, runtime.yml
+
+Rules can have sub-rules (e.g., `fqcn[action]`, `fqcn[canonical]`, `name[casing]`, `name[template]`).
+
+### Inline suppression
+
+Suppress a rule on a specific line with `# noqa`:
+
+```yaml
+- name: This task needs special permissions
+  ansible.builtin.file:
+    path: /etc/app.conf
+    mode: "0777" # noqa: risky-file-permissions
+```
+
+Suppress multiple rules:
+
+```yaml
+- name: Legacy task  # noqa: fqcn[action] no-changed-when
+  shell: /opt/legacy.sh
+```
+
+## Configuration
+
+### Config file locations
+
+ansible-lint searches for configuration in this order (within the project and parent directories, but not outside the git repo):
+
+1. `.ansible-lint`
+2. `.ansible-lint.yml`
+3. `.ansible-lint.yaml`
+4. `.config/ansible-lint.yml`
+5. `.config/ansible-lint.yaml`
+
+### Configuration reference
+
+```yaml
+# .ansible-lint
+profile: moderate
+
+# Paths to exclude from linting
+exclude_paths:
+  - .github/
+  - changelogs/
+  - molecule/
+
+# Rules to skip entirely
+skip_list:
+  - yaml[line-length]
+  - no-changed-when
+
+# Rules to report as warnings (non-blocking)
+warn_list:
+  - experimental
+  - role-name[path]
+
+# Opt-in rules to activate
+enable_list:
+  - fqcn
+  - no-log-password
+
+# Rules allowed to auto-fix (default: all)
+write_list:
+  - all
+
+# Disable network access
+offline: false
+
+# Mock unavailable modules during syntax check
+mock_modules:
+  - custom_internal_module
+
+# Mock unavailable roles during syntax check
+mock_roles:
+  - custom_internal_role
+
+# Variable naming pattern (regex)
+var_naming_pattern: "^[a-z_][a-z0-9_]*$"
+
+# Loop variable prefix pattern (regex)
+loop_var_prefix: "^(__|{role}_)"
+
+# Task name prefix for name[prefix] rule
+task_name_prefix: "{stem} | "
+
+# Maximum nested block depth
+max_block_depth: 20
+
+# Custom rule directories
+rulesdir:
+  - ./custom_rules/
+
+# Extra variables for syntax check
+extra_vars:
+  foo: bar
+
+# SARIF output file (for CI integration)
+sarif_file: ansible-lint-results.sarif
+```
+
+### Ignore file
+
+For gradual adoption, create `.ansible-lint-ignore` to suppress known violations:
+
+```text
+# Format: filename rule-id [# comment]
+playbooks/legacy.yml fqcn[action]
+roles/old_role/tasks/main.yml no-changed-when  # TODO: fix later
+```
+
+Auto-generate from current violations:
+
+```bash
+ansible-lint --generate-ignore
+```
+
+## Profiles in detail
+
+### min
+
+Ensures content is loadable by Ansible:
+
+- `internal-error` — ansible-lint internal failures
+- `load-failure` — files that cannot be loaded
+- `parser-error` — YAML/Jinja parsing failures
+- `syntax-check` — `ansible-playbook --syntax-check` failures
+
+### basic
+
+Standard formatting and style (includes all `min` rules):
+
+- `command-instead-of-module` — use modules instead of shell commands
+- `command-instead-of-shell` — use `command` when shell features aren't needed
+- `deprecated-bare-vars` / `deprecated-module` / `deprecated-local-action` — outdated syntax
+- `jinja` — Jinja2 spacing and syntax
+- `key-order` — consistent key ordering in tasks
+- `name` — task naming conventions (casing, templates, prefixes)
+- `no-free-form` — avoid free-form module arguments
+- `no-jinja-when` — don't wrap `when` values in `{{ }}`
+- `partial-become` — incomplete privilege escalation
+- `role-name` — role naming conventions
+- `schema` — validate against Ansible JSON schemas
+- `var-naming` — variable naming conventions
+- `yaml` — YAML formatting (via yamllint)
+
+### moderate
+
+Maintainability and quality (includes all `basic` rules):
+
+- `galaxy` — galaxy.yml metadata completeness
+- `ignore-errors` — avoid blanket `ignore_errors: true`
+- `meta-incorrect` / `meta-no-tags` — role metadata issues
+- `no-changed-when` — tasks that change state must declare `changed_when`
+- `no-handler` — use handlers instead of `when: result.changed`
+- `no-relative-paths` — avoid `../` in paths
+- `max-block-depth` / `max-tasks` — complexity limits
+
+### safety
+
+Security and determinism (includes all `moderate` rules):
+
+- `latest` — avoid `latest` as a version/tag
+- `no-log-password` — sensitive data must use `no_log`
+- `no-prompting` — avoid interactive prompts
+- `package-latest` — avoid `state: latest` for packages
+- `risky-file-permissions` — files must specify explicit permissions
+- `risky-octal` — catch malformed octal permissions
+- `risky-shell-pipe` — pipes must handle non-zero exit codes
+
+### shared
+
+Galaxy/Automation Hub publishing quality (includes all `safety` rules):
+
+- `galaxy[no-changelog]` — changelog required
+- `galaxy[tags]` — tags required in galaxy.yml
+- `galaxy[version-incorrect]` — valid semver version
+- `meta-runtime` — runtime.yml requirements
+- `no-tabs` — no tab characters
+
+### production
+
+AAP certified/validated content standards (includes all `shared` rules):
+
+- `avoid-dot-notation` — no dot notation for dict access
+- `fqcn` — fully qualified collection names required everywhere
+- `import-task-no-when` — no `when` on `import_tasks`
+- `meta-no-dependencies` — no collection dependencies in certified content
+- `sanity` — passes `ansible-test sanity`
+- `single-entry-point` — one role entry point
+- `use-loop` — prefer `loop` over `with_*`
+
+## Autofix
+
+ansible-lint can automatically fix many common issues:
+
+```bash
+# Fix all fixable issues
+ansible-lint --fix
+
+# Fix only specific rules
+ansible-lint --fix yaml,key-order,jinja
+```
+
+Rules with autofix support:
+
+| Rule | What it fixes |
+|------|---------------|
+| `command-instead-of-shell` | Converts `shell` to `command` when safe |
+| `deprecated-local-action` | Converts to `delegate_to: localhost` |
+| `fqcn` | Adds fully qualified collection names |
+| `jinja` | Fixes Jinja2 spacing |
+| `key-order` | Reorders task keys to standard order |
+| `name` | Fixes task name casing |
+| `no-free-form` | Converts free-form to structured arguments |
+| `no-jinja-when` | Removes `{{ }}` wrapping in `when` |
+| `no-log-password` | Adds `no_log: true` to password tasks |
+| `partial-become` | Completes partial `become` blocks |
+| `yaml` | Reformats YAML (always runs with `--fix`) |
+
+YAML reformatting always runs when `--fix` is used, regardless of `write_list` or `skip_list` settings.
+
+## CLI reference
+
+```bash
+# Lint specific files
+ansible-lint playbook.yml roles/myrole/
+
+# Lint with a specific profile
+ansible-lint --profile safety
+
+# List all available rules
+ansible-lint -L
+
+# List available profiles
+ansible-lint -P
+
+# Output in SARIF format (for CI)
+ansible-lint -f sarif --sarif-file results.sarif
+
+# Output in Code Climate format
+ansible-lint -f codeclimate
+
+# Skip specific rules
+ansible-lint -x yaml[line-length],no-changed-when
+
+# Run only specific tags
+ansible-lint -t security
+
+# Strict mode (non-zero exit on warnings)
+ansible-lint -s
+
+# Offline mode (no network)
+ansible-lint --offline
+
+# Verbose output
+ansible-lint -vvv
+```
+
+**Output formats:**
+
+| Format | Flag | Use case |
+|--------|------|----------|
+| `full` | `-f full` | Detailed human-readable output (default) |
+| `brief` | `-f brief` | Compact output |
+| `sarif` | `-f sarif` | SARIF JSON for CI integration |
+| `json` | `-f json` | Alias for SARIF |
+| `codeclimate` | `-f codeclimate` | GitLab Code Quality integration |
+| `pep8` | `-f pep8` | Compact one-line-per-finding |
+| `quiet` | `-f quiet` | Minimal output |
+| `md` | `-f md` | Markdown formatted |
+
+## YAML formatting
+
+ansible-lint uses the `yamllint` library internally with these defaults:
+
+- Line length: max 160 characters
+- Comments: 1 space minimum from content
+- Braces: max 1 space inside
+- Octal values: forbids both implicit and explicit
+- Truthy: consistent boolean formatting
+
+If you have a `.yamllint` file, it takes precedence — but it must remain compatible with the ansible-lint reformatter.
+
+## Editor integration
+
+### Language Server (LSP)
+
+ansible-lint integrates with editors via the Ansible Language Server:
+
+- **VS Code**: Official `redhat.ansible` extension
+- **Vim/Neovim**: `coc-ansible`
+- **Emacs**: `lsp-mode` with Ansible client
+
+The Language Server runs ansible-lint in the background on file open and save, presenting findings as editor diagnostics (errors and warnings).
+
+### VS Code settings
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `ansible.validation.enabled` | `true` | Enable/disable validation |
+| `ansible.validation.lint.enabled` | `true` | Enable/disable ansible-lint |
+| `ansible.validation.lint.path` | `"ansible-lint"` | Path to ansible-lint executable |
+| `ansible.validation.lint.arguments` | `""` | Extra CLI arguments |
+| `ansible.validation.lint.autoFixOnSave` | `false` | Run `--fix` on save |
+
+### How it works
+
+1. When you open or save an Ansible file, the Language Server invokes ansible-lint
+2. Findings appear as VS Code errors (rule violations) or warnings (rules in `warn_list`)
+3. Quick fixes are available for rules that support autofix
+4. If ansible-lint is unavailable, the server falls back to `ansible-playbook --syntax-check`
+
+## CI/CD integration
+
+### GitHub Actions
+
+```yaml
+- name: Run ansible-lint
+  uses: ansible/ansible-lint@main
+  with:
+    args: "--profile moderate"
+    working_directory: ./ansible/
+```
+
+### Pre-commit hook
+
+```yaml
+# .pre-commit-config.yaml
+repos:
+  - repo: https://github.com/ansible/ansible-lint
+    rev: v26.4.0
+    hooks:
+      - id: ansible-lint
+```
+
+### SARIF output for CI
+
+Generate machine-readable results alongside human output:
+
+```bash
+ansible-lint --sarif-file results.sarif
+```
+
+This writes SARIF to the file while still showing normal output on stdout — useful for uploading to GitHub Code Scanning, SonarQube, or other SARIF consumers.
+
+### Environment variables
+
+| Variable | Purpose |
+|----------|---------|
+| `ANSIBLE_LINT_NODEPS` | Skip dependency installation and module-dependent checks |
+
+## Custom rules
+
+Write custom rules by extending `AnsibleLintRule`:
+
+```python
+from ansiblelint.rules import AnsibleLintRule
+
+class MyCustomRule(AnsibleLintRule):
+    id = "custom-001"
+    description = "Ensure all tasks use company namespace"
+    severity = "MEDIUM"
+    tags = ["custom", "company"]
+
+    def matchtask(self, task, file):
+        module = task.get("action", {}).get("__ansible_module__", "")
+        if module and not module.startswith("company."):
+            return "Task uses non-company module: %s" % module
+```
+
+Place custom rules in a directory and reference it:
+
+```yaml
+# .ansible-lint
+rulesdir:
+  - ./custom_rules/
+```
+
+Custom rules with autofix support can implement `TransformMixin`:
+
+```python
+from ansiblelint.rules import AnsibleLintRule, TransformMixin
+
+class MyFixableRule(AnsibleLintRule, TransformMixin):
+    id = "custom-002"
+    # ...
+
+    def transform(self, match, lintable, data):
+        # Modify data in place to fix the issue
+        pass
+```
+
+## Next steps
+
+Your content passes linting. Now prove it works:
+
+- [Test with Molecule](/vscode-ansible/python-tools/molecule/) — verify your roles and playbooks against real infrastructure
+- [Run playbooks with ansible-navigator](/vscode-ansible/python-tools/ansible-navigator/) — execute and debug interactively or in containers
+
+## Links
+
+- [PyPI: ansible-lint](https://pypi.org/project/ansible-lint/)
+- [GitHub: ansible/ansible-lint](https://github.com/ansible/ansible-lint)

--- a/docs/src/content/docs/python-tools/ansible-lint/reference.mdx
+++ b/docs/src/content/docs/python-tools/ansible-lint/reference.mdx
@@ -1,0 +1,592 @@
+---
+title: "ansible-lint: Reference"
+description: Complete rule catalog, configuration options, profile compositions, and CLI flags for ansible-lint.
+---
+
+This page provides exhaustive reference material for ansible-lint. For an introduction and typical usage, see the [ansible-lint guide](/vscode-ansible/python-tools/ansible-lint/).
+
+## CLI flags
+
+```text
+ansible-lint [-h] [-P | -L | -T]
+  [-f {brief,full,md,json,codeclimate,quiet,pep8,sarif}]
+  [--sarif-file SARIF_FILE] [-q]
+  [--profile {min,basic,moderate,safety,shared,production}]
+  [-p] [--project-dir PROJECT_DIR] [-r RULESDIR] [-R] [-s]
+  [--fix [WRITE_LIST]] [--show-relpath] [-t TAGS] [-v]
+  [-x SKIP_LIST] [--generate-ignore] [-w WARN_LIST]
+  [--enable-list ENABLE_LIST] [--nocolor] [--force-color]
+  [--exclude EXCLUDE_PATHS [...]] [-c CONFIG_FILE]
+  [-i IGNORE_FILE] [--offline] [--version]
+  [lintables ...]
+```
+
+| Flag | Short | Description | Default |
+|------|-------|-------------|---------|
+| `--help` | `-h` | Show help | — |
+| `--list-profiles` | `-P` | List available profiles | — |
+| `--list-rules` | `-L` | List all rules with descriptions | — |
+| `--list-tags` | `-T` | List rules with their tags | — |
+| `--format` | `-f` | Output format: `brief`, `full`, `md`, `json`, `codeclimate`, `quiet`, `pep8`, `sarif` | `full` |
+| `--sarif-file` | | Write SARIF to file (alongside normal stdout) | — |
+| `--quiet` | `-q` | Quieter output | — |
+| `--profile` | | Profile: `min`, `basic`, `moderate`, `safety`, `shared`, `production` | `null` |
+| `--parseable` | `-p` | Parseable output (legacy) | — |
+| `--project-dir` | | Project root directory | auto-detected |
+| `--rulesdir` | `-r` | Custom rule directories (repeatable) | — |
+| `--use-default-rules` | `-R` | When set with `-r`, don't load default rules | — |
+| `--strict` | `-s` | Non-zero exit on warnings | — |
+| `--fix` | | Auto-fix issues (optional: comma-separated rule list) | — |
+| `--show-relpath` | | Show relative paths in output | — |
+| `--tags` | `-t` | Run only rules with these tags (comma-separated) | — |
+| `--verbose` | `-v` | Increase verbosity | — |
+| `--skip-list` | `-x` | Skip rules (comma-separated IDs or tags) | — |
+| `--generate-ignore` | | Generate `.ansible-lint-ignore` from findings | — |
+| `--warn-list` | `-w` | Report as warnings (comma-separated) | — |
+| `--enable-list` | | Enable opt-in rules (comma-separated) | — |
+| `--nocolor` | | Disable colored output | — |
+| `--force-color` | | Force colored output | — |
+| `--exclude` | | Paths to exclude (repeatable) | — |
+| `--config-file` | `-c` | Configuration file path | auto-detected |
+| `--ignore-file` | `-i` | Ignore file path | auto-detected |
+| `--yamllint-file` | | Specify alternate yamllint config file | — |
+| `--offline` | | Disable network access | — |
+| `--version` | | Show version | — |
+
+## Configuration file options
+
+Complete list of all configuration keys for `.ansible-lint` / `.ansible-lint.yml`:
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `profile` | `string\|null` | `null` | Profile level |
+| `exclude_paths` | `list[string]` | `[]` | Paths to exclude |
+| `skip_list` | `list[string]` | `[]` | Rules/tags to skip |
+| `warn_list` | `list[string]` | `[]` | Rules/tags to report as warnings |
+| `enable_list` | `list[string]` | `[]` | Opt-in rules to activate |
+| `write_list` | `list[string]` | `["all"]` | Rules allowed to auto-fix |
+| `offline` | `boolean` | `false` | Disable network |
+| `mock_modules` | `list[string]` | `[]` | Modules to mock |
+| `mock_roles` | `list[string]` | `[]` | Roles to mock |
+| `loop_var_prefix` | `string` | `"^(__|&#123;role&#125;_)"` | Loop variable regex |
+| `var_naming_pattern` | `string` | `"^[a-z_][a-z0-9_]*$"` | Variable naming regex |
+| `use_default_rules` | `boolean` | `true` | Load built-in rules |
+| `rulesdir` | `list[string]` | `[]` | Custom rule directories |
+| `extra_vars` | `dict` | `&#123;&#125;` | Variables for syntax check |
+| `kinds` | `list[dict]` | `[]` | Custom file kind mappings |
+| `task_name_prefix` | `string` | `"&#123;stem&#125; \| "` | Prefix for `name[prefix]` rule |
+| `max_block_depth` | `integer` | `20` | Max nested block depth |
+| `supported_ansible_also` | `list[string]` | `[]` | Additional Ansible versions |
+| `only_builtins_allow_collections` | `list[string]` | `[]` | Allowed collections for only-builtins |
+| `only_builtins_allow_modules` | `list[string]` | `[]` | Allowed modules for only-builtins |
+| `sarif_file` | `string` | `""` | SARIF output path |
+| `quiet` | `boolean` | `false` | Reduce output verbosity |
+| `strict` | `boolean` | `false` | Non-zero exit on warnings |
+| `verbosity` | `integer` | `0` | Verbosity level (0-3) |
+| `tags` | `list[string]` | `[]` | Report only rules with these tags |
+| `skip_action_validation` | `boolean` | `false` | Skip action validation for tasks |
+
+### CLI override behavior
+
+- Scalar options (profile, config_file): CLI **replaces** config value
+- List options (skip_list, warn_list, exclude_paths): CLI **extends** config value
+
+## Complete rule catalog
+
+### args
+
+| Sub-rule | Description | Profile |
+|----------|-------------|---------|
+| `args[module]` | Validate module arguments against schema | `basic` |
+
+### avoid-implicit
+
+| Sub-rule | Description | Profile |
+|----------|-------------|---------|
+| `avoid-implicit[copy-content]` | Non-string content passed to copy module | `production` |
+
+### command-instead-of-module
+
+| Sub-rule | Description | Profile | Autofix |
+|----------|-------------|---------|---------|
+| `command-instead-of-module` | Use Ansible module instead of shell command | `basic` | — |
+
+### command-instead-of-shell
+
+| Sub-rule | Description | Profile | Autofix |
+|----------|-------------|---------|---------|
+| `command-instead-of-shell` | Use `command` instead of `shell` when shell features aren't used | `basic` | Yes |
+
+### complexity
+
+| Sub-rule | Description | Profile |
+|----------|-------------|---------|
+| `complexity[nesting]` | Excessive block nesting (exceeds `max_block_depth`) | `moderate` |
+| `complexity[tasks]` | Too many tasks in a file (exceeds `max_tasks`, default: 100) | `moderate` |
+| `complexity[play]` | Too many tasks at play level | `moderate` |
+
+### deprecated-bare-vars
+
+| Sub-rule | Description | Profile |
+|----------|-------------|---------|
+| `deprecated-bare-vars` | Do not use bare variables in loops | `basic` |
+
+### deprecated-local-action
+
+| Sub-rule | Description | Profile | Autofix |
+|----------|-------------|---------|---------|
+| `deprecated-local-action` | Use `delegate_to: localhost` instead | `basic` | Yes |
+
+### deprecated-module
+
+| Sub-rule | Description | Profile |
+|----------|-------------|---------|
+| `deprecated-module` | Avoid deprecated modules | `basic` |
+
+### empty-string-compare
+
+| Sub-rule | Description | Profile |
+|----------|-------------|---------|
+| `empty-string-compare` | Don't compare to empty string | `basic` |
+
+### fqcn
+
+| Sub-rule | Description | Profile | Autofix |
+|----------|-------------|---------|---------|
+| `fqcn[action]` | Use FQCN for module/action names | `production` | Yes |
+| `fqcn[action-core]` | Use FQCN for builtin module names | `production` | Yes |
+| `fqcn[canonical]` | Use canonical FQCN | `production` | Yes |
+| `fqcn[deep]` | Use FQCN in all contexts | `production` | Yes |
+| `fqcn[keyword]` | Use FQCN for keyword values | `production` | Yes |
+
+### galaxy
+
+| Sub-rule | Description | Profile |
+|----------|-------------|---------|
+| `galaxy[no-changelog]` | Collection must have a changelog | `shared` |
+| `galaxy[no-runtime]` | Collection must have `meta/runtime.yml` | `moderate` |
+| `galaxy[tags]` | galaxy.yml must have tags | `shared` |
+| `galaxy[version-incorrect]` | galaxy.yml version must be valid semver | `shared` |
+| `galaxy[version-missing]` | galaxy.yml must have version | `shared` |
+| `galaxy[tags-format]` | Tags must match regex format | `shared` |
+| `galaxy[tags-length]` | Tags cannot exceed 64 characters | `shared` |
+| `galaxy[tags-count]` | Cannot exceed 20 tags | `shared` |
+| `galaxy[invalid-dependency-version]` | Invalid dependency version range | `shared` |
+
+### ignore-errors
+
+| Sub-rule | Description | Profile |
+|----------|-------------|---------|
+| `ignore-errors` | Avoid using `ignore_errors` | `moderate` |
+
+### inline-env-var
+
+| Sub-rule | Description | Profile |
+|----------|-------------|---------|
+| `inline-env-var` | Don't use inline environment variables | `basic` |
+
+### internal-error
+
+| Sub-rule | Description | Profile |
+|----------|-------------|---------|
+| `internal-error` | ansible-lint internal error | `min` |
+
+### jinja
+
+| Sub-rule | Description | Profile | Autofix |
+|----------|-------------|---------|---------|
+| `jinja[invalid]` | Invalid Jinja2 syntax | `basic` | — |
+| `jinja[spacing]` | Jinja2 spacing | `basic` | Yes |
+
+### key-order
+
+| Sub-rule | Description | Profile | Autofix |
+|----------|-------------|---------|---------|
+| `key-order[task]` | Task key ordering | `basic` | Yes |
+| `key-order[play]` | Play key ordering | `basic` | Yes |
+
+### latest
+
+| Sub-rule | Description | Profile |
+|----------|-------------|---------|
+| `latest[git]` | Git version must be pinned | `safety` |
+| `latest[hg]` | Mercurial version must be pinned | `safety` |
+
+### literal-compare
+
+| Sub-rule | Description | Profile |
+|----------|-------------|---------|
+| `literal-compare` | Don't compare to literal True/False | `basic` |
+
+### load-failure
+
+| Sub-rule | Description | Profile |
+|----------|-------------|---------|
+| `load-failure[*]` | File could not be loaded | `min` |
+
+### loop-var-prefix
+
+| Sub-rule | Description | Profile |
+|----------|-------------|---------|
+| `loop-var-prefix` | Loop variables must match prefix pattern | `basic` |
+
+### meta-incorrect
+
+| Sub-rule | Description | Profile |
+|----------|-------------|---------|
+| `meta-incorrect` | meta/main.yml has invalid content | `moderate` |
+
+### meta-no-tags
+
+| Sub-rule | Description | Profile |
+|----------|-------------|---------|
+| `meta-no-tags` | Role meta must have tags | `moderate` |
+
+### meta-runtime
+
+| Sub-rule | Description | Profile |
+|----------|-------------|---------|
+| `meta-runtime[unsupported-version]` | runtime.yml specifies unsupported version | `shared` |
+
+### meta-video-links
+
+| Sub-rule | Description | Profile |
+|----------|-------------|---------|
+| `meta-video-links` | meta/main.yml video links must be valid | `moderate` |
+
+### name
+
+| Sub-rule | Description | Profile | Autofix |
+|----------|-------------|---------|---------|
+| `name[casing]` | Task name casing | `basic` | Yes |
+| `name[missing]` | Task must have a name | `basic` | — |
+| `name[play]` | Play must have a name | `basic` | — |
+| `name[prefix]` | Task name must match prefix pattern | `basic` | Yes |
+| `name[template]` | Task name should not be templated | `basic` | — |
+| `name[unique]` | All task names within a play must be unique | `basic` | — |
+
+### no-changed-when
+
+| Sub-rule | Description | Profile |
+|----------|-------------|---------|
+| `no-changed-when` | Tasks that may change must have `changed_when` | `moderate` |
+
+### no-free-form
+
+| Sub-rule | Description | Profile | Autofix |
+|----------|-------------|---------|---------|
+| `no-free-form` | Avoid free-form module arguments | `basic` | Yes |
+
+### no-handler
+
+| Sub-rule | Description | Profile |
+|----------|-------------|---------|
+| `no-handler` | Use handlers instead of `when: result.changed` | `moderate` |
+
+### no-jinja-when
+
+| Sub-rule | Description | Profile | Autofix |
+|----------|-------------|---------|---------|
+| `no-jinja-when` | Don't wrap `when` in `{{ }}` | `basic` | Yes |
+
+### no-log-password
+
+| Sub-rule | Description | Profile | Autofix |
+|----------|-------------|---------|---------|
+| `no-log-password` | Password tasks must use `no_log` | `safety` | Yes |
+
+### no-prompting
+
+| Sub-rule | Description | Profile |
+|----------|-------------|---------|
+| `no-prompting` | Avoid interactive `vars_prompt` | `safety` |
+
+### no-relative-paths
+
+| Sub-rule | Description | Profile |
+|----------|-------------|---------|
+| `no-relative-paths` | Don't use `../` in paths | `moderate` |
+
+### no-same-owner
+
+| Sub-rule | Description | Profile |
+|----------|-------------|---------|
+| `no-same-owner` | Don't use `--same-owner` in tar commands | `safety` |
+
+### no-tabs
+
+| Sub-rule | Description | Profile |
+|----------|-------------|---------|
+| `no-tabs` | No tab characters | `shared` |
+
+### only-builtins
+
+| Sub-rule | Description | Profile |
+|----------|-------------|---------|
+| `only-builtins` | Only use builtin modules | opt-in |
+
+### package-latest
+
+| Sub-rule | Description | Profile |
+|----------|-------------|---------|
+| `package-latest` | Don't use `state: latest` | `safety` |
+
+### parser-error
+
+| Sub-rule | Description | Profile |
+|----------|-------------|---------|
+| `parser-error` | YAML/Jinja2 parsing error | `min` |
+
+### partial-become
+
+| Sub-rule | Description | Profile | Autofix |
+|----------|-------------|---------|---------|
+| `partial-become[play]` | Incomplete become at play level | `basic` | Yes |
+| `partial-become[task]` | Incomplete become at task level | `basic` | Yes |
+
+### playbook-extension
+
+| Sub-rule | Description | Profile |
+|----------|-------------|---------|
+| `playbook-extension` | Playbook files should use `.yml` extension | `basic` |
+
+### risky-file-permissions
+
+| Sub-rule | Description | Profile |
+|----------|-------------|---------|
+| `risky-file-permissions` | File tasks must specify `mode` | `safety` |
+
+### risky-octal
+
+| Sub-rule | Description | Profile |
+|----------|-------------|---------|
+| `risky-octal` | Octal file modes must be correct | `safety` |
+
+### risky-shell-pipe
+
+| Sub-rule | Description | Profile |
+|----------|-------------|---------|
+| `risky-shell-pipe` | Shell pipes must handle failures | `safety` |
+
+### role-name
+
+| Sub-rule | Description | Profile |
+|----------|-------------|---------|
+| `role-name[path]` | Role directory name conventions | `basic` |
+
+### run-once
+
+| Sub-rule | Description | Profile |
+|----------|-------------|---------|
+| `run-once[play]` | Caution with `run_once` in plays | `moderate` |
+| `run-once[task]` | Caution with `run_once` on tasks | `moderate` |
+
+### sanity
+
+| Sub-rule | Description | Profile |
+|----------|-------------|---------|
+| `sanity[*]` | Passes ansible-test sanity | `production` |
+| `sanity[cannot-ignore]` | Ignore file contains a disallowed test | `production` |
+| `sanity[bad-ignore]` | Ignore file entry is formatted incorrectly | `production` |
+
+### schema
+
+| Sub-rule | Description | Profile |
+|----------|-------------|---------|
+| `schema[*]` | Validates against Ansible JSON schemas | `basic` |
+| `schema[moves]` | Module has moved between versions | `basic` |
+| `schema[changelog]` | Validates changelog schema | `basic` |
+| `schema[molecule]` | Validates molecule config | `basic` |
+| `schema[rulebook]` | Validates EDA rulebooks | `basic` |
+
+### syntax-check
+
+| Sub-rule | Description | Profile |
+|----------|-------------|---------|
+| `syntax-check[*]` | Passes `ansible-playbook --syntax-check` | `min` |
+
+### var-naming
+
+| Sub-rule | Description | Profile |
+|----------|-------------|---------|
+| `var-naming[no-jinja]` | Variable names must not contain Jinja | `basic` |
+| `var-naming[no-keyword]` | Variable names must not be Python keywords | `basic` |
+| `var-naming[no-reserved]` | Variable names must not be Ansible reserved | `basic` |
+| `var-naming[pattern]` | Variable names must match pattern | `basic` |
+| `var-naming[read-only]` | Don't override read-only variables | `basic` |
+
+### warning
+
+| Sub-rule | Description | Profile |
+|----------|-------------|---------|
+| `warning[raw-non-string]` | Raw non-string values | `basic` |
+
+### yaml
+
+| Sub-rule | Description | Profile | Autofix |
+|----------|-------------|---------|---------|
+| `yaml[brackets]` | Bracket spacing | `basic` | Yes |
+| `yaml[colons]` | Colon spacing | `basic` | Yes |
+| `yaml[commas]` | Comma spacing | `basic` | Yes |
+| `yaml[comments]` | Comment formatting | `basic` | Yes |
+| `yaml[comments-indentation]` | Comment indentation | `basic` | Yes |
+| `yaml[document-end]` | Document end marker | `basic` | Yes |
+| `yaml[document-start]` | Document start marker | `basic` | Yes |
+| `yaml[empty-lines]` | Empty line count | `basic` | Yes |
+| `yaml[empty-values]` | Empty values | `basic` | Yes |
+| `yaml[hyphens]` | Hyphen spacing | `basic` | Yes |
+| `yaml[indentation]` | Indentation | `basic` | Yes |
+| `yaml[key-duplicates]` | Duplicate keys | `basic` | — |
+| `yaml[key-ordering]` | Key ordering | `basic` | Yes |
+| `yaml[line-length]` | Line length (max 160) | `basic` | — |
+| `yaml[new-line-at-end-of-file]` | Trailing newline | `basic` | Yes |
+| `yaml[octal-values]` | Octal value formatting | `basic` | Yes |
+| `yaml[trailing-spaces]` | Trailing whitespace | `basic` | Yes |
+| `yaml[truthy]` | Boolean formatting | `basic` | Yes |
+
+## Profile compositions
+
+Each profile includes all rules from the profile below it. These tables show which rules are **added** at each level.
+
+### min (base)
+
+`internal-error`, `load-failure`, `parser-error`, `syntax-check`
+
+### basic (adds to min)
+
+`args`, `command-instead-of-module`, `command-instead-of-shell`, `deprecated-bare-vars`, `deprecated-local-action`, `deprecated-module`, `empty-string-compare`, `inline-env-var`, `jinja`, `key-order`, `literal-compare`, `loop-var-prefix`, `name`, `no-free-form`, `no-jinja-when`, `partial-become`, `playbook-extension`, `role-name`, `schema`, `var-naming`, `warning`, `yaml`
+
+### moderate (adds to basic)
+
+`complexity`, `galaxy[no-runtime]`, `galaxy[version-missing]`, `ignore-errors`, `meta-incorrect`, `meta-no-tags`, `meta-video-links`, `no-changed-when`, `no-handler`, `no-relative-paths`, `run-once`
+
+### safety (adds to moderate)
+
+`latest`, `no-log-password`, `no-prompting`, `no-same-owner`, `package-latest`, `risky-file-permissions`, `risky-octal`, `risky-shell-pipe`
+
+### shared (adds to safety)
+
+`galaxy[no-changelog]`, `galaxy[tags]`, `galaxy[version-incorrect]`, `meta-runtime`, `no-tabs`
+
+### production (adds to shared)
+
+`avoid-implicit`, `fqcn`, `sanity`
+
+## yamllint defaults
+
+ansible-lint uses yamllint internally with these built-in defaults:
+
+```yaml
+extends: default
+rules:
+  comments:
+    min-spaces-from-content: 1
+  comments-indentation: false
+  document-start: disable
+  document-end: disable
+  line-length:
+    max: 160
+  braces:
+    max-spaces-inside: 1
+  octal-values:
+    forbid-implicit-octal: true
+    forbid-explicit-octal: true
+  truthy:
+    allowed-values:
+      - "true"
+      - "false"
+      - "yes"
+      - "no"
+```
+
+A `.yamllint` file in your project takes precedence, but must remain compatible with the ansible-lint reformatter when using `--fix`.
+
+## Ignore file format
+
+File: `.ansible-lint-ignore` or `.config/ansible-lint-ignore.txt`
+
+```text
+# Format: <filename> <rule-id> [# comment]
+# Use 'skip' suffix to suppress the "ignored" warning:
+
+playbooks/legacy.yml fqcn[action]
+playbooks/legacy.yml no-changed-when  # TODO: fix in Q3
+roles/old_role/tasks/main.yml command-instead-of-shell skip
+```
+
+## Output format details
+
+### SARIF (recommended for CI)
+
+```bash
+ansible-lint -f sarif
+# or
+ansible-lint -f json  # alias
+```
+
+Produces SARIF v2.1.0 JSON. Upload to GitHub Code Scanning, SonarQube, or any SARIF consumer.
+
+### Code Climate
+
+```bash
+ansible-lint -f codeclimate
+```
+
+Maps severity: warnings → `minor`, errors → `major`. Used by GitLab Code Quality.
+
+### Dual output (human + machine)
+
+```bash
+ansible-lint --sarif-file results.sarif
+```
+
+Writes SARIF to file while showing normal human-readable output on stdout.
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | No issues found |
+| `1` | Lint issues found (violations) |
+| `2` | Lint issues found (errors during linting) |
+
+With `--strict` (`-s`): warnings also cause non-zero exit.
+
+## Behavioral notes
+
+### Execution directory
+
+As of v25.7.0, ansible-lint must be run from the project root. Running from a subdirectory may produce zero findings.
+
+### GitHub Actions annotations
+
+When `GITHUB_ACTIONS=true` and `GITHUB_WORKFLOW` are detected, ansible-lint automatically outputs GitHub annotation format.
+
+### `.cache` implicit exclude
+
+The `.cache/` directory is automatically excluded unless `exclude_paths` is explicitly defined in the config file.
+
+### Requirements auto-discovery
+
+ansible-lint searches these locations for dependencies to install automatically:
+- `requirements.yml`
+- `roles/requirements.yml`
+- `collections/requirements.yml`
+- `tests/requirements.yml`
+- `tests/integration/requirements.yml`
+- `tests/unit/requirements.yml`
+- `galaxy.yml`
+
+### Ignore file alternate location
+
+In addition to `.ansible-lint-ignore`, the file `.config/ansible-lint-ignore.txt` is also searched.
+
+## Environment variables
+
+| Variable | Description |
+|----------|-------------|
+| `ANSIBLE_LINT_NODEPS` | Skip dependency installation and module-dependent checks |
+| `ANSIBLE_LINT_CUSTOM_RULESDIR` | Additional rules lookup path |
+| `ANSIBLE_LINT_IGNORE_FILE` | Override default ignore file name |
+| `ANSIBLE_LINT_WRITE_TMP` | Dump fixes to temp files instead of overwriting (for testing) |
+| `ANSIBLE_LINT_SKIP_SCHEMA_UPDATE` | Skip schema refresh |

--- a/docs/src/content/docs/python-tools/ansible-navigator.mdx
+++ b/docs/src/content/docs/python-tools/ansible-navigator.mdx
@@ -1,12 +1,440 @@
 ---
 title: ansible-navigator
-description: A text-based user interface for running and developing Ansible content.
+description: A text-based user interface for running, developing, and troubleshooting Ansible content with execution environment support.
 ---
 
-ansible-navigator provides a TUI for running playbooks, browsing collections, inspecting execution environments, and managing Ansible configuration. It supports both direct execution and execution environment (container) modes.
+ansible-navigator is a command-line tool and text-based user interface (TUI) for creating, reviewing, running, and troubleshooting Ansible content. It serves as the primary interface for running playbooks — either directly or inside execution environment containers — and provides interactive exploration of collections, inventories, configurations, and documentation.
 
-- [Documentation](https://ansible.readthedocs.io/projects/navigator/)
-- [PyPI](https://pypi.org/project/ansible-navigator/)
-- [GitHub](https://github.com/ansible/ansible-navigator)
+Navigator acts as an orchestrator between the user and a container engine (Podman or Docker), running Ansible content with the same isolation and reproducibility you get in production with Ansible Automation Platform.
 
-Content coming soon. This page will cover how ansible-navigator integrates with the editor's playbook execution features.
+## Installation
+
+```bash
+# Via the full suite (recommended)
+pip install ansible-dev-tools
+
+# Standalone
+pip install ansible-navigator
+```
+
+Verify installation:
+
+```bash
+ansible-navigator --version
+```
+
+## Core concepts
+
+### Execution environments (EE)
+
+An execution environment is a container image that serves as an Ansible control node. It contains Python, `ansible-core`, `ansible-runner`, collections, Python dependencies, and system packages — everything needed to run your playbooks consistently.
+
+By default, Navigator runs with EE **enabled** — all commands execute inside a container. This ensures your playbooks run the same way locally as they do in CI/CD and Ansible Automation Platform.
+
+### TUI vs stdout modes
+
+Navigator has two output modes:
+
+| Mode | Description | Best for |
+|------|-------------|----------|
+| **interactive** (default) | Curses-based TUI with drill-down navigation | Development, debugging, exploring |
+| **stdout** | Plain terminal output like `ansible-playbook` | CI/CD, scripts, log capture |
+
+Switch between modes:
+
+```bash
+# Interactive (default)
+ansible-navigator run site.yml
+
+# stdout mode
+ansible-navigator run site.yml --mode stdout
+```
+
+### Playbook artifacts
+
+Navigator captures detailed run data (plays, tasks, hosts, stdout) as JSON artifact files. These can be replayed later for review without re-running the playbook:
+
+```bash
+# Replay a previous run
+ansible-navigator replay /path/to/artifact.json
+```
+
+## Subcommands
+
+| Subcommand | Colon command | Description |
+|------------|---------------|-------------|
+| `run` | `:run` | Run a playbook |
+| `collections` | `:collections` | Explore available collections |
+| `config` | `:config` | Explore current Ansible configuration |
+| `doc` | `:doc` | Review module/plugin documentation |
+| `inventory` | `:inventory` | Explore an inventory |
+| `images` | `:images` | Explore execution environment images |
+| `exec` | `:exec` | Run a command within an execution environment |
+| `lint` | `:lint` | Lint files/directories for errors |
+| `builder` | `:builder` | Build an execution environment |
+| `replay` | `:replay` | Explore a previous run via artifact |
+| `settings` | `:settings` | Review current navigator settings |
+| `welcome` | `:welcome` | Show the welcome page |
+
+### Mapping to Ansible commands
+
+| Ansible command | Navigator equivalent |
+|-----------------|---------------------|
+| `ansible-playbook` | `ansible-navigator run` |
+| `ansible-config` | `ansible-navigator config` |
+| `ansible-doc` | `ansible-navigator doc` |
+| `ansible-inventory` | `ansible-navigator inventory` |
+| `ansible-lint` | `ansible-navigator lint` |
+| `ansible-builder` | `ansible-navigator builder` |
+| `ansible-galaxy` | `ansible-navigator exec -- ansible-galaxy ...` |
+| `ansible-test` | `ansible-navigator exec -- ansible-test ...` |
+| `ansible-vault` | `ansible-navigator exec -- ansible-vault ...` |
+
+### Running playbooks
+
+```bash
+# Basic playbook run
+ansible-navigator run site.yml -i inventory.yml
+
+# With extra variables
+ansible-navigator run site.yml -i inventory.yml -e "target=staging"
+
+# Limit to specific hosts
+ansible-navigator run site.yml -i inventory.yml --limit webservers
+
+# In stdout mode for CI
+ansible-navigator run site.yml -i inventory.yml --mode stdout
+
+# Without execution environment (use local Ansible)
+ansible-navigator run site.yml --execution-environment false
+```
+
+### Exploring collections
+
+```bash
+# Browse all available collections
+ansible-navigator collections
+
+# View a specific module's documentation
+ansible-navigator doc ansible.builtin.copy
+
+# View a plugin by type
+ansible-navigator doc ansible.netcommon.cli_command --type module
+```
+
+### Running commands in an EE
+
+```bash
+# Open a shell inside the EE
+ansible-navigator exec
+
+# Run a specific command
+ansible-navigator exec -- ansible-galaxy collection list
+
+# Run ansible-test sanity
+ansible-navigator exec -- ansible-test sanity --docker
+```
+
+## Configuration
+
+### Settings file locations
+
+Navigator searches for configuration in this order:
+
+1. `ANSIBLE_NAVIGATOR_CONFIG` environment variable
+2. `./ansible-navigator.yml` (project directory — no leading dot)
+3. `~/.ansible-navigator.yml` (home directory — with leading dot)
+
+Supported formats: `.yml`, `.yaml`, `.json`
+
+### Priority order (lowest to highest)
+
+1. Default internal values
+2. Settings file
+3. Environment variables
+4. CLI flags
+5. TUI colon commands
+
+### Complete settings reference
+
+```yaml
+ansible-navigator:
+  # Default subcommand when no subcommand specified
+  app: welcome
+
+  # Ansible configuration
+  ansible:
+    config:
+      path: /path/to/ansible.cfg
+    cmdline: "--forks 15"
+    inventory:
+      entries:
+        - /path/to/inventory.yml
+    playbook:
+      path: /path/to/playbook.yml
+
+  # ansible-builder settings (for :builder)
+  ansible-builder:
+    workdir: /path/to/workdir
+
+  # ansible-lint settings (for :lint)
+  ansible-lint:
+    config: ~/ansible-lint.yml
+    lintables: ~/myproject/
+
+  # ansible-runner settings
+  ansible-runner:
+    artifact-dir: /tmp/artifacts
+    rotate-artifacts-count: 10
+    timeout: 300
+    job-events: false
+
+  # Color settings
+  color:
+    enable: true
+    osc4: true
+
+  # Editor settings (for :open from TUI)
+  editor:
+    command: vi +{line_number} {filename}
+    console: true
+
+  # Disable interactive prompts (like AAP Controller)
+  enable-prompts: false
+
+  # Exec settings
+  exec:
+    shell: true
+    command: /bin/bash
+
+  # Execution environment settings
+  execution-environment:
+    container-engine: auto
+    enabled: true
+    environment-variables:
+      pass:
+        - SSH_AUTH_SOCK
+        - MY_TOKEN
+      set:
+        ANSIBLE_NOCOLOR: "false"
+    image: ghcr.io/ansible/community-ansible-dev-tools:latest
+    pull:
+      arguments:
+        - "--tls-verify=false"
+      policy: tag
+    volume-mounts:
+      - src: "/host/path"
+        dest: "/container/path"
+        options: "Z"
+    container-options:
+      - "--net=host"
+
+  # Output format for stdout mode (json or yaml)
+  format: yaml
+
+  # Image inspection details
+  images:
+    details:
+      - ansible_version
+      - python_version
+
+  # Custom inventory columns
+  inventory-columns:
+    - ansible_network_os
+    - ansible_connection
+
+  # Logging
+  logging:
+    level: warning
+    append: true
+    file: ./ansible-navigator.log
+
+  # Default mode
+  mode: interactive
+
+  # Playbook artifact settings
+  playbook-artifact:
+    enable: true
+    replay: /path/to/artifact.json
+    save-as: "{playbook_dir}/{playbook_name}-artifact-{time_stamp}.json"
+
+  # Time zone for timestamps
+  time-zone: UTC
+```
+
+### Key execution environment settings
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `execution-environment.enabled` | `true` | Run inside container |
+| `execution-environment.container-engine` | `auto` | `auto`, `podman`, or `docker` |
+| `execution-environment.image` | (community image) | Container image to use |
+| `execution-environment.pull.policy` | `tag` | `always`, `missing`, `never`, `tag` |
+| `execution-environment.volume-mounts` | — | Additional bind mounts |
+| `execution-environment.container-options` | — | Extra container engine args |
+| `execution-environment.environment-variables.pass` | — | Host env vars to pass through |
+| `execution-environment.environment-variables.set` | — | New env vars inside container |
+
+### Environment variables
+
+Every setting has a corresponding `ANSIBLE_NAVIGATOR_*` environment variable:
+
+```bash
+export ANSIBLE_NAVIGATOR_MODE=stdout
+export ANSIBLE_NAVIGATOR_EXECUTION_ENVIRONMENT_IMAGE=my-ee:latest
+export ANSIBLE_NAVIGATOR_EXECUTION_ENVIRONMENT_ENABLED=false
+```
+
+## Execution environment management
+
+### Disabling EEs
+
+Run with local Ansible installation:
+
+```bash
+ansible-navigator run site.yml --execution-environment false
+```
+
+Or in settings:
+
+```yaml
+ansible-navigator:
+  execution-environment:
+    enabled: false
+```
+
+### Pull policies
+
+| Policy | Behavior |
+|--------|----------|
+| `always` | Pull image before every run |
+| `missing` | Pull only if not present locally |
+| `never` | Never pull (fail if not present) |
+| `tag` | Pull if tag is `latest` or image not present |
+
+### Volume mounts
+
+Navigator automatically mounts the project directory. Add custom mounts:
+
+```yaml
+ansible-navigator:
+  execution-environment:
+    volume-mounts:
+      - src: /home/user/.ssh
+        dest: /home/runner/.ssh
+        options: "ro"
+      - src: /tmp/artifacts
+        dest: /tmp/artifacts
+        options: "Z"
+```
+
+### Passing environment variables
+
+```yaml
+ansible-navigator:
+  execution-environment:
+    environment-variables:
+      pass:
+        - SSH_AUTH_SOCK
+        - AWS_ACCESS_KEY_ID
+        - AWS_SECRET_ACCESS_KEY
+      set:
+        ANSIBLE_NOCOLOR: "false"
+        MY_CUSTOM_VAR: "value"
+```
+
+### Container engine discovery
+
+In `auto` mode, Navigator checks for `podman` first, then falls back to `docker`.
+
+## TUI navigation
+
+When running in interactive mode, the TUI provides:
+
+- **Drill-down navigation**: Click or press numbers to zoom into plays, tasks, hosts, results
+- **Keyboard shortcuts**: Arrow keys, Enter, Esc (back), numbers for selection
+- **Search and filter**: `/` to search within structured output
+- **`:help`**: Shows available colon commands at any time
+- **`:open`**: Open the current file in your configured editor
+
+### Editor configuration for TUI
+
+Configure what happens when you use `:open`:
+
+```yaml
+# VS Code
+ansible-navigator:
+  editor:
+    command: code -g {filename}:{line_number}
+    console: false
+
+# PyCharm
+ansible-navigator:
+  editor:
+    command: charm --line {line_number} {filename}
+    console: false
+
+# Vim (default)
+ansible-navigator:
+  editor:
+    command: vi +{line_number} {filename}
+    console: true
+
+# Emacs
+ansible-navigator:
+  editor:
+    command: emacs -nw +{line_number} {filename}
+    console: true
+```
+
+Set `console: false` for GUI editors (VS Code, PyCharm) — this tells Navigator the editor is not terminal-based.
+
+## VS Code extension integration
+
+The VS Code extension leverages ansible-navigator for:
+
+- **Playbook execution**: Running playbooks with real-time progress streaming via a callback plugin
+- **Execution environment awareness**: Detecting available EE images, displaying their contents (collections, Python packages, Ansible version)
+- **Collection browsing**: Using navigator's image introspection to show what's inside EE images
+
+The extension communicates with ansible-navigator through its stdout mode and artifact capture, providing a graphical overlay on top of navigator's capabilities.
+
+## CI/CD usage
+
+For CI/CD pipelines, use stdout mode:
+
+```yaml
+ansible-navigator:
+  mode: stdout
+  execution-environment:
+    enabled: true
+    image: my-org/my-ee:latest
+    pull:
+      policy: always
+  playbook-artifact:
+    enable: true
+    save-as: "{playbook_dir}/artifacts/{playbook_name}-{time_stamp}.json"
+```
+
+```bash
+ansible-navigator run deploy.yml -i inventory/production.yml --mode stdout
+```
+
+Artifacts are saved for later replay and debugging:
+
+```bash
+# On a developer machine, replay the CI run
+ansible-navigator replay artifacts/deploy-2026-06-23.json
+```
+
+## Next steps
+
+You're running playbooks successfully. Now package and secure your automation:
+
+- [Build a custom execution environment with ansible-builder](/vscode-ansible/python-tools/ansible-builder/) — create a container image with exactly the collections and dependencies your playbooks need
+- [Sign your project with ansible-sign](/vscode-ansible/python-tools/ansible-sign/) — cryptographically verify content integrity before production deployment
+
+## Links
+
+- [PyPI: ansible-navigator](https://pypi.org/project/ansible-navigator/)
+- [GitHub: ansible/ansible-navigator](https://github.com/ansible/ansible-navigator)

--- a/docs/src/content/docs/python-tools/ansible-navigator/reference.mdx
+++ b/docs/src/content/docs/python-tools/ansible-navigator/reference.mdx
@@ -1,0 +1,444 @@
+---
+title: "ansible-navigator: Reference"
+description: Complete settings reference, environment variables, and CLI flags for all ansible-navigator subcommands.
+---
+
+This page provides exhaustive reference material for ansible-navigator. For an introduction and typical usage, see the [ansible-navigator guide](/vscode-ansible/python-tools/ansible-navigator/).
+
+## Settings file locations
+
+Searched in order (first found wins):
+
+1. `ANSIBLE_NAVIGATOR_CONFIG` environment variable
+2. `./ansible-navigator.yml` (project directory — no dot prefix)
+3. `./ansible-navigator.yaml`
+4. `./ansible-navigator.json`
+5. `~/.ansible-navigator.yml` (home directory — with dot prefix)
+6. `~/.ansible-navigator.yaml`
+7. `~/.ansible-navigator.json`
+
+Only one settings file per directory is allowed. If multiple are found, Navigator exits with an error.
+
+## Priority order (lowest to highest)
+
+1. Default internal values
+2. Settings file
+3. Environment variables (`ANSIBLE_NAVIGATOR_*`)
+4. CLI flags
+5. TUI colon commands
+
+## Complete settings reference
+
+```yaml
+ansible-navigator:
+  ansible:
+    config:
+      path: <string>              # Path to ansible.cfg
+    cmdline: <string>             # Extra cmdline args for ansible
+    doc:
+      plugin:
+        name: <string>            # Default plugin name for :doc
+        type: <string>            # Default plugin type (become, cache, callback, etc.)
+    inventory:
+      entries:                    # Inventory sources
+        - <string>
+    playbook:
+      path: <string>             # Default playbook path
+
+  ansible-builder:
+    workdir: <string>            # Working directory for :builder
+
+  ansible-lint:
+    config: <string>             # Path to ansible-lint config
+    lintables: <string>          # Path to lint
+
+  ansible-runner:
+    artifact-dir: <string>       # Artifact directory
+    rotate-artifacts-count: <int> # Number of artifact sets to keep
+    timeout: <int>               # Runner timeout in seconds
+    job-events: <boolean>        # Enable job events
+
+  app: <string>                  # Default subcommand (welcome, run, collections, etc.)
+
+  collection-doc-cache-path: <string>  # Path to doc cache DB
+
+  color:
+    enable: <boolean>            # Enable colored output
+    osc4: <boolean>              # Use OSC4 terminal colors
+
+  editor:
+    command: <string>            # Editor command template
+    console: <boolean>           # Editor is terminal-based
+
+  enable-prompts: <boolean>      # Allow interactive prompts
+
+  exec:
+    shell: <boolean>             # Use shell for exec commands
+    command: <string>            # Default exec command
+
+  execution-environment:
+    container-engine: <string>   # auto, podman, or docker
+    enabled: <boolean>           # Enable/disable EE
+    environment-variables:
+      pass: []                   # Host vars to pass through
+      set: {}                    # Vars to set in container
+    image: <string>              # Container image
+    pull:
+      arguments: []              # Extra pull args
+      policy: <string>           # always, missing, never, tag
+    volume-mounts: []            # Additional mounts
+    container-options: []        # Extra container args
+
+  format: <string>               # stdout format: json or yaml
+
+  images:
+    details:                  # Choices: ansible_collections, ansible_version,
+      - ansible_version       # everything, os_release, python_packages,
+      - python_version        # python_version, redhat_release, system_packages
+
+  inventory-columns: []          # Extra inventory columns
+
+  logging:
+    level: <string>              # critical, error, warning, info, debug
+    append: <boolean>            # Append to log file
+    file: <string>               # Log file path
+
+  mode: <string>                 # interactive or stdout
+
+  playbook-artifact:
+    enable: <boolean>            # Enable artifact creation
+    replay: <string>             # Path to artifact for replay
+    save-as: <string>            # Artifact save path template
+
+  settings:
+    effective: <boolean>         # Show effective settings
+    sample: <boolean>            # Show sample config
+    schema: <string>             # Schema format (json)
+    sources: <boolean>           # Show settings sources
+
+  time-zone: <string>            # Timezone for timestamps (e.g., UTC, America/New_York)
+```
+
+## Settings field reference
+
+### `ansible-navigator.ansible`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `config.path` | `string` | — | Path to `ansible.cfg` |
+| `cmdline` | `string` | — | Extra command-line args (e.g., `"--forks 15"`) |
+| `doc.plugin.name` | `string` | — | Default plugin for `:doc` |
+| `doc.plugin.type` | `string` | — | Plugin type filter |
+| `inventory.entries` | `list[string]` | `[]` | Inventory file paths |
+| `playbook.path` | `string` | — | Default playbook path |
+
+### `ansible-navigator.execution-environment`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `container-engine` | `string` | `auto` | `auto`, `podman`, `docker` |
+| `enabled` | `boolean` | `true` | Run in container |
+| `environment-variables.pass` | `list[string]` | `[]` | Host env vars to forward |
+| `environment-variables.set` | `dict` | `{}` | New env vars to create |
+| `image` | `string` | (community image) | Container image to use |
+| `pull.arguments` | `list[string]` | `[]` | Extra `pull` arguments |
+| `pull.policy` | `string` | `tag` | `always`, `missing`, `never`, `tag` |
+| `volume-mounts` | `list[dict]` | `[]` | Additional volume mounts |
+| `container-options` | `list[string]` | `[]` | Extra container engine args |
+
+#### Volume mount entry format
+
+```yaml
+volume-mounts:
+  - src: "/host/path"
+    dest: "/container/path"
+    options: "Z"          # SELinux label, ro, rw, etc.
+```
+
+### `ansible-navigator.editor`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `command` | `string` | `vi +&#123;line_number&#125; &#123;filename&#125;` | Command template |
+| `console` | `boolean` | `true` | Whether editor runs in terminal |
+
+**Placeholders:** `&#123;filename&#125;`, `&#123;line_number&#125;`
+
+**IDE examples:**
+
+| Editor | `command` | `console` |
+|--------|-----------|-----------|
+| vi/vim | `vi +&#123;line_number&#125; &#123;filename&#125;` | `true` |
+| VS Code | `code -g &#123;filename&#125;:&#123;line_number&#125;` | `false` |
+| PyCharm | `charm --line &#123;line_number&#125; &#123;filename&#125;` | `false` |
+| Emacs (terminal) | `emacs -nw +&#123;line_number&#125; &#123;filename&#125;` | `true` |
+| Emacs (GUI) | `emacs +&#123;line_number&#125; &#123;filename&#125;` | `false` |
+| code-server | `code-server &#123;filename&#125;` | `false` |
+
+### `ansible-navigator.logging`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `level` | `string` | `warning` | `critical`, `error`, `warning`, `info`, `debug` |
+| `append` | `boolean` | `true` | Append to log (vs overwrite) |
+| `file` | `string` | `./ansible-navigator.log` | Log file path |
+
+### `ansible-navigator.playbook-artifact`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enable` | `boolean` | `true` | Create artifacts |
+| `replay` | `string` | — | Artifact path for replay |
+| `save-as` | `string` | `&#123;playbook_dir&#125;/&#123;playbook_name&#125;-artifact-&#123;time_stamp&#125;.json` | Save path template |
+
+**Template variables:** `&#123;playbook_dir&#125;`, `&#123;playbook_name&#125;`, `&#123;time_stamp&#125;`
+
+## Environment variables
+
+Most settings map to an environment variable with the `ANSIBLE_NAVIGATOR_` prefix. However, some settings use standard Ansible or system environment variables instead:
+
+### Non-prefixed environment variables
+
+| Setting | Environment variable |
+|---------|---------------------|
+| `color.enable` | `NO_COLOR` |
+| `time-zone` | `TZ` |
+| `ansible.config.path` | `ANSIBLE_CONFIG` |
+| `ansible.inventory.entries` | `ANSIBLE_INVENTORY` |
+| `ansible-lint.config` | `ANSIBLE_LINT_CONFIG` |
+
+### Prefixed environment variables
+
+Nested keys use underscores:
+
+| Setting path | Environment variable |
+|-------------|---------------------|
+| `mode` | `ANSIBLE_NAVIGATOR_MODE` |
+| `execution-environment.enabled` | `ANSIBLE_NAVIGATOR_EXECUTION_ENVIRONMENT_ENABLED` |
+| `execution-environment.image` | `ANSIBLE_NAVIGATOR_EXECUTION_ENVIRONMENT_IMAGE` |
+| `execution-environment.container-engine` | `ANSIBLE_NAVIGATOR_EXECUTION_ENVIRONMENT_CONTAINER_ENGINE` |
+| `execution-environment.pull.policy` | `ANSIBLE_NAVIGATOR_EXECUTION_ENVIRONMENT_PULL_POLICY` |
+| `ansible.config.path` | `ANSIBLE_NAVIGATOR_ANSIBLE_CONFIG_PATH` |
+| `ansible.playbook.path` | `ANSIBLE_NAVIGATOR_ANSIBLE_PLAYBOOK_PATH` |
+| `logging.level` | `ANSIBLE_NAVIGATOR_LOGGING_LEVEL` |
+| `logging.file` | `ANSIBLE_NAVIGATOR_LOGGING_FILE` |
+| `editor.command` | `ANSIBLE_NAVIGATOR_EDITOR_COMMAND` |
+| `editor.console` | `ANSIBLE_NAVIGATOR_EDITOR_CONSOLE` |
+| `playbook-artifact.enable` | `ANSIBLE_NAVIGATOR_PLAYBOOK_ARTIFACT_ENABLE` |
+| `color.enable` | `ANSIBLE_NAVIGATOR_COLOR_ENABLE` |
+| `format` | `ANSIBLE_NAVIGATOR_FORMAT` |
+| `time-zone` | `ANSIBLE_NAVIGATOR_TIME_ZONE` |
+| `app` | `ANSIBLE_NAVIGATOR_APP` |
+| `enable-prompts` | `ANSIBLE_NAVIGATOR_ENABLE_PROMPTS` |
+
+## Subcommand CLI flags
+
+### `ansible-navigator run`
+
+| Flag | Description |
+|------|-------------|
+| `<playbook>` | Playbook path (positional) |
+| `-i, --inventory <path>` | Inventory path (repeatable) |
+| `-e, --extra-vars <vars>` | Extra variables (key=value or @file) |
+| `-l, --limit <pattern>` | Limit to hosts |
+| `-t, --tags <tags>` | Run only tagged tasks |
+| `--skip-tags <tags>` | Skip tagged tasks |
+| `-C, --check` | Check mode (dry run) |
+| `-D, --diff` | Show diffs |
+| `--forks <n>` | Parallelism level |
+| `--become` / `-b` | Become (privilege escalation) |
+| `--become-method <method>` | Escalation method |
+| `--become-user <user>` | Target user |
+| `--vault-id <id>` | Vault identity |
+| `--vault-password-file <path>` | Vault password file |
+| `--mode <mode>` | `interactive` or `stdout` |
+| `--execution-environment <bool>` | Enable/disable EE |
+| `--execution-environment-image <image>` | EE image |
+| `--pull-policy <policy>` | Image pull policy |
+| `--container-engine <engine>` | Container runtime |
+| `--pass-environment-variable <var>` | Forward env var (repeatable) |
+| `--set-environment-variable <k=v>` | Set env var (repeatable) |
+| `--execution-environment-volume-mounts <mount>` | Volume mount (repeatable) |
+| `--container-options <opts>` | Extra container args (repeatable) |
+| `--playbook-artifact-enable <bool>` | Enable artifact creation |
+| `--pull-arguments <args>` | Extra arguments for image pull (e.g., `--tls-verify=false`) |
+
+### `ansible-navigator collections`
+
+| Flag | Description |
+|------|-------------|
+| `--mode <mode>` | `interactive` or `stdout` |
+| `--execution-environment <bool>` | Enable/disable EE |
+
+### `ansible-navigator config`
+
+| Flag | Description |
+|------|-------------|
+| `--mode <mode>` | `interactive` or `stdout` |
+| `--execution-environment <bool>` | Enable/disable EE |
+
+### `ansible-navigator doc`
+
+| Flag | Description |
+|------|-------------|
+| `<plugin>` | Plugin name (positional) |
+| `--type <type>` | Plugin type: `become`, `cache`, `callback`, `cliconf`, `connection`, `filter`, `httpapi`, `inventory`, `keyword`, `lookup`, `module`, `netconf`, `role`, `shell`, `strategy`, `test`, `vars` |
+| `--mode <mode>` | `interactive` or `stdout` |
+| `--execution-environment <bool>` | Enable/disable EE |
+
+### `ansible-navigator inventory`
+
+| Flag | Description |
+|------|-------------|
+| `-i, --inventory <path>` | Inventory path (repeatable) |
+| `--list` | List all hosts |
+| `--graph` | Display inventory graph |
+| `--host <host>` | Show host variables |
+| `--mode <mode>` | `interactive` or `stdout` |
+| `--execution-environment <bool>` | Enable/disable EE |
+
+### `ansible-navigator images`
+
+| Flag | Description |
+|------|-------------|
+| `--mode <mode>` | `interactive` or `stdout` |
+| `--execution-environment <bool>` | Enable/disable EE |
+| `--details <fields>` | Details to show (e.g., `ansible_version,python_version`) |
+
+### `ansible-navigator exec`
+
+| Flag | Description |
+|------|-------------|
+| `--` | Separator for command arguments |
+| `--execution-environment-image <image>` | EE image |
+| `--container-engine <engine>` | Container runtime |
+| `--pass-environment-variable <var>` | Forward env var |
+| `--set-environment-variable <k=v>` | Set env var |
+| `--execution-environment-volume-mounts <mount>` | Volume mount |
+
+### `ansible-navigator lint`
+
+| Flag | Description |
+|------|-------------|
+| `<lintables>` | Files/directories to lint (positional) |
+| `--mode <mode>` | `interactive` or `stdout` |
+| `--execution-environment <bool>` | Enable/disable EE |
+| `--lint-config <path>` | ansible-lint config path |
+
+### `ansible-navigator replay`
+
+| Flag | Description |
+|------|-------------|
+| `<artifact>` | Artifact JSON file path (positional) |
+| `--mode <mode>` | `interactive` or `stdout` |
+
+### `ansible-navigator settings`
+
+| Flag | Description |
+|------|-------------|
+| `--effective` | Show effective (merged) settings |
+| `--sample` | Show sample configuration |
+| `--schema <format>` | Show settings JSON schema |
+| `--sources` | Show where each setting came from |
+
+## TUI colon commands
+
+Available during interactive mode:
+
+| Command | Description |
+|---------|-------------|
+| `:back` | Go back one level (same as Esc) |
+| `:collections` | Switch to collections view |
+| `:config` | Switch to config view |
+| `:doc <plugin>` | View plugin documentation |
+| `:exec <command>` | Run command in EE |
+| `:filter <text>` | Filter current view |
+| `:help` | Show help |
+| `:images` | Switch to images view |
+| `:inventory <path>` | Open inventory |
+| `:lint <path>` | Lint files |
+| `:log` | View log |
+| `:open` | Open current file in editor |
+| `:quit` | Exit (same as Ctrl+C) |
+| `:replay <path>` | Replay artifact |
+| `:run <playbook>` | Run a playbook |
+| `:rr` | Rerun last playbook |
+| `:settings` | View settings |
+| `:welcome` | Return to welcome page |
+| `:write <path>` | Write current content to file |
+
+## TUI keyboard shortcuts
+
+| Key | Action |
+|-----|--------|
+| `0-9` | Select numbered item |
+| `Enter` | Select/drill into |
+| `Esc` | Go back one level |
+| `:` | Enter colon command |
+| `/` | Search/filter |
+| `↑/↓` | Navigate items |
+| `←/→` | Scroll horizontally |
+| `PgUp/PgDn` | Page through results |
+| `Tab` | Switch between panes |
+
+## Pull policy behavior
+
+| Policy | When image exists locally | When image does not exist |
+|--------|--------------------------|---------------------------|
+| `always` | Pull (update) | Pull |
+| `missing` | Use local | Pull |
+| `never` | Use local | Error |
+| `tag` | Use local (unless tag is `latest`) | Pull |
+
+## Container engine discovery (`auto` mode)
+
+1. Check for `podman` in PATH → use if found
+2. Check for `docker` in PATH → use if found
+3. Error if neither found
+
+## Operational notes
+
+### SSH key handling in execution environments
+
+Navigator automatically handles SSH keys when running in an EE:
+- Mounts the ssh-agent socket and sets `SSH_AUTH_SOCK`
+- Mounts `~/.ssh/` to `/root/.ssh/` (for OpenSSH)
+- Mounts `~/.ssh/` to `/home/runner/.ssh/` (for paramiko)
+
+### Volume mount environment variable delimiter
+
+When defining volume mounts via environment variables, use semicolons (`;`) as delimiters because mount definitions contain colons:
+
+```bash
+export ANSIBLE_NAVIGATOR_EXECUTION_ENVIRONMENT_VOLUME_MOUNTS="/tmp/src:/tmp/dest:Z;/data/input:/data/input:ro"
+```
+
+### `enable-prompts` side effects
+
+Setting `enable-prompts: true` has two side effects:
+- Forces mode to `stdout` (TUI cannot handle prompts)
+- Disables playbook artifact creation
+
+### Vault passwords in execution environments
+
+Three documented patterns for vault access inside EEs:
+
+1. **GPG-encrypted script**: Mount a decrypt script and pass via `--senv` / `--penv`
+2. **Password file**: Link a password file and set `ANSIBLE_VAULT_PASSWORD_FILE` + custom volume mount
+3. **Environment variable**: Use `HISTCONTROL=ignorespace` to avoid shell history, pass via `--set-environment-variable`
+
+### `ansible.cfg` placement for EEs
+
+The ansible.cfg must be in the project directory (auto-mounted) or referenced via `ANSIBLE_CONFIG` with a custom volume mount to the file's location.
+
+### Pass-through parameters
+
+Use `--` to pass arguments directly to ansible-playbook:
+
+```bash
+ansible-navigator run site.yml -- --forks 15 --start-at-task "Install packages"
+```
+
+### Podman `/dev/mqueue` requirement
+
+Podman requires `/dev/mqueue` to exist on the host. Some operating systems do not create this by default.

--- a/docs/src/content/docs/python-tools/ansible-sign.mdx
+++ b/docs/src/content/docs/python-tools/ansible-sign.mdx
@@ -1,0 +1,270 @@
+---
+title: ansible-sign
+description: Sign and verify Ansible project content using GPG for supply chain integrity.
+---
+
+ansible-sign is a utility for signing and verifying Ansible project directory contents using GPG. It generates checksum manifests of project files and signs them cryptographically, enabling downstream consumers (Ansible Automation Platform, AWX, CI/CD pipelines) to verify that content has not been tampered with since it was signed.
+
+## Installation
+
+```bash
+# Via the full suite (recommended)
+pip install ansible-dev-tools
+
+# Standalone
+pip install ansible-sign
+```
+
+Verify installation:
+
+```bash
+ansible-sign --version
+```
+
+## Core concepts
+
+### How signing works
+
+1. ansible-sign scans your project directory for tracked files
+2. It generates SHA-256 checksums for each file, creating a **checksum manifest**
+3. The manifest is signed with your GPG private key, producing a **detached signature**
+4. Both the manifest (`.ansible-sign/sha256sum.txt`) and signature (`.ansible-sign/sha256sum.txt.sig`) are stored in the project
+
+### How verification works
+
+1. The verifier reads the signed manifest and signature
+2. GPG verifies the signature against the signer's public key
+3. File checksums are recalculated and compared against the manifest
+4. Any modified, added, or removed files cause verification to fail
+
+### MANIFEST.in
+
+The `MANIFEST.in` file controls which files are included in the checksum manifest. It uses Python's distutils manifest template syntax:
+
+```text
+include *.yml
+include *.yaml
+recursive-include roles *
+recursive-include playbooks *
+recursive-include inventory *
+recursive-include group_vars *
+recursive-include host_vars *
+exclude .git/*
+exclude .ansible-sign/*
+```
+
+If no `MANIFEST.in` exists, ansible-sign defaults to including all files tracked by git (minus the `.ansible-sign/` directory itself).
+
+### The `.ansible-sign/` directory
+
+After signing, your project contains:
+
+```text
+.ansible-sign/
+├── sha256sum.txt      # Checksum manifest
+└── sha256sum.txt.sig  # GPG detached signature
+```
+
+These files should be committed to version control so that consumers can verify the project.
+
+## CLI reference
+
+### `ansible-sign project gpg-sign`
+
+Sign the current project:
+
+```bash
+# Sign with default GPG key
+ansible-sign project gpg-sign .
+
+# Sign with a specific key
+ansible-sign project gpg-sign . --fingerprint ABCD1234...
+
+# Sign a project at a specific path
+ansible-sign project gpg-sign /path/to/project
+
+# Force re-sign (overwrite existing signature)
+ansible-sign project gpg-sign . --force
+```
+
+### `ansible-sign project gpg-verify`
+
+Verify a signed project:
+
+```bash
+# Verify the current directory
+ansible-sign project gpg-verify .
+
+# Verify with a specific keyring
+ansible-sign project gpg-verify . --keyring /path/to/keyring.gpg
+
+# Verify a project at a specific path
+ansible-sign project gpg-verify /path/to/project
+```
+
+Exit codes:
+
+| Code | Meaning |
+|------|---------|
+| `0` | Verification successful — all files match |
+| `1` | Verification failed — signature invalid or files modified |
+| `2` | Error — missing signature, missing keyring, or other problem |
+
+### Global options
+
+| Flag | Description |
+|------|-------------|
+| `--debug` | Enable debug output |
+| `--version` | Show version |
+| `-h, --help` | Show help |
+
+## GPG key management
+
+### Generating a key pair
+
+If you don't have a GPG key:
+
+```bash
+gpg --full-generate-key
+```
+
+Choose RSA 4096-bit, set an appropriate expiration, and provide your name and email.
+
+### Listing keys
+
+```bash
+# List public keys
+gpg --list-keys
+
+# List private keys (for signing)
+gpg --list-secret-keys
+```
+
+### Exporting for verification
+
+Export your public key for distribution to team members and automation platforms:
+
+```bash
+# Export as ASCII armor
+gpg --export --armor your.email@example.com > signing-key.pub
+
+# Import on another machine
+gpg --import signing-key.pub
+```
+
+## Workflow
+
+### Signing a project
+
+```bash
+cd /path/to/ansible-project
+
+# Create MANIFEST.in if you want to control which files are signed
+cat > MANIFEST.in << 'EOF'
+include *.yml
+include *.yaml
+recursive-include roles *
+recursive-include playbooks *
+recursive-include inventory *
+recursive-include group_vars *
+recursive-include host_vars *
+recursive-include collections *
+exclude .git/*
+EOF
+
+# Sign the project
+ansible-sign project gpg-sign .
+
+# Commit the signature
+git add .ansible-sign/ MANIFEST.in
+git commit -m "Sign project content"
+git push
+```
+
+### Verifying before deployment
+
+```bash
+# Clone or pull the project
+git clone git@github.com:myorg/ansible-project.git
+cd ansible-project
+
+# Verify signature before running
+ansible-sign project gpg-verify .
+if [ $? -eq 0 ]; then
+  ansible-navigator run site.yml
+else
+  echo "ERROR: Project signature verification failed!"
+  exit 1
+fi
+```
+
+## AWX/Controller integration
+
+Ansible Automation Platform Controller (and AWX) supports automatic content verification on project sync. When configured:
+
+1. Controller syncs the project from SCM (git)
+2. Before making the content available for job execution, it runs `ansible-sign project gpg-verify`
+3. If verification fails, the project sync fails and jobs cannot run the unverified content
+
+### Configuring in Controller
+
+1. Upload the signing public key to Controller's credential store as a **GPG Public Key** credential
+2. Attach the credential to the Project
+3. Enable "Content Signing Verification" on the Project settings
+4. On next sync, Controller automatically verifies the project signature
+
+### Configuring in AWX
+
+The same workflow applies to AWX (the open-source upstream of Controller):
+
+1. Create a GPG Public Key credential
+2. Associate it with the project
+3. AWX verifies on every project update
+
+## CI/CD integration
+
+### Signing in CI
+
+Add signing as a step in your release pipeline:
+
+```yaml
+# GitHub Actions example
+- name: Import GPG key
+  run: echo "${{ secrets.GPG_PRIVATE_KEY }}" | gpg --import
+
+- name: Sign project
+  run: |
+    ansible-sign project gpg-sign . --fingerprint ${{ secrets.GPG_FINGERPRINT }}
+    git add .ansible-sign/
+    git commit -m "Update project signature"
+    git push
+```
+
+### Verifying in CI
+
+Add verification as a gate before deployment:
+
+```yaml
+- name: Import signing public key
+  run: echo "${{ secrets.GPG_PUBLIC_KEY }}" | gpg --import
+
+- name: Verify project signature
+  run: ansible-sign project gpg-verify .
+```
+
+## Security considerations
+
+- **Protect your private key**: Store GPG private keys in secure credential stores (vault, CI secrets), never in the repository
+- **Key rotation**: Establish a key rotation policy; update Controller/AWX credentials when rotating
+- **MANIFEST.in scope**: Be deliberate about what files are covered — exclude generated files, caches, and editor artifacts
+- **Git integration**: The default behavior (signing all git-tracked files) is the safest starting point
+- **Signature freshness**: Re-sign after any content change; stale signatures will cause verification failures
+
+## Next steps
+
+Your content is signed and ready for production. To see how all the tools fit together in a complete development cycle, read the [end-to-end workflow guide](/vscode-ansible/python-tools/workflow/).
+
+## Links
+
+- [PyPI: ansible-sign](https://pypi.org/project/ansible-sign/)
+- [GitHub: ansible/ansible-sign](https://github.com/ansible/ansible-sign)

--- a/docs/src/content/docs/python-tools/molecule.mdx
+++ b/docs/src/content/docs/python-tools/molecule.mdx
@@ -1,0 +1,527 @@
+---
+title: molecule
+description: Functional testing framework for Ansible collections, playbooks, and roles.
+---
+
+Molecule is the testing framework for Ansible content. It manages the full lifecycle of test infrastructure — provisioning instances, applying your Ansible content, running verification, and tearing everything down. Molecule supports testing against containers, virtual machines, cloud infrastructure, network devices, and APIs.
+
+Molecule uses scenario-based configuration where each scenario is a self-contained test with its own infrastructure, playbooks, and verification steps.
+
+## Installation
+
+```bash
+# Via the full suite (recommended)
+pip install ansible-dev-tools
+
+# Standalone
+pip install molecule
+
+# With Docker driver
+pip install molecule-plugins[docker]
+
+# With Podman driver
+pip install molecule-plugins[podman]
+```
+
+Verify installation:
+
+```bash
+molecule --version
+```
+
+## Core concepts
+
+### Scenarios
+
+A scenario is a self-contained test case with its own:
+
+- Infrastructure definition (what to create)
+- Converge playbook (what to test)
+- Verification playbook (how to validate)
+- Destroy playbook (how to clean up)
+
+Scenarios live under `extensions/molecule/` (for collections) or `molecule/` (for roles and playbooks):
+
+```text
+extensions/molecule/
+├── default/
+│   ├── molecule.yml
+│   ├── create.yml
+│   ├── converge.yml
+│   ├── verify.yml
+│   └── destroy.yml
+└── integration/
+    ├── molecule.yml
+    ├── converge.yml
+    └── verify.yml
+```
+
+### Test sequence
+
+Molecule executes tests as an ordered sequence of actions:
+
+```text
+dependency → cleanup → destroy → syntax → create → prepare →
+converge → idempotence → side_effect → verify → cleanup → destroy
+```
+
+Each action maps to a playbook or built-in check:
+
+| Action | Playbook | Purpose |
+|--------|----------|---------|
+| `dependency` | — | Install role/collection dependencies |
+| `cleanup` | `cleanup.yml` | Clean external resources before destroy |
+| `destroy` | `destroy.yml` | Tear down test infrastructure |
+| `syntax` | — | Ansible syntax check on converge playbook |
+| `create` | `create.yml` | Provision test infrastructure |
+| `prepare` | `prepare.yml` | Pre-configure instances (runs once) |
+| `converge` | `converge.yml` | Apply the role/playbook under test |
+| `idempotence` | — | Re-run converge, assert no changes |
+| `side_effect` | `side_effect.yml` | Trigger side effects (e.g., failover) |
+| `verify` | `verify.yml` | Run verification assertions |
+
+### Drivers
+
+Drivers manage the test infrastructure lifecycle. Available via the `molecule-plugins` package:
+
+| Driver | Install extra | Description |
+|--------|---------------|-------------|
+| `docker` | `[docker]` | Docker containers |
+| `podman` | `[podman]` | Podman containers |
+| `vagrant` | `[vagrant]` | Vagrant VMs |
+| `ec2` | `[ec2]` | AWS EC2 instances |
+| `gce` | `[gce]` | Google Compute Engine |
+| `azure` | `[azure]` | Azure VMs |
+| `openstack` | `[openstack]` | OpenStack instances |
+
+The **default** (delegated) driver is built into Molecule core — you provide your own `create.yml` and `destroy.yml` playbooks using any Ansible modules.
+
+Additional drivers:
+
+| Driver | Package | Description |
+|--------|---------|-------------|
+| `kubevirt` | `molecule-kubevirt` | KubeVirt VMs |
+
+## Configuration
+
+### Ansible-native configuration (recommended)
+
+The modern configuration approach uses `molecule.yml` with four top-level sections:
+
+```yaml
+---
+ansible:
+  executor:
+    backend: ansible-playbook
+    args:
+      ansible_playbook:
+        - --inventory=inventory/
+        - --extra-vars=environment=test
+  env:
+    ANSIBLE_FORCE_COLOR: "true"
+    ANSIBLE_HOST_KEY_CHECKING: "false"
+    ANSIBLE_STDOUT_CALLBACK: yaml
+  cfg:
+    defaults:
+      host_key_checking: false
+      gathering: smart
+      timeout: 30
+    ssh_connection:
+      pipelining: true
+  playbooks:
+    create: create.yml
+    destroy: destroy.yml
+    converge: converge.yml
+    prepare: prepare.yml
+    verify: verify.yml
+    cleanup: cleanup.yml
+    side_effect: side_effect.yml
+
+scenario:
+  test_sequence:
+    - create
+    - converge
+    - verify
+    - destroy
+
+shared_state: true
+
+verifier:
+  name: ansible
+```
+
+### Pre-ansible-native configuration (legacy)
+
+The legacy format uses `driver`, `platforms`, and `provisioner` sections:
+
+```yaml
+---
+driver:
+  name: docker
+platforms:
+  - name: instance-1
+    image: ubuntu:22.04
+    groups:
+      - web_servers
+  - name: instance-2
+    image: centos:stream9
+    groups:
+      - db_servers
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      host_key_checking: false
+  env:
+    ANSIBLE_STDOUT_CALLBACK: yaml
+  playbooks:
+    converge: converge.yml
+  inventory:
+    group_vars:
+      all:
+        app_version: "2.0"
+verifier:
+  name: ansible
+scenario:
+  test_sequence:
+    - dependency
+    - cleanup
+    - destroy
+    - syntax
+    - create
+    - prepare
+    - converge
+    - idempotence
+    - verify
+    - cleanup
+    - destroy
+dependency:
+  name: galaxy
+  options:
+    role-file: requirements.yml
+    requirements-file: collections.yml
+```
+
+### Configuration file locations
+
+Molecule searches for configuration in this order:
+
+1. `$HOME/.config/molecule/config.yml` — global defaults
+2. Project root `config.yml` — project-wide defaults
+3. `extensions/molecule/config.yml` — collection base config
+4. Per-scenario `molecule.yml` — scenario-specific overrides
+
+### Variable substitution
+
+`molecule.yml` supports shell-style variable substitution:
+
+```yaml
+platforms:
+  - name: instance-${MOLECULE_SCENARIO_NAME}
+    image: ${CONTAINER_IMAGE:-ubuntu:22.04}
+```
+
+### Environment variables
+
+| Variable | Description |
+|----------|-------------|
+| `MOLECULE_DEBUG` | Enable debug output |
+| `MOLECULE_SCENARIO_NAME` | Current scenario name |
+| `MOLECULE_EPHEMERAL_DIRECTORY` | Temp directory for scenario |
+| `MOLECULE_SCENARIO_DIRECTORY` | Path to scenario directory |
+| `MOLECULE_PROJECT_DIRECTORY` | Path to project root |
+| `MOLECULE_INVENTORY_FILE` | Generated inventory path |
+| `MOLECULE_INSTANCE_CONFIG` | Instance configuration path |
+| `MOLECULE_VERBOSITY` | Verbosity level |
+
+## Verifiers
+
+### Ansible verifier (default)
+
+The default verifier runs `verify.yml` with Ansible assertion modules:
+
+```yaml
+# verify.yml
+---
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Check that nginx is installed
+      ansible.builtin.package_facts:
+        manager: auto
+
+    - name: Assert nginx is present
+      ansible.builtin.assert:
+        that:
+          - "'nginx' in ansible_facts.packages"
+        fail_msg: "nginx is not installed"
+
+    - name: Check nginx is running
+      ansible.builtin.service_facts:
+
+    - name: Assert nginx service is active
+      ansible.builtin.assert:
+        that:
+          - "ansible_facts.services['nginx.service'].state == 'running'"
+```
+
+### Testinfra verifier
+
+For Python-based testing with pytest/testinfra:
+
+```yaml
+verifier:
+  name: testinfra
+  options:
+    n: 1
+    verbose: true
+  additional_files_or_dirs:
+    - ../shared_tests/
+```
+
+```python
+# tests/test_default.py
+def test_nginx_installed(host):
+    nginx = host.package("nginx")
+    assert nginx.is_installed
+
+def test_nginx_running(host):
+    nginx = host.service("nginx")
+    assert nginx.is_running
+    assert nginx.is_enabled
+```
+
+## CLI reference
+
+### Running tests
+
+```bash
+# Run the full test sequence for the default scenario
+molecule test
+
+# Test a specific scenario
+molecule test -s integration
+
+# Test all scenarios
+molecule test --all
+
+# Run scenarios in parallel
+molecule test --all --parallel
+
+# Run with multiple workers
+molecule test --all --workers 4
+
+# Pass extra arguments to ansible-playbook
+molecule converge -- --extra-vars="debug=true"
+```
+
+### Development workflow commands
+
+```bash
+# Create instances only
+molecule create
+
+# Apply the converge playbook (create if needed)
+molecule converge
+
+# Run verification
+molecule verify
+
+# Destroy instances
+molecule destroy
+
+# Destroy all scenarios
+molecule destroy --all
+
+# Prepare instances (run once)
+molecule prepare
+
+# Check idempotence
+molecule idempotence
+
+# Interactive login to an instance
+molecule login --host instance-1
+
+# Run syntax check
+molecule syntax
+```
+
+### Utility commands
+
+```bash
+# Initialize a new scenario
+molecule init scenario my_scenario
+
+# List scenario status
+molecule list
+
+# Show the action matrix for a command
+molecule matrix test
+
+# Reset molecule temporary files
+molecule reset
+
+# List available drivers
+molecule drivers
+```
+
+### Global flags
+
+| Flag | Description |
+|------|-------------|
+| `--debug` | Verbose output (passes `-vvv` to ansible-playbook) |
+| `-s, --scenario-name` | Target specific scenario |
+| `--parallel / --no-parallel` | Run scenarios concurrently (deprecated, use `--workers`) |
+| `--workers N` | Number of concurrent scenario workers |
+
+## Custom test sequences
+
+Configure which actions run for each command:
+
+```yaml
+scenario:
+  create_sequence:
+    - dependency
+    - create
+    - prepare
+  converge_sequence:
+    - dependency
+    - create
+    - prepare
+    - converge
+  destroy_sequence:
+    - cleanup
+    - destroy
+  test_sequence:
+    - dependency
+    - cleanup
+    - destroy
+    - syntax
+    - create
+    - prepare
+    - converge
+    - idempotence
+    - verify
+    - cleanup
+    - destroy
+```
+
+### Multiple verify and side_effect steps
+
+For complex test scenarios, include multiple side effects and verification steps:
+
+```yaml
+test_sequence:
+  - converge
+  - side_effect reboot.yaml
+  - verify after_reboot/
+  - side_effect alter_configs.yaml
+  - converge
+  - verify
+```
+
+## Executor backends
+
+### ansible-playbook (default)
+
+Runs playbooks directly using locally installed Ansible:
+
+```yaml
+ansible:
+  executor:
+    backend: ansible-playbook
+    args:
+      ansible_playbook:
+        - --inventory=inventory/
+```
+
+### ansible-navigator
+
+Runs playbooks inside execution environments for reproducible testing:
+
+```yaml
+ansible:
+  executor:
+    backend: ansible-navigator
+    args:
+      ansible_navigator:
+        - --execution-environment-image=custom-ee:latest
+        - --mode=stdout
+```
+
+## CI/CD integration
+
+### GitHub Actions
+
+```yaml
+name: Molecule
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: pip install ansible-dev-tools molecule-plugins[docker]
+      - name: Run molecule
+        run: molecule test --all
+        env:
+          PY_COLORS: "1"
+          ANSIBLE_FORCE_COLOR: "1"
+```
+
+### GitLab CI
+
+```yaml
+molecule:
+  image: ghcr.io/ansible/community-ansible-dev-tools:latest
+  services:
+    - docker:dind
+  variables:
+    DOCKER_HOST: tcp://docker:2375
+  script:
+    - molecule test --all
+```
+
+### Tips for CI
+
+- Set `PY_COLORS=1` and `ANSIBLE_FORCE_COLOR=1` to force colored output
+- Use `--workers` for parallel scenario execution
+- Set unique `MOLECULE_EPHEMERAL_DIRECTORY` per parallel job to avoid conflicts
+- Use the `community-ansible-dev-tools` container image for pre-installed tooling
+
+## Shared state
+
+Enable shared state to let scenarios share ephemeral data for efficient multi-scenario testing:
+
+```yaml
+shared_state: true
+```
+
+This is useful when multiple scenarios test different aspects of the same infrastructure and you want to avoid reprovisioning for each scenario.
+
+## Editor integration
+
+Projects scaffolded by `ansible-creator` include Molecule scenarios by default. The VS Code extension recognizes Molecule directory structures and provides:
+
+- File detection for `molecule.yml` and scenario playbooks
+- Ansible language support in all Molecule playbooks
+- Integration with ansible-lint for scenario files
+
+## Next steps
+
+Your scenarios pass locally. Now scale your testing and prepare for execution:
+
+- [Run a full test matrix with tox-ansible](/vscode-ansible/python-tools/tox-ansible/) — test across Python versions and ansible-core releases
+- [Execute playbooks with ansible-navigator](/vscode-ansible/python-tools/ansible-navigator/) — run your content in execution environments
+
+## Links
+
+- [PyPI: molecule](https://pypi.org/project/molecule/)
+- [GitHub: ansible/molecule](https://github.com/ansible/molecule)
+- [GitHub: molecule-plugins](https://github.com/ansible-community/molecule-plugins)

--- a/docs/src/content/docs/python-tools/molecule/reference.mdx
+++ b/docs/src/content/docs/python-tools/molecule/reference.mdx
@@ -1,0 +1,767 @@
+---
+title: "molecule: Reference"
+description: Complete molecule.yml schema, environment variables, action definitions, driver configuration, and CLI flags.
+---
+
+This page provides exhaustive reference material for Molecule. For an introduction and typical usage, see the [Molecule guide](/vscode-ansible/python-tools/molecule/).
+
+## CLI flags
+
+### Global options
+
+| Flag | Description |
+|------|-------------|
+| `--debug` | Enable debug mode (passes `-vvv` to ansible-playbook) |
+| `--base-config <path>` | Path to base configuration file |
+| `--env-file <path>` | Path to environment file (`.env.yml`) |
+| `--version` | Show version |
+| `-h, --help` | Show help |
+
+### `molecule test`
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `-s, --scenario-name <name>` | Target scenario (supports nested: `group/scenario`) | `default` |
+| `--all` | Run all scenarios |  — |
+| `--parallel / --no-parallel` | Run scenarios concurrently (deprecated) | `false` |
+| `--workers <n>` | Number of concurrent scenario workers | `1` |
+| `--command-borders` | Show command boundaries in output | — |
+| `--report` | Generate test report | — |
+| `--shared-state` | Share ephemeral state across scenarios | `false` |
+| `--` | Pass remaining args to ansible-playbook | — |
+
+### `molecule converge`
+
+| Flag | Description |
+|------|-------------|
+| `-s, --scenario-name <name>` | Target scenario |
+| `--` | Pass remaining args to ansible-playbook |
+
+### `molecule create`
+
+| Flag | Description |
+|------|-------------|
+| `-s, --scenario-name <name>` | Target scenario |
+| `--driver <name>` | Override driver |
+
+### `molecule destroy`
+
+| Flag | Description |
+|------|-------------|
+| `-s, --scenario-name <name>` | Target scenario |
+| `--all` | Destroy all scenarios |
+| `--parallel` | Destroy in parallel |
+| `--driver <name>` | Override driver |
+
+### `molecule verify`
+
+| Flag | Description |
+|------|-------------|
+| `-s, --scenario-name <name>` | Target scenario |
+
+### `molecule prepare`
+
+| Flag | Description |
+|------|-------------|
+| `-s, --scenario-name <name>` | Target scenario |
+| `--force` | Force re-preparation (even if already prepared) |
+
+### `molecule login`
+
+| Flag | Description |
+|------|-------------|
+| `-s, --scenario-name <name>` | Target scenario |
+| `--host <name>` | Instance to connect to |
+
+### `molecule init scenario`
+
+| Flag | Description |
+|------|-------------|
+| `<name>` | Scenario name (positional) |
+| `--driver-name <name>` | Driver to use |
+
+### `molecule list`
+
+| Flag | Description |
+|------|-------------|
+| `-s, --scenario-name <name>` | Target scenario |
+| `--format <fmt>` | Output format: `simple`, `plain`, `yaml` |
+
+### `molecule matrix`
+
+| Flag | Description |
+|------|-------------|
+| `<subcommand>` | Show action list for this subcommand (positional) |
+| `-s, --scenario-name <name>` | Target scenario |
+
+## molecule.yml schema: Ansible-native configuration
+
+### Top-level structure
+
+```yaml
+---
+ansible: {}
+scenario: {}
+shared_state: false
+verifier: {}
+```
+
+### `ansible` section
+
+```yaml
+ansible:
+  executor:
+    backend: <string>        # "ansible-playbook" or "ansible-navigator"
+    args:
+      ansible_playbook: []   # list of CLI args
+      ansible_navigator: []  # list of CLI args
+  env: {}                    # environment variables (key: value)
+  cfg: {}                    # ansible.cfg sections (nested dict)
+  playbooks:
+    create: <string>         # create playbook filename
+    destroy: <string>        # destroy playbook filename
+    converge: <string>       # converge playbook filename
+    prepare: <string>        # prepare playbook filename
+    verify: <string>         # verify playbook filename
+    cleanup: <string>        # cleanup playbook filename
+    side_effect: <string>    # side_effect playbook filename
+```
+
+#### `ansible.executor`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `backend` | `string` | `ansible-playbook` | Executor backend |
+| `args.ansible_playbook` | `list[string]` | `[]` | Extra args for ansible-playbook |
+| `args.ansible_navigator` | `list[string]` | `[]` | Extra args for ansible-navigator |
+
+#### `ansible.env`
+
+Key-value pairs set as environment variables during playbook execution:
+
+| Common variables | Purpose |
+|-----------------|---------|
+| `ANSIBLE_FORCE_COLOR` | Force colored output |
+| `ANSIBLE_HOST_KEY_CHECKING` | Disable SSH host key checking |
+| `ANSIBLE_STDOUT_CALLBACK` | Output callback (e.g., `yaml`, `debug`) |
+| `ANSIBLE_COLLECTIONS_PATH` | Collection search path |
+| `ANSIBLE_ROLES_PATH` | Role search path |
+
+#### `ansible.cfg`
+
+Nested dict that generates an `ansible.cfg` for the scenario:
+
+```yaml
+ansible:
+  cfg:
+    defaults:
+      host_key_checking: false
+      gathering: smart
+      fact_caching: memory
+      timeout: 30
+      stdout_callback: yaml
+    ssh_connection:
+      ssh_args: -o ControlMaster=auto -o ControlPersist=60s
+      pipelining: true
+    privilege_escalation:
+      become: true
+      become_method: sudo
+```
+
+#### `ansible.playbooks`
+
+| Field | Default filename | Description |
+|-------|-----------------|-------------|
+| `create` | `create.yml` | Provisions test infrastructure |
+| `destroy` | `destroy.yml` | Tears down test infrastructure |
+| `converge` | `converge.yml` | Applies content under test |
+| `prepare` | `prepare.yml` | Pre-configures instances |
+| `verify` | `verify.yml` | Runs verification |
+| `cleanup` | `cleanup.yml` | Cleans external resources |
+| `side_effect` | `side_effect.yml` | Produces side effects |
+
+### `scenario` section
+
+```yaml
+scenario:
+  create_sequence: []
+  converge_sequence: []
+  destroy_sequence: []
+  check_sequence: []
+  test_sequence: []
+```
+
+#### Default sequences
+
+**`test_sequence`** (full test):
+```yaml
+- dependency
+- cleanup
+- destroy
+- syntax
+- create
+- prepare
+- converge
+- idempotence
+- side_effect
+- verify
+- cleanup
+- destroy
+```
+
+**`create_sequence`:**
+```yaml
+- dependency
+- create
+- prepare
+```
+
+**`converge_sequence`:**
+```yaml
+- dependency
+- create
+- prepare
+- converge
+```
+
+**`destroy_sequence`:**
+```yaml
+- dependency
+- cleanup
+- destroy
+```
+
+**`check_sequence`:**
+```yaml
+- dependency
+- cleanup
+- destroy
+- create
+- prepare
+- converge
+- check
+- destroy
+```
+
+### `shared_state`
+
+| Value | Behavior |
+|-------|----------|
+| `false` (default) | Each scenario has independent ephemeral state |
+| `true` | Scenarios share ephemeral directory for efficient multi-scenario testing |
+
+### `verifier` section
+
+```yaml
+verifier:
+  name: <string>        # "ansible" or "testinfra"
+  enabled: <boolean>    # true/false
+  env: {}               # environment variables
+  options: {}           # verifier-specific options
+  directory: <string>   # test file directory
+  additional_files_or_dirs: []  # extra test paths
+```
+
+#### Ansible verifier
+
+```yaml
+verifier:
+  name: ansible
+  enabled: true
+  env:
+    ANSIBLE_VERBOSITY: 1
+```
+
+#### Testinfra verifier
+
+```yaml
+verifier:
+  name: testinfra
+  enabled: true
+  options:
+    n: 1                # pytest parallelism
+    verbose: true
+    capture: no
+    tb: short
+    sudo: true
+  env:
+    PYTHONPATH: /custom/path
+  directory: tests/
+  additional_files_or_dirs:
+    - ../shared_tests/test_common.py
+```
+
+## molecule.yml schema: Pre-ansible-native (legacy)
+
+### Top-level structure
+
+```yaml
+---
+driver: {}
+platforms: []
+provisioner: {}
+verifier: {}
+scenario: {}
+dependency: {}
+```
+
+### `driver` section
+
+```yaml
+driver:
+  name: <string>        # driver name
+  options:
+    managed: <boolean>  # whether Molecule manages instance lifecycle
+    login_cmd_template: <string>  # SSH command template
+    ansible_connection_options:
+      ansible_connection: <string>
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `name` | `string` | `default` | Driver identifier |
+| `options.managed` | `boolean` | `true` | Molecule manages create/destroy |
+
+### `platforms` section
+
+```yaml
+platforms:
+  - name: <string>         # instance name (required)
+    image: <string>        # container/VM image
+    groups: []             # inventory groups
+    children: []           # child groups
+    command: <string>      # container override command
+    privileged: <boolean>  # privileged mode
+    volumes: []            # volume mounts
+    exposed_ports: []      # exposed ports
+    published_ports: []    # published ports
+    networks: []           # network attachments
+    env: {}                # environment variables
+    pre_build_image: <boolean>  # skip image build
+```
+
+Platform fields vary by driver. Common fields for container drivers (docker/podman):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | `string` | Instance name (must be unique) |
+| `image` | `string` | Container image |
+| `groups` | `list[string]` | Ansible inventory groups |
+| `children` | `list[string]` | Child groups |
+| `command` | `string` | Override container CMD |
+| `privileged` | `boolean` | Run in privileged mode |
+| `volumes` | `list[string]` | Bind mounts (`/host:/container[:opts]`) |
+| `exposed_ports` | `list[string]` | Ports to expose |
+| `published_ports` | `list[string]` | Ports to publish (`host:container`) |
+| `networks` | `list[dict]` | Network configurations |
+| `env` | `dict` | Container environment variables |
+| `pre_build_image` | `boolean` | Use existing image (don't build) |
+| `tmpfs` | `list[string]` | tmpfs mounts |
+| `capabilities` | `list[string]` | Linux capabilities |
+| `security_opts` | `list[string]` | Security options |
+| `cgroupns_mode` | `string` | cgroup namespace mode |
+
+### `provisioner` section
+
+```yaml
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      host_key_checking: false
+    ssh_connection:
+      pipelining: true
+  connection_options:
+    ansible_connection: ssh
+  env:
+    ANSIBLE_STDOUT_CALLBACK: yaml
+  playbooks:
+    create: create.yml
+    destroy: destroy.yml
+    converge: converge.yml
+    prepare: prepare.yml
+    verify: verify.yml
+    cleanup: cleanup.yml
+    side_effect: side_effect.yml
+  inventory:
+    hosts: {}
+    group_vars:
+      all:
+        key: value
+    host_vars:
+      instance-1:
+        key: value
+    links:
+      hosts: inventory/hosts.yml
+      group_vars: inventory/group_vars/
+      host_vars: inventory/host_vars/
+  options:
+    become: true
+    v: true
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | `string` | Always `ansible` |
+| `config_options` | `dict` | ansible.cfg sections |
+| `connection_options` | `dict` | Connection variables |
+| `env` | `dict` | Environment variables |
+| `playbooks` | `dict` | Playbook filenames |
+| `inventory` | `dict` | Inventory configuration |
+| `inventory.links` | `dict` | Symlinks to external inventory files |
+| `options` | `dict` | Extra ansible-playbook options |
+
+### `dependency` section
+
+```yaml
+dependency:
+  name: galaxy
+  options:
+    role-file: requirements.yml
+    requirements-file: collections.yml
+    force: false
+  env:
+    ANSIBLE_GALAXY_SERVER_LIST: automation_hub
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `name` | `string` | `galaxy` | Dependency manager |
+| `options.role-file` | `string` | `requirements.yml` | Role requirements |
+| `options.requirements-file` | `string` | — | Collection requirements |
+| `options.force` | `boolean` | `false` | Force re-download |
+
+### Shell dependency manager
+
+```yaml
+dependency:
+  name: shell
+  command: path/to/command --flag1 subcommand --flag2
+  enabled: true
+  env:
+    FOO: bar
+```
+
+## Provisioner details
+
+### Skip tags
+
+Molecule recognizes special tags to exclude tasks from certain phases:
+
+| Tag | Effect |
+|-----|--------|
+| `molecule-notest` | Task is always skipped by Molecule |
+| `notest` | Alias for `molecule-notest` |
+| `molecule-idempotence-notest` | Task is skipped only during the idempotence action |
+
+### Provisioner logging
+
+```yaml
+provisioner:
+  name: ansible
+  log: true
+```
+
+### Playbook loading order
+
+Molecule resolves playbooks in this order:
+1. `provisioner.playbooks.<driver_name>.<action>` (driver-specific)
+2. `provisioner.playbooks.<action>` (generic)
+3. Bundled default playbook for the driver/action
+
+### Inventory links
+
+Use symlinks to external inventory files instead of inline definitions:
+
+```yaml
+provisioner:
+  inventory:
+    links:
+      hosts: inventory/hosts.yml
+      group_vars: inventory/group_vars/
+      host_vars: inventory/host_vars/
+```
+
+### Disallowed config_options
+
+These keys cannot be set in `provisioner.config_options` as they would break Molecule:
+- `library`
+- `filter_plugins`
+- `privilege_escalation`
+
+## Environment variables
+
+### Molecule-provided variables
+
+Available in `molecule.yml` via `$&#123;VAR&#125;` substitution and in playbooks as facts:
+
+| Variable | Description |
+|----------|-------------|
+| `MOLECULE_DEBUG` | Debug mode enabled |
+| `MOLECULE_FILE` | Path to `molecule.yml` |
+| `MOLECULE_ENV_FILE` | Path to `.env.yml` |
+| `MOLECULE_STATE_FILE` | Path to state file |
+| `MOLECULE_INVENTORY_FILE` | Path to generated inventory |
+| `MOLECULE_EPHEMERAL_DIRECTORY` | Temp directory for scenario |
+| `MOLECULE_SCENARIO_DIRECTORY` | Path to scenario directory |
+| `MOLECULE_PROJECT_DIRECTORY` | Path to project root |
+| `MOLECULE_INSTANCE_CONFIG` | Path to instance config file |
+| `MOLECULE_DEPENDENCY_NAME` | Dependency manager name |
+| `MOLECULE_SCENARIO_NAME` | Current scenario name |
+| `MOLECULE_VERBOSITY` | Verbosity level |
+| `MOLECULE_DRIVER_NAME` | Driver name (pre-native only) |
+| `MOLECULE_PROVISIONER_NAME` | Provisioner name (pre-native only) |
+| `MOLECULE_VERIFIER_NAME` | Verifier name (pre-native only) |
+| `MOLECULE_ANSIBLE_ARGS_STRICT_MODE` | Reverts to legacy behavior where ansible_args are excluded from create/destroy |
+| `MOLECULE_VERIFIER_TEST_DIRECTORY` | Path to verifier test directory (pre-ansible-native) |
+
+### Variable substitution in molecule.yml
+
+Shell-style substitution with defaults:
+
+```yaml
+platforms:
+  - name: instance-${MOLECULE_SCENARIO_NAME}
+    image: ${CONTAINER_IMAGE:-ubuntu:22.04}
+    env:
+      CI: ${CI:-false}
+```
+
+| Syntax | Behavior |
+|--------|----------|
+| `$&#123;VAR&#125;` | Value of VAR (error if unset) |
+| `$&#123;VAR:-default&#125;` | Value of VAR, or `default` if unset/empty |
+| `$&#123;VAR-default&#125;` | Value of VAR, or `default` if unset (not empty) |
+
+## Action reference
+
+### `dependency`
+
+Installs role and collection dependencies. Runs `ansible-galaxy` with the configured requirements files.
+
+### `cleanup`
+
+Runs `cleanup.yml` to clean external resources (load balancers, DNS entries, etc.) before destroying instances. Runs both before `destroy` in the test sequence.
+
+### `destroy`
+
+Runs `destroy.yml` to tear down test infrastructure.
+
+### `syntax`
+
+Runs `ansible-playbook --syntax-check` on the converge playbook. No playbook of its own.
+
+### `create`
+
+Runs `create.yml` to provision test infrastructure.
+
+### `prepare`
+
+Runs `prepare.yml` to pre-configure instances (install Python, configure repos, etc.). Only runs once unless `--force` is used.
+
+### `converge`
+
+Runs `converge.yml` — the main playbook that applies the role or content under test.
+
+### `idempotence`
+
+Re-runs the converge playbook and asserts no tasks report `changed`. No playbook of its own — reuses `converge.yml`.
+
+### `side_effect`
+
+Runs `side_effect.yml` to produce side effects (failover, reboot, config changes) for testing recovery scenarios.
+
+### `verify`
+
+Runs `verify.yml` (Ansible verifier) or pytest (Testinfra verifier) to validate the system state.
+
+### `check`
+
+Runs `ansible-playbook --check` (dry-run mode) on the converge playbook.
+
+## Configuration file locations
+
+Searched in order (later files override earlier):
+
+| Path | Scope | Description |
+|------|-------|-------------|
+| `$HOME/.config/molecule/config.yml` | Global | User-wide defaults |
+| `<project>/config.yml` | Project | Project-wide defaults |
+| `<project>/extensions/molecule/config.yml` | Collection | Collection base config |
+| `<scenario>/molecule.yml` | Scenario | Scenario-specific config |
+| `<project>/.env.yml` | Project | Variables injected into molecule.yml rendering |
+
+## Nested scenarios
+
+For collections with many components, scenarios can be organized in nested directories:
+
+```text
+extensions/molecule/
+├── appliance_vlans/
+│   ├── merged/
+│   │   ├── molecule.yml
+│   │   └── converge.yml
+│   └── replaced/
+│       ├── molecule.yml
+│       └── converge.yml
+└── interfaces/
+    └── default/
+        ├── molecule.yml
+        └── converge.yml
+```
+
+Target nested scenarios with `/` separator:
+
+```bash
+# Run a specific nested scenario
+molecule test -s appliance_vlans/merged
+
+# Wildcard targeting
+molecule test -s "appliance_vlans/*"
+```
+
+Enable recursive discovery with the `MOLECULE_GLOB` environment variable:
+
+```bash
+export MOLECULE_GLOB="extensions/molecule/**/molecule.yml"
+```
+
+Scenario names are derived from their relative path within `extensions/molecule/`.
+
+## Driver-specific configuration
+
+### Docker (`molecule-plugins[docker]`)
+
+```yaml
+platforms:
+  - name: instance
+    image: ubuntu:22.04
+    dockerfile: Dockerfile.j2
+    command: /sbin/init
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    tmpfs:
+      - /run
+      - /tmp
+    networks:
+      - name: molecule_net
+    exposed_ports:
+      - "8080/tcp"
+    published_ports:
+      - "0.0.0.0:8080:8080/tcp"
+    env:
+      DEBIAN_FRONTEND: noninteractive
+    pre_build_image: true
+```
+
+### Podman (`molecule-plugins[podman]`)
+
+```yaml
+platforms:
+  - name: instance
+    image: registry.access.redhat.com/ubi9/ubi-init:latest
+    command: /sbin/init
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    security_opts:
+      - label=disable
+    capabilities:
+      - SYS_ADMIN
+    tmpfs:
+      - /run
+      - /tmp
+```
+
+### Full platform properties (container drivers)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | `string` | Instance name (required, unique) |
+| `image` | `string` | Container image |
+| `hostname` | `string` | Container hostname |
+| `command` | `string` | Override container CMD |
+| `privileged` | `boolean` | Privileged mode |
+| `memory` | `string` | Memory limit (e.g., `512m`) |
+| `cpus` | `integer` | CPU count |
+| `groups` | `list[string]` | Ansible inventory groups |
+| `children` | `list[string]` | Child groups |
+| `env` | `dict` | Container environment variables |
+| `volumes` | `list[string]` | Bind mounts (`/host:/container[:opts]`) |
+| `tmpfs` | `list[string]` | tmpfs mounts |
+| `exposed_ports` | `list[string]` | Ports to expose |
+| `published_ports` | `list[string]` | Published ports (`host:container`) |
+| `networks` | `list[dict]` | Networks with `name`, `aliases`, `ipv4_address` |
+| `network_mode` | `string` | Network mode (bridge, host, none) |
+| `ulimits` | `list[string]` | ulimit settings |
+| `cgroupns_mode` | `string` | cgroup namespace mode |
+| `capabilities` | `list[string]` | Linux capabilities |
+| `security_opts` | `list[string]` | Security options |
+| `pre_build_image` | `boolean` | Use existing image (skip build) |
+| `pkg_extras` | `list[string]` | Extra packages for image build |
+| `registry` | `dict` | Registry config with `url`, `credentials` |
+| `dockerfile` | `string` | Path to Dockerfile template |
+| `port_bindings` | `dict` | Port binding configuration |
+
+### Delegated/Default (built-in)
+
+```yaml
+driver:
+  name: default
+  options:
+    managed: true
+    ansible_connection_options:
+      ansible_connection: ssh
+```
+
+With `managed: true`, you must provide `create.yml` and `destroy.yml` that manage the infrastructure using any Ansible modules.
+
+With `managed: false`, Molecule skips create/destroy and assumes instances already exist. Your inventory must provide connection details.
+
+## Delegated driver instance-config
+
+When using the delegated/default driver with `managed: true`, your `create.yml` must write instance connection details to `instance_config`. The schema varies by connection type:
+
+### SSH instances
+
+```yaml
+- address: "192.168.1.10"
+  identity_file: "/path/to/key"
+  instance: "my-instance"
+  port: 22
+  user: "root"
+  shell_type: "sh"
+  password: ""
+  become_method: "sudo"
+  become_pass: ""
+```
+
+### WinRM instances
+
+```yaml
+- address: "192.168.1.20"
+  instance: "win-instance"
+  connection: "winrm"
+  port: 5986
+  user: "Administrator"
+  password: "secret"
+  shell_type: "powershell"
+  winrm_transport: "ntlm"
+  winrm_cert_pem: ""
+  winrm_cert_key_pem: ""
+  winrm_server_cert_validation: "ignore"
+```
+
+### `driver.safe_files`
+
+Files listed in `safe_files` are preserved when instances are destroyed:
+
+```yaml
+driver:
+  name: default
+  safe_files:
+    - foo
+    - .molecule/bar
+```

--- a/docs/src/content/docs/python-tools/overview.mdx
+++ b/docs/src/content/docs/python-tools/overview.mdx
@@ -1,26 +1,173 @@
 ---
 title: Python Tools Overview
-description: The Python CLI tools that form the foundation of the Ansible development experience.
+description: The complete suite of Python CLI tools that form the foundation of the Ansible development experience.
 ---
 
-The Ansible developer tools ecosystem is built on a set of Python CLI packages maintained by the Ansible team at Red Hat. These tools work standalone from the command line and are also integrated into the VS Code extension and MCP server.
+
+The Ansible developer tools ecosystem is built on a curated set of Python CLI packages maintained by the Ansible team at Red Hat. These tools handle every phase of Ansible content development — from scaffolding new projects, through linting and testing, to building execution environments and signing content for distribution.
+
+All tools work standalone from the command line and are deeply integrated into the VS Code extension, Language Server, and MCP server.
 
 ## ansible-dev-tools (ADT)
 
-The meta-package that installs the full suite in one command:
+The `ansible-dev-tools` meta-package installs the entire suite in one command:
 
 ```bash
 pip install ansible-dev-tools
 ```
 
-- [PyPI](https://pypi.org/project/ansible-dev-tools/)
-- [GitHub](https://github.com/ansible/ansible-dev-tools)
+After installation, verify all tool versions with a single command:
 
-## Ansible Development Environment (ADE)
+```bash
+adt --version
+```
 
-A CLI for managing isolated Ansible development environments.
+```text
+ansible-builder                          3.1.1
+ansible-core                             2.21.0
+ansible-creator                          26.4.3
+ansible-dev-environment                  26.6.0
+ansible-dev-tools                        26.4.6
+ansible-lint                             26.4.0
+ansible-navigator                        26.4.0
+ansible-sign                             0.1.5
+molecule                                 26.4.0
+tox-ansible                              26.6.0
+```
 
-- [PyPI](https://pypi.org/project/ade/)
-- [GitHub](https://github.com/ansible/ade)
+### The `adt server` command
 
-Content coming soon. This page will provide a comprehensive overview of the Python tooling ecosystem.
+The `adt server` command launches a Django/Gunicorn REST API that the VS Code extension uses to power content scaffolding. It exposes endpoints for creating playbooks, collections, execution environments, and devfiles — all driven by dynamic schemas from `ansible-creator`.
+
+```bash
+adt server
+```
+
+The server runs on port 8000 by default and is typically managed automatically by the extension.
+
+### Container image
+
+All ADT tools come pre-installed in the `community-ansible-dev-tools` container image:
+
+```bash
+podman pull ghcr.io/ansible/community-ansible-dev-tools:latest
+```
+
+This image can be used as:
+
+- A **development container** via VS Code Dev Containers or GitHub Codespaces
+- A **base image** for custom execution environments
+- An **interactive environment** for Ansible development without local installation
+
+```bash
+podman run -it --rm \
+  -v $PWD:/workdir \
+  ghcr.io/ansible/community-ansible-dev-tools:latest
+```
+
+### DevContainer support
+
+The `ansible-dev-tools` repository provides sample `devcontainer.json` files for both Podman and Docker. Copy the `.devcontainer` directory into your Ansible project to get a fully configured development environment with all tools available.
+
+## Tool categories
+
+The tools are organized into three functional groups reflecting the Ansible content lifecycle:
+
+### Creation tools
+
+| Tool | Purpose |
+|------|---------|
+| [ansible-creator](/vscode-ansible/python-tools/ansible-creator/) | Scaffold collections, playbooks, roles, plugins, and execution environments |
+| [ansible-dev-environment](/vscode-ansible/python-tools/ansible-dev-environment/) | Manage isolated virtual environments for collection development |
+
+### Linting and testing tools
+
+| Tool | Purpose |
+|------|---------|
+| [ansible-lint](/vscode-ansible/python-tools/ansible-lint/) | Check playbooks, roles, and collections for best practices |
+| [molecule](/vscode-ansible/python-tools/molecule/) | Functional testing framework for Ansible content |
+| [tox-ansible](/vscode-ansible/python-tools/tox-ansible/) | Generate multi-version test matrices for collections |
+
+### Execution and deployment tools
+
+| Tool | Purpose |
+|------|---------|
+| [ansible-navigator](/vscode-ansible/python-tools/ansible-navigator/) | Run and inspect Ansible content with a TUI or in execution environments |
+| [ansible-builder](/vscode-ansible/python-tools/ansible-builder/) | Build execution environment container images |
+| [ansible-sign](/vscode-ansible/python-tools/ansible-sign/) | Sign and verify Ansible project content with GPG |
+
+## Installation options
+
+### Full suite (recommended)
+
+```bash
+pip install ansible-dev-tools
+```
+
+### Individual tools
+
+Each tool can be installed independently:
+
+```bash
+pip install ansible-lint
+pip install molecule
+pip install ansible-navigator
+```
+
+### System packages
+
+On Fedora and RHEL:
+
+```bash
+dnf install ansible-lint
+```
+
+### From the container image
+
+No local Python installation required:
+
+```bash
+podman run -it --rm \
+  -v $PWD:/workdir \
+  ghcr.io/ansible/community-ansible-dev-tools:latest
+```
+
+## Your journey through the toolkit
+
+These tools aren't standalone utilities — they form a connected pipeline. Each step produces what the next step consumes:
+
+```text
+Scaffold ──▶ Environment ──▶ Lint ──▶ Test ──▶ Execute ──▶ Package ──▶ Sign
+creator      ade              lint    molecule  navigator   builder     sign
+                                      tox
+```
+
+### Where to start
+
+**Starting a new project?** Begin with [ansible-creator](/vscode-ansible/python-tools/ansible-creator/) to scaffold a collection or playbook project, then [set up your environment with ade](/vscode-ansible/python-tools/ansible-dev-environment/).
+
+**Already have content?** Jump to [ansible-lint](/vscode-ansible/python-tools/ansible-lint/) to validate it, then [Molecule](/vscode-ansible/python-tools/molecule/) to test it.
+
+**Ready to run playbooks?** Go straight to [ansible-navigator](/vscode-ansible/python-tools/ansible-navigator/) for interactive or container-based execution.
+
+**Preparing for production?** Read [ansible-builder](/vscode-ansible/python-tools/ansible-builder/) to create custom execution environments, then [ansible-sign](/vscode-ansible/python-tools/ansible-sign/) to secure them.
+
+**Want the full picture?** The [end-to-end workflow guide](/vscode-ansible/python-tools/workflow/) walks through the entire lifecycle from empty directory to signed release.
+
+### The editor and AI layer
+
+Underneath your workflow, the VS Code extension, Language Server, and MCP server integrate with every tool:
+
+- **ansible-creator** powers the extension's scaffolding panels via `adt server`
+- **ansible-lint** provides real-time diagnostics through the Language Server
+- **ansible-navigator** handles playbook execution with progress streaming
+- **ansible-builder** and **ansible-navigator** provide execution environment introspection
+- **ansible-dev-environment** manages Python environments the extension discovers
+
+AI agents connected via the MCP server access the same capabilities — scaffolding, linting, environment queries — without manual steps.
+
+## Links
+
+- [PyPI: ansible-dev-tools](https://pypi.org/project/ansible-dev-tools/)
+- [GitHub: ansible/ansible-dev-tools](https://github.com/ansible/ansible-dev-tools)
+- [Container image: ghcr.io/ansible/community-ansible-dev-tools](https://github.com/ansible/community-ansible-dev-tools-image)

--- a/docs/src/content/docs/python-tools/tox-ansible.mdx
+++ b/docs/src/content/docs/python-tools/tox-ansible.mdx
@@ -1,0 +1,283 @@
+---
+title: tox-ansible
+description: Tox plugin that dynamically generates test environments for Ansible collections across Python and ansible-core versions.
+---
+
+tox-ansible is a plugin for the [tox](https://tox.wiki/) testing automation tool that dynamically generates a full matrix of test environments for Ansible collections. It creates combinations of Python interpreters and ansible-core versions, running integration, sanity, and unit tests across all of them — both locally and in GitHub Actions.
+
+## Installation
+
+```bash
+# Via the full suite (recommended)
+pip install ansible-dev-tools
+
+# Standalone
+pip install tox-ansible
+```
+
+Verify installation:
+
+```bash
+tox --version
+# tox-ansible should appear in the plugin list
+```
+
+## Core concepts
+
+### Dynamic environment generation
+
+Unlike standard tox where you manually define every test environment, tox-ansible **automatically discovers** your collection structure and generates environments based on:
+
+- Available Python interpreters on the system
+- Supported ansible-core versions
+- Test types found in the collection (integration, unit, sanity)
+
+This means your `tox.ini` can be minimal — tox-ansible handles the combinatorial explosion.
+
+### Test types
+
+tox-ansible generates environments for three test types:
+
+| Type | What it tests | How |
+|------|---------------|-----|
+| **integration** | Molecule scenarios | Discovers `extensions/molecule/` scenarios and runs them |
+| **unit** | Python unit tests | Runs `pytest` against `tests/unit/` |
+| **sanity** | Ansible sanity checks | Runs `ansible-test sanity` |
+
+### Environment naming
+
+Generated environments follow the pattern:
+
+```text
+{python_version}-{ansible_core_version}-{test_type}[-{scenario}]
+```
+
+Examples:
+
+```text
+py312-2.17-integration-default
+py311-2.16-unit
+py312-2.17-sanity
+py312-2.17-integration-failover
+```
+
+## Configuration
+
+### Minimal `tox.ini`
+
+For most collections, a minimal configuration is sufficient:
+
+```ini
+[tox]
+requires =
+    tox>=4.0
+    tox-ansible>=26.0
+
+[ansible]
+# tox-ansible reads this section
+skip =
+    # Skip specific scenarios or test types
+    2.16-integration
+```
+
+### Configuration options
+
+The `[ansible]` section in `tox.ini` supports:
+
+| Key | Description |
+|-----|-------------|
+| `skip` | List of environment patterns to skip |
+| `python` | Python versions to test (defaults to discovered interpreters) |
+| `ansible-core` | ansible-core versions to test |
+
+### Integration with ansible-dev-environment
+
+tox-ansible delegates collection installation to `ade` (ansible-dev-environment), ensuring:
+
+- Collections are installed in editable mode within each tox environment
+- Python and collection dependencies are properly resolved
+- Each environment is fully isolated
+
+## CLI usage
+
+### List generated environments
+
+```bash
+# See all environments tox-ansible will generate
+tox list
+```
+
+### Run all tests
+
+```bash
+# Run the full matrix
+tox
+```
+
+### Run specific environments
+
+```bash
+# Run only integration tests on Python 3.12 with ansible-core 2.17
+tox -e py312-2.17-integration
+
+# Run only unit tests
+tox -e py312-2.17-unit
+
+# Run sanity checks
+tox -e py312-2.17-sanity
+
+# Run a specific molecule scenario
+tox -e py312-2.17-integration-default
+```
+
+### Parallel execution
+
+```bash
+# Run environments in parallel
+tox -p auto
+
+# Run with a specific number of workers
+tox -p 4
+```
+
+## GitHub Actions integration
+
+### `--gh-matrix` flag
+
+tox-ansible can output its generated environment list as a GitHub Actions matrix JSON, enabling dynamic CI matrices:
+
+```bash
+tox --gh-matrix
+```
+
+This outputs JSON suitable for use in a GitHub Actions matrix strategy.
+
+### Workflow example
+
+```yaml
+name: Collection Tests
+on: [push, pull_request]
+
+jobs:
+  generate-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.matrix.outputs.envlist }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install tox-ansible
+        run: pip install tox-ansible
+      - name: Generate matrix
+        id: matrix
+        run: |
+          echo "envlist=$(tox --gh-matrix)" >> $GITHUB_OUTPUT
+
+  test:
+    needs: generate-matrix
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        env: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.env.python }}
+      - name: Install dependencies
+        run: pip install ansible-dev-tools molecule-plugins[docker]
+      - name: Run tests
+        run: tox -e ${{ matrix.env.name }}
+        env:
+          PY_COLORS: "1"
+          ANSIBLE_FORCE_COLOR: "1"
+```
+
+### Benefits over static matrices
+
+| Static matrix | tox-ansible matrix |
+|---------------|-------------------|
+| Must manually list all Python × Ansible combinations | Auto-discovers available combinations |
+| Breaks when new versions are released | Adapts to new versions automatically |
+| Duplicates information between tox.ini and workflow | Single source of truth in `tox.ini` |
+| Hard to keep in sync | Always consistent |
+
+## Collection testing workflow
+
+### Typical project structure
+
+```text
+my_collection/
+├── galaxy.yml
+├── tox.ini
+├── plugins/
+│   └── modules/
+│       └── my_module.py
+├── tests/
+│   └── unit/
+│       └── test_my_module.py
+└── extensions/
+    └── molecule/
+        ├── default/
+        │   ├── molecule.yml
+        │   ├── converge.yml
+        │   └── verify.yml
+        └── failover/
+            ├── molecule.yml
+            ├── converge.yml
+            └── verify.yml
+```
+
+### Running locally
+
+```bash
+# Install the collection in development mode
+ade install -e .[test] --venv .venv
+source .venv/bin/activate
+
+# Run all tests via tox
+tox
+
+# Run just the default molecule scenario
+tox -e py312-2.17-integration-default
+
+# Run unit tests only
+tox -e py312-2.17-unit
+```
+
+### What tox-ansible does for each environment
+
+1. Creates an isolated virtual environment
+2. Installs the specified ansible-core version
+3. Uses `ade` to install the collection in editable mode
+4. Installs test dependencies
+5. Runs the appropriate test command:
+   - Integration: `molecule test -s <scenario>`
+   - Unit: `pytest tests/unit/`
+   - Sanity: `ansible-test sanity`
+
+## Additional test runners
+
+tox-ansible also supports:
+
+- **galaxy-importer** — validates the collection for Galaxy publishing
+- Custom test commands via standard tox `[testenv]` configuration
+
+## Editor integration
+
+Collections scaffolded by `ansible-creator` include a pre-configured `tox.ini` that works with tox-ansible out of the box. The VS Code extension recognizes tox configurations and provides task integration for running tests.
+
+## Next steps
+
+Your collection is tested across the matrix. Now run it for real and package it:
+
+- [Run playbooks with ansible-navigator](/vscode-ansible/python-tools/ansible-navigator/) — execute in containers with the same isolation as production
+- [Build an execution environment with ansible-builder](/vscode-ansible/python-tools/ansible-builder/) — package your collection and its dependencies into a container image
+
+## Links
+
+- [PyPI: tox-ansible](https://pypi.org/project/tox-ansible/)
+- [GitHub: ansible/tox-ansible](https://github.com/ansible/tox-ansible)

--- a/docs/src/content/docs/python-tools/workflow.mdx
+++ b/docs/src/content/docs/python-tools/workflow.mdx
@@ -1,0 +1,255 @@
+---
+title: End-to-End Workflow
+description: How all Ansible developer tools work together through the complete content lifecycle.
+---
+
+This page walks through a real development cycle — from an empty directory to signed, production-ready Ansible content — showing how each tool in the suite connects to the next. The individual tool pages cover features in depth; this page shows the journey.
+
+## The lifecycle
+
+```text
+ ┌──────────┐    ┌──────────┐    ┌──────────┐    ┌──────────┐
+ │ Scaffold │───▶│  Develop │───▶│   Test   │───▶│ Execute  │
+ │          │    │          │    │          │    │          │
+ │ creator  │    │ ade      │    │ lint     │    │navigator │
+ │          │    │ lint     │    │ molecule │    │ builder  │
+ │          │    │          │    │ tox      │    │ sign     │
+ └──────────┘    └──────────┘    └──────────┘    └──────────┘
+```
+
+## Phase 1: Scaffold
+
+You're starting a new Ansible collection. Instead of creating directories and boilerplate by hand, use **ansible-creator**:
+
+```bash
+ansible-creator init collection myorg.network_automation ~/projects/network_automation
+```
+
+This generates a complete project structure: plugins, roles, tests, molecule scenarios, CI workflows, devcontainer configuration, and a pre-configured `tox.ini`. You're starting with community best practices built in.
+
+**What you have now:** A fully structured collection with placeholder content, ready for development.
+
+**Tool used:** [ansible-creator](/vscode-ansible/python-tools/ansible-creator/)
+
+## Phase 2: Set up your environment
+
+Before writing code, create an isolated development environment using **ansible-dev-environment**:
+
+```bash
+cd ~/projects/network_automation
+ade install -e .[test] --venv .venv
+source .venv/bin/activate
+```
+
+This creates a virtual environment, installs your collection in editable mode (via symlink), resolves all Python and collection dependencies, and installs test dependencies. Changes to your source files are immediately visible to Ansible without reinstalling.
+
+**What you have now:** An isolated workspace where your collection is importable, testable, and won't conflict with other projects.
+
+**Tool used:** [ansible-dev-environment](/vscode-ansible/python-tools/ansible-dev-environment/)
+
+## Phase 3: Write and lint
+
+Open the project in VS Code with the Ansible extension. As you write playbooks, roles, and modules, **ansible-lint** runs continuously in the background via the Language Server, catching issues in real time:
+
+- Missing FQCNs flagged as you type
+- Naming convention violations highlighted
+- Security issues (missing `no_log`, risky permissions) surfaced immediately
+
+You can also run it explicitly:
+
+```bash
+ansible-lint --profile moderate
+```
+
+Fix common issues automatically:
+
+```bash
+ansible-lint --fix
+```
+
+**What you have now:** Clean, linted content that follows community best practices.
+
+**Tool used:** [ansible-lint](/vscode-ansible/python-tools/ansible-lint/)
+
+## Phase 4: Test locally
+
+Your scaffolded project came with Molecule scenarios. Run them to verify your roles work against real infrastructure:
+
+```bash
+# Run the default scenario
+molecule test
+
+# During development, iterate faster:
+molecule converge   # apply your role
+molecule verify     # check assertions
+molecule destroy    # clean up
+```
+
+Molecule provisions test containers (or VMs), applies your role, runs verification assertions, and tears everything down. The converge playbook exercises your role; the verify playbook proves it did what you intended.
+
+**What you have now:** Confidence that your content works against real targets.
+
+**Tool used:** [molecule](/vscode-ansible/python-tools/molecule/)
+
+## Phase 5: Test the matrix
+
+Before publishing, verify your collection works across the supported matrix of Python versions and ansible-core releases. **tox-ansible** generates this matrix automatically:
+
+```bash
+# See what environments will be tested
+tox list
+
+# Run the full matrix
+tox
+
+# Or run a specific combination
+tox -e py312-2.17-integration-default
+```
+
+For CI, generate a GitHub Actions matrix dynamically:
+
+```bash
+tox --gh-matrix
+```
+
+**What you have now:** Proof that your collection works across all supported Python and Ansible versions.
+
+**Tool used:** [tox-ansible](/vscode-ansible/python-tools/tox-ansible/)
+
+## Phase 6: Run for real
+
+Your collection is tested. Now run your playbooks against actual infrastructure using **ansible-navigator**:
+
+```bash
+# Interactive mode for development
+ansible-navigator run site.yml -i inventory/staging.yml
+
+# stdout mode for CI/CD
+ansible-navigator run site.yml -i inventory/production.yml --mode stdout
+```
+
+Navigator runs your playbook inside an execution environment container by default, giving you the same isolation you'll have in production with Ansible Automation Platform. Use the TUI to drill into results, inspect task output, and debug failures interactively.
+
+**What you have now:** Validated automation running against real infrastructure in a reproducible container environment.
+
+**Tool used:** [ansible-navigator](/vscode-ansible/python-tools/ansible-navigator/)
+
+## Phase 7: Build your execution environment
+
+The default community EE image works for development, but production needs a custom image with exactly your collections and dependencies — nothing more, nothing less. Use **ansible-builder**:
+
+```yaml
+# execution-environment.yml
+---
+version: 3
+images:
+  base_image:
+    name: docker.io/redhat/ubi9:latest
+dependencies:
+  ansible_core:
+    package_pip: ansible-core==2.17.0
+  ansible_runner:
+    package_pip: ansible-runner
+  galaxy:
+    collections:
+      - name: myorg.network_automation
+      - name: ansible.netcommon
+      - name: ansible.utils
+  python:
+    - netmiko>=4.0
+    - paramiko
+  system:
+    - openssh-clients
+options:
+  tags:
+    - myorg/network-ee:latest
+    - myorg/network-ee:1.0.0
+```
+
+```bash
+ansible-builder build
+```
+
+This produces a minimal, production-ready container image that ansible-navigator and Ansible Automation Platform can use.
+
+**What you have now:** A custom execution environment image containing exactly what your automation needs.
+
+**Tool used:** [ansible-builder](/vscode-ansible/python-tools/ansible-builder/)
+
+## Phase 8: Sign and ship
+
+Before deploying to Automation Platform, sign your project to ensure no one can tamper with the content between your CI pipeline and production:
+
+```bash
+ansible-sign project gpg-sign .
+git add .ansible-sign/
+git commit -m "Sign release v1.0.0"
+git tag v1.0.0
+git push origin v1.0.0
+```
+
+When Ansible Automation Platform Controller syncs this project, it automatically verifies the signature. If any file has been modified since signing, the sync fails and the content cannot run.
+
+**What you have now:** Cryptographically verified content that can be trusted in production.
+
+**Tool used:** [ansible-sign](/vscode-ansible/python-tools/ansible-sign/)
+
+## The complete picture
+
+Here's every tool in sequence with the artifact each produces:
+
+| Phase | Tool | Input | Output |
+|-------|------|-------|--------|
+| Scaffold | ansible-creator | A name and a command | Complete project structure |
+| Environment | ade | Project directory | Isolated venv with editable install |
+| Lint | ansible-lint | Your Ansible files | Clean, best-practice content |
+| Unit test | molecule | Scenarios + converge playbooks | Passing functional tests |
+| Matrix test | tox-ansible | tox.ini + collection | Green matrix across versions |
+| Execute | ansible-navigator | Playbook + inventory + EE | Successful automation runs |
+| Package | ansible-builder | EE definition | Custom container image |
+| Sign | ansible-sign | Project directory | Verified, tamper-proof release |
+
+## Where the editor fits
+
+Throughout this entire lifecycle, the VS Code extension (and its Language Server and MCP server) integrates with the tools at every stage:
+
+- **Scaffolding**: The extension's Creator panel calls `ansible-creator` through the `adt server` API
+- **Linting**: The Language Server runs `ansible-lint` on every save and surfaces diagnostics inline
+- **Testing**: Molecule scenarios get full Ansible language support in the editor
+- **Execution**: The extension can invoke `ansible-navigator` for playbook runs with progress streaming
+- **EE awareness**: The extension introspects execution environment images to show installed collections and versions
+
+AI agents connected via the MCP server have access to the same lifecycle — scaffolding projects, running diagnostics, and querying environment state — without any manual steps.
+
+## CI/CD pipeline
+
+In practice, several of these phases run in your CI/CD pipeline rather than locally:
+
+```yaml
+# .github/workflows/ci.yml (simplified)
+jobs:
+  lint:
+    steps:
+      - uses: ansible/ansible-lint@main
+
+  test:
+    needs: lint
+    strategy:
+      matrix:
+        env: ${{ fromJSON(needs.matrix.outputs.envlist) }}
+    steps:
+      - run: tox -e ${{ matrix.env.name }}
+
+  build-ee:
+    needs: test
+    steps:
+      - run: ansible-builder build --tag myorg/network-ee:${{ github.sha }}
+      - run: podman push myorg/network-ee:${{ github.sha }}
+
+  sign:
+    needs: build-ee
+    steps:
+      - run: ansible-sign project gpg-sign .
+```
+
+The tools compose naturally in CI because they're all designed to run headlessly with machine-readable output (SARIF, JSON, exit codes).


### PR DESCRIPTION
## Summary
- Replaces stub Python Tools pages with comprehensive, canonical documentation for all 8 ansible-dev-tools components (ansible-creator, ansible-dev-environment, ansible-lint, molecule, tox-ansible, ansible-navigator, ansible-builder, ansible-sign)
- Each tool receives a guide page (concepts, installation, usage) and where warranted a detailed reference page (CLI flags, configuration schemas, environment variables)
- Establishes narrative coherence through lifecycle-ordered sidebar, cross-page "Next steps" links, and an end-to-end workflow page

## Changes
- **ADR-016 amendment**: Updated decision and consequences sections to reflect the docs site as the single authoritative source (status remains `Implemented` per convention; amendment details in Revision History)
- **16 new/updated MDX files**: Guide + reference pages for each tool
- **Sidebar restructured**: Three lifecycle groups (Scaffold, Validate, Execute & Ship) with Reference badges for tools with complex schemas
- **Workflow page**: End-to-end development scenario connecting all tools
- **Overview reframing**: Reader journey guidance replacing static tool list
- **MDX escaping**: HTML entities for curly-brace template variables in table cells (MDX parser limitation)

### Reference page strategy
Tools with complex schemas/config get dedicated reference pages: ansible-builder, ansible-navigator, ansible-lint, molecule, ansible-creator, ansible-dev-environment. Tools with minimal CLI surfaces (ansible-sign, tox-ansible) include complete reference material in their main guide page.

## Quality of life
- AI-authored additions: All documentation content, ADR amendment, sidebar configuration
- Audited against upstream documentation for each tool to ensure completeness parity

## Test plan
- [x] All 16 sidebar slugs verified against actual filesystem paths
- [x] `docs/astro.config.mjs` syntax validated
- [x] Internal link patterns consistent (`/vscode-ansible/python-tools/...`)
- [x] Prettier formatting fixed (multi-line objects for badge entries)
- [x] MDX build error fixed (escaped `{word}` in inline code table cells)
- [ ] `npm run ci` — docs-only changes; CI pipeline operates on extension source