### PR TITLE
fix: enable eslint-plugin-sonarjs plugin

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,5 +1,5 @@
 // @ts-check
-// cspell: ignore tseslint
+// cspell: ignore tseslint sonarjs
 import eslint from "@eslint/js";
 import tseslint from "typescript-eslint";
 import tsParser from "@typescript-eslint/parser";
@@ -10,6 +10,7 @@ import { fileURLToPath } from "url";
 import { defineConfig, includeIgnoreFile } from "eslint/config";
 import { createRequire } from "module";
 import importPlugin from "eslint-plugin-import";
+import { configs as sonarjsConfigs } from "eslint-plugin-sonarjs";
 const require = createRequire(import.meta.url);
 /** @type {import('eslint').ESLint.Plugin} */
 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- local CJS plugin loaded via require
@@ -21,16 +22,15 @@ const gitignorePath = path.resolve(import.meta.dirname, ".gitignore");
 
 export default defineConfig(
   includeIgnoreFile(gitignorePath, "Imported .gitignore patterns"),
-  ...[
-    importPlugin.flatConfigs.recommended,
-    eslint.configs.recommended,
-    prettierRecommendedConfig,
-    tseslint.configs.recommended,
-    tseslint.configs.strict,
-    // TODO: enable later
-    // tseslint.configs.stylistic,
-    // tseslint.configs.strictTypeChecked,
-  ],
+  importPlugin.flatConfigs.recommended,
+  eslint.configs.recommended,
+  sonarjsConfigs.recommended,
+  prettierRecommendedConfig,
+  tseslint.configs.recommended,
+  tseslint.configs.strict,
+  // TODO: enable later
+  // tseslint.configs.stylistic,
+  // tseslint.configs.strictTypeChecked,
   {
     /** Files that use type-aware linting (TS/JS in src, packages, test). */
     files: ["**/*.{js,mjs,ts,tsx,mts,cjs}"],
@@ -95,6 +95,38 @@ export default defineConfig(
       "@typescript-eslint/restrict-template-expressions": "error",
       "@typescript-eslint/no-unsafe-argument": "error",
       "@typescript-eslint/no-unsafe-return": "error",
+      // Ignored on purpose
+      "sonarjs/no-os-command-from-path": "off",
+      "sonarjs/publicly-writable-directories": "off",
+      // TODO: address later (rules with 5+ violations)
+      "sonarjs/cognitive-complexity": "off",
+      "sonarjs/prefer-regexp-exec": "off",
+      "sonarjs/no-trivial-assertions": "off",
+      "sonarjs/super-linear-regex": "off",
+      "sonarjs/public-static-readonly": "off",
+      "sonarjs/different-types-comparison": "off",
+      "sonarjs/prefer-specific-assertions": "off",
+      "sonarjs/no-clear-text-protocols": "off",
+      "sonarjs/todo-tag": "off",
+      "sonarjs/no-redundant-jump": "off",
+      "sonarjs/constructor-for-side-effects": "off",
+      "sonarjs/no-undefined-argument": "off",
+      "sonarjs/no-nested-conditional": "off",
+      "sonarjs/prefer-single-boolean-return": "off",
+      "sonarjs/no-floating-point-equality": "off",
+      // TODO: address later (fewer violations but non-trivial fixes)
+      "sonarjs/class-name": "off",
+      "sonarjs/no-try-promise": "off",
+      "sonarjs/no-skipped-tests": "off",
+      "sonarjs/no-nested-template-literals": "off",
+      "sonarjs/no-nested-assignment": "off",
+      "sonarjs/no-control-regex": "off",
+      "sonarjs/no-all-duplicated-branches": "off",
+      "sonarjs/post-message": "off",
+      "sonarjs/no-small-switch": "off",
+      "sonarjs/no-async-constructor": "off",
+      "sonarjs/function-return-type": "off",
+      "sonarjs/fixme-tag": "off",
     },
     settings: {
       // workaround for vscode imports in test files

--- a/package.json
+++ b/package.json
@@ -1119,6 +1119,7 @@
     "eslint-import-resolver-typescript": "^4.4.5",
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-prettier": "^5.5.6",
+    "eslint-plugin-sonarjs": "^4.1.0",
     "express": "^5.2.1",
     "find-process": "^2.1.1",
     "glob": "^13.0.6",

--- a/packages/ansible-language-server/src/providers/completionProvider.ts
+++ b/packages/ansible-language-server/src/providers/completionProvider.ts
@@ -454,7 +454,10 @@ export async function doCompletion(
               } else {
                 priority = priorityMap.choice;
               }
-              const insertValue = new String(choice).toString();
+              const insertValue =
+                typeof choice === "string"
+                  ? choice
+                  : String(choice as boolean | number);
               const completionItem: CompletionItem = {
                 label: insertValue,
                 detail: choice === defaultChoice ? "default" : undefined,

--- a/packages/ansible-language-server/src/services/docsLibraryUtilsForPAC.ts
+++ b/packages/ansible-language-server/src/services/docsLibraryUtilsForPAC.ts
@@ -33,14 +33,12 @@ export async function findModulesUtils(
   documentUri?: string,
 ): Promise<[IModuleMetadata | undefined, string | undefined]> {
   const playbookAdjacentModules = new Map<string, IModuleMetadata>();
-  const playbookAdjacentModuleFqcns = new Set<string>();
   const playbookAdjacentDocFragments = new Map<string, IModuleMetadata>();
 
   // find documentation for PAC
   findDocumentation(playbookAdjacentCollectionsPath, "collection").forEach(
     (doc) => {
       playbookAdjacentModules.set(doc.fqcn, doc);
-      playbookAdjacentModuleFqcns.add(doc.fqcn);
     },
   );
 
@@ -56,15 +54,6 @@ export async function findModulesUtils(
   ).forEach((r, collection) =>
     playbookAdjacentPluginRouting.set(collection, r),
   );
-
-  // add all valid redirect routes as possible FQCNs
-  for (const [collection, routesByType] of playbookAdjacentPluginRouting) {
-    for (const [name, route] of routesByType.get("modules") || []) {
-      if (route.redirect && !route.tombstone) {
-        playbookAdjacentModuleFqcns.add(`${collection}.${name}`);
-      }
-    }
-  }
 
   // Now, start finding the module
   let hitFqcn;
@@ -120,23 +109,13 @@ export async function findModulesUtils(
 export async function getModuleFqcnsUtils(
   playbookAdjacentCollectionsPath: string,
 ): Promise<Set<string>> {
-  const playbookAdjacentModules = new Map<string, IModuleMetadata>();
   const playbookAdjacentModuleFqcns = new Set<string>();
-  const playbookAdjacentDocFragments = new Map<string, IModuleMetadata>();
 
   findDocumentation(playbookAdjacentCollectionsPath, "collection").forEach(
     (doc) => {
-      playbookAdjacentModules.set(doc.fqcn, doc);
       playbookAdjacentModuleFqcns.add(doc.fqcn);
     },
   );
-
-  findDocumentation(
-    playbookAdjacentCollectionsPath,
-    "collection_doc_fragment",
-  ).forEach((doc) => {
-    playbookAdjacentDocFragments.set(doc.fqcn, doc);
-  });
 
   (
     await findPluginRouting(playbookAdjacentCollectionsPath, "collection")

--- a/packages/ansible-language-server/src/utils/getAnsibleMetaData.ts
+++ b/packages/ansible-language-server/src/utils/getAnsibleMetaData.ts
@@ -22,7 +22,7 @@ export interface ansibleMetaDataType {
   "ansible information"?: ansibleMetaDataEntryType;
   "python information"?: ansibleMetaDataEntryType;
   "ansible-lint information"?: ansibleMetaDataEntryType;
-  "execution environment information"?: ansibleMetaDataEntryType | undefined;
+  "execution environment information"?: ansibleMetaDataEntryType;
 }
 
 export async function getAnsibleMetaData(

--- a/packages/ansible-language-server/src/utils/yaml.ts
+++ b/packages/ansible-language-server/src/utils/yaml.ts
@@ -54,7 +54,7 @@ export class AncestryBuilder<N extends Node | Pair = Node> {
   ): AncestryBuilder<X> {
     this._index--;
     if (isPair(this.get())) {
-      if (!type || !(type === Pair.prototype.constructor)) {
+      if (!type || type !== Pair.prototype.constructor) {
         this._index--;
       }
     }
@@ -287,7 +287,7 @@ export function getDeclaredCollections(modulePath: Node[] | null): string[] {
     // traverse the YAML up through the Ansible blocks
     const builder = new AncestryBuilder(path).parent(YAMLSeq).parent(YAMLMap);
     const key = builder.getStringKey();
-    if (key && /^block|rescue|always$/.test(key)) {
+    if (key && /^(?:block|rescue|always)$/.test(key)) {
       declaredCollections.push(...getDeclaredCollectionsForMap(builder.get()));
       path = builder.getPath();
     } else {

--- a/packages/ansible-language-server/test/interfaces.test.ts
+++ b/packages/ansible-language-server/test/interfaces.test.ts
@@ -1,4 +1,5 @@
 import { IPullPolicy } from "@src/interfaces/extensionSettings.js";
+import { expect } from "vitest";
 
 describe("interfaces", function () {
   describe("IPullPolicy", function () {
@@ -6,8 +7,7 @@ describe("interfaces", function () {
       // Type existence is verified by TypeScript at compile time.
       // If IPullPolicy doesn't exist, this file won't compile.
       const _test: IPullPolicy = "always";
-      // Suppress unused variable warning
-      void _test;
+      expect(_test).toBe("always");
     });
   });
 });

--- a/packages/ansible-mcp-server/test/inputSchemaValidation.test.ts
+++ b/packages/ansible-mcp-server/test/inputSchemaValidation.test.ts
@@ -48,7 +48,7 @@ describe("MCP Tool InputSchema Validation", () => {
         toolsWithSchema.push(toolName);
       }
     }
-    return toolsWithSchema.sort();
+    return toolsWithSchema.sort((a, b) => a.localeCompare(b));
   }
 
   /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -200,6 +200,9 @@ importers:
       eslint-plugin-prettier:
         specifier: ^5.5.6
         version: 5.5.6(eslint-config-prettier@10.1.8(eslint@10.5.0(jiti@2.7.0)))(eslint@10.5.0(jiti@2.7.0))(prettier@3.8.4)
+      eslint-plugin-sonarjs:
+        specifier: ^4.1.0
+        version: 4.1.0(eslint@10.5.0(jiti@2.7.0))
       express:
         specifier: ^5.2.1
         version: 5.2.1
@@ -3098,6 +3101,10 @@ packages:
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
+  builtin-modules@3.3.0:
+    resolution: {integrity: sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==}
+    engines: {node: '>=6'}
+
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
     engines: {node: '>=18'}
@@ -3895,6 +3902,11 @@ packages:
       eslint-config-prettier:
         optional: true
 
+  eslint-plugin-sonarjs@4.1.0:
+    resolution: {integrity: sha512-rh+FlVz0yfd2RNIb6WqSkuGh0addX/Qi5scwQ5FphXDFrM6fZKcxP1+attJ78yUKcyYfiu6MTaISPpAFPzqRJw==}
+    peerDependencies:
+      eslint: ^8.0.0 || ^9.0.0 || ^10.0.0
+
   eslint-scope@9.1.2:
     resolution: {integrity: sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
@@ -4238,6 +4250,9 @@ packages:
   function.prototype.name@1.1.8:
     resolution: {integrity: sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==}
     engines: {node: '>= 0.4'}
+
+  functional-red-black-tree@1.0.1:
+    resolution: {integrity: sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==}
 
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
@@ -4946,6 +4961,10 @@ packages:
     resolution: {integrity: sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==}
     engines: {node: '>=12', npm: '>=6'}
 
+  jsx-ast-utils-x@0.1.0:
+    resolution: {integrity: sha512-eQQBjBnsVtGacsG9uJNB8qOr3yA8rga4wAaGG1qRcBzSIvfhERLrWxMAM1hp5fcS6Abo8M4+bUBTekYR0qTPQw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   jszip@3.10.1:
     resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
 
@@ -5123,6 +5142,9 @@ packages:
 
   lodash.isstring@4.0.1:
     resolution: {integrity: sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==}
+
+  lodash.merge@4.6.2:
+    resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
   lodash.once@4.1.1:
     resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
@@ -6015,9 +6037,17 @@ packages:
     resolution: {integrity: sha512-8HrF5ZsXk5FAH9dgsx3BlUer73nIhuj+9OrQwEbLTPOBzGkL1lsFCR01am+v+0m2Cmbs1nP12hLDl5FA7EszKA==}
     engines: {node: '>=6.0.0'}
 
+  refa@0.12.1:
+    resolution: {integrity: sha512-J8rn6v4DBb2nnFqkqwy6/NnTYMcgLA+sLr0iIO41qpv0n+ngb7ksag2tMRl0inb1bbO/esUwzW1vbJi7K0sI0g==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
     engines: {node: '>= 0.4'}
+
+  regexp-ast-analysis@0.7.1:
+    resolution: {integrity: sha512-sZuz1dYW/ZsfG17WSAG7eS85r5a0dDsvg+7BiiYR5o6lKCAtUrEwdmRmaGF6rwVj3LcmAeYkOWKEPlbPzN3Y3A==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
@@ -6174,6 +6204,10 @@ packages:
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
     engines: {node: '>=v12.22.7'}
+
+  scslre@0.3.0:
+    resolution: {integrity: sha512-3A6sD0WYP7+QrjbfNA2FN3FsOaGGFoekCVgTyypy53gPxhbkCIjtO6YWgdrfM+n/8sI8JeXZOIxsHjMTNxQ4nQ==}
+    engines: {node: ^14.0.0 || >=16.0.0}
 
   secretlint@10.2.2:
     resolution: {integrity: sha512-xVpkeHV/aoWe4vP4TansF622nBEImzCY73y/0042DuJ29iKIaqgoJ8fGxre3rVSHHbxar4FdJobmTnLp9AU0eg==}
@@ -10086,6 +10120,8 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
+  builtin-modules@3.3.0: {}
+
   bundle-name@4.1.0:
     dependencies:
       run-applescript: 7.1.0
@@ -10994,6 +11030,23 @@ snapshots:
     optionalDependencies:
       eslint-config-prettier: 10.1.8(eslint@10.5.0(jiti@2.7.0))
 
+  eslint-plugin-sonarjs@4.1.0(eslint@10.5.0(jiti@2.7.0)):
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      builtin-modules: 3.3.0
+      bytes: 3.1.2
+      eslint: 10.5.0(jiti@2.7.0)
+      functional-red-black-tree: 1.0.1
+      globals: 17.7.0
+      jsx-ast-utils-x: 0.1.0
+      lodash.merge: 4.6.2
+      minimatch: 10.2.5
+      scslre: 0.3.0
+      semver: 7.8.5
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
+      yaml: 2.9.0
+
   eslint-scope@9.1.2:
     dependencies:
       '@types/esrecurse': 4.3.1
@@ -11434,6 +11487,8 @@ snapshots:
       functions-have-names: 1.2.3
       hasown: 2.0.3
       is-callable: 1.2.7
+
+  functional-red-black-tree@1.0.1: {}
 
   functions-have-names@1.2.3: {}
 
@@ -12176,6 +12231,8 @@ snapshots:
       ms: 2.1.3
       semver: 7.8.5
 
+  jsx-ast-utils-x@0.1.0: {}
+
   jszip@3.10.1:
     dependencies:
       lie: 3.3.0
@@ -12353,6 +12410,8 @@ snapshots:
   lodash.isplainobject@4.0.6: {}
 
   lodash.isstring@4.0.1: {}
+
+  lodash.merge@4.6.2: {}
 
   lodash.once@4.1.1: {}
 
@@ -13497,6 +13556,10 @@ snapshots:
     dependencies:
       minimatch: 3.1.5
 
+  refa@0.12.1:
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+
   reflect.getprototypeof@1.0.10:
     dependencies:
       call-bind: 1.0.9
@@ -13507,6 +13570,11 @@ snapshots:
       get-intrinsic: 1.3.0
       get-proto: 1.0.1
       which-builtin-type: 1.2.1
+
+  regexp-ast-analysis@0.7.1:
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      refa: 0.12.1
 
   regexp.prototype.flags@1.5.4:
     dependencies:
@@ -13690,6 +13758,12 @@ snapshots:
   saxes@6.0.0:
     dependencies:
       xmlchars: 2.2.0
+
+  scslre@0.3.0:
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      refa: 0.12.1
+      regexp-ast-analysis: 0.7.1
 
   secretlint@10.2.2:
     dependencies:

--- a/src/features/lightspeed/contentMatchesWebview.ts
+++ b/src/features/lightspeed/contentMatchesWebview.ts
@@ -4,8 +4,6 @@ import { SettingsManager } from "@src/settings";
 import {
   ContentMatchesRequestParams,
   ContentMatchesResponseParams,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  IContentMatch,
   IContentMatchParams,
   ISuggestionDetails,
 } from "@src/interfaces/lightspeed";

--- a/src/features/lightspeed/providers/base.ts
+++ b/src/features/lightspeed/providers/base.ts
@@ -203,10 +203,7 @@ export abstract class BaseLLMProvider<
           "$1[REDACTED]",
         )
         .replaceAll(/(apiKey["']?\s*[:=]\s*["']?)[^"'\s,}]+/gi, "$1[REDACTED]")
-        .replaceAll(
-          /key["']?\s*[:=]\s*["'][A-Za-z0-9_-]{20,}["']/gi,
-          "key: [REDACTED]",
-        )
+        .replaceAll(/key["']?\s*[:=]\s*["'][\w-]{20,}["']/gi, "key: [REDACTED]")
         .replaceAll(
           /(x-goog-api-key["']?\s*[:=]\s*["']?)[^"'\s,}&]+/gi,
           "$1[REDACTED]",

--- a/src/features/lightspeed/providers/rhcustom.ts
+++ b/src/features/lightspeed/providers/rhcustom.ts
@@ -147,7 +147,10 @@ export class RHCustomProvider extends BaseLLMProvider<RHCustomConfig> {
 
       if (endMatch) {
         // Extract only the content between the code blocks
-        const yamlContent = remainingContent.substring(0, endMatch.index);
+        const yamlContent = remainingContent.substring(
+          0,
+          endMatch.index ?? remainingContent.length,
+        );
         console.log(
           "[RHCustom Provider] Extracted YAML from code block, length:",
           yamlContent.length,

--- a/src/features/lightspeed/utils/watchers.ts
+++ b/src/features/lightspeed/utils/watchers.ts
@@ -63,7 +63,7 @@ export function watchRolesDirectory(
     if (stats.isFile()) {
       dirPath = path.dirname(dirPath);
     }
-    if (dirPath in StandardRolePaths) {
+    if (StandardRolePaths.includes(dirPath)) {
       Reflect.deleteProperty(ansibleRolesCache["common"], dirPath);
     } else {
       const workspaceFolders = vscode.workspace.workspaceFolders;

--- a/src/features/utils/applyModelines.ts
+++ b/src/features/utils/applyModelines.ts
@@ -141,7 +141,7 @@ function _parseGenericValue(value: string): string | number | boolean {
   value = value.trim();
   if (/^(true|false)$/i.test(value)) {
     return value.toLowerCase() === "true";
-  } else if (/^[0-9]+$/.test(value)) {
+  } else if (/^\d+$/.test(value)) {
     return parseInt(value, 10);
   }
   return value.replace(/['"]/g, "");

--- a/src/features/vault.ts
+++ b/src/features/vault.ts
@@ -457,6 +457,7 @@ const handleLiteralMultiline = (
 const handleFoldedMultiline = (lines: string[], leadingSpacesCount: number) => {
   const text = prepareMultiline(lines, leadingSpacesCount).reduce(
     foldedMultilineReducer,
+    "",
   );
   const chompingStyle = getChompingStyle(lines);
   if (chompingStyle === ChompingStyle.Strip) {
@@ -496,20 +497,18 @@ const reindentText = (
   const leadingSpacesCount = (indentationLevel + 1) * tabSize;
   const lines = text.split("\n");
   let trailingNewlines = 0;
-  for (const line of lines.reverse()) {
-    if (line === "") {
+  for (let i = lines.length - 1; i >= 0; i--) {
+    if (lines[i] === "") {
       trailingNewlines++;
     } else {
       break;
     }
   }
-  lines.reverse();
   if (lines.length > 1) {
     const leadingWhitespaces = " ".repeat(leadingSpacesCount);
     const rejoinedLines = lines
       .map((line) => `${leadingWhitespaces}${line}`)
       .join("\n");
-    rejoinedLines.replace(/\n$/, "");
     if (trailingNewlines > 1) {
       return `${MultilineStyle.Literal}${ChompingStyle.Keep}\n${rejoinedLines}`;
     } else if (trailingNewlines === 0) {

--- a/test/unit/contentCreator/utilities.test.ts
+++ b/test/unit/contentCreator/utilities.test.ts
@@ -133,8 +133,7 @@ describe(__filename, function () {
   describe("'expandPath()' utility functions for the content creator", function () {
     expandPathTests.forEach(({ name, pathUrl, expected }) => {
       it(`should provide details for ${name}`, function () {
-        const result = expandPath(pathUrl);
-        assert.equal(result, expected);
+        expect(expandPath(pathUrl)).toBe(expected);
       });
     });
   });

--- a/test/unit/lightspeed/explorerWebviewProvider.test.ts
+++ b/test/unit/lightspeed/explorerWebviewProvider.test.ts
@@ -33,14 +33,10 @@ describe("LightspeedExplorerWebviewViewProvider", () => {
     };
 
     // Setup mock webview view
-    const onDidDisposeCallbacks: Array<() => void> = [];
     mockWebviewView = {
       webview: mockWebview,
       visible: true,
-      onDidDispose: vi.fn((callback: () => void) => {
-        onDidDisposeCallbacks.push(callback);
-        return { dispose: vi.fn() };
-      }),
+      onDidDispose: vi.fn(() => ({ dispose: vi.fn() })),
       onDidChangeVisibility: vi.fn(),
     } as unknown as vscode.WebviewView;
 

--- a/test/unit/lightspeed/utils/scanner.test.ts
+++ b/test/unit/lightspeed/utils/scanner.test.ts
@@ -30,7 +30,7 @@ describe("CollectionFinder", () => {
       await finder.refreshCache();
 
       const names = finder.cache.map((c) => c.fqcn);
-      expect(names).toEqual([...names].sort());
+      expect(names).toEqual([...names].sort((a, b) => a.localeCompare(b)));
     });
   });
 

--- a/test/wdio/mock-server.ts
+++ b/test/wdio/mock-server.ts
@@ -151,6 +151,7 @@ export function start(port: number): Promise<void> {
   }
   return new Promise((resolve, reject) => {
     const app = express();
+    app.disable("x-powered-by");
     app.use(express.json());
 
     const routes: Array<[string, "get" | "post"]> = [

--- a/tools/helper.mts
+++ b/tools/helper.mts
@@ -153,7 +153,7 @@ function findPackagedVsix(): string[] {
     return [];
   }
   return names
-    .filter((name) => /^ansible-[0-9].*\.vsix$/.test(name))
+    .filter((name) => /^ansible-\d.*\.vsix$/.test(name))
     .map((name) => join("out", name));
 }
 

--- a/webviews/lightspeed/src/utils/outlineLineNumbers.ts
+++ b/webviews/lightspeed/src/utils/outlineLineNumbers.ts
@@ -1,5 +1,5 @@
 export function textIsOnlyLineNumber(input: string): boolean {
-  return /^\d*[.]?[ ]?$/.test(input);
+  return /^\d*\.? ?$/.test(input);
 }
 
 export function digitsInNumber(number: number): number {
@@ -46,7 +46,7 @@ export function removeLine(
 export function reapplyLineNumbers(textField: HTMLTextAreaElement): void {
   textField.value = textField.value
     .split("\n")
-    .map((line, idx) => `${idx + 1}. ${line.replace(/^\d+[.]?[\s]?/, "")}`)
+    .map((line, idx) => `${idx + 1}. ${line.replace(/^\d+\.?\s?/, "")}`)
     .join("\n");
 }
 


### PR DESCRIPTION
Disable high-volume SonarJS rules for follow-up and resolve
straightforward violations so eslint passes cleanly.

Co-authored-by: Cursor <cursoragent@cursor.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- fix: enable eslint-plugin-sonarjs plugin — added SonarJS to ESLint, disabled high-volume rules for later follow-up, and fixed a few straightforward lint issues across completion, docs, tests, utilities, and watchers to keep lint passing cleanly.

_AI-assisted._

<!-- end of auto-generated comment: release notes by coderabbit.ai -->