### PR TITLE
docs: add editor integration pages

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -73,6 +73,9 @@ export default defineConfig({
                     label: 'Editor Integration',
                     items: [
                         { slug: 'editor/vscode-extension' },
+                        { slug: 'editor/cursor' },
+                        { slug: 'editor/ibm-bob' },
+                        { slug: 'editor/devspaces' },
                         { slug: 'editor/language-server' },
                         { slug: 'editor/settings' },
                     ],
@@ -95,30 +98,12 @@ export default defineConfig({
                         {
                             label: 'Python Tools',
                             items: [
-                                {
-                                    slug: 'python-tools/ansible-creator/reference',
-                                    badge: 'Reference',
-                                },
-                                {
-                                    slug: 'python-tools/ansible-dev-environment/reference',
-                                    badge: 'Reference',
-                                },
-                                {
-                                    slug: 'python-tools/ansible-lint/reference',
-                                    badge: 'Reference',
-                                },
-                                {
-                                    slug: 'python-tools/molecule/reference',
-                                    badge: 'Reference',
-                                },
-                                {
-                                    slug: 'python-tools/ansible-navigator/reference',
-                                    badge: 'Reference',
-                                },
-                                {
-                                    slug: 'python-tools/ansible-builder/reference',
-                                    badge: 'Reference',
-                                },
+                                { slug: 'python-tools/ansible-creator/reference' },
+                                { slug: 'python-tools/ansible-dev-environment/reference' },
+                                { slug: 'python-tools/ansible-lint/reference' },
+                                { slug: 'python-tools/molecule/reference' },
+                                { slug: 'python-tools/ansible-navigator/reference' },
+                                { slug: 'python-tools/ansible-builder/reference' },
                             ],
                         },
                         { slug: 'reference/commands' },

--- a/docs/src/content/docs/editor/cursor.mdx
+++ b/docs/src/content/docs/editor/cursor.mdx
@@ -1,0 +1,69 @@
+---
+title: Cursor
+description: Using the Ansible extension in Cursor -- automatic MCP registration, manual configuration, and differences from VS Code.
+---
+
+[Cursor](https://www.cursor.com/) is a VS Code fork with built-in AI capabilities. The Ansible extension installs and works identically to VS Code for all editing, sidebar, and playbook features. The primary difference is how the MCP server is registered.
+
+## Installation
+
+Install the extension from Cursor's extension panel -- search for **Ansible** (publisher: Red Hat, ID: `redhat.ansible`). The same marketplace package is used for both VS Code and Cursor.
+
+## MCP server auto-registration
+
+When the extension activates in Cursor, it detects the IDE via `vscode.env.appName` and automatically registers the MCP server using Cursor's extension API:
+
+```typescript
+cursor.mcp.registerServer({
+  name: 'ansible-environments',
+  server: { command: 'node', args: [serverPath], env: { ... } }
+})
+```
+
+The server is immediately available and enabled with no manual configuration needed. You can verify registration by running the **Ansible: Show MCP Status** command (`ansible-environments.showMcpStatus`), which opens a status panel showing the server path, Cursor API availability, and config file state.
+
+## Manual MCP configuration
+
+If the Cursor extension API is unavailable (older Cursor versions), the extension falls back to writing an `mcp.json` configuration file.
+
+Run the **Ansible: Configure Cursor MCP** command (`ansible-environments.configureCursorMcp`). You will be prompted to choose where to save the configuration:
+
+| Scope | File path | Effect |
+|-------|-----------|--------|
+| **Global** | `~/.cursor/mcp.json` | Available in all Cursor workspaces |
+| **Workspace** | `.cursor/mcp.json` | Available only in the current workspace |
+
+The command writes the server entry and prompts you to enable it in Cursor Settings (`Ctrl+Shift+J`) under **Features > MCP**.
+
+The generated `mcp.json` entry looks like:
+
+```json
+{
+  "mcpServers": {
+    "ansible-environments": {
+      "command": "node",
+      "args": ["/path/to/packages/mcp-server/out/server.js"],
+      "env": {}
+    }
+  }
+}
+```
+
+## Feature parity with VS Code
+
+All extension features work identically in Cursor:
+
+- Sidebar views (Environment Managers, Collections, Creator, Playbooks, AI Tools, AI Skills)
+- Webview panels (Plugin Docs, Creator Forms, EE Details, Playbook Config/Progress)
+- Status bar items (Python environment, Ansible metadata)
+- Language Server (completions, hover, diagnostics, semantic tokens)
+- Playbook execution (terminal and progress modes)
+- Vault encrypt/decrypt
+
+The one difference is the chat integration: where VS Code routes AI prompts through GitHub Copilot Chat, Cursor routes them through its native chat interface. The `ansibleEnvironments.llm.chatProvider` setting does not apply in Cursor since Cursor manages its own chat UI.
+
+## Next steps
+
+- [MCP Server](/vscode-ansible/ai/mcp-server/) -- capabilities and tool catalog
+- [Connecting AI Agents](/vscode-ansible/ai/connecting-agents/) -- connecting other AI agents
+- [VS Code](/vscode-ansible/editor/vscode-extension/) -- full feature reference

--- a/docs/src/content/docs/editor/devspaces.mdx
+++ b/docs/src/content/docs/editor/devspaces.mdx
@@ -1,0 +1,64 @@
+---
+title: Red Hat Dev Spaces
+description: Using the Ansible extension in Red Hat OpenShift Dev Spaces -- cloud-hosted workspaces with pre-configured Python environments.
+---
+
+[Red Hat OpenShift Dev Spaces](https://developers.redhat.com/products/openshift-dev-spaces/overview) provides cloud-hosted development workspaces based on Eclipse Che. Workspaces run in containers on OpenShift and use the **checode** editor (a VS Code derivative), making them compatible with the Ansible extension.
+
+## Installation
+
+Add the extension to your workspace by including it in your devfile configuration:
+
+```yaml
+components:
+  - name: che-code
+    container:
+      image: quay.io/devspaces/udi-rhel8:latest
+    attributes:
+      che-code.eclipse.org/vscode-extensions:
+        - redhat.ansible
+```
+
+Alternatively, install the extension from the Extensions view within an active Dev Spaces workspace -- search for **Ansible** (publisher: Red Hat, ID: `redhat.ansible`).
+
+## Python environment
+
+The extension automatically discovers Python environments available in the workspace container. When the container image includes `ansible-dev-tools`, all CLI tools (ansible-lint, ansible-creator, ansible-navigator, molecule, etc.) are available immediately with no additional installation.
+
+For custom workspace images, ensure the image includes:
+
+- Python 3.10 or later
+- `ansible-dev-tools` (recommended) or individual tools as needed
+
+The extension's Environment Managers view displays all detected Python interpreters, and the status bar shows the active selection.
+
+## Ansible Lightspeed authentication
+
+Ansible Lightspeed (IBM watsonx Code Assistant) authentication works in Dev Spaces through the `checode` URI scheme. The extension supports OAuth callback redirects for:
+
+- `checode://` URI scheme (Dev Spaces editor)
+- Authorities ending in `.openshiftapps.com` (OpenShift-hosted workspaces)
+
+No additional OAuth configuration is needed -- sign in through the Lightspeed view as you would in desktop VS Code.
+
+## Dev Container scaffolding
+
+Use [ansible-creator](/vscode-ansible/python-tools/ansible-creator/) to generate `.devcontainer/` configurations for Ansible projects:
+
+```bash
+ansible-creator add resource devcontainer
+```
+
+This produces Docker and Podman variants pre-configured with `ansible-dev-tools`, making it straightforward to set up consistent workspace images for Dev Spaces or any Dev Container environment.
+
+## Considerations
+
+- **Playbook execution** -- playbooks run within the workspace container. If the container has network access to target hosts, terminal-based execution works normally. The Unix socket-based progress viewer also works within the container.
+- **MCP server** -- the MCP server runs inside the workspace container alongside the extension. AI agents connected to the workspace can use the server's tools for collection discovery, scaffolding, and playbook generation.
+- **Execution environments** -- the EE view requires a container runtime (Podman or Docker) inside the workspace container. Nested container support depends on your Dev Spaces cluster configuration.
+
+## Links
+
+- [Red Hat OpenShift Dev Spaces](https://developers.redhat.com/products/openshift-dev-spaces/overview)
+- [Dev Spaces Documentation](https://docs.redhat.com/en/documentation/red_hat_openshift_dev_spaces/)
+- [VS Code](/vscode-ansible/editor/vscode-extension/) -- full feature reference

--- a/docs/src/content/docs/editor/ibm-bob.mdx
+++ b/docs/src/content/docs/editor/ibm-bob.mdx
@@ -1,0 +1,54 @@
+---
+title: IBM Bob
+description: Using the Ansible extension in IBM Bob -- installation, feature compatibility, and MCP integration with Bob's agentic modes.
+---
+
+[IBM Bob](https://bob.ibm.com/) is an AI-first development partner built on VS Code. It is a standalone IDE (not an extension) that provides agentic modes (Ask, Plan, Code, Advance) for orchestrating the full software development lifecycle. Since Bob is a VS Code fork, the Ansible extension is compatible.
+
+## Installation
+
+Install the extension from Bob's extension panel -- search for **Ansible** (publisher: Red Hat, ID: `redhat.ansible`). Alternatively, download the `.vsix` package from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=redhat.ansible) and sideload it via **Extensions > Install from VSIX**.
+
+## Feature compatibility
+
+All core extension features work in IBM Bob:
+
+- **Sidebar views** -- Environment Managers, Ansible Dev Tools, Installed Collections, Collection Sources, Execution Environments, Creator, Playbooks, AI Tools, AI Skills
+- **Webview panels** -- Plugin Documentation, Creator Forms, EE Details, Package Details, Playbook Config, Playbook Progress
+- **Status bar** -- Python environment indicator, Ansible metadata indicator
+- **Language Server** -- completions, hover, diagnostics, semantic tokens
+- **Playbook execution** -- run in terminal and run with progress modes
+- **Vault** -- encrypt/decrypt from the editor context menu
+
+## MCP integration
+
+The Ansible extension ships an MCP server that exposes collection discovery, plugin documentation, scaffolding, and playbook generation to AI agents. Bob supports MCP tool-calling through its agentic modes, allowing Bob to use Ansible tools during planning and code generation sessions.
+
+MCP server configuration in Bob may differ from VS Code and Cursor. Consult the [IBM Bob documentation](https://bob.ibm.com/docs/) for details on how to register MCP servers in your Bob workspace.
+
+The extension's MCP server binary is available at:
+
+```
+<extension-install-path>/packages/mcp-server/out/server.js
+```
+
+You can also run it standalone via the CLI entry point:
+
+```bash
+npx ansible-environments-mcp
+```
+
+For details on the MCP server's capabilities and available tools, see:
+
+- [MCP Server](/vscode-ansible/ai/mcp-server/)
+- [Connecting AI Agents](/vscode-ansible/ai/connecting-agents/)
+
+## Ansible Lightspeed
+
+IBM Bob uses its own multi-model orchestration (Granite, Claude, Mistral) for AI-assisted development. Ansible Lightspeed is a separate IBM watsonx Code Assistant service that can be enabled independently via the `ansible.lightspeed.enabled` setting. Both can run side by side -- Bob handles general coding assistance while Lightspeed provides Ansible-specific inline suggestions and playbook generation.
+
+## Links
+
+- [IBM Bob](https://bob.ibm.com/)
+- [Bob Quickstart](https://bob.ibm.com/docs/ide/getting-started/quickstart)
+- [VS Code](/vscode-ansible/editor/vscode-extension/) -- full feature reference

--- a/docs/src/content/docs/editor/language-server.mdx
+++ b/docs/src/content/docs/editor/language-server.mdx
@@ -1,13 +1,120 @@
 ---
 title: Language Server
-description: The Ansible Language Server -- completions, diagnostics, hover docs, and go-to-definition for any LSP-compatible editor.
+description: The Ansible Language Server -- completions, diagnostics, hover, and semantic tokens for any LSP-compatible editor.
 ---
 
-The Ansible Language Server implements the Language Server Protocol (LSP), providing editing intelligence that works in VS Code and any other LSP-compatible editor.
+The Ansible Language Server implements the [Language Server Protocol](https://microsoft.github.io/language-server-protocol/) (LSP), providing editing intelligence for Ansible playbooks and roles. It runs as a separate process and communicates with the editor over JSON-RPC, making it usable in VS Code, Cursor, IBM Bob, Neovim, Emacs, and any other LSP-compatible editor.
 
-Content coming soon. This page will cover:
+## Capabilities
 
-- Language server capabilities (completions, diagnostics, hover, go-to-definition)
-- ansible-lint integration for real-time diagnostics
-- Standalone usage outside VS Code (Neovim, Emacs, etc.)
-- Server settings and configuration
+| Capability | Description |
+|------------|-------------|
+| **Completions** | Context-aware suggestions for play, block, role, and task keywords. FQCN module names from installed collections. Module options with aliases, choices, and default values. Inventory hosts and groups. Variables from the current scope. |
+| **Completion resolve** | Enriches completion items with full documentation on selection -- module descriptions, option details, and examples fetched from the plugin doc cache. |
+| **Hover** | Documentation popups for keywords, modules, and module options. Shows descriptions, types, default values, and choices drawn from `ansible-doc` output. |
+| **Diagnostics** | Real-time validation using ansible-lint (preferred) or `ansible-playbook --syntax-check` as a fallback. YAML structural validation is always active. Diagnostics update on file open, save, and content change. |
+| **Semantic tokens** | Syntax highlighting tokens for modules, keywords, and properties. Enables theme-aware highlighting beyond what TextMate grammars provide. |
+
+### Completion context
+
+The completion provider understands Ansible document structure and offers context-specific suggestions:
+
+| Context | What is suggested |
+|---------|-------------------|
+| Play level | Play keywords (`hosts`, `tasks`, `roles`, `vars`, `handlers`, etc.) |
+| Block level | Block keywords (`block`, `rescue`, `always`, `when`, `become`, etc.) |
+| Task level | Module names (FQCN from installed collections), task keywords (`name`, `register`, `when`, `loop`, etc.) |
+| Module options | Option names, aliases, sub-options. Choices are shown as enum values. |
+| Role level | Role keywords (`role`, `when`, `tags`, `become`, etc.) |
+| Variables | Variable names from `vars`, `set_fact`, `register`, and inventory |
+
+## Diagnostics
+
+The Language Server runs validation automatically on three events:
+
+1. **File open** -- full validation against the current document
+2. **Content change** -- returns cached diagnostics for responsiveness
+3. **File save** -- re-runs full validation with the latest content
+
+### ansible-lint integration
+
+When ansible-lint is available and enabled (`ansible.validation.lint.enabled`), the server delegates validation to it. ansible-lint provides rule-based diagnostics covering best practices, deprecated syntax, FQCN enforcement, and more.
+
+When ansible-lint is not available, the server falls back to `ansible-playbook --syntax-check`, which catches YAML and basic Ansible syntax errors but does not enforce style rules.
+
+Configure the lint executable path and arguments via:
+
+- `ansible.validation.lint.path` -- path to the `ansible-lint` binary (default: `ansible-lint`)
+- `ansible.validation.lint.arguments` -- extra CLI arguments appended to every invocation
+
+## Standalone usage
+
+The Language Server can be used outside VS Code with any LSP-compatible editor.
+
+### Neovim
+
+Using [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig):
+
+```lua
+require('lspconfig').ansiblels.setup({
+  cmd = { 'node', '/path/to/packages/language-server/out/server.js', '--stdio' },
+  filetypes = { 'yaml.ansible' },
+  settings = {
+    ansible = {
+      validation = {
+        lint = { enabled = true },
+      },
+    },
+  },
+})
+```
+
+### Emacs
+
+Using [lsp-mode](https://emacs-lsp.github.io/lsp-mode/):
+
+```elisp
+(with-eval-after-load 'lsp-mode
+  (lsp-register-client
+   (make-lsp-client
+    :new-connection (lsp-stdio-connection
+                     '("node" "/path/to/packages/language-server/out/server.js" "--stdio"))
+    :major-modes '(yaml-mode)
+    :server-id 'ansible-ls)))
+```
+
+### Server arguments
+
+The Language Server accepts these command-line arguments:
+
+| Argument | Description |
+|----------|-------------|
+| `--stdio` | Communicate over stdin/stdout (default for most editors) |
+| `--node-ipc` | Communicate over Node IPC (used by VS Code) |
+
+## Custom LSP notifications
+
+The server supports two non-standard notifications for integration with the extension's status bar:
+
+| Notification | Direction | Purpose |
+|-------------|-----------|---------|
+| `update/ansible-metadata` | Server -> Client | Sends ansible-core version, Python version, lint availability, and EE info to the status bar |
+| `resync/ansible-inventory` | Client -> Server | Forces a refresh of the cached inventory data |
+
+## Current scope
+
+The following LSP capabilities are not yet implemented:
+
+- Go to definition
+- Code actions / quick fixes
+- Document symbols / outline
+- Formatting
+- Rename
+- Signature help
+- Document links
+
+Contributions in these areas are welcome -- see [Contributing](/vscode-ansible/development/contributing/).
+
+## Configuration
+
+All Language Server settings are under the `ansible.*` namespace. See the [Settings Reference](/vscode-ansible/editor/settings/) for the complete list of configuration options.

--- a/docs/src/content/docs/editor/settings.mdx
+++ b/docs/src/content/docs/editor/settings.mdx
@@ -1,6 +1,109 @@
 ---
 title: Settings Reference
-description: Complete reference for all extension and language server settings.
+description: Complete reference for all extension and Language Server settings.
 ---
 
-Content coming soon. This page will provide a complete reference for all `ansible.*` settings available in the VS Code extension and Language Server.
+This page documents all settings contributed by the Ansible extension and consumed by the Language Server. Settings are organized into three namespaces.
+
+## Extension settings (`ansibleEnvironments.*`)
+
+These settings are declared in the extension manifest and appear in the Settings UI.
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `ansibleEnvironments.enableAiFeatures` | boolean | `true` | Show AI Tools and AI Skills sidebar views, sparkle icons, and AI prompt buttons |
+| `ansibleEnvironments.skillSources` | array | See below | AI skill source registry. Each entry points to a GitHub repo or local directory containing SKILL.md files |
+| `ansibleEnvironments.pluginDocZoom` | number | `100` | Zoom level for the plugin documentation webview (50--200%) |
+| `ansibleEnvironments.pluginDocTheme` | string | `auto` | Theme for plugin documentation: `auto` (follow editor), `light`, or `dark` |
+| `ansibleEnvironments.githubCollectionOrgs` | string[] | `["ansible", "ansible-collections", "redhat-cop"]` | GitHub organizations to scan for Ansible collections in the Collection Sources view |
+| `ansibleEnvironments.llm.chatProvider` | string | `vscode` | Chat UI for AI features: `vscode` (GitHub Copilot Chat) or `openllm` (Open LLM Provider) |
+| `ansibleEnvironments.llm.provider` | string | `""` | *(Advanced)* LLM provider/vendor override. Leave empty for auto-selection |
+| `ansibleEnvironments.llm.model` | string | `""` | *(Advanced)* LLM model ID override. Leave empty for auto-selection |
+
+### Skill sources default
+
+```json
+[
+  {
+    "id": "ai-forge",
+    "type": "github",
+    "url": "https://github.com/ansible-community/ai-forge",
+    "trust": "community"
+  }
+]
+```
+
+Each skill source object requires:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `id` | string | Unique identifier for the source |
+| `type` | string | Transport type: `github`, `registry`, or `local` |
+| `url` | string | GitHub repo URL or local directory path |
+| `trust` | string | Trust level: `community`, `certified`, `partner`, or `private` |
+| `refreshInterval` | number | *(Optional)* Hours between cache refreshes (default: 24) |
+
+## Lightspeed settings (`ansible.lightspeed.*`)
+
+These settings control the Ansible Lightspeed (IBM watsonx Code Assistant) integration.
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `ansible.lightspeed.enabled` | boolean | `false` | Enable the Lightspeed sidebar view, authentication, and AI features |
+| `ansible.lightspeed.URL` | string | `https://c.ai.ansible.redhat.com` | Ansible Lightspeed API endpoint URL |
+| `ansible.lightspeed.suggestions.enabled` | boolean | `true` | Enable inline code suggestions from Lightspeed (requires `ansible.lightspeed.enabled`) |
+
+## Language Server settings (`ansible.*`)
+
+These settings are consumed by the Language Server via LSP configuration requests. They have defaults in the server code but are **not declared in the extension manifest** on the `next` branch, which means they do not appear in the Settings UI. They are fully functional when set manually in `settings.json`.
+
+### Ansible
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `ansible.ansible.path` | string | `"ansible"` | Path to the `ansible` executable |
+| `ansible.ansible.useFullyQualifiedCollectionNames` | boolean | `true` | Use fully qualified collection names (FQCN) when inserting module names in completions |
+
+### Python
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `ansible.python.interpreterPath` | string | `""` | Path to the Python interpreter. Used to locate ansible and ansible-lint in a virtual environment |
+| `ansible.python.activationScript` | string | `""` | Path to a custom activation script for a Python virtual environment |
+
+### Completion
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `ansible.completion.provideModuleOptionAliases` | boolean | `true` | Include option aliases in module option completion suggestions |
+
+### Validation
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `ansible.validation.enabled` | boolean | `true` | Master toggle for validation. When enabled without ansible-lint, falls back to `ansible-playbook --syntax-check` |
+| `ansible.validation.lint.enabled` | boolean | `true` | Use ansible-lint for validation instead of syntax-check |
+| `ansible.validation.lint.path` | string | `"ansible-lint"` | Path to the `ansible-lint` executable |
+| `ansible.validation.lint.arguments` | string | `""` | Extra command-line arguments appended to every ansible-lint invocation |
+| `ansible.validation.lint.autoFixOnSave` | boolean | `false` | Run `ansible-lint --fix` automatically when saving a file |
+
+## Setting these in `settings.json`
+
+All settings can be configured in your `settings.json` file. The `ansibleEnvironments.*` and `ansible.lightspeed.*` settings also appear in the graphical Settings UI. The `ansible.*` Language Server settings must be set manually:
+
+```json
+{
+  "ansible.ansible.path": "/usr/bin/ansible",
+  "ansible.python.interpreterPath": "/path/to/venv/bin/python",
+  "ansible.validation.lint.enabled": true,
+  "ansible.validation.lint.path": "/path/to/venv/bin/ansible-lint",
+  "ansible.validation.lint.arguments": "--profile production",
+  "ansibleEnvironments.enableAiFeatures": true,
+  "ansibleEnvironments.githubCollectionOrgs": [
+    "ansible",
+    "ansible-collections",
+    "redhat-cop",
+    "my-org"
+  ]
+}
+```

--- a/docs/src/content/docs/editor/vscode-extension.mdx
+++ b/docs/src/content/docs/editor/vscode-extension.mdx
@@ -1,14 +1,92 @@
 ---
-title: VS Code Extension
-description: The Ansible extension for VS Code and compatible editors -- environment management, collections, scaffolding, and playbook execution.
+title: VS Code
+description: The Ansible extension for Visual Studio Code -- sidebar views, webview panels, playbook execution, scaffolding, and MCP server integration.
 ---
 
-The VS Code extension brings the full Ansible developer tools experience into your editor. It integrates with the Python CLI tools, provides a Language Server for editing intelligence, and hosts the MCP server for AI agent connectivity.
+The Ansible VS Code extension (`redhat.ansible`) brings the full Ansible developer tools experience into Visual Studio Code. It integrates with the [Python CLI tools](/vscode-ansible/python-tools/overview/), provides a [Language Server](/vscode-ansible/editor/language-server/) for editing intelligence, and hosts the [MCP server](/vscode-ansible/ai/mcp-server/) for AI agent connectivity.
 
-Content coming soon. This page will cover:
+## Installation
 
-- Installing from the VS Code marketplace
-- First-run experience and environment detection
-- Sidebar views (environments, collections, playbooks, EEs)
-- Playbook execution and run configuration
-- Scaffolding with ansible-creator
+Install the extension from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=redhat.ansible) or search for **Ansible** (publisher: Red Hat) in the Extensions view (`Ctrl+Shift+X`).
+
+The extension automatically installs two dependencies:
+
+| Dependency | Purpose |
+|------------|---------|
+| `ms-python.python` | Python interpreter discovery and environment management |
+| `redhat.vscode-yaml` | YAML language support used by the Language Server |
+
+## Sidebar views
+
+The extension adds an **Ansible Environments** activity bar with the following tree views:
+
+| View | Description |
+|------|-------------|
+| **Environment Managers** | Python environments grouped by manager (venv, system, conda). Select the active interpreter for Ansible tooling. |
+| **Ansible Dev Tools** | Inventory of installed `ansible-dev-tools` packages with version info. Install or upgrade directly from the view. |
+| **Installed Collections** | Collections installed in the active environment, expandable to plugin types and individual plugins with inline documentation. |
+| **Collection Sources** | Browse collections from Ansible Galaxy and configurable GitHub organizations (`ansible`, `ansible-collections`, `redhat-cop` by default). Search, install, and view plugin docs from source. |
+| **Execution Environments** | Container images discovered by ansible-navigator. Expand to inspect bundled collections, Python packages, and system packages. |
+| **Creator** | Scaffolding tree built from `ansible-creator schema`. Click any template node to open a schema-driven form for generating collections, roles, plugins, or devcontainers. |
+| **Playbooks** | Workspace playbook discovery with folder and play hierarchy. Run playbooks, configure per-playbook settings, and view progress. |
+| **AI Tools** | Browsable catalog of MCP tools with "use in chat" and "copy prompt" actions. Visible when `ansibleEnvironments.enableAiFeatures` is enabled. |
+| **AI Skills** | Skills loaded from configured sources (default: [ai-forge](https://github.com/ansible-community/ai-forge)). Use in chat or copy prompt text. Visible when `ansibleEnvironments.enableAiFeatures` is enabled. |
+| **Lightspeed** | IBM watsonx Code Assistant (Ansible Lightspeed) sign-in, inline suggestions, and generation shortcuts. Visible when `ansible.lightspeed.enabled` is enabled. |
+
+## Webview panels
+
+Rich UI panels open in the editor area for detailed views and interactive forms:
+
+| Panel | Purpose |
+|-------|---------|
+| **Plugin Documentation** | Rendered documentation for any Ansible module, lookup, filter, or other plugin type. Opens from the Collections or Collection Sources views. |
+| **Creator Form** | Schema-driven form for ansible-creator scaffolding. Fields, defaults, and validation are generated from the CLI's JSON schema. |
+| **EE Details** | Detailed view of an execution environment image -- collections, Python packages, system packages, and image metadata. |
+| **Package Details** | Python or system package detail view showing version, summary, and dependencies. |
+| **Playbook Config** | Per-playbook run configuration -- inventory, extra vars, verbosity, limit, tags, and other `ansible-playbook` flags. |
+| **Playbook Progress** | Live execution progress with task-level status updates via a custom Ansible callback plugin and Unix socket. |
+
+## Status bar
+
+Two status bar items appear when editing Ansible files:
+
+- **Python Environment** (right) -- shows the active Python interpreter. Click to switch environments via the QuickPick selector.
+- **Ansible Metadata** (right) -- shows the ansible-core version, execution environment tag, and lint health. Data is fetched from the Language Server via a custom `update/ansible-metadata` notification.
+
+## Playbook execution
+
+The extension provides two ways to run playbooks:
+
+**Run in terminal** -- opens an integrated terminal with the virtual environment activated and runs `ansible-playbook` with the configured flags. Suitable for interactive sessions where you need full terminal access.
+
+**Run with progress** -- launches the playbook in the background and opens the Playbook Progress panel. A custom Ansible callback plugin streams task-level events over a Unix socket, providing live status updates without blocking the editor.
+
+Per-playbook configuration is stored in `.cache/ansible-environments/playbooks/` and can be edited via the Playbook Config panel or the `ansiblePlaybooks.editConfig` command.
+
+## Scaffolding
+
+The Creator sidebar view is built from `ansible-creator schema`, which returns the full set of available scaffolding templates. Each leaf node in the tree represents a scaffolding command (e.g., "Collection", "Playbook Project", "Devcontainer"). Clicking a node opens a schema-driven form that maps directly to `ansible-creator` CLI arguments.
+
+After form submission, the extension runs the `ansible-creator` command in an integrated terminal and refreshes the workspace.
+
+See the [ansible-creator guide](/vscode-ansible/python-tools/ansible-creator/) for details on available templates.
+
+## Vault
+
+The extension provides Ansible Vault encryption and decryption from the editor context menu. Select text in any Ansible file, right-click, and choose **Vault: Encrypt/Decrypt**. The vault password is passed via a temporary FIFO -- it is never written to disk.
+
+## MCP server
+
+On VS Code 1.99 and later, the extension automatically registers the Ansible MCP server using `vscode.lm.registerMcpServerDefinitionProvider()`. The server is immediately available to GitHub Copilot and other MCP-compatible tools without manual configuration.
+
+For details on the MCP server's capabilities and connecting other agents, see:
+
+- [MCP Server](/vscode-ansible/ai/mcp-server/)
+- [Connecting AI Agents](/vscode-ansible/ai/connecting-agents/)
+
+## Next steps
+
+- [Language Server](/vscode-ansible/editor/language-server/) -- completions, diagnostics, hover, and semantic tokens
+- [Settings Reference](/vscode-ansible/editor/settings/) -- all `ansibleEnvironments.*` and `ansible.*` settings
+- [Cursor](/vscode-ansible/editor/cursor/) -- using the extension in Cursor
+- [IBM Bob](/vscode-ansible/editor/ibm-bob/) -- using the extension in IBM Bob

--- a/docs/src/content/docs/python-tools/overview.mdx
+++ b/docs/src/content/docs/python-tools/overview.mdx
@@ -35,16 +35,6 @@ molecule                                 26.4.0
 tox-ansible                              26.6.0
 ```
 
-### The `adt server` command
-
-The `adt server` command launches a Django/Gunicorn REST API that the VS Code extension uses to power content scaffolding. It exposes endpoints for creating playbooks, collections, execution environments, and devfiles — all driven by dynamic schemas from `ansible-creator`.
-
-```bash
-adt server
-```
-
-The server runs on port 8000 by default and is typically managed automatically by the extension.
-
 ### Container image
 
 All ADT tools come pre-installed in the `community-ansible-dev-tools` container image:


### PR DESCRIPTION
## Summary
- Write full documentation for the Editor Integration section covering VS Code, Cursor, IBM Bob, and Red Hat Dev Spaces
- Rewrite Language Server and Settings Reference stubs with complete content

## Changes
- `docs/astro.config.mjs`: add `editor/cursor`, `editor/ibm-bob`, `editor/devspaces` sidebar entries; remove redundant `badge: 'Reference'` from Reference section entries
- `docs/src/content/docs/editor/vscode-extension.mdx`: rewrite stub with sidebar views, webview panels, status bar, playbook execution, scaffolding, vault, MCP server
- `docs/src/content/docs/editor/cursor.mdx`: new page -- installation, auto-registration via Cursor API, manual mcp.json fallback, feature parity
- `docs/src/content/docs/editor/ibm-bob.mdx`: new page -- installation, feature compatibility, MCP integration with Bob's agentic modes, Lightspeed note
- `docs/src/content/docs/editor/devspaces.mdx`: new page -- devfile installation, Python env auto-discovery, Lightspeed OAuth (checode scheme), devcontainer scaffolding
- `docs/src/content/docs/editor/language-server.mdx`: rewrite stub with LSP capabilities, completion contexts, diagnostics, standalone usage (Neovim/Emacs), custom notifications, current scope
- `docs/src/content/docs/editor/settings.mdx`: rewrite stub with all `ansibleEnvironments.*`, `ansible.lightspeed.*`, and `ansible.*` Language Server settings
- `docs/src/content/docs/python-tools/overview.mdx`: remove internal-only `adt server` section

## Quality of life
- AI-authored: 6 editor integration documentation pages, settings reference tables

## Test plan
- [x] `npm run ci` passes (compile + lint + test:coverage + build)
- [x] `npm run docs:build` passes (35 pages, no broken links)

Made with [Cursor](https://cursor.com)