### PR TITLE
chore(performance): use parallel github steps and reduce runner build chain length

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -30,13 +30,6 @@ runs:
           ${{ github.workspace }}/.cache/uv
         key: py-${{ env.IMAGE_OS_VERSION }}-${{ matrix.id }}-${{ hashFiles('uv.lock', '.python-version') }}
 
-    - name: Enable caching for prek
-      if: ${{ inputs.prek == '1' }}
-      uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
-      with:
-        path: ~/.cache/prek/
-        key: pre-commit-4|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
-
     - name: Get pnpm store directory
       id: pnpm-cache-dir-path
       run: echo "dir=$(pnpm store path)" >> $GITHUB_OUTPUT

--- a/.github/actions/task/action.yml
+++ b/.github/actions/task/action.yml
@@ -6,10 +6,6 @@ inputs:
     description: Slack webhook URL for failure notifications
     required: false
     default: ""
-  prek:
-    description: Whether to run prek hooks (lint)
-    required: false
-    default: "0" # set to "1" to run prek action early (~1m)
 
 outputs:
   context:
@@ -22,48 +18,6 @@ outputs:
 runs:
   using: "composite"
   steps:
-    # needed by our prek system hooks like toml
-    - name: Install uv (cache)
-      if: ${{ inputs.prek == '1' }}
-      uses: astral-sh/setup-uv@v8.2.0
-
-    # needed by our prek systems hooks like biome
-    - name: Install node (cache)
-      if: ${{ inputs.prek == '1' }}
-      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
-      with:
-        node-version: "24"
-
-    - name: Install pnpm # needs node 24
-      if: ${{ inputs.prek == '1' }}
-      uses: pnpm/action-setup@v6
-      with:
-        cache: true
-        run_install: |
-          - recursive: true
-            args: [--frozen-lockfile]
-
-    - name: Debug
-      if: ${{ inputs.prek == '1' }}
-      shell: bash
-      run: |
-        which -a pnpm
-        pnpm --version
-
-    - name: Run prek
-      if: ${{ inputs.prek == '1' }}
-      uses: j178/prek-action@v2
-      # ideally prek should run in under 30s, but we keep a hard limit of 3
-      # minutes to count for slower hooks and uncached data. If a hook is
-      # slower, even occasionally it should be moved outside and included in
-      # another build step, like 'build' or 'package'.
-      # timeout-minutes: 3
-      with:
-        # show-verbose-logs: true
-        # we want to run in verbose to report speed of each hook
-        extra-args: "--all-files -v"
-        install-only: false
-        prek-version: ">=0.3.8"
 
     - name: Workaround for https://github.com/actions/runner/issues/2033
       shell: bash
@@ -72,8 +26,6 @@ runs:
 
     - name: Run setup steps (composite action)
       uses: ./.github/actions/setup
-      with:
-        prek: ${{ inputs.prek == '1' }}
 
     - name: task setup
       if: runner.os != 'Windows'
@@ -129,13 +81,6 @@ runs:
       # timeout-minutes: 4
       run: |
         task als:package && task als:package --status
-
-    - name: Run context-specific command if it is a known task
-      if: >-
-        steps.extract_context.outputs.context != '' &&
-        !contains(steps.extract_context.outputs.tasks, steps.extract_context.outputs.context)
-      shell: bash
-      run: task ${{ steps.extract_context.outputs.context }}
 
     - name: task docs
       shell: bash

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,17 +43,6 @@ env:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  lint:
-    runs-on: ubuntu-26.04
-    continue-on-error: false
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          fetch-depth: 0 # we need tags for dynamic versioning
-          show-progress: false
-      - name: Run prek hooks (lint)
-        uses: ./.github/actions/prek
-
   package:
     runs-on: ubuntu-26.04
     continue-on-error: false
@@ -73,8 +62,6 @@ jobs:
 
   build:
     name: ${{ matrix.name }}
-    needs:
-      - lint
 
     environment:
       name: ci
@@ -129,14 +116,6 @@ jobs:
             # in order to enable the caching
             continue-on-error: true
 
-          - name: test (linux-wdio)
-            id: test-linux-wdio
-            task-name: wdio
-            os: ubuntu-26.04
-            env:
-              SKIP_PODMAN: 1
-              SKIP_DOCKER: 1
-
           - name: test (wsl)
             id: test-wsl
             task-name: test
@@ -151,6 +130,57 @@ jobs:
           fetch-depth: 0 # we need tags for dynamic versioning
           fetch-tags: true # needed for dynamic versioning
           show-progress: false
+
+      # # We want to lint as early as possible, even before running setup action
+      # # and stop if it fails to save compute resources.
+      # - name: Install uv (cache)
+      #   if: ${{ runner.os == 'Linux' }}
+      #   uses: astral-sh/setup-uv@v8.2.0
+
+      # # needed by our prek systems hooks like biome
+      # - name: Install node (cache)
+      #   if: ${{ runner.os == 'Linux' }}
+      #   uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      #   with:
+      #     node-version: "24"
+
+      # - name: Install pnpm # needs node 24
+      #   if: ${{ runner.os == 'Linux' }}
+      #   uses: pnpm/action-setup@v6
+      #   with:
+      #     cache: true
+      #     run_install: |
+      #       - recursive: true
+      #         args: [--frozen-lockfile]
+
+      # - name: Debug
+      #   if: ${{ runner.os == 'Linux' }}
+      #   shell: bash
+      #   run: |
+      #     which -a pnpm
+      #     pnpm --version
+
+      # - name: Enable caching for prek
+      #   if: ${{ runner.os == 'Linux' }}
+      #   uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
+      #   with:
+      #     path: ~/.cache/prek/
+      #     key: prek-4|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
+
+      # - name: Run prek
+      #   if: ${{ runner.os == 'Linux' }}
+      #   uses: j178/prek-action@v2
+      #   # ideally prek should run in under 30s, but we keep a hard limit of 3
+      #   # minutes to count for slower hooks and uncached data. If a hook is
+      #   # slower, even occasionally it should be moved outside and included in
+      #   # another build step, like 'build' or 'package'.
+      #   # timeout-minutes: 3
+      #   with:
+      #     # show-verbose-logs: true
+      #     # we want to run in verbose to report speed of each hook
+      #     extra-args: "--all-files -v"
+      #     install-only: false
+      #     prek-version: ">=0.3.8"
 
       - name: Run setup steps (composite action)
         uses: ./.github/actions/setup
@@ -275,6 +305,7 @@ jobs:
 
       # Workaround for: https://github.com/actions/runner/issues/1864
       - name: Ensure HOME is defined
+        if: runner.os != 'Windows'
         run: |
           set -euxo pipefail
           if [ -z "${HOME:-}" ]; then
@@ -300,16 +331,33 @@ jobs:
             exit 98
           }
 
+      - parallel:
+          - name: task lint
+            if: runner.os == 'Linux'
+            id: lint
+            run: task lint && task lint --status
+
+          - name: task build / package
+            # Warning: ensure that conditional templates have a negative condition
+            # expanding to an empty string because otherwise it will fail the command
+            # with exit code 1 even if the command effectively succeeded!
+            run: |
+              task build -v -x
+              task build -v --status
+              ${{ runner.os != 'Windows' && 'task package -v' || '' }}
+              ${{ runner.os != 'Windows' && 'task package -v --status' || ''}}
+
+          - name: task docs
+            id: docs
+            shell: bash
+            # timeout-minutes: 2
+            run: task docs && task docs --status
+
       - name: task setup
         # starting podman machine can randomly get stuck on macos
         timeout-minutes: 25
         run: task setup && task setup --status
         id: setup
-
-      - name: task build
-        id: build
-        run: |
-          task build && task build --status
 
       ## uncomment to debug on GHA runner
       # - name: Setup tmate session
@@ -325,45 +373,36 @@ jobs:
           EOT
           podman info
 
-      - name: task package
-        if: ${{ matrix.task-name != 'wdio' && runner.os != 'Windows' }}
-        id: package
-        run: |
-          task package -v ${{ matrix.env.TASKFILE_ARGS }} && task package -v ${{ matrix.env.TASKFILE_ARGS }} --status
+      - parallel:
+          - name: task unit (ext, vue, als, mcp)
+            id: unit
+            if: ${{ !cancelled() && contains(matrix.name, 'test') }}
+            run: |
+              task unit ${{ matrix.env.TASKFILE_ARGS }} && task unit ${{ matrix.env.TASKFILE_ARGS }} --status
 
-      - name: save ready_to_test=true
-        id: ready_to_test
-        if: ${{ contains(matrix.name, 'test') && success() }}
-        run: echo "ready_to_test=true" >> "$GITHUB_OUTPUT"
+          - name: task e2e (vscode-test)
+            id: e2e
+            # https://github.com/ansible/vscode-ansible/issues/1451
+            if: ${{ !cancelled() && contains(matrix.name, 'test') }}
+            run: |
+              set -e
+              task build 2>out/log/build-before.txt
+              task e2e ${{ matrix.env.TASKFILE_ARGS }}
+              task build 2>out/log/build-after.txt
+              task build --status --verbose
+            # Add these once e2e is fixed:
+            #  || { task flush && task e2e ${{ matrix.env.TASKFILE_ARGS }}; }
+            #  task e2e ${{ matrix.env.TASKFILE_ARGS }} --status
 
-      - name: task ${{ matrix.task-name }}
-        if: "${{ !contains(matrix.name, 'test') && !contains(matrix.name, 'wdio') && steps.ready_to_test.outputs.ready_to_test == 'true' }}"
-        run: task ${{ matrix.task-name }} ${{ matrix.env.TASKFILE_ARGS }} && task ${{ matrix.task-name }} ${{ matrix.env.TASKFILE_ARGS }} --status
+          - name: task wdio (VS Code UI)
+            id: wdio
+            if: ${{ runner.os != 'Windows' }}
+            run: task wdio && task wdio --status && task build --status
+            timeout-minutes: 30
 
-      - name: task unit (ext, vue, als, mcp)
-        if: contains(matrix.name, 'test') && matrix.task-name != 'wdio' && steps.ready_to_test.outputs.ready_to_test == 'true'
-        run: |
-          task unit ${{ matrix.env.TASKFILE_ARGS }} && task unit ${{ matrix.env.TASKFILE_ARGS }} --status
-
-      - name: task e2e (vscode-test)
-        # https://github.com/ansible/vscode-ansible/issues/1451
-        if: ${{ !cancelled() && contains(matrix.name, 'test') && matrix.task-name != 'wdio' && steps.ready_to_test.outputs.ready_to_test == 'true' }}
-        run: |
-          set -e
-          task build 2>out/log/build-before.txt
-          task e2e ${{ matrix.env.TASKFILE_ARGS }}
-          task build 2>out/log/build-after.txt
-          task build --status --verbose
-        # Add these once e2e is fixed:
-        #  || { task flush && task e2e ${{ matrix.env.TASKFILE_ARGS }}; }
-        #  task e2e ${{ matrix.env.TASKFILE_ARGS }} --status
-
-      - name: task wdio (VS Code UI)
-        if: ${{ matrix.task-name == 'wdio' && steps.ready_to_test.outputs.ready_to_test == 'true' }}
-        run: |
-          task wdio
-          task build --status
-        timeout-minutes: 30
+      - name: task coverage
+        if: ${{ runner.os != 'Windows' }}
+        run: task coverage
 
       - name: task finish
         run: task finish
@@ -407,7 +446,7 @@ jobs:
         if: ${{ !cancelled() && (runner.os != 'Windows' || contains(matrix.name, 'wsl')) }}
         uses: ansible/actions/upload-artifact@main
         with:
-          name: logs-${{ matrix.name }}-${{ matrix.id }}-${{ github.run_attempt }}.zip
+          name: logs-${{ matrix.id }}-${{ matrix.os }}-${{ github.run_attempt }}.zip
           path: |
             out/als
             out/coverage
@@ -458,7 +497,7 @@ jobs:
 
   mcp-server-image:
     runs-on: ubuntu-26.04
-    needs: [package, lint]
+    needs: [package]
     permissions:
       contents: read
       packages: write
@@ -630,7 +669,7 @@ jobs:
           files: "out/*.vsix"
 
       - run: |
-          pnpm install -y --frozen-lockfile
+          pnpm install -y --frozen-lockfile --reporter append-only
           ls -la out/*.vsix
 
       - name: Publish extension to marketplaces

--- a/Taskfile.base.yml
+++ b/Taskfile.base.yml
@@ -9,7 +9,7 @@ vars:
 tasks:
   pnpm:
     cmds:
-      - pnpm -r install --frozen-lockfile
+      - pnpm -r install --frozen-lockfile --reporter append-only
     deps:
       - mise
     dir: "{{ .TASKFILE_DIR }}"
@@ -29,6 +29,9 @@ tasks:
       - bash ./tools/uv.sh
     deps:
       - mise
+    vars:
+      VIRTUAL_ENV:
+        sh: echo "${HOME}/.local/share/virtualenvs/vsa"
     generates:
       - "{{ .VIRTUAL_ENV }}/pyvenv.cfg"
       - "{{ .VIRTUAL_ENV }}/CACHEDIR.TAG"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -17,8 +17,6 @@ env:
   # Overridden by some specific jobs
   CODE_VERSION: max
 vars:
-  VIRTUAL_ENV:
-    sh: echo "${HOME}/.local/share/virtualenvs/vsa"
   XVFB:
     # prefix to add to allow execution of test in headless machines (CI)
     # keep the space after log filename as it is needed.
@@ -44,6 +42,7 @@ tasks:
       - git clean -dxf
   finish:
     desc: Commands to run at the end of build and test processes
+    platforms: [linux, darwin]
     dir: "{{ .TASKFILE_DIR }}"
     cmds:
       # clean up uv cache, important for CI especially for caching size reduction
@@ -155,7 +154,7 @@ tasks:
     desc: Lint the project
     interactive: true
     cmds:
-      - "{{.VIRTUAL_ENV}}/bin/prek run -a -v --color=always"
+      - uv run prek run -a -v --color=always
       - defer: { task: finish }
     silent: true
     sources:
@@ -331,6 +330,7 @@ tasks:
       - defer: tools/sanitize-logs.py out/{{.TEST_PREFIX}}/*.log
   coverage:
     desc: Consolidate and filter coverage reports
+    platforms: [linux, darwin]
     sources:
       - out/coverage/*/lcov.info
     generates:

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -20,38 +20,35 @@ $ task -l
 The diagram below shows the dependencies between the command task commands.
 
 ``` mermaid
-flowchart TD
-    build --> setup
-    docs --> setup
+flowchart BT
+
+    subgraph wave1
+      lint
+      build
+      docs
+      deps
+    end
+
+    subgraph test
+      e2e
+      unit
+      wdio
+    end
+
+    docs
+    test --> setup
     package --> build
-    test --> build
-    test --> ui
-    test --> e2e
-    test --> mcp
-    test --> unit
-    test --> als
     default --> lint
     default --> docs
     default --> package
     default --> test
-    lint --> setup
     clean
     code --> package
-    deps --> setup
-    ui --> build
     unit --> build
-    e2e --> build
-    mcp --> build
-    als --> build
+    e2e --> package
 
-    subgraph testing
-      test
-      mcp
-      ui
-      e2e
-      unit
-      als
-    end
+
+
 ```
 
 ## Release and publication of extension

--- a/packages/ansible-mcp-server/Taskfile.yml
+++ b/packages/ansible-mcp-server/Taskfile.yml
@@ -6,8 +6,6 @@ env:
   DOCKER_CLI_HINTS: "false"
 vars:
   PROJECT: ansible-mcp-server
-  VIRTUAL_ENV:
-    sh: echo "${HOME}/.local/share/virtualenvs/vsa"
 includes:
   base:
     taskfile: ../../Taskfile.base.yml

--- a/tools/helper.mts
+++ b/tools/helper.mts
@@ -7,7 +7,7 @@
  *   node tools/helper.mts --package
  *   node tools/helper.mts --publish
  */
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import {
   copyFileSync,
   linkSync,
@@ -35,16 +35,25 @@ function pySplit(s: string, sep: string, maxsplit: number): string[] {
   return [head, ...rest];
 }
 
-function getTags(cmd: string): string {
+let warnedMissingTags = false;
+
+function git(...args: string[]): string {
+  return execFileSync("git", args, { encoding: "utf8" }).trimEnd();
+}
+
+function getTags(match: string): string {
   try {
-    return execSync(cmd, { encoding: "utf8", shell: "/bin/sh" }).trimEnd();
+    return git("describe", "--dirty", "--tags", "--long", "--match", match);
   } catch {
+    if (!warnedMissingTags) {
+      warnedMissingTags = true;
+      console.warn(
+        "This repository is missing tags. Fetch tags from upstream repository.",
+      );
+    }
     const now = new Date();
     const yy = now.getFullYear() % 100;
     const month = now.getMonth() + 1;
-    console.warn(
-      "This repository is missing tags. Fetch tags from upstream repository.",
-    );
     return `v${String(yy).padStart(2, "0")}.${month}.1-1-no_tags`;
   }
 }
@@ -52,14 +61,14 @@ function getTags(cmd: string): string {
 /** Best-effort tag sync when a git remote exists (no-op in shallow/offline contexts). */
 function fetchTagsIfPossible(): void {
   try {
-    execSync("git ls-remote", {
+    execFileSync("git", ["ls-remote"], {
       stdio: ["ignore", "ignore", "ignore"],
     });
-    execSync("git fetch --tags", {
+    execFileSync("git", ["fetch", "--tags"], {
       stdio: ["ignore", "ignore", "ignore"],
     });
   } catch {
-    console.warn("ignored git remote command");
+    // offline or shallow clone; version resolution still proceeds
   }
 }
 
@@ -73,7 +82,7 @@ function resolveVersion(): ResolvedVersion {
   fetchTagsIfPossible();
 
   let preRelease = false;
-  let result = getTags('git describe --dirty --tags --long --match "v*.*"');
+  let result = getTags("v*.*");
   let gitTag = result;
   const firstParts = pySplit(gitTag, "-", 2);
   let tag = firstParts[0] ?? "";
@@ -84,9 +93,11 @@ function resolveVersion(): ResolvedVersion {
 
   if (suffix.includes("-dirty") || commitsSince !== "0") {
     preRelease = true;
-    result = getTags('git describe --dirty --tags --long --match "v*.*.0"');
+    result = getTags("v*.*.0");
     gitTag = result;
-    tag = pySplit(gitTag, "-", 2)[0] ?? "";
+    const secondParts = pySplit(gitTag, "-", 2);
+    tag = secondParts[0] ?? "";
+    const secondSuffix = secondParts[2] ?? "";
     version = tag.slice(1);
     versionInfo = version.split(".").map((x) => Number.parseInt(x, 10));
 
@@ -102,22 +113,33 @@ function resolveVersion(): ResolvedVersion {
 
     let lastTagTimestamp: number;
     let lastCommitTimestamp: number;
-    try {
-      lastTagTimestamp = Number.parseInt(
-        execSync(`git -P log -1 --format=%ct ${tag}`, {
-          encoding: "utf8",
-        }).trimEnd(),
-        10,
-      );
-      lastCommitTimestamp = Number.parseInt(
-        execSync("git -P show --no-patch --format=%ct HEAD", {
-          encoding: "utf8",
-        }).trimEnd(),
-        10,
-      );
-    } catch {
+    if (suffix.includes("no_tags") || secondSuffix.includes("no_tags")) {
       lastTagTimestamp = 1_721_335_286;
       lastCommitTimestamp = 1_722_605_520;
+    } else {
+      try {
+        lastTagTimestamp = Number.parseInt(
+          execFileSync("git", ["-P", "log", "-1", "--format=%ct", tag], {
+            encoding: "utf8",
+            stdio: ["ignore", "pipe", "ignore"],
+          }).trimEnd(),
+          10,
+        );
+        lastCommitTimestamp = Number.parseInt(
+          execFileSync(
+            "git",
+            ["-P", "show", "--no-patch", "--format=%ct", "HEAD"],
+            {
+              encoding: "utf8",
+              stdio: ["ignore", "pipe", "ignore"],
+            },
+          ).trimEnd(),
+          10,
+        );
+      } catch {
+        lastTagTimestamp = 1_721_335_286;
+        lastCommitTimestamp = 1_722_605_520;
+      }
     }
     versionInfo[2] = lastCommitTimestamp - lastTagTimestamp;
   }
@@ -140,9 +162,13 @@ function usage(): void {
 }
 
 function run(parts: string[]): void {
-  const cmd = parts.filter((p) => p.length > 0).join(" ");
-  console.error(`run: ${cmd}`);
-  execSync(cmd, { stdio: "inherit" });
+  const args = parts.filter((p) => p.length > 0);
+  const command = args[0];
+  if (command === undefined) {
+    throw new Error("empty command");
+  }
+  console.error(`run: ${args.join(" ")}`);
+  execFileSync(command, args.slice(1), { stdio: "inherit" });
 }
 
 function findPackagedVsix(): string[] {


### PR DESCRIPTION
- `lint`, `docs` and `build` can run in parallel
- `unit`, `e2e` and `wdio` can run in parallel

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
CI is reorganized to shorten the runner build chain by running early lint/docs/package work in parallel with unit/e2e/wdio test work, while decoupling build from lint dependencies.

- Add a dedicated early `package` job and remove `lint` dependencies from `build`/`mcp-server-image`
- Split the `test` matrix execution into two parallel step groups (Linux-only `task lint` plus docs/build/package, and unit/e2e/wdio plus finish)
- Remove `prek` plumbing from the CI task composite action (including input/conditional `prek`-hook behavior) and simplify setup/task flow
- Adjust task runner behavior (command execution and caching/reporting tweaks) and tighten platform constraints

Original commit message: chore(performance): use parallel github actions steps
<!-- end of auto-generated comment: release notes by coderabbit.ai -->