### PR TITLE
chore: post-process coverage reports

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -20,6 +20,7 @@ runs:
       shell: bash
 
     - name: Enable caching for python
+      if: runner.os != 'Windows'
       # left out due to having their own caching: pnpm, node_modules, mise
       uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
       with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -97,7 +97,7 @@ jobs:
       id-token: write # codecov actions
       checks: read # codecov actions
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         # Avoid letting github do the matrix multiplication and use manual
         # includes for each job, this gives us fine control over job name.
@@ -154,8 +154,6 @@ jobs:
 
       - name: Run setup steps (composite action)
         uses: ./.github/actions/setup
-        with:
-          job_name: ${{ matrix.name }}
 
       # https://github.com/marketplace/actions/setup-wsl
       - name: Activate WSL
@@ -404,12 +402,12 @@ jobs:
             tar cf - --dereference out | tar xf - -C "$GITHUB_WORKSPACE"
           fi
 
-      - name: Upload test logs and reports as logs-${{ steps.setup.outputs.OS_VERSION }}-${{ matrix.task-name }}.zip
+      - name: Upload test logs and reports as logs-${{ matrix.name }}-${{ matrix.task-name }}.zip
         # git-leaks not support on Windows (except WSL which runs Linux)
         if: ${{ !cancelled() && (runner.os != 'Windows' || contains(matrix.name, 'wsl')) }}
         uses: ansible/actions/upload-artifact@main
         with:
-          name: logs-${{ steps.setup.outputs.OS_VERSION }}-${{ matrix.id }}-${{ github.run_attempt }}.zip
+          name: logs-${{ matrix.name }}-${{ matrix.id }}-${{ github.run_attempt }}.zip
           path: |
             out/als
             out/coverage
@@ -423,11 +421,11 @@ jobs:
           retention-days: 90
 
       - name: Upload test coverage data to codecov.io
-        if: ${{ always() && hashFiles('out/coverage/**/*coverage.xml') != '' && github.event_name != 'schedule' }}
+        if: ${{ always() && hashFiles('out/coverage/cobertura-coverage.xml') != '' && github.event_name != 'schedule' }}
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           name: ${{ matrix.name }}
-          files: ./out/coverage/**/*coverage.xml
+          files: ./out/coverage/cobertura-coverage.xml
           disable_search: true
           fail_ci_if_error: true
           use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
@@ -547,10 +545,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      # needed for pycobertura
-      - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v8.2.0
-
       - name: Download artifacts
         uses: actions/download-artifact@v8
         with:
@@ -563,21 +557,6 @@ jobs:
           find . -name '*\?*' -exec rm -r {} \; || true
           find . -name '*"*' -exec rm -r {} \; || true
           find . -name '*:*' -exec rm -r {} \; || true
-
-      - name: pycobertura diff across different platform runs
-        run: |
-          git diff
-          git status --porcelain --ignored
-          LINUX_COVERAGE=$(ls -1 logs-*linux*.zip/coverage/unit/cobertura-coverage.xml | sort | tail -1)
-          MACOS_COVERAGE=$(ls -1 logs-*macos*.zip/coverage/unit/cobertura-coverage.xml | sort | tail -1)
-          WSL_COVERAGE=$(ls -1 logs-*wsl*.zip/coverage/unit/cobertura-coverage.xml | sort | tail -1)
-          cp -f "${LINUX_COVERAGE}" linux.xml
-          cp -f "${MACOS_COVERAGE}" macos.xml
-          cp -f "${WSL_COVERAGE}" wsl.xml
-          # linux vs macos (tool needs source code to be present)
-          uv tool run pycobertura diff linux.xml macos.xml || true
-          # linux vs wsl  (tool needs source code to be present)
-          uv tool run pycobertura diff linux.xml wsl.xml || true
 
       - name: SonarCloud scan
         # Run only for pull requests or push to main

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -190,6 +190,7 @@ tasks:
       # .vsix file is no longer needed for executing tests.
       # This is just for making sure that the package step works w/o issues.
       - task: package
+      - defer: { task: coverage }
       - defer: { task: finish }
     interactive: true
   e2e:
@@ -206,7 +207,6 @@ tasks:
       TMP: "{{ .TASKFILE_DIR }}/out/e2e/tmp"
     generates:
       - out/junit/e2e-test-results.xml
-      - out/coverage/e2e/cobertura-coverage.xml
       - out/coverage/e2e/lcov.info
       - out/log/e2e/e2e.log
     sources:
@@ -222,6 +222,7 @@ tasks:
       - ansible-lint --version --offline
       # cannot put coverage option inside .vscode-test.mjs
       - "{{.XVFB}}vscode-test --install-extensions out/ansible-*.vsix --coverage --coverage-output ./out/coverage/e2e --coverage-reporter text --coverage-reporter cobertura --coverage-reporter lcovonly"
+      - defer: { task: coverage }
       - defer: { task: collect-logs, vars: { TEST_PREFIX: "{{.TEST_PREFIX}}" } }
     interactive: true
   wdio:
@@ -324,3 +325,11 @@ tasks:
     cmds:
       - find .vscode-test/user-data/logs -name "*.log" -type f -exec cp -v {} out/{{.TEST_PREFIX}}/ \; 2>/dev/null || true
       - defer: tools/sanitize-logs.py out/{{.TEST_PREFIX}}/*.log
+  coverage:
+    desc: Consolidate and filter coverage reports
+    sources:
+      - out/coverage/*/lcov.info
+    generates:
+      - out/coverage/cobertura-coverage.xml
+    cmds:
+      - node tools/mk-cobertura.mts -o out/coverage/cobertura-coverage.xml -e "node_modules" -e "dist" -e ".*\/dist" out/coverage/*/lcov.info

--- a/package.json
+++ b/package.json
@@ -1081,6 +1081,7 @@
   "devDependencies": {
     "@biomejs/biome": "^2.5.0",
     "@eslint/js": "^10.0.1",
+    "@splicemood/lcov-to-cobertura": "^0.1.1",
     "@types/express": "^5.0.6",
     "@types/ini": "^4.1.1",
     "@types/js-yaml": "^4.0.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.5.0(jiti@2.7.0))
+      '@splicemood/lcov-to-cobertura':
+        specifier: ^0.1.1
+        version: 0.1.1
       '@types/express':
         specifier: ^5.0.6
         version: 5.0.6
@@ -2203,6 +2206,11 @@ packages:
 
   '@so-ric/colorspace@1.1.6':
     resolution: {integrity: sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==}
+
+  '@splicemood/lcov-to-cobertura@0.1.1':
+    resolution: {integrity: sha512-qT3ebtNYMgzdkb1OUxFRJ30Y1e/Lj5m976Oc5x//LDplJCH6Lzex6GJojfdvLhSVb76/MEoDg+eyUrwfxmvRFQ==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -8955,6 +8963,8 @@ snapshots:
     dependencies:
       color: 5.0.3
       text-hex: 1.0.0
+
+  '@splicemood/lcov-to-cobertura@0.1.1': {}
 
   '@standard-schema/spec@1.1.0': {}
 

--- a/tools/mk-cobertura.mts
+++ b/tools/mk-cobertura.mts
@@ -1,0 +1,162 @@
+#!/usr/bin/env node
+/**
+ * Converts multiple lcov.info files into a single cobertura-compatible XML file
+ * while being able to remove some extra folders from the source path especially
+ * as tools like vscode-test fails to perform the filtering itself.
+ */
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+interface Options {
+  baseDir: string;
+  excludes: string[];
+  help: boolean;
+  inputs: string[];
+  output: string;
+  version: boolean;
+}
+
+function usage(): string {
+  return [
+    "Converts lcov output to cobertura-compatible XML",
+    "",
+    "Usage:",
+    "  node tools/mk-cobertura.mts lcov-file.dat [lcov-file2.dat ...] [-b source/dir] [-e <exclude path regex>] [-o output.xml] [-d]",
+    "",
+    "Options:",
+    "  -b, --base-dir   Directory where source files are located",
+    "  -e, --excludes   Regex of source paths to exclude; can be repeated",
+    "  -o, --output     Path to store cobertura xml file",
+    "  -v, --version    Display version info",
+  ].join("\n");
+}
+
+function parseArgs(argv: string[]): Options {
+  const options: Options = {
+    baseDir: ".",
+    excludes: [],
+    help: false,
+    inputs: [],
+    output: "coverage.xml",
+    version: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "-b" || arg === "--base-dir") {
+      const value = argv[++index];
+      if (value === undefined) {
+        throw new Error(`${arg} requires a value`);
+      }
+      options.baseDir = value;
+    } else if (arg === "-e" || arg === "--excludes") {
+      const value = argv[++index];
+      if (value === undefined) {
+        throw new Error(`${arg} requires a value`);
+      }
+      options.excludes.push(value);
+    } else if (arg === "-o" || arg === "--output") {
+      const value = argv[++index];
+      if (value === undefined) {
+        throw new Error(`${arg} requires a value`);
+      }
+      options.output = value;
+    } else if (arg === "-v" || arg === "--version") {
+      options.version = true;
+    } else if (arg === "-h" || arg === "--help") {
+      options.help = true;
+    } else if (arg?.startsWith("-")) {
+      throw new Error(`Unknown option: ${arg}`);
+    } else {
+      options.inputs.push(arg);
+    }
+  }
+
+  return options;
+}
+
+function pathExcluded(sourcePath: string, excludes: string[]): boolean {
+  return excludes.some((exclude) => new RegExp(exclude).test(sourcePath));
+}
+
+function filterLcovByPath(lcovData: string, excludes: string[]): string {
+  if (excludes.length === 0) {
+    return lcovData;
+  }
+
+  const kept: string[] = [];
+  for (const record of lcovData.split(/end_of_record\n?/)) {
+    const trimmed = record.trim();
+    if (!trimmed) {
+      continue;
+    }
+
+    const sourcePath = /^SF:(.+)$/m.exec(trimmed)?.[1]?.trim();
+    if (sourcePath !== undefined && pathExcluded(sourcePath, excludes)) {
+      continue;
+    }
+
+    kept.push(trimmed);
+  }
+
+  return kept.map((record) => `${record}\nend_of_record`).join("\n");
+}
+
+function readLcovFiles(inputs: string[]): string {
+  return inputs
+    .map((input) => readFileSync(input, "utf8").trimEnd())
+    .filter((data) => data.length > 0)
+    .join("\n");
+}
+
+function runUpstream(
+  input: string,
+  options: Pick<Options, "baseDir" | "output">,
+): void {
+  const args = [input, "-b", options.baseDir, "-o", options.output];
+  execFileSync("lcov-to-cobertura", args, { stdio: "inherit" });
+}
+
+function main(argv = process.argv.slice(2)): number {
+  let options: Options;
+  try {
+    options = parseArgs(argv);
+  } catch (error) {
+    process.stderr.write(
+      `${error instanceof Error ? error.message : String(error)}\n`,
+    );
+    process.stderr.write(`${usage()}\n`);
+    return 1;
+  }
+
+  if (options.version) {
+    process.stdout.write("[lcov_cobertura path-excludes]\n");
+    return 0;
+  }
+
+  if (options.help || options.inputs.length === 0) {
+    process.stdout.write(`${usage()}\n`);
+    return options.help ? 0 : 1;
+  }
+
+  const lcovData = readLcovFiles(options.inputs);
+  const filtered = filterLcovByPath(lcovData, options.excludes);
+  const tempDir = mkdtempSync(path.join(tmpdir(), "lcov-to-cobertura-"));
+  const filteredInput = path.join(tempDir, "filtered.lcov");
+
+  try {
+    writeFileSync(filteredInput, filtered, "utf8");
+    runUpstream(filteredInput, options);
+    return 0;
+  } finally {
+    rmSync(tempDir, { force: true, recursive: true });
+  }
+}
+
+if (fileURLToPath(import.meta.url) === path.resolve(process.argv[1] ?? "")) {
+  process.exitCode = main();
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -25,7 +25,6 @@ const reporters = ["default", "junit"]; // text-summary shows only overall cover
 if (process.env.GITHUB_ACTIONS) {
   reporters.push("github-actions");
 }
-const coverage_reporters = ["cobertura", "lcovonly", "text-summary", "text"];
 
 // Disable coverage when the user is running a targeted subset of tests, e.g.:
 //   vitest -t "my test name"
@@ -157,7 +156,11 @@ export default defineConfig({
       provider: "v8",
       reportOnFailure: false,
       reportsDirectory: `${__dirname}/out/coverage/unit`,
-      reporter: coverage_reporters,
+      reporter: [
+        ["lcovonly", { file: "lcov.info", projectRoot: __dirname }],
+        "text-summary",
+        "text",
+      ],
       skipFull: true,
       thresholds: {
         // We cannot enable until we normalize the results across all platforms.


### PR DESCRIPTION
- use lcov.info as default output format
- post-process lcov.info and remove excluded locations
- generate a single cobertura report from all locaded lcov.info files
- Reduced uploaded content from >15mb to ~1mb


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Changed coverage generation to default to `lcov.info`, filter excluded paths, and merge all collected `lcov.info` files into one Cobertura XML, reducing uploaded coverage size.

Original commit: chore: post-process coverage reports

<!-- end of auto-generated comment: release notes by coderabbit.ai -->