### PR TITLE
chore: enable c8 coverage for wdio testing

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -231,13 +231,17 @@ tasks:
       - build
     env:
       TS_NODE_PROJECT: test/wdio/tsconfig.json
+    generates:
+      - out/coverage/wdio/lcov.info
     sources:
       - "{src,test}/**/*"
       - wdio.conf.ts
+      - tools/wdio-coverage.mts
     cmds:
       - "pnpm pretest:wdio"
       - "node tools/ensure-chromedriver.mts"
       - "{{.XVFB}}pnpm test:wdio"
+      - defer: { task: coverage }
     interactive: true
   unit:
     desc: Run unit tests with coverage report

--- a/codecov.yml
+++ b/codecov.yml
@@ -44,3 +44,4 @@ github_checks:
   annotations: true
 ignore:
   - ".agents/**"  # Exclude agent skill documentation from coverage
+  - "wdio.conf.ts"

--- a/package.json
+++ b/package.json
@@ -1098,6 +1098,7 @@
     "@vitejs/plugin-vue": "^6.0.5",
     "@vitest/coverage-v8": "^4.1.9",
     "@vitest/ui": "^4.1.9",
+    "c8": "^11.0.0",
     "@vscode/test-cli": "^0.0.15",
     "@vscode/test-electron": "^3.0.0",
     "@vscode/vsce": "^3.9.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -164,6 +164,9 @@ importers:
       '@wdio/spec-reporter':
         specifier: ^9.0.0
         version: 9.29.0
+      c8:
+        specifier: ^11.0.0
+        version: 11.0.0
       cspell-cli:
         specifier: ^10.0.1
         version: 10.0.1
@@ -8569,7 +8572,7 @@ snapshots:
       proxy-agent: 6.5.0
       semver: 7.8.5
       tar-fs: 3.1.2
-      yargs: 17.7.2
+      yargs: 17.7.3
     transitivePeerDependencies:
       - bare-abort-controller
       - bare-buffer
@@ -10034,7 +10037,7 @@ snapshots:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
@@ -10100,7 +10103,7 @@ snapshots:
       istanbul-reports: 3.2.0
       test-exclude: 8.0.0
       v8-to-istanbul: 9.3.0
-      yargs: 17.7.2
+      yargs: 17.7.3
       yargs-parser: 21.1.1
 
   cac@7.0.0: {}
@@ -10531,10 +10534,7 @@ snapshots:
   debug@4.3.4:
     dependencies:
       ms: 2.1.2
-
-  debug@4.4.3:
-    dependencies:
-      ms: 2.1.3
+    optional: true
 
   debug@4.4.3(supports-color@8.1.1):
     dependencies:
@@ -11152,7 +11152,7 @@ snapshots:
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.2.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
@@ -11190,7 +11190,7 @@ snapshots:
 
   extract-zip@2.0.1:
     dependencies:
-      debug: 4.3.4
+      debug: 4.4.3(supports-color@8.1.1)
       get-stream: 5.2.0
       yauzl: 2.10.0
     optionalDependencies:
@@ -11335,7 +11335,7 @@ snapshots:
 
   finalhandler@2.1.1:
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -11525,7 +11525,7 @@ snapshots:
     dependencies:
       basic-ftp: 5.3.1
       data-uri-to-buffer: 6.0.2
-      debug: 4.3.4
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -12803,7 +12803,8 @@ snapshots:
 
   mrmime@2.0.1: {}
 
-  ms@2.1.2: {}
+  ms@2.1.2:
+    optional: true
 
   ms@2.1.3: {}
 
@@ -13099,7 +13100,7 @@ snapshots:
     dependencies:
       '@tootallnate/quickjs-emscripten': 0.23.0
       agent-base: 7.1.4
-      debug: 4.3.4
+      debug: 4.4.3(supports-color@8.1.1)
       get-uri: 6.0.5
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
@@ -13322,7 +13323,7 @@ snapshots:
   proxy-agent@6.3.1:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.3.4
+      debug: 4.4.3(supports-color@8.1.1)
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
       lru-cache: 7.18.3
@@ -13627,7 +13628,7 @@ snapshots:
 
   router@2.2.0:
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
@@ -13716,7 +13717,7 @@ snapshots:
 
   send@1.2.1:
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -13859,7 +13860,7 @@ snapshots:
   socks-proxy-agent@8.0.5:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.3.4
+      debug: 4.4.3(supports-color@8.1.1)
       socks: 2.8.9
     transitivePeerDependencies:
       - supports-color

--- a/tools/wdio-coverage.mts
+++ b/tools/wdio-coverage.mts
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+/**
+ * Convert V8 coverage JSON emitted by the VS Code extension host during WDIO
+ * runs into lcov output for consolidation with other test coverage reports.
+ */
+import { existsSync, mkdirSync, readdirSync } from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+import { Report } from "c8";
+
+type C8ReportWithExclude = Report & {
+  exclude: {
+    exclude: string[];
+    relativePath: boolean;
+  };
+};
+
+const projectRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+const defaultTempDir = path.join(projectRoot, "out/tmp/.v8-coverage-wdio");
+const defaultReportsDir = path.join(projectRoot, "out/coverage/wdio");
+
+/**
+ * Generate WDIO coverage reports from collected V8 coverage data.
+ * @returns Whether a report was written.
+ */
+export async function writeWdioCoverageReport(options?: {
+  tempDirectory?: string;
+  reportsDirectory?: string;
+}): Promise<boolean> {
+  const tempDirectory = options?.tempDirectory ?? defaultTempDir;
+  const reportsDirectory = options?.reportsDirectory ?? defaultReportsDir;
+
+  if (!existsSync(tempDirectory) || readdirSync(tempDirectory).length === 0) {
+    console.warn(
+      `No WDIO V8 coverage data found in ${tempDirectory}; skipping report.`,
+    );
+    return false;
+  }
+
+  mkdirSync(reportsDirectory, { recursive: true });
+
+  const report = new Report({
+    exclude: [
+      "**/node_modules/**",
+      "**/.wdio-vscode/**",
+      "**/.vscode-test/**",
+      "**/test/**",
+    ],
+    excludeNodeModules: true,
+    mergeAsync: true,
+    reporter: ["text-summary", "lcovonly"],
+    reportsDirectory,
+    src: [
+      path.join(projectRoot, "src"),
+      path.join(projectRoot, "dist"),
+      path.join(projectRoot, "packages/ansible-language-server/src"),
+      path.join(projectRoot, "packages/ansible-mcp-server/src"),
+      path.join(projectRoot, "webviews"),
+    ],
+    tempDirectory,
+  } as ConstructorParameters<typeof Report>[0]);
+
+  // Istanbul's exclude checks are case-sensitive on Windows; see vscode-test-cli.
+  const c8Report = report as C8ReportWithExclude;
+  c8Report.exclude.relativePath = false;
+  c8Report.exclude.exclude.push("**/.wdio-vscode/**", "**/.vscode-test/**");
+
+  await report.run();
+  return true;
+}
+
+const invokedDirectly =
+  process.argv[1] !== undefined &&
+  fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
+
+if (invokedDirectly) {
+  try {
+    await writeWdioCoverageReport();
+  } catch (error: unknown) {
+    console.error(error);
+    process.exit(1);
+  }
+}

--- a/wdio.conf.ts
+++ b/wdio.conf.ts
@@ -1,8 +1,20 @@
 /// <reference types="wdio-vscode-service" />
+import { execFileSync } from "node:child_process";
+import { mkdirSync, rmSync } from "node:fs";
 import path from "node:path";
 
 const testRoot = path.resolve(process.cwd(), ".wdio-vscode");
 const extensionsDir = path.join(testRoot, "extensions");
+const coverageTempDir = path.resolve(
+  process.cwd(),
+  "out/tmp/.v8-coverage-wdio",
+);
+
+function prepareCoverageCollection(): void {
+  rmSync(coverageTempDir, { recursive: true, force: true });
+  mkdirSync(coverageTempDir, { recursive: true });
+  process.env.NODE_V8_COVERAGE = coverageTempDir;
+}
 
 export const config: WebdriverIO.Config = {
   runner: "local",
@@ -49,5 +61,12 @@ export const config: WebdriverIO.Config = {
   mochaOpts: {
     ui: "bdd",
     timeout: 120000,
+  },
+  onPrepare: prepareCoverageCollection,
+  onComplete: () => {
+    execFileSync("node", ["tools/wdio-coverage.mts"], {
+      cwd: process.cwd(),
+      stdio: "inherit",
+    });
   },
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Enabled c8-based coverage for WDIO tests by collecting V8 coverage during runs and converting it to LCOV afterward.
- Added a dedicated WDIO coverage report task, wired it into Taskfile coverage consolidation, and excluded WDIO config from Codecov analysis.
- Added `c8` as a dev dependency and a small Node/TypeScript helper to generate reports.

chore: enable c8 coverage for wdio testing
_AI-assisted (Cursor)._

<!-- end of auto-generated comment: release notes by coderabbit.ai -->