### PR TITLE
docs: move tool references to Reference section

### DIFF
--- a/.sdlc/adrs/ADR-005-architectural-invariants.md
+++ b/.sdlc/adrs/ADR-005-architectural-invariants.md
@@ -125,14 +125,14 @@ violates this invariant.
 **Test**: If a human can perform an action via the extension UI, an
 agent must be able to perform the same action via an MCP tool.
 
-### 12. MCP tools and skills conform to documented best practices (ADR-017)
+### 12. MCP tools and skills conform to documented best practices (ADR-018)
 
 Tools must have behavioral annotations (`readOnlyHint`,
 `destructiveHint`, `idempotentHint`), valid `inputSchema` with
 `type: "object"`, server-side input validation, and machine-readable
 error responses with recoverability signals. Skills must conform to
 the agentskills.io frontmatter spec and support three-level
-progressive disclosure. The compliance checklist in ADR-017 is the
+progressive disclosure. The compliance checklist in ADR-018 is the
 authority.
 
 **Test**: If a new tool is added without behavioral annotations or a
@@ -174,7 +174,7 @@ new skill lacks valid frontmatter, the PR violates this invariant.
   layer (invariants 9, 10)
 - [ADR-012](ADR-012-mcp-tool-parity.md): MCP tool parity
   (invariant 11)
-- [ADR-017](ADR-017-mcp-skills-compliance.md): MCP and skills
+- [ADR-018](ADR-018-mcp-skills-compliance.md): MCP and skills
   compliance policy (invariant 12)
 
 ---

--- a/.sdlc/adrs/ADR-018-mcp-skills-compliance.md
+++ b/.sdlc/adrs/ADR-018-mcp-skills-compliance.md
@@ -1,4 +1,4 @@
-# ADR-017: MCP and Skills Compliance Policy
+# ADR-018: MCP and Skills Compliance Policy
 
 ## Status
 
@@ -264,10 +264,10 @@ checklist covers semantic properties that automation cannot assess.
 
 - [ADR-005](ADR-005-architectural-invariants.md): Architectural
   invariants — this ADR adds invariant 12
-- [ADR-012](ADR-012-mcp-tool-parity.md): MCP tool parity — ADR-017
+- [ADR-012](ADR-012-mcp-tool-parity.md): MCP tool parity — ADR-018
   governs quality; ADR-012 governs coverage
 - [ADR-014](ADR-014-internal-skills-as-prompt-source.md): Internal
-  skills as prompt source — ADR-017 governs the format and spec
+  skills as prompt source — ADR-018 governs the format and spec
   conformance of those skill files
 
 ---

--- a/.sdlc/adrs/README.md
+++ b/.sdlc/adrs/README.md
@@ -31,6 +31,7 @@ Decisions that have been accepted but are not yet fully implemented.
 | [ADR-012](ADR-012-mcp-tool-parity.md) | MCP Tool Parity for Extension Capabilities | 2026-06-17 |
 | [ADR-013](ADR-013-scm-plugin-docs-via-shallow-clone.md) | SCM Collection Plugin Documentation via Shallow Clone | 2026-06-17 |
 | [ADR-014](ADR-014-internal-skills-as-prompt-source.md) | Internal Skills as AI Prompt Source of Truth | 2026-06-18 |
+| [ADR-018](ADR-018-mcp-skills-compliance.md) | MCP and Skills Compliance Policy | 2026-06-23 |
 
 ## Proposed
 
@@ -43,7 +44,7 @@ Decisions under consideration — not yet accepted or implemented.
 ## Creating New ADRs
 
 1. Copy the template from `../templates/adr.md`
-2. Use the next available number (currently ADR-018)
+2. Use the next available number (currently ADR-019)
 3. Include:
    - Status (Proposed → Accepted → Implemented)
    - Date

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -48,30 +48,14 @@ export default defineConfig({
                             label: 'Scaffold',
                             items: [
                                 { slug: 'python-tools/ansible-creator' },
-                                {
-                                    slug: 'python-tools/ansible-creator/reference',
-                                    badge: 'Reference',
-                                },
                                 { slug: 'python-tools/ansible-dev-environment' },
-                                {
-                                    slug: 'python-tools/ansible-dev-environment/reference',
-                                    badge: 'Reference',
-                                },
                             ],
                         },
                         {
                             label: 'Validate',
                             items: [
                                 { slug: 'python-tools/ansible-lint' },
-                                {
-                                    slug: 'python-tools/ansible-lint/reference',
-                                    badge: 'Reference',
-                                },
                                 { slug: 'python-tools/molecule' },
-                                {
-                                    slug: 'python-tools/molecule/reference',
-                                    badge: 'Reference',
-                                },
                                 { slug: 'python-tools/tox-ansible' },
                             ],
                         },
@@ -79,15 +63,7 @@ export default defineConfig({
                             label: 'Execute & Ship',
                             items: [
                                 { slug: 'python-tools/ansible-navigator' },
-                                {
-                                    slug: 'python-tools/ansible-navigator/reference',
-                                    badge: 'Reference',
-                                },
                                 { slug: 'python-tools/ansible-builder' },
-                                {
-                                    slug: 'python-tools/ansible-builder/reference',
-                                    badge: 'Reference',
-                                },
                                 { slug: 'python-tools/ansible-sign' },
                             ],
                         },
@@ -115,7 +91,39 @@ export default defineConfig({
                 },
                 {
                     label: 'Reference',
-                    items: [{ slug: 'reference/commands' }, { slug: 'reference/best-practices' }],
+                    items: [
+                        {
+                            label: 'Python Tools',
+                            items: [
+                                {
+                                    slug: 'python-tools/ansible-creator/reference',
+                                    badge: 'Reference',
+                                },
+                                {
+                                    slug: 'python-tools/ansible-dev-environment/reference',
+                                    badge: 'Reference',
+                                },
+                                {
+                                    slug: 'python-tools/ansible-lint/reference',
+                                    badge: 'Reference',
+                                },
+                                {
+                                    slug: 'python-tools/molecule/reference',
+                                    badge: 'Reference',
+                                },
+                                {
+                                    slug: 'python-tools/ansible-navigator/reference',
+                                    badge: 'Reference',
+                                },
+                                {
+                                    slug: 'python-tools/ansible-builder/reference',
+                                    badge: 'Reference',
+                                },
+                            ],
+                        },
+                        { slug: 'reference/commands' },
+                        { slug: 'reference/best-practices' },
+                    ],
                 },
                 {
                     label: 'Roadmap',

--- a/docs/src/content/docs/python-tools/ansible-builder.mdx
+++ b/docs/src/content/docs/python-tools/ansible-builder.mdx
@@ -499,5 +499,6 @@ Your execution environment is built. Secure it for production:
 
 ## Links
 
+- [CLI Reference](/vscode-ansible/python-tools/ansible-builder/reference/) — complete v3 schema specification, CLI flags, and bindep format
 - [PyPI: ansible-builder](https://pypi.org/project/ansible-builder/)
 - [GitHub: ansible/ansible-builder](https://github.com/ansible/ansible-builder)

--- a/docs/src/content/docs/python-tools/ansible-creator.mdx
+++ b/docs/src/content/docs/python-tools/ansible-creator.mdx
@@ -285,5 +285,6 @@ Your project is scaffolded. Now start developing:
 
 ## Links
 
+- [CLI Reference](/vscode-ansible/python-tools/ansible-creator/reference/) — complete CLI flags, scaffolded file trees, and configuration schema
 - [PyPI: ansible-creator](https://pypi.org/project/ansible-creator/)
 - [GitHub: ansible/ansible-creator](https://github.com/ansible/ansible-creator)

--- a/docs/src/content/docs/python-tools/ansible-dev-environment.mdx
+++ b/docs/src/content/docs/python-tools/ansible-dev-environment.mdx
@@ -206,5 +206,6 @@ With your development environment set up, you're ready to scaffold content:
 
 ## Links
 
+- [CLI Reference](/vscode-ansible/python-tools/ansible-dev-environment/reference/) — complete CLI flags for all ade subcommands
 - [PyPI: ansible-dev-environment](https://pypi.org/project/ansible-dev-environment/)
 - [GitHub: ansible/ansible-dev-environment](https://github.com/ansible/ansible-dev-environment)

--- a/docs/src/content/docs/python-tools/ansible-lint.mdx
+++ b/docs/src/content/docs/python-tools/ansible-lint.mdx
@@ -459,5 +459,6 @@ Your content passes linting. Now prove it works:
 
 ## Links
 
+- [CLI Reference](/vscode-ansible/python-tools/ansible-lint/reference/) — complete rule catalog, configuration options, profiles, and CLI flags
 - [PyPI: ansible-lint](https://pypi.org/project/ansible-lint/)
 - [GitHub: ansible/ansible-lint](https://github.com/ansible/ansible-lint)

--- a/docs/src/content/docs/python-tools/ansible-navigator.mdx
+++ b/docs/src/content/docs/python-tools/ansible-navigator.mdx
@@ -436,5 +436,6 @@ You're running playbooks successfully. Now package and secure your automation:
 
 ## Links
 
+- [CLI Reference](/vscode-ansible/python-tools/ansible-navigator/reference/) — complete settings reference, environment variables, and CLI flags
 - [PyPI: ansible-navigator](https://pypi.org/project/ansible-navigator/)
 - [GitHub: ansible/ansible-navigator](https://github.com/ansible/ansible-navigator)

--- a/docs/src/content/docs/python-tools/molecule.mdx
+++ b/docs/src/content/docs/python-tools/molecule.mdx
@@ -522,6 +522,7 @@ Your scenarios pass locally. Now scale your testing and prepare for execution:
 
 ## Links
 
+- [CLI Reference](/vscode-ansible/python-tools/molecule/reference/) — complete molecule.yml schema, environment variables, drivers, and CLI flags
 - [PyPI: molecule](https://pypi.org/project/molecule/)
 - [GitHub: ansible/molecule](https://github.com/ansible/molecule)
 - [GitHub: molecule-plugins](https://github.com/ansible-community/molecule-plugins)


### PR DESCRIPTION
## Summary
- Move 6 inline tool reference pages from Python Tools workflow sub-groups (Scaffold, Validate, Execute & Ship) into the bottom-level Reference sidebar section under a "Python Tools" sub-group
- Add CLI Reference links from each tool's workflow page to its reference page
- Renumber ADR-017-mcp-skills-compliance to ADR-018 to fix duplicate numbering from concurrent PRs

## Changes
- `docs/astro.config.mjs`: remove reference badge entries from workflow sub-groups, add them under Reference > Python Tools
- 6 tool workflow pages (`ansible-creator`, `ansible-dev-environment`, `ansible-lint`, `molecule`, `ansible-navigator`, `ansible-builder`): add CLI Reference link in Links section
- `.sdlc/adrs/`: rename ADR-017 to ADR-018, update all cross-references in ADR-005, ADR-018, and README

## Quality of life
- AI-authored: sidebar reorganization and CLI reference links for improved navigation

## Test plan
- [x] `npm run ci` passes (compile + lint + test:coverage + build)
- [x] `npm run docs:build` passes (32 pages, no broken links)

Made with [Cursor](https://cursor.com)