### PR TITLE
chore: extract preflight job into composite task action

### DIFF
--- a/.github/actions/task/action.yml
+++ b/.github/actions/task/action.yml
@@ -1,0 +1,146 @@
+name: task
+description: Reusable task runner, use to template main CI jobs
+
+inputs:
+  slack_webhook_url:
+    description: Slack webhook URL for failure notifications
+    required: false
+    default: ""
+
+outputs:
+  context:
+    description: Extracted commit context from conventional commit message
+    value: ${{ steps.extract_context.outputs.context }}
+  tasks:
+    description: JSON list of known task names and aliases
+    value: ${{ steps.extract_context.outputs.tasks }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Workaround for https://github.com/actions/runner/issues/2033
+      shell: bash
+      run: |
+        chown -R $(id -u):$(id -g) $PWD
+
+    - name: task setup
+      if: runner.os != 'Windows'
+      shell: bash
+      # timeout-minutes: 7 # expected under 10s for container builds
+      run: |
+        set -ex
+        pwd
+        git config --global --add safe.directory '*'
+        mise install
+        mise list
+        mise cfg
+        mise exec -v -- which python3
+        mise exec -- printenv NODE_OPTIONS || true
+        task setup && task setup --status
+
+    - name: Extract commit context from conventional commit and list of known tasks
+      id: extract_context
+      shell: bash
+      env:
+        PR_TITLE: ${{ github.event.pull_request.title }}
+      run: |
+        set -e
+        # Use PR title if available, otherwise use commit message
+        if [[ -n "$PR_TITLE" ]]; then
+          MESSAGE="$PR_TITLE"
+          echo "Using PR title: $MESSAGE"
+        else
+          MESSAGE=$(git log -1 --pretty=%s)
+          echo "Using commit message: $MESSAGE"
+        fi
+
+        # Extract context/scope from conventional commit format: type(scope): message
+        # Matches patterns like: feat(mcp):, fix(ui):, chore(build):, etc.
+        if [[ "$MESSAGE" =~ ^[a-z]+\(([a-z0-9/-]+)\): ]]; then
+          CONTEXT="${BASH_REMATCH[1]}"
+          echo "Extracted context: $CONTEXT"
+          echo "context=$CONTEXT" >> "$GITHUB_OUTPUT"
+        else
+          echo "No context found in message"
+          echo "context=" >> "$GITHUB_OUTPUT"
+        fi
+        echo "tasks=$(task -l --json | jq -c '[.tasks[] | [.name] + (.aliases // []) | .[]]')" >> "$GITHUB_OUTPUT"
+
+    - name: task build
+      shell: bash
+      # timeout-minutes: 2 # expected under 1 minutes
+      run: |
+        task build && task build --status
+
+    - name: task als:package
+      shell: bash
+      # timeout-minutes: 4
+      run: |
+        task als:package && task als:package --status
+
+    - name: Run context-specific command if it is a known task
+      if: >-
+        steps.extract_context.outputs.context != '' &&
+        !contains(steps.extract_context.outputs.tasks, steps.extract_context.outputs.context)
+      shell: bash
+      run: task ${{ steps.extract_context.outputs.context }}
+
+    - name: task docs
+      shell: bash
+      # timeout-minutes: 2
+      run: |
+        task docs && task docs --status
+
+    - name: task dry (check that test frameworks are not misconfigured, but do not run tests)
+      shell: bash
+      run: task dry
+
+    # this is kept here just to ensure 'task lint' command does not drift but
+    # our main linting is run directly by 'prek' job, without involving task.
+    - name: task lint
+      # keep linting before any other task, to allow it be faster and independent
+      shell: bash
+      # timeout-minutes: 3
+      run: |
+        task lint
+
+    - name: task package
+      shell: bash
+      # timeout-minutes: 4
+      run: |
+        task als:package && task als:package --status
+        task package && task package --status
+
+    - name: task finish
+      shell: bash
+      run: task finish
+
+    - name: Upload vsix artifact
+      uses: actions/upload-artifact@v7
+      with:
+        path: out/ansible-*.vsix
+        archive: false
+        if-no-files-found: error
+        retention-days: 90
+
+    - name: Upload ansible-ansible-language-server npm package
+      uses: actions/upload-artifact@v7
+      with:
+        path: out/ansible-ansible-language-server-*.tgz
+        archive: false
+        if-no-files-found: error
+        retention-days: 90
+
+    - name: Upload ansible-ansible-mcp-server npm package
+      uses: actions/upload-artifact@v7
+      with:
+        path: out/ansible-ansible-mcp-server-*.tgz
+        archive: false
+        if-no-files-found: error
+        retention-days: 90
+
+    - name: Report unexpected failures
+      if: ${{ always() && failure() && github.ref == 'refs/heads/main' }}
+      uses: ./.github/actions/report
+      with:
+        slack_webhook_url: ${{ inputs.slack_webhook_url }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -97,127 +97,16 @@ jobs:
         MISE_TRUSTED_CONFIG_PATHS: /
     continue-on-error: false
     outputs:
-      commit_context: ${{ steps.extract_context.outputs.context }}
+      commit_context: ${{ steps.build.outputs.context }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0 # we need tags for dynamic versioning
           show-progress: false
 
-      - name: Workaround for https://github.com/actions/runner/issues/2033
-        run: |
-          chown -R $(id -u):$(id -g) $PWD
-
-      - name: task setup
-        if: runner.os != 'Windows'
-        timeout-minutes: 7 # expected under 10s for container builds
-        run: |
-          set -ex
-          pwd
-          git config --global --add safe.directory '*'
-          mise install
-          mise list
-          mise cfg
-          mise exec -v -- which python3
-          mise exec -- printenv NODE_OPTIONS || true
-          task setup && task setup --status
-
-      - name: Extract commit context from conventional commit and list of known tasks
-        id: extract_context
-        shell: bash
-        env:
-          PR_TITLE: ${{ github.event.pull_request.title }}
-        run: |
-          set -e
-          # Use PR title if available, otherwise use commit message
-          if [[ -n "$PR_TITLE" ]]; then
-            MESSAGE="$PR_TITLE"
-            echo "Using PR title: $MESSAGE"
-          else
-            MESSAGE=$(git log -1 --pretty=%s)
-            echo "Using commit message: $MESSAGE"
-          fi
-
-          # Extract context/scope from conventional commit format: type(scope): message
-          # Matches patterns like: feat(mcp):, fix(ui):, chore(build):, etc.
-          if [[ "$MESSAGE" =~ ^[a-z]+\(([a-z0-9/-]+)\): ]]; then
-            CONTEXT="${BASH_REMATCH[1]}"
-            echo "Extracted context: $CONTEXT"
-            echo "context=$CONTEXT" >> "$GITHUB_OUTPUT"
-          else
-            echo "No context found in message"
-            echo "context=" >> "$GITHUB_OUTPUT"
-          fi
-          echo "tasks=$(task -l --json | jq -c '[.tasks[] | [.name] + (.aliases // []) | .[]]')" >> "$GITHUB_OUTPUT"
-
-      - name: task build
-        timeout-minutes: 2 # expected under 1 minutes
-        run: |
-          task build && task build --status
-
-      - name: task als:package
-        timeout-minutes: 4
-        run: |
-          task als:package && task als:package --status
-
-      - name: Run context-specific command if it is a known task
-        if: >-
-          steps.extract_context.outputs.context != '' &&
-          !contains(steps.extract_context.outputs.tasks, steps.extract_context.outputs.context)
-        run: task ${{ steps.extract_context.outputs.context }}
-
-      - name: task docs
-        timeout-minutes: 2
-        run: |
-          task docs && task docs --status
-
-      - name: task dry (check that test frameworks are not misconfigured, but do not run tests)
-        run: task dry
-
-      # this is kept here just to ensure 'task lint' command does not drift but
-      # our main linting is run directly by 'prek' job, without involving task.
-      - name: task lint
-        # keep linting before any other task, to allow it be faster and independent
-        timeout-minutes: 3
-        run: |
-          task lint
-
-      - name: task package
-        timeout-minutes: 4
-        run: |
-          task als:package && task als:package --status
-          task package && task package --status
-
-      - name: task finish
-        run: task finish
-
-      - name: Upload vsix artifact
-        uses: actions/upload-artifact@v7
-        with:
-          path: out/ansible-*.vsix
-          archive: false
-          if-no-files-found: error
-          retention-days: 90
-
-      - name: Upload ansible-ansible-language-server npm package
-        uses: actions/upload-artifact@v7
-        with:
-          path: out/ansible-ansible-language-server-*.tgz
-          archive: false
-          if-no-files-found: error
-          retention-days: 90
-
-      - name: Upload ansible-ansible-mcp-server npm package
-        uses: actions/upload-artifact@v7
-        with:
-          path: out/ansible-ansible-mcp-server-*.tgz
-          archive: false
-          if-no-files-found: error
-          retention-days: 90
-
-      - name: Report unexpected failures
-        if: ${{ always() && failure() && github.ref == 'refs/heads/main' }}
-        uses: ./.github/actions/report
+      - name: Run preflight task steps (composite action)
+        id: build
+        uses: ./.github/actions/task
         with:
           slack_webhook_url: ${{ secrets.DEVTOOLS_CI_SLACK_URL }}
 


### PR DESCRIPTION
## Summary

- Move all preflight CI steps into a new `.github/actions/build` composite action
- Replace inline preflight steps in `ci.yaml` with a single call to the composite action
- Add a `.gitignore` exception so the action is not excluded by a global `build/` rule

## Test plan

- [ ] CI `preflight` job completes successfully on this PR
- [ ] Artifacts (vsix, als, mcp-server npm packages) are uploaded as before
- [ ] Downstream jobs (`builder-image`, `mcp-server-image`, `check`) still pass


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Extracted the CI preflight logic into a reusable composite action and updated the workflow to call it, reducing inline YAML and centralizing setup, context parsing, task execution, and artifact uploads.
- Added a `.gitignore` exception so `.github/actions/build` remains tracked despite the global `build/` ignore rule.

Original commit message: Extract preflight CI steps into reusable composite action
<!-- end of auto-generated comment: release notes by coderabbit.ai -->