### PR TITLE
chore: codecov config tunning

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,8 +1,10 @@
+# cspell: ignore carryforward
 codecov:
   require_ci_to_pass: false
   notify:
     after_n_builds: 3 # effectively number of uploads: linux, macos, wsl
-    wait_for_ci: false
+    wait_for_ci: false # do not wait for other CI checks to pass before reporting
+    notify_error: true # comment on upload failures
 comment:
   # https://docs.codecov.com/docs/pull-request-comments
   layout: "condensed_header, condensed_files, condensed_footer"
@@ -27,6 +29,9 @@ coverage:
     changes:
       default:
         enabled: false
+flag_management:
+  default_rules:
+    carryforward: false
 github_checks:
   annotations: true
 ignore:


### PR DESCRIPTION
This should prevent invalid coverage drop being reported by codecov
which apparently might be caused by previous use of flags.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- `chore: codecov config tunning`: tightened `codecov.yml` notification settings to avoid false coverage-drop reports by enabling error notifications, documenting the `after_n_builds`/`wait_for_ci` behavior, and adding `flag_management` to stop `default_rules` from carrying forward.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->