### PR TITLE
chore: codecov and test cleanup code

### DIFF
--- a/.vscode-test.mjs
+++ b/.vscode-test.mjs
@@ -52,7 +52,6 @@ export default defineConfig({
     ],
   },
   coverage: {
-    includeAll: true,
-    exclude: ["**/node_modules", "out/server/external"],
+    // options here not working due https://github.com/microsoft/vscode-test-cli/issues/40#issuecomment-3622010158
   },
 });

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -219,6 +219,7 @@ tasks:
     cmds:
       - rimraf .vscode-test/user-data/logs/*
       - mkdir -p out/e2e/tmp
+      - ansible-lint --version --offline
       # cannot put coverage option inside .vscode-test.mjs
       - "{{.XVFB}}vscode-test --install-extensions out/ansible-*.vsix --coverage --coverage-output ./out/coverage/e2e --coverage-reporter text --coverage-reporter cobertura --coverage-reporter lcovonly"
       - defer: { task: collect-logs, vars: { TEST_PREFIX: "{{.TEST_PREFIX}}" } }

--- a/codecov.yml
+++ b/codecov.yml
@@ -20,6 +20,14 @@ coverage:
       default:
         target: auto
         threshold: 0.5%
+      tests:
+        target: 100%
+        threshold: 0%
+        flags:
+          - test
+        paths:
+          - test/
+          - packages/*/test/
     # Enforce coverage only on lines changed in the pull request.
     patch:
       default:

--- a/test/e2e/rootMochaHooks.ts
+++ b/test/e2e/rootMochaHooks.ts
@@ -1,11 +1,8 @@
-import * as cp from "child_process";
 import { createLogger, format, transports } from "winston";
 import path from "path";
 import fs from "fs";
 
 type ConsoleMethod = "log" | "info" | "warn" | "error";
-
-const PRETEST_ERR_RC = 2;
 
 process.env = {
   ...process.env,
@@ -16,31 +13,6 @@ process.env = {
 const testHome = path.resolve("out/e2e/tmp/home");
 fs.mkdirSync(testHome, { recursive: true });
 process.env.HOME = testHome;
-
-// display ansible-lint version and exit testing if ansible-lint is absent
-const command = "ansible-lint --version --offline";
-try {
-  // ALWAYS use 'shell: true' when we execute external commands inside the
-  // extension because some of the tools may be installed in a way that does
-  // not make them available without a shell, common examples tools that may
-  // do this are: mise, asdf, pyenv.
-  const result = cp.spawnSync(command, { shell: true });
-  if (result.status === 0) {
-    console.info(`Detected: ${result.stdout.toString()}`);
-  } else {
-    throw new Error(
-      `rc=${result.status} stderr=${result.stderr.toString()} stdout=${result.stdout.toString()}`,
-    );
-  }
-} catch (err) {
-  const env = Object.entries(process.env)
-    .map(([k, v]) => `${k}=${v}`)
-    .join("\n");
-  console.error(
-    `error: test requisites not met, '${command}' returned ${err instanceof Error ? err.message : String(err)}\n${env}`,
-  );
-  process.exit(PRETEST_ERR_RC);
-}
 
 // Capturing console output and redirecting it to a file to avoid console
 // pollution from language server logging during test execution.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- chore: codecov and test cleanup code — tightened coverage reporting by adding a test-only Codecov status, removed broken VS Code test coverage options, and simplified e2e setup by checking `ansible-lint` offline during task execution and dropping the Mocha preflight dependency check.

Original commit message: chore: codecov and test cleanup code

<!-- end of auto-generated comment: release notes by coderabbit.ai -->