### PR TITLE
feat(extension): add ux-walkthrough skill

### DIFF
--- a/.agents/skills/ux-walkthrough/SKILL.md
+++ b/.agents/skills/ux-walkthrough/SKILL.md
@@ -1,0 +1,264 @@
+---
+name: ux-walkthrough
+description: >
+  Guide a team member through all Ansible Environments extension
+  functionality as an end user. Collect structured UX feedback and
+  produce a Jira-ready report. Use when the user says "ux walkthrough",
+  "dogfood the extension", "test the extension as a user", "ux review",
+  or wants to evaluate release readiness.
+argument-hint: "[--epic EPIC-KEY] [--resume] [--no-ai]"
+user-invocable: true
+metadata:
+  author: ansible-environments team
+  version: 1.0.0
+---
+
+# UX Walkthrough (Team Dogfooding)
+
+Guide a team member through **every user-facing capability** of the Ansible
+Environments VS Code extension. This is an **interactive** skill — one module
+at a time, hands-on exercises, structured reflection, and a report for Jira.
+
+**Not** the developer `onboard` skill. **Not** the MCP `get_extension_walkthrough`
+tool (that demos MCP to end users). This skill is for **internal release
+readiness** feedback.
+
+## References
+
+| File | Purpose |
+|------|---------|
+| [`walkthrough-modules.md`](walkthrough-modules.md) | Module order, exercises, steps (human + JSON block) |
+| [`walkthrough-modules.json`](walkthrough-modules.json) | Same content — for Phase 2 extension panel |
+| [`catalog.md`](catalog.md) | Full feature inventory by module |
+| [`report-template.md`](report-template.md) | Report scaffold |
+| [`docs/.../feature-ansible-ide-experience.md`](../../../docs/src/content/docs/roadmap/feature-ansible-ide-experience.md) | PRD user stories & acceptance criteria |
+
+## Arguments
+
+| Flag | Behavior |
+|------|----------|
+| `--epic AAP-XXXX` | Stamp epic on report + Jira story proposals |
+| `--resume` | Continue from `last_module` in latest in-progress report |
+| `--no-ai` | Skip `ai-authoring`, `mcp-skills`, and `lightspeed` modules |
+
+## Session start
+
+### 0. Workspace preparation (before build/F5)
+
+**Ask first** — use `AskQuestion` or a direct prompt:
+
+| Option | What happens |
+|--------|----------------|
+| **Scaffold a sample project** | Agent creates a small playbook project (similar to `~/github/demo`) under `~/ansible-ux-walkthrough/` |
+| **Use an existing project** | User provides a path (e.g. `~/github/demo`) that already has playbooks/inventory |
+
+Record the chosen path in the report frontmatter: `environment.workspace`.
+
+**Sample project layout** (when scaffolding):
+
+```
+~/ansible-ux-walkthrough/
+  ansible.cfg
+  inventory/hosts.yml
+  playbooks/site.yml
+  playbooks/webservers.yml
+  playbooks/patch.yml
+  roles/webserver/tasks/main.yml
+  ...
+```
+
+Mirror the structure of a realistic demo — multiple playbooks, inventory, one
+simple role. Do **not** commit this to the extension repo; it lives in the
+reviewer's home directory.
+
+**Virtual environment — use the sidebar:**
+
+Venv creation and ansible-dev-tools installation now work from the sidebar
+on all editors (VS Code, Cursor, OpenVSX) via the tiered capability model
+(ADR-019). The reviewer should **not** create the venv manually in a
+terminal — that's what Module 1 tests.
+
+After F5 and opening the workspace, the reviewer will use the Environment
+Managers sidebar to create a venv and install ansible-dev-tools. If the
+`ms-python.vscode-python-envs` extension is installed, the native wizard
+handles it; otherwise the extension falls back to terminal commands
+automatically. Either path should feel seamless — note any friction as
+UX feedback.
+
+### 1. Launch the extension (repo window)
+
+1. **Build the extension** (repo root):
+   ```bash
+   npm run compile && npm run build
+   ```
+2. **Press F5** — opens the **Extension Development Host** window.
+3. **Open the workspace** — in the dev host: **File → Open Folder** →
+   `<workspace-path>` (the scaffolded or existing Ansible project).
+   Do not use the empty `examples/` folder unless it has content.
+4. **Do all walkthrough steps in the dev host window** — Activity Bar,
+   sidebar views, and output channel.
+
+**Cursor (optional):** Canvas progress UI stays in the repo window while the
+reviewer exercises the extension in the dev host.
+
+Alternative for packaged testing (not the default): `npm run package:install`.
+
+Ask for: reviewer name, epic key, workspace path, whether AI and Lightspeed
+are enabled **in the Extension Development Host window**.
+
+### 2. Initialize report
+
+Create `.sdlc/ux-reports/YYYY-MM-DD-<reviewer>.md` from [`report-template.md`](report-template.md).
+Create the directory first if it does not exist: `mkdir -p .sdlc/ux-reports`.
+
+Fill frontmatter: `reviewer`, `date`, `epic`, `extension_version` (from `package.json`),
+`environment` (OS, editor, AI/Lightspeed flags, workspace path).
+
+On `--resume`, find the newest report with `session_status: in_progress` and read
+`last_module` instead of creating a new file.
+
+### 3. Open progress Canvas (Cursor only)
+
+If the reviewer uses **Cursor**, create or update a Canvas at:
+
+```
+~/.cursor/projects/<workspace>/canvases/ux-walkthrough-progress.canvas.tsx
+```
+
+Follow the [Canvas skill](~/.cursor/skills-cursor/canvas/SKILL.md): single file,
+`cursor/canvas` imports only, inline data, no `fetch`.
+
+**Canvas must show:**
+
+- Vertical stepper for all 12 modules (`pending` | `current` | `complete` | `skipped`)
+- Current module card: title, exercise, next step, US/AC mapping
+- Session stats: modules done, issue counts by severity, average value score
+- Epic key if provided
+
+**Update the Canvas after each module** when you append to the report.
+
+If not using Cursor, skip Canvas and track progress in the report frontmatter only.
+
+## Module loop
+
+Read module definitions from [`walkthrough-modules.md`](walkthrough-modules.md).
+Process modules in `order` sequence. Skip modules where:
+
+- `--no-ai` and `requiresAi: true` → mark `skipped` in report and Canvas
+- Lightspeed disabled and `requiresLightspeed: true` → mark `skipped`
+
+For each module, run this loop:
+
+### A. Orient
+
+Present from `catalog.md` and the module JSON entry:
+
+- What capability area this covers (PRD US/AC)
+- Where to find it in the UI (view ID, command palette names)
+- What "done" looks like
+
+### B. Try (hands-on)
+
+Give the reviewer the `exercise` text and walk through `steps` one at a time.
+Wait for them to complete each step before advancing. Do not rush.
+
+Point to specific commands they can run from Command Palette if helpful.
+
+### C. Reflect — five questions
+
+Ask these **in order**. Wait for answers:
+
+1. **Expectation** — What did you expect to happen?
+2. **Outcome** — Did it work? (`yes` / `partial` / `no`)
+3. **User mental model** — What would end users expect?
+4. **Issues** — Bugs, confusion, missing affordances? (repro steps for bugs)
+5. **Value** — Will users find this valuable? Score 1–5 and brief why.
+
+### D. Record
+
+Append to the report under **Module findings** using the template block.
+
+For each issue, add a row to **Issues catalog** with:
+
+- Auto-increment ID: `UX-001`, `UX-002`, …
+- Severity: `blocker` | `major` | `minor` | `enhancement`
+- Type: `bug` | `ux-gap` | `expectation-mismatch` | `missing-feature` | `polish`
+- Module ID and US/AC mapping
+
+Update report frontmatter:
+
+- `last_module: <module-id>`
+- `modules_completed: <count>`
+- `issues_count` tallies
+- `session_status: in_progress`
+
+Update Canvas module states and stats.
+
+**US-18 check:** For non-AI modules (1–7, 11), if core functionality requires AI,
+log as `blocker` with type `ux-gap` — violates "works without AI".
+
+Ask: "Ready for the next module, or pause here?" Respect pauses.
+
+## Module sequence
+
+| Order | ID | Title | Skip when |
+|------:|----|-------|-----------|
+| 0 | `setup` | Setup & First Impressions | never |
+| 1 | `environment` | Environment & Tool Management | never |
+| 2 | `editor-lsp` | Editor & Language Server | never |
+| 3 | `collections-installed` | Installed Collections & Plugin Docs | never |
+| 4 | `collections-remote` | Collection Sources & Installation | never |
+| 5 | `creator` | Content Scaffolding | never |
+| 6 | `playbooks` | Playbook Execution | never |
+| 7 | `execution-envs` | Execution Environments | never |
+| 8 | `ai-authoring` | AI-Assisted Authoring | `--no-ai` |
+| 9 | `mcp-skills` | MCP Tools & AI Skills | `--no-ai` |
+| 10 | `lightspeed` | Ansible Lightspeed | Lightspeed disabled |
+| 11 | `cross-cutting` | Cross-Cutting UX | never |
+
+## Session wrap-up
+
+When all applicable modules are done:
+
+1. Write **Executive summary** (3–5 sentences on release readiness)
+2. Complete **Value matrix** table
+3. Generate **Proposed Jira stories** for every `blocker`, `major`, and `minor` issue
+4. List **Open questions for PM** (branding, Lightspeed positioning, scope)
+5. Note **Walkthrough content feedback** for `walkthrough-modules.md` improvements
+6. Set `session_status: complete` in report frontmatter
+7. Final Canvas update — all modules complete or skipped
+
+Tell the reviewer:
+
+> Your report is at `.sdlc/ux-reports/<file>.md`. Say "create Jira tickets
+> from my UX report" when ready to file stories under the epic.
+
+## Jira follow-up
+
+Do **not** auto-create Jira issues. When asked, use the `jira-integration`
+skill (user-level, at `~/.agents/skills/jira-integration/`). If that skill
+is not installed, guide the reviewer through manual Jira filing using the
+**Proposed Jira stories** section of the report:
+
+1. Read **Proposed Jira stories** from the report
+2. Show human-readable preview per story
+3. Create Stories/Tasks linked to the epic after confirmation
+
+## Agent rules
+
+- **One module at a time** — never dump the full journey
+- **Canvas always visible in Cursor** — create at start, update after each module
+- **Record as you go** — do not batch findings to the end
+- **Bugs need repro steps** — distinguish from ux-gap and expectation-mismatch
+- **Cite PRD** — reference US-# and AC-# in findings
+- **Feed Phase 2** — unclear step instructions go in Walkthrough content feedback
+- **Be honest about gaps** — e.g. go-to-definition not yet implemented (see `.sdlc/todos/pending/add-goto-definition-provider.md`)
+
+## Related skills
+
+| Skill | When |
+|-------|------|
+| `onboard` | New developer learning the codebase |
+| `manage-todos` | Track extension work items in `.sdlc/todos/` |
+| `jira-integration` | File stories from the report (user-level skill, `~/.agents/`) |
+| `submit-pr` | Ship fixes from walkthrough findings |

--- a/.agents/skills/ux-walkthrough/catalog.md
+++ b/.agents/skills/ux-walkthrough/catalog.md
@@ -1,0 +1,213 @@
+# UX Walkthrough Feature Catalog
+
+Reference for the `ux-walkthrough` skill. Organized by module ID.
+Maps to PRD: [`feature-ansible-ide-experience.md`](../../../docs/src/content/docs/roadmap/feature-ansible-ide-experience.md).
+
+Legend: **Non-AI** = works without `ansibleEnvironments.enableAiFeatures`.
+
+---
+
+## Module 0: `setup` — Setup & First Impressions
+
+| Feature | Trigger | Description | Non-AI | Implementation |
+|---------|---------|-------------|--------|----------------|
+| Activity bar container | Ansible icon | Opens Ansible Environments sidebar | yes | `package.json` `viewsContainers` |
+| Tree views (10) | Sidebar scroll | Env, Dev Tools, Collections, Sources, EEs, Creator, Playbooks, AI Tools*, AI Skills*, Lightspeed* | yes* | `src/views/*Provider.ts` |
+| Output channel | Output → Ansible Environments | Extension logs | yes | `src/extension.ts` |
+
+*AI views require `enableAiFeatures`; Lightspeed view requires `ansible.lightspeed.enabled`.
+
+**AC:** AC-8
+
+---
+
+## Module 1: `environment` — Environment & Tool Management
+
+| Feature | Command / trigger | Description | Non-AI | Implementation |
+|---------|-------------------|-------------|--------|----------------|
+| Environment Managers | View: `ansibleDevToolsEnvManagers` | Python managers → environments | yes | `EnvironmentManagersProvider.ts` |
+| Refresh environments | `ansibleDevToolsEnvManagers.refresh` | Reload env tree | yes | |
+| Create environment | `ansibleDevToolsEnvManagers.create` | One-click venv creation | yes | |
+| Select environment | `ansibleDevTools.selectEnvironment` | Active env for Ansible tools | yes | |
+| Ansible Dev Tools | View: `ansibleDevToolsPackages` | ADT package versions | yes | `AnsibleDevToolsProvider.ts` |
+| Install ADT | `ansibleDevToolsPackages.install` | Install meta-package | yes | |
+| Upgrade ADT | `ansibleDevToolsPackages.upgrade` | Upgrade packages | yes | |
+| Python status bar | `ansible.statusBar.pythonClick` | Env details QuickPick | yes | `statusBar/pythonStatusBar.ts` |
+| Ansible status bar | `ansible.statusBar.ansibleClick` | Tool versions QuickPick | yes | `statusBar/ansibleStatusBar.ts` |
+
+**US:** US-1, US-2 | **AC:** AC-1
+
+---
+
+## Module 2: `editor-lsp` — Editor & Language Server
+
+| Feature | Trigger | Description | Non-AI | Implementation |
+|---------|---------|-------------|--------|----------------|
+| Syntax highlighting | Open ansible file | Grammars + injections | yes | `syntaxes/`, `package.json` |
+| File association | Open/save YAML | Modeline + playbook heuristic | yes | `features/fileAssociation.ts` |
+| Auto-completion | Ctrl+Space | Modules, options, inventory, Jinja | yes | `language-server/.../completionProvider.ts` |
+| Hover | Mouse over symbol | Plugin docs markdown | yes | `hoverProvider.ts` |
+| Semantic tokens | Theme | Modules, keywords, properties | yes | `semanticTokenProvider.ts` |
+| YAML diagnostics | Edit/save | Parse errors | yes | `validationProvider.ts` |
+| ansible-lint | Edit/save | Lint squiggles | yes | `services/ansibleLint.ts` |
+| syntax-check fallback | Lint disabled | `ansible-playbook --syntax-check` | yes | `services/ansiblePlaybook.ts` |
+| Vault encrypt/decrypt | `ansibleEnvironments.vault` | ansible-vault integration | yes | `features/vault.ts` |
+| YAML/JSON schemas | Edit config files | galaxy.yml, molecule, EE, etc. | yes | `package.json` yamlValidation |
+| Go to definition | — | **Not implemented** | — | todo: add-goto-definition-provider |
+
+**US:** US-18 | **AC:** AC-8
+
+---
+
+## Module 3: `collections-installed` — Installed Collections
+
+| Feature | Command / trigger | Description | Non-AI | Implementation |
+|---------|-------------------|-------------|--------|----------------|
+| Collections tree | View: `ansibleDevToolsCollections` | Collection → type → plugin | yes | `CollectionsProvider.ts` |
+| Refresh | `ansibleDevToolsCollections.refresh` | Reload index | yes | |
+| Search plugins | `ansibleDevToolsCollections.search` | Keyword search | yes | |
+| Plugin documentation | `ansibleDevToolsCollections.showPluginDoc` | Rich doc webview | yes | `PluginDocPanel.ts` |
+| Sample task generator | Plugin Doc → Sample Task tab | minimal / documented / full | yes | `ui/.../SampleTaskView.tsx` |
+| AI summary* | `ansibleDevToolsCollections.aiSummary` | Chat prompt | no | `extension.ts` |
+
+**US:** US-3 | **AC:** AC-2
+
+---
+
+## Module 4: `collections-remote` — Collection Sources
+
+| Feature | Command / trigger | Description | Non-AI | Implementation |
+|---------|-------------------|-------------|--------|----------------|
+| Sources tree | View: `ansibleCollectionSources` | Galaxy + GitHub orgs | yes | `CollectionSourcesProvider.ts` |
+| Search collections | `ansibleCollectionSources.search` | Unified search | yes | |
+| Filter Galaxy | `ansibleCollectionSources.filterGalaxyCollections` | Filter list | yes | |
+| Galaxy plugin docs | `ansibleCollectionSources.showGalaxyPluginDoc` | Uninstalled docs | yes | `GalaxyDocsCache` |
+| GitHub plugin docs | `ansibleCollectionSources.showGitHubPluginDoc` | SCM docs | yes | `SCMDocsCache` |
+| Install from Galaxy | `ansibleCollectionSources.installGalaxyCollection` | via `ade` | yes | |
+| Add GitHub org | `ansibleCollectionSources.addSource` | Settings-driven | yes | |
+| AI summaries* | various `aiSummary` commands | Chat prompts | no | |
+
+**US:** US-4 | **AC:** AC-2
+
+---
+
+## Module 5: `creator` — Content Scaffolding
+
+| Feature | Command / trigger | Description | Non-AI | Implementation |
+|---------|-------------------|-------------|--------|----------------|
+| Creator tree | View: `ansibleCreator` | ansible-creator commands | yes | `CreatorProvider.ts` |
+| Open form | `ansibleCreator.openForm` | Schema-driven webview | yes | `CreatorFormPanel.ts` |
+| Live CLI preview | Creator form | Exact command preview | yes | `@ansible/ui` SchemaForm |
+| AI overview* | `ansibleCreator.aiSummary` | Chat prompt | no | |
+
+**US:** US-5 | **AC:** AC-3
+
+---
+
+## Module 6: `playbooks` — Playbook Execution
+
+| Feature | Command / trigger | Description | Non-AI | Implementation |
+|---------|-------------------|-------------|--------|----------------|
+| Playbooks tree | View: `ansiblePlaybooks` | Workspace playbook discovery | yes | `PlaybooksProvider.ts` |
+| Go to play | `ansiblePlaybooks.goToPlay` | Editor navigation | yes | |
+| Edit config | `ansiblePlaybooks.editConfig` | Per-playbook run form | yes | `PlaybookConfigPanel.ts` |
+| Edit defaults | `ansiblePlaybooks.editDefaults` | Global defaults form | yes | |
+| Run playbook | `ansiblePlaybooks.run` | Integrated terminal | yes | |
+| Progress viewer | `ansiblePlaybooks.runWithProgress` | Real-time tree + stats | yes | `PlaybookProgressPanel.ts` |
+| Failure AI analysis* | Progress panel | Analyze failed task | no | |
+| AI summary* | `ansiblePlaybooks.aiSummary` | Chat prompt | no | |
+
+**US:** US-6 | **AC:** AC-4
+
+---
+
+## Module 7: `execution-envs` — Execution Environments
+
+| Feature | Command / trigger | Description | Non-AI | Implementation |
+|---------|-------------------|-------------|--------|----------------|
+| EE tree | View: `ansibleExecutionEnvironments` | Images via ansible-navigator | yes | `ExecutionEnvironmentsProvider.ts` |
+| EE detail | `ansibleExecutionEnvironments.showDetail` | Metadata webview | yes | `EEDetailPanel.ts` |
+| Package detail | `ansibleExecutionEnvironments.showPackageDetail` | Python/system packages | yes | `PackageDetailPanel.ts` |
+| AI summary* | `ansibleExecutionEnvironments.aiSummary` | Chat prompt | no | |
+
+**US:** US-7 | **AC:** AC-5
+
+---
+
+## Module 8: `ai-authoring` — AI Content Authoring
+
+| Feature | Trigger | Description | Implementation |
+|---------|---------|-------------|----------------|
+| AI summaries | Sparkle icons on views/items | One-click chat prompts | `extension.ts`, `packages/common/src/skills/` |
+| Chat integration | Use in Chat buttons | Copilot or Open LLM Provider | `LlmService.ts` |
+| Plugin doc AI builder | Plugin Doc toolbar | Task from schema | `PluginDocView.tsx` |
+| LLM selection | `ansibleEnvironments.selectLlmModel` | Provider/model pick | `LlmService.ts` |
+| LLM status | `ansibleEnvironments.showLlmStatus` | Status webview | |
+
+Builtin skills (13): Build Ansible Task, Explain Plugin, Summarize Playbook, etc.
+See `packages/common/src/skills/`.
+
+**US:** US-8–11 | **AC:** AC-6 | **Requires AI**
+
+---
+
+## Module 9: `mcp-skills` — MCP & Skills
+
+| Feature | Command / trigger | Description | Implementation |
+|---------|-------------------|-------------|----------------|
+| AI Tools tree | View: `ansibleMcpTools` | MCP tools by category | `McpToolsProvider.ts` |
+| Use in Chat | `ansibleMcpTools.useInChat` | Inject tool prompt | |
+| Copy prompt | `ansibleMcpTools.copyPrompt` | Opens chat with pre-filled prompt (clipboard fallback) | |
+| AI Skills tree | View: `ansibleSkills` | External + builtin skills | `SkillsProvider.ts` |
+| MCP status | `ansible-environments.showMcpStatus` | Connection webview | `mcp/cursorConfig.ts` |
+| Configure Cursor MCP | `ansible-environments.configureCursorMcp` | Guided setup | |
+| MCP server (23+ tools) | External agent | Discovery, generation, EE, creator | `packages/mcp-server/` |
+
+**US:** US-18 | **AC:** AC-8 | **Requires AI features enabled**
+
+---
+
+## Module 10: `lightspeed` — Ansible Lightspeed
+
+| Feature | Command / trigger | Description | Implementation |
+|---------|-------------------|-------------|----------------|
+| Lightspeed view | View: `ansibleLightspeed` | Auth-aware shortcuts | `packages/lightspeed/` |
+| Sign in | `ansible.lightspeed.oauth` | OAuth | |
+| Generate playbook | `ansible.lightspeed.playbookGeneration` | Webview panel | |
+| Generate role | `ansible.lightspeed.roleGeneration` | Webview panel | |
+| Explain playbook/role | `ansible.lightspeed.playbookExplanation` | Explanation panel | |
+| Inline suggestions | Type in task | Ghost text | `inlineSuggestions.ts` |
+| Lightspeed status bar | Click when unauthenticated | Sign-in prompt | |
+
+**Requires:** `ansible.lightspeed.enabled = true`
+
+---
+
+## Module 11: `cross-cutting` — Cross-Cutting UX
+
+| Area | What to verify | Non-AI |
+|------|----------------|--------|
+| `enableAiFeatures` toggle | Core views work with AI off | yes |
+| Empty states | Helpful messaging, next actions | yes |
+| Error states | Missing tools (navigator, ade) | yes |
+| Settings | `ansibleEnvironments.*`, `ansible.lightspeed.*`, LSP `ansible.*` | yes |
+| Extension dependencies | Python + YAML extensions required | yes |
+| Best practices | Embedded in prompts and scaffolding | yes |
+
+**US:** US-18, US-19 | **AC:** AC-8
+
+---
+
+## Counts summary
+
+| Category | Count |
+|----------|------:|
+| VS Code commands | 68+ |
+| Tree views | 10 |
+| Webview panels | 11 |
+| LSP features | 12 (go-to-definition pending) |
+| Extension settings | 13 |
+| LSP settings | 10 |
+| Static MCP tools | 21 |
+| Skill MCP tools | 4 |
+| Builtin AI skills | 13 |

--- a/.agents/skills/ux-walkthrough/report-template.md
+++ b/.agents/skills/ux-walkthrough/report-template.md
@@ -1,0 +1,101 @@
+---
+title: UX Walkthrough Report
+reviewer:
+date:
+epic:
+extension_version:
+session_status: in_progress
+last_module:
+modules_completed: 0
+modules_total: 12
+issues_count:
+  blocker: 0
+  major: 0
+  minor: 0
+  enhancement: 0
+environment:
+  os:
+  editor:
+  launch_mode: F5 Extension Development Host
+  workspace:          # path to Ansible project (scaffolded or existing)
+  venv_path:            # e.g. <workspace>/.venv
+---
+
+# UX Walkthrough Report
+
+## Executive summary
+
+<!-- 3–5 sentences on overall release-readiness impression. Fill at session end. -->
+
+## Module findings
+
+<!-- One subsection per completed module. Copy this block for each module: -->
+
+### Module: {module-id} — {title}
+
+**Maps to:** {US-#} / {AC-#}
+
+| Question | Response |
+|----------|----------|
+| Expectation — What did you expect? | |
+| Outcome — Did it work? (yes / partial / no) | |
+| User mental model — What would end users expect? | |
+| Issues found | |
+| Value (1–5) | |
+
+**Notes:**
+
+---
+
+## Issues catalog
+
+| ID | Severity | Module | US/AC | Type | Summary |
+|----|----------|--------|-------|------|---------|
+| UX-001 | | | | | |
+
+Severity: `blocker` | `major` | `minor` | `enhancement`
+
+Type: `bug` | `ux-gap` | `expectation-mismatch` | `missing-feature` | `polish`
+
+## Value matrix
+
+| Module | Score (1–5) | Rationale |
+|--------|-------------|-----------|
+| setup | | |
+| environment | | |
+| editor-lsp | | |
+| collections-installed | | |
+| collections-remote | | |
+| creator | | |
+| playbooks | | |
+| execution-envs | | |
+| ai-authoring | | |
+| mcp-skills | | |
+| lightspeed | | |
+| cross-cutting | | |
+
+## Proposed Jira stories
+
+<!-- One block per issue with severity blocker, major, or minor. Example: -->
+
+### [UX-001] Short summary
+
+- **Issue type:** Bug | Story | Task
+- **Epic:** <!-- epic key -->
+- **Priority:** Highest | High | Medium | Low
+- **Maps to:** US-6 / AC-4
+- **Labels:** ux-review, ansible-ide
+
+**Description:**
+
+**Acceptance criteria:**
+- [ ]
+- [ ]
+
+## Open questions for PM
+
+<!-- Branding, positioning, scope, Lightspeed relationship, etc. -->
+
+## Walkthrough content feedback
+
+<!-- Step instructions that confused reviewers — feed back into walkthrough-modules.json for Phase 2 -->

--- a/.agents/skills/ux-walkthrough/walkthrough-modules.json
+++ b/.agents/skills/ux-walkthrough/walkthrough-modules.json
@@ -1,0 +1,448 @@
+{
+  "version": 1,
+  "modules": [
+    {
+      "id": "setup",
+      "order": 0,
+      "title": "Setup & First Impressions",
+      "userStories": [],
+      "acceptanceCriteria": [
+        "AC-8"
+      ],
+      "requiresAi": false,
+      "requiresLightspeed": false,
+      "exercise": "Choose or scaffold an Ansible workspace, build the extension, press F5, open the workspace in the dev host, then explore the sidebar.",
+      "steps": [
+        {
+          "title": "Choose workspace",
+          "description": "Scaffold ~/ansible-ux-walkthrough/ or use an existing path with playbooks (e.g. ~/github/demo)."
+        },
+        {
+          "title": "Build the extension",
+          "description": "In the repo window: npm run compile && npm run build"
+        },
+        {
+          "title": "Press F5 (Run Extension)",
+          "description": "Opens Extension Development Host window."
+        },
+        {
+          "title": "Open workspace folder",
+          "description": "In dev host: File \u2192 Open Folder \u2192 your Ansible project path."
+        },
+        {
+          "title": "Open Ansible Environments",
+          "description": "Click Ansible icon in Activity Bar.",
+          "view": "ansibleDevToolsEnvManagers"
+        },
+        {
+          "title": "Scan sidebar views",
+          "description": "Scroll through all tree views."
+        },
+        {
+          "title": "Check output channel",
+          "description": "Output \u2192 Ansible Environments. Confirm no activation errors."
+        }
+      ]
+    },
+    {
+      "id": "environment",
+      "order": 1,
+      "title": "Environment & Tool Management",
+      "userStories": [
+        "US-1",
+        "US-2"
+      ],
+      "acceptanceCriteria": [
+        "AC-1"
+      ],
+      "requiresAi": false,
+      "requiresLightspeed": false,
+      "exercise": "Create a venv from the sidebar, install ansible-dev-tools, select the environment, and verify the Dev Tools tree populates.",
+      "steps": [
+        {
+          "title": "Open Environment Managers",
+          "command": "ansibleDevToolsEnvManagers.refresh",
+          "view": "ansibleDevToolsEnvManagers"
+        },
+        {
+          "title": "Create virtual environment",
+          "description": "Click the + button or run 'Ansible Environments: Create Environment' from Command Palette. Enter a name (e.g. .venv). The extension creates the venv and selects it automatically.",
+          "command": "ansibleDevToolsEnvManagers.create"
+        },
+        {
+          "title": "Verify environment selected",
+          "description": "Confirm the new venv appears selected in Environment Managers and the Python status bar updates.",
+          "view": "ansibleDevToolsEnvManagers"
+        },
+        {
+          "title": "Install ansible-dev-tools",
+          "description": "In the Dev Tools Packages view, click 'Install ansible-dev-tools' or run the command. Verify the tree populates with package versions.",
+          "command": "ansibleDevToolsPackages.install",
+          "view": "ansibleDevToolsPackages"
+        },
+        {
+          "title": "Inspect Dev Tools",
+          "description": "Verify all expected packages appear (ansible-lint, ansible-navigator, ansible-creator, etc.).",
+          "command": "ansibleDevToolsPackages.refresh",
+          "view": "ansibleDevToolsPackages"
+        },
+        {
+          "title": "Status bar",
+          "description": "Click the Python status bar item. Verify QuickPick shows the active environment and offers Change/Refresh.",
+          "command": "ansible.statusBar.pythonClick"
+        }
+      ]
+    },
+    {
+      "id": "editor-lsp",
+      "order": 2,
+      "title": "Editor & Language Server",
+      "userStories": [
+        "US-18"
+      ],
+      "acceptanceCriteria": [
+        "AC-8"
+      ],
+      "requiresAi": false,
+      "requiresLightspeed": false,
+      "exercise": "Completion, hover, diagnostics, vault encrypt/decrypt in a playbook file.",
+      "steps": [
+        {
+          "title": "Open a playbook",
+          "description": "Open .yml playbook or test fixture."
+        },
+        {
+          "title": "Auto-completion",
+          "description": "Ctrl+Space on module and options."
+        },
+        {
+          "title": "Hover docs",
+          "description": "Hover FQCN or keyword."
+        },
+        {
+          "title": "Diagnostics",
+          "description": "Trigger YAML or ansible-lint squiggle."
+        },
+        {
+          "title": "Vault",
+          "command": "ansibleEnvironments.vault"
+        }
+      ]
+    },
+    {
+      "id": "collections-installed",
+      "order": 3,
+      "title": "Installed Collections & Plugin Docs",
+      "userStories": [
+        "US-3"
+      ],
+      "acceptanceCriteria": [
+        "AC-2"
+      ],
+      "requiresAi": false,
+      "requiresLightspeed": false,
+      "exercise": "Browse plugins, open Plugin Doc panel, try sample task generator.",
+      "steps": [
+        {
+          "title": "Installed Collections",
+          "command": "ansibleDevToolsCollections.refresh",
+          "view": "ansibleDevToolsCollections"
+        },
+        {
+          "title": "Search plugins",
+          "command": "ansibleDevToolsCollections.search"
+        },
+        {
+          "title": "Plugin documentation",
+          "command": "ansibleDevToolsCollections.showPluginDoc"
+        },
+        {
+          "title": "Sample task generator",
+          "description": "Plugin Doc panel \u2192 Sample Task tab."
+        }
+      ]
+    },
+    {
+      "id": "collections-remote",
+      "order": 4,
+      "title": "Collection Sources & Installation",
+      "userStories": [
+        "US-4"
+      ],
+      "acceptanceCriteria": [
+        "AC-2"
+      ],
+      "requiresAi": false,
+      "requiresLightspeed": false,
+      "exercise": "Search Galaxy/GitHub, view uninstalled plugin docs, optional install.",
+      "steps": [
+        {
+          "title": "Collection Sources",
+          "command": "ansibleCollectionSources.refresh",
+          "view": "ansibleCollectionSources"
+        },
+        {
+          "title": "Search collections",
+          "command": "ansibleCollectionSources.search"
+        },
+        {
+          "title": "Galaxy browse",
+          "command": "ansibleCollectionSources.filterGalaxyCollections"
+        },
+        {
+          "title": "Uninstalled plugin docs",
+          "command": "ansibleCollectionSources.showGalaxyPluginDoc"
+        },
+        {
+          "title": "Optional install",
+          "command": "ansibleCollectionSources.installGalaxyCollection"
+        }
+      ]
+    },
+    {
+      "id": "creator",
+      "order": 5,
+      "title": "Content Scaffolding (Creator)",
+      "userStories": [
+        "US-5"
+      ],
+      "acceptanceCriteria": [
+        "AC-3"
+      ],
+      "requiresAi": false,
+      "requiresLightspeed": false,
+      "exercise": "Open creator form, review CLI preview, scaffold to temp dir.",
+      "steps": [
+        {
+          "title": "Creator view",
+          "command": "ansibleCreator.refresh",
+          "view": "ansibleCreator"
+        },
+        {
+          "title": "Open form",
+          "command": "ansibleCreator.openForm"
+        },
+        {
+          "title": "CLI preview",
+          "description": "Confirm live ansible-creator command."
+        },
+        {
+          "title": "Scaffold",
+          "description": "Submit to temp directory."
+        }
+      ]
+    },
+    {
+      "id": "playbooks",
+      "order": 6,
+      "title": "Playbook Execution & Visualization",
+      "userStories": [
+        "US-6"
+      ],
+      "acceptanceCriteria": [
+        "AC-4"
+      ],
+      "requiresAi": false,
+      "requiresLightspeed": false,
+      "exercise": "Edit run config, run with progress viewer.",
+      "steps": [
+        {
+          "title": "Playbooks view",
+          "command": "ansiblePlaybooks.refresh",
+          "view": "ansiblePlaybooks"
+        },
+        {
+          "title": "Go to play",
+          "command": "ansiblePlaybooks.goToPlay"
+        },
+        {
+          "title": "Edit config",
+          "command": "ansiblePlaybooks.editConfig"
+        },
+        {
+          "title": "Progress viewer",
+          "command": "ansiblePlaybooks.runWithProgress"
+        },
+        {
+          "title": "Terminal run",
+          "command": "ansiblePlaybooks.run"
+        }
+      ]
+    },
+    {
+      "id": "execution-envs",
+      "order": 7,
+      "title": "Execution Environment Inspection",
+      "userStories": [
+        "US-7"
+      ],
+      "acceptanceCriteria": [
+        "AC-5"
+      ],
+      "requiresAi": false,
+      "requiresLightspeed": false,
+      "exercise": "List EEs, expand image, inspect package detail.",
+      "steps": [
+        {
+          "title": "EE view",
+          "command": "ansibleExecutionEnvironments.refresh",
+          "view": "ansibleExecutionEnvironments"
+        },
+        {
+          "title": "EE detail",
+          "command": "ansibleExecutionEnvironments.showDetail"
+        },
+        {
+          "title": "Package detail",
+          "command": "ansibleExecutionEnvironments.showPackageDetail"
+        }
+      ]
+    },
+    {
+      "id": "ai-authoring",
+      "order": 8,
+      "title": "AI-Assisted Content Authoring",
+      "userStories": [
+        "US-8",
+        "US-9",
+        "US-10",
+        "US-11"
+      ],
+      "acceptanceCriteria": [
+        "AC-6"
+      ],
+      "requiresAi": true,
+      "requiresLightspeed": false,
+      "exercise": "AI summaries, plugin doc AI builder, graceful no-LLM fallback.",
+      "steps": [
+        {
+          "title": "Enable AI",
+          "description": "ansibleEnvironments.enableAiFeatures = true"
+        },
+        {
+          "title": "Collection AI summary",
+          "command": "ansibleDevToolsCollections.aiSummary"
+        },
+        {
+          "title": "Plugin AI summary",
+          "command": "ansibleDevToolsCollections.aiPluginSummary"
+        },
+        {
+          "title": "Playbook AI summary",
+          "command": "ansiblePlaybooks.aiSummary"
+        }
+      ]
+    },
+    {
+      "id": "mcp-skills",
+      "order": 9,
+      "title": "MCP Tools & AI Skills",
+      "userStories": [
+        "US-18"
+      ],
+      "acceptanceCriteria": [
+        "AC-8"
+      ],
+      "requiresAi": true,
+      "requiresLightspeed": false,
+      "exercise": "Browse AI Tools/Skills, MCP status, Cursor config, LLM selection.",
+      "steps": [
+        {
+          "title": "AI Tools",
+          "command": "ansibleMcpTools.refresh",
+          "view": "ansibleMcpTools"
+        },
+        {
+          "title": "Use in chat",
+          "command": "ansibleMcpTools.useInChat"
+        },
+        {
+          "title": "AI Skills",
+          "command": "ansibleSkills.refresh",
+          "view": "ansibleSkills"
+        },
+        {
+          "title": "MCP status",
+          "command": "ansible-environments.showMcpStatus"
+        },
+        {
+          "title": "Cursor MCP",
+          "command": "ansible-environments.configureCursorMcp"
+        },
+        {
+          "title": "LLM model",
+          "command": "ansibleEnvironments.selectLlmModel"
+        }
+      ]
+    },
+    {
+      "id": "lightspeed",
+      "order": 10,
+      "title": "Ansible Lightspeed",
+      "userStories": [
+        "US-8"
+      ],
+      "acceptanceCriteria": [
+        "AC-6"
+      ],
+      "requiresAi": false,
+      "requiresLightspeed": true,
+      "exercise": "Sign in, generation, explanation, inline suggestions.",
+      "steps": [
+        {
+          "title": "Enable Lightspeed",
+          "description": "ansible.lightspeed.enabled = true"
+        },
+        {
+          "title": "Lightspeed view",
+          "view": "ansibleLightspeed"
+        },
+        {
+          "title": "Sign in",
+          "command": "ansible.lightspeed.oauth"
+        },
+        {
+          "title": "Generate playbook",
+          "command": "ansible.lightspeed.playbookGeneration"
+        },
+        {
+          "title": "Explain playbook",
+          "command": "ansible.lightspeed.playbookExplanation"
+        }
+      ]
+    },
+    {
+      "id": "cross-cutting",
+      "order": 11,
+      "title": "Cross-Cutting UX",
+      "userStories": [
+        "US-18",
+        "US-19"
+      ],
+      "acceptanceCriteria": [
+        "AC-8"
+      ],
+      "requiresAi": false,
+      "requiresLightspeed": false,
+      "exercise": "Non-AI path, empty/error states, settings clarity.",
+      "steps": [
+        {
+          "title": "Disable AI features",
+          "description": "Toggle enableAiFeatures off; verify core views."
+        },
+        {
+          "title": "Empty/error states",
+          "description": "Note messaging when data or tools missing."
+        },
+        {
+          "title": "Settings review",
+          "description": "Search ansible in Settings."
+        },
+        {
+          "title": "Output channel",
+          "description": "Review Ansible Environments logs."
+        }
+      ]
+    }
+  ]
+}

--- a/.agents/skills/ux-walkthrough/walkthrough-modules.md
+++ b/.agents/skills/ux-walkthrough/walkthrough-modules.md
@@ -1,0 +1,222 @@
+# Walkthrough Modules (machine-readable)
+
+Structured step definitions for the UX walkthrough skill and (Phase 2) the
+extension Walkthrough panel.
+
+**Single source of truth:** [`walkthrough-modules.json`](walkthrough-modules.json).
+The fenced block below is a **readable snapshot** for documentation purposes.
+When the two diverge, the JSON file wins. Always edit the JSON file first,
+then update this block to match.
+
+**Agent:** Parse [`walkthrough-modules.json`](walkthrough-modules.json) to
+drive module order, exercises, and Canvas content. Do not parse the block below.
+
+```json
+{
+  "version": 1,
+  "modules": [
+    {
+      "id": "setup",
+      "order": 0,
+      "title": "Setup & First Impressions",
+      "userStories": [],
+      "acceptanceCriteria": ["AC-8"],
+      "requiresAi": false,
+      "requiresLightspeed": false,
+      "exercise": "Choose or scaffold an Ansible workspace, build the extension, press F5, open the workspace in the dev host, then explore the sidebar.",
+      "steps": [
+        { "title": "Choose workspace", "description": "Scaffold ~/ansible-ux-walkthrough/ or use an existing path with playbooks (e.g. ~/github/demo)." },
+        { "title": "Build the extension", "description": "In the repo window: npm run compile && npm run build" },
+        { "title": "Press F5 (Run Extension)", "description": "Opens Extension Development Host window." },
+        { "title": "Open workspace folder", "description": "In dev host: File → Open Folder → your Ansible project path." },
+        { "title": "Open Ansible Environments", "description": "Click Ansible icon in Activity Bar.", "view": "ansibleDevToolsEnvManagers" },
+        { "title": "Scan sidebar views", "description": "Scroll through all tree views." },
+        { "title": "Check output channel", "description": "Output → Ansible Environments. Confirm no activation errors." }
+      ]
+    },
+    {
+      "id": "environment",
+      "order": 1,
+      "title": "Environment & Tool Management",
+      "userStories": ["US-1", "US-2"],
+      "acceptanceCriteria": ["AC-1"],
+      "requiresAi": false,
+      "requiresLightspeed": false,
+      "exercise": "Create a venv from the sidebar, install ansible-dev-tools, select the environment, and verify the Dev Tools tree populates.",
+      "steps": [
+        { "title": "Open Environment Managers", "command": "ansibleDevToolsEnvManagers.refresh", "view": "ansibleDevToolsEnvManagers" },
+        { "title": "Create virtual environment", "description": "Click + or Command Palette → 'Ansible Environments: Create Environment'. Enter a name (e.g. .venv).", "command": "ansibleDevToolsEnvManagers.create" },
+        { "title": "Verify environment selected", "description": "Confirm the new venv appears in Environment Managers and the Python status bar updates.", "view": "ansibleDevToolsEnvManagers" },
+        { "title": "Install ansible-dev-tools", "description": "In Dev Tools Packages view, click 'Install ansible-dev-tools'. Verify tree populates.", "command": "ansibleDevToolsPackages.install", "view": "ansibleDevToolsPackages" },
+        { "title": "Inspect Dev Tools", "description": "Verify expected packages appear (ansible-lint, ansible-navigator, etc.).", "command": "ansibleDevToolsPackages.refresh", "view": "ansibleDevToolsPackages" },
+        { "title": "Status bar", "description": "Click Python status bar. Verify QuickPick shows active environment.", "command": "ansible.statusBar.pythonClick" }
+      ]
+    },
+    {
+      "id": "editor-lsp",
+      "order": 2,
+      "title": "Editor & Language Server",
+      "userStories": ["US-18"],
+      "acceptanceCriteria": ["AC-8"],
+      "requiresAi": false,
+      "requiresLightspeed": false,
+      "exercise": "Completion, hover, diagnostics, vault encrypt/decrypt in a playbook file.",
+      "steps": [
+        { "title": "Open a playbook", "description": "Open .yml playbook or test fixture." },
+        { "title": "Auto-completion", "description": "Ctrl+Space on module and options." },
+        { "title": "Hover docs", "description": "Hover FQCN or keyword." },
+        { "title": "Diagnostics", "description": "Trigger YAML or ansible-lint squiggle." },
+        { "title": "Vault", "command": "ansibleEnvironments.vault" }
+      ]
+    },
+    {
+      "id": "collections-installed",
+      "order": 3,
+      "title": "Installed Collections & Plugin Docs",
+      "userStories": ["US-3"],
+      "acceptanceCriteria": ["AC-2"],
+      "requiresAi": false,
+      "requiresLightspeed": false,
+      "exercise": "Browse plugins, open Plugin Doc panel, try sample task generator.",
+      "steps": [
+        { "title": "Installed Collections", "command": "ansibleDevToolsCollections.refresh", "view": "ansibleDevToolsCollections" },
+        { "title": "Search plugins", "command": "ansibleDevToolsCollections.search" },
+        { "title": "Plugin documentation", "command": "ansibleDevToolsCollections.showPluginDoc" },
+        { "title": "Sample task generator", "description": "Plugin Doc panel → Sample Task tab." }
+      ]
+    },
+    {
+      "id": "collections-remote",
+      "order": 4,
+      "title": "Collection Sources & Installation",
+      "userStories": ["US-4"],
+      "acceptanceCriteria": ["AC-2"],
+      "requiresAi": false,
+      "requiresLightspeed": false,
+      "exercise": "Search Galaxy/GitHub, view uninstalled plugin docs, optional install.",
+      "steps": [
+        { "title": "Collection Sources", "command": "ansibleCollectionSources.refresh", "view": "ansibleCollectionSources" },
+        { "title": "Search collections", "command": "ansibleCollectionSources.search" },
+        { "title": "Galaxy browse", "command": "ansibleCollectionSources.filterGalaxyCollections" },
+        { "title": "Uninstalled plugin docs", "command": "ansibleCollectionSources.showGalaxyPluginDoc" },
+        { "title": "Optional install", "command": "ansibleCollectionSources.installGalaxyCollection" }
+      ]
+    },
+    {
+      "id": "creator",
+      "order": 5,
+      "title": "Content Scaffolding (Creator)",
+      "userStories": ["US-5"],
+      "acceptanceCriteria": ["AC-3"],
+      "requiresAi": false,
+      "requiresLightspeed": false,
+      "exercise": "Open creator form, review CLI preview, scaffold to temp dir.",
+      "steps": [
+        { "title": "Creator view", "command": "ansibleCreator.refresh", "view": "ansibleCreator" },
+        { "title": "Open form", "command": "ansibleCreator.openForm" },
+        { "title": "CLI preview", "description": "Confirm live ansible-creator command." },
+        { "title": "Scaffold", "description": "Submit to temp directory." }
+      ]
+    },
+    {
+      "id": "playbooks",
+      "order": 6,
+      "title": "Playbook Execution & Visualization",
+      "userStories": ["US-6"],
+      "acceptanceCriteria": ["AC-4"],
+      "requiresAi": false,
+      "requiresLightspeed": false,
+      "exercise": "Edit run config, run with progress viewer.",
+      "steps": [
+        { "title": "Playbooks view", "command": "ansiblePlaybooks.refresh", "view": "ansiblePlaybooks" },
+        { "title": "Go to play", "command": "ansiblePlaybooks.goToPlay" },
+        { "title": "Edit config", "command": "ansiblePlaybooks.editConfig" },
+        { "title": "Progress viewer", "command": "ansiblePlaybooks.runWithProgress" },
+        { "title": "Terminal run", "command": "ansiblePlaybooks.run" }
+      ]
+    },
+    {
+      "id": "execution-envs",
+      "order": 7,
+      "title": "Execution Environment Inspection",
+      "userStories": ["US-7"],
+      "acceptanceCriteria": ["AC-5"],
+      "requiresAi": false,
+      "requiresLightspeed": false,
+      "exercise": "List EEs, expand image, inspect package detail.",
+      "steps": [
+        { "title": "EE view", "command": "ansibleExecutionEnvironments.refresh", "view": "ansibleExecutionEnvironments" },
+        { "title": "EE detail", "command": "ansibleExecutionEnvironments.showDetail" },
+        { "title": "Package detail", "command": "ansibleExecutionEnvironments.showPackageDetail" }
+      ]
+    },
+    {
+      "id": "ai-authoring",
+      "order": 8,
+      "title": "AI-Assisted Content Authoring",
+      "userStories": ["US-8", "US-9", "US-10", "US-11"],
+      "acceptanceCriteria": ["AC-6"],
+      "requiresAi": true,
+      "requiresLightspeed": false,
+      "exercise": "AI summaries, plugin doc AI builder, graceful no-LLM fallback.",
+      "steps": [
+        { "title": "Enable AI", "description": "ansibleEnvironments.enableAiFeatures = true" },
+        { "title": "Collection AI summary", "command": "ansibleDevToolsCollections.aiSummary" },
+        { "title": "Plugin AI summary", "command": "ansibleDevToolsCollections.aiPluginSummary" },
+        { "title": "Playbook AI summary", "command": "ansiblePlaybooks.aiSummary" }
+      ]
+    },
+    {
+      "id": "mcp-skills",
+      "order": 9,
+      "title": "MCP Tools & AI Skills",
+      "userStories": ["US-18"],
+      "acceptanceCriteria": ["AC-8"],
+      "requiresAi": true,
+      "requiresLightspeed": false,
+      "exercise": "Browse AI Tools/Skills, MCP status, Cursor config, LLM selection.",
+      "steps": [
+        { "title": "AI Tools", "command": "ansibleMcpTools.refresh", "view": "ansibleMcpTools" },
+        { "title": "Use in chat", "command": "ansibleMcpTools.useInChat" },
+        { "title": "AI Skills", "command": "ansibleSkills.refresh", "view": "ansibleSkills" },
+        { "title": "MCP status", "command": "ansible-environments.showMcpStatus" },
+        { "title": "Cursor MCP", "command": "ansible-environments.configureCursorMcp" },
+        { "title": "LLM model", "command": "ansibleEnvironments.selectLlmModel" }
+      ]
+    },
+    {
+      "id": "lightspeed",
+      "order": 10,
+      "title": "Ansible Lightspeed",
+      "userStories": ["US-8"],
+      "acceptanceCriteria": ["AC-6"],
+      "requiresAi": false,
+      "requiresLightspeed": true,
+      "exercise": "Sign in, generation, explanation, inline suggestions.",
+      "steps": [
+        { "title": "Enable Lightspeed", "description": "ansible.lightspeed.enabled = true" },
+        { "title": "Lightspeed view", "view": "ansibleLightspeed" },
+        { "title": "Sign in", "command": "ansible.lightspeed.oauth" },
+        { "title": "Generate playbook", "command": "ansible.lightspeed.playbookGeneration" },
+        { "title": "Explain playbook", "command": "ansible.lightspeed.playbookExplanation" }
+      ]
+    },
+    {
+      "id": "cross-cutting",
+      "order": 11,
+      "title": "Cross-Cutting UX",
+      "userStories": ["US-18", "US-19"],
+      "acceptanceCriteria": ["AC-8"],
+      "requiresAi": false,
+      "requiresLightspeed": false,
+      "exercise": "Non-AI path, empty/error states, settings clarity.",
+      "steps": [
+        { "title": "Disable AI features", "description": "Toggle enableAiFeatures off; verify core views." },
+        { "title": "Empty/error states", "description": "Note messaging when data or tools missing." },
+        { "title": "Settings review", "description": "Search ansible in Settings." },
+        { "title": "Output channel", "description": "Review Ansible Environments logs." }
+      ]
+    }
+  ]
+}
+```


### PR DESCRIPTION
## Summary
- Add team dogfooding skill for structured UX evaluation of all 12 extension capability modules
- Updated to use sidebar commands for venv creation and devtools installation (leveraging ADR-019 tiered capability model) instead of manual terminal steps

## Changes
- **SKILL.md**: Sidebar-first flow for venv creation and ADT install; fixed PRD relative link; added `mkdir -p` for ux-reports directory; clarified `jira-integration` as user-level skill with manual fallback
- **walkthrough-modules.json/md**: Setup module no longer includes manual `python3 -m venv` step; Environment module promotes `Create Environment` and `Install ansible-dev-tools` to primary steps; declared JSON as single source of truth
- **catalog.md**: Fixed PRD relative link; corrected builtin skills count 14→13; corrected `copyPrompt` description (opens chat, not clipboard); updated MCP tools count 19→21

## Quality of life
- **ux-walkthrough skill** (5 files): Structured walkthrough with 12 modules, feature catalog, report template, and machine-readable JSON for Phase 2 extension panel
- **report-template.md**: Jira-ready report scaffold with issues catalog, value matrix, and proposed stories

## Test plan
- [x] `npm run ci` passes (compile + lint + test:coverage + build)
- [x] All 8 Copilot review comments addressed and threads resolved
- [ ] Manual: run walkthrough Module 1 to verify venv creation + ADT install from sidebar