### PR TITLE
fix(core): resolve UX bugs and rename to Ansible

### DIFF
--- a/.agents/skills/ux-walkthrough/SKILL.md
+++ b/.agents/skills/ux-walkthrough/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ux-walkthrough
 description: >
-  Guide a team member through all Ansible Environments extension
+  Guide a team member through all Ansible extension
   functionality as an end user. Collect structured UX feedback and
   produce a Jira-ready report. Use when the user says "ux walkthrough",
   "dogfood the extension", "test the extension as a user", "ux review",

--- a/.agents/skills/ux-walkthrough/catalog.md
+++ b/.agents/skills/ux-walkthrough/catalog.md
@@ -11,9 +11,9 @@ Legend: **Non-AI** = works without `ansibleEnvironments.enableAiFeatures`.
 
 | Feature | Trigger | Description | Non-AI | Implementation |
 |---------|---------|-------------|--------|----------------|
-| Activity bar container | Ansible icon | Opens Ansible Environments sidebar | yes | `package.json` `viewsContainers` |
+| Activity bar container | Ansible icon | Opens Ansible sidebar | yes | `package.json` `viewsContainers` |
 | Tree views (10) | Sidebar scroll | Env, Dev Tools, Collections, Sources, EEs, Creator, Playbooks, AI Tools*, AI Skills*, Lightspeed* | yes* | `src/views/*Provider.ts` |
-| Output channel | Output → Ansible Environments | Extension logs | yes | `src/extension.ts` |
+| Output channel | Output → Ansible | Extension logs | yes | `src/extension.ts` |
 
 *AI views require `enableAiFeatures`; Lightspeed view requires `ansible.lightspeed.enabled`.
 

--- a/.agents/skills/ux-walkthrough/walkthrough-modules.json
+++ b/.agents/skills/ux-walkthrough/walkthrough-modules.json
@@ -30,7 +30,7 @@
           "description": "In dev host: File \u2192 Open Folder \u2192 your Ansible project path."
         },
         {
-          "title": "Open Ansible Environments",
+          "title": "Open Ansible",
           "description": "Click Ansible icon in Activity Bar.",
           "view": "ansibleDevToolsEnvManagers"
         },
@@ -40,7 +40,7 @@
         },
         {
           "title": "Check output channel",
-          "description": "Output \u2192 Ansible Environments. Confirm no activation errors."
+          "description": "Output \u2192 Ansible. Confirm no activation errors."
         }
       ]
     },
@@ -66,7 +66,7 @@
         },
         {
           "title": "Create virtual environment",
-          "description": "Click the + button or run 'Ansible Environments: Create Environment' from Command Palette. Enter a name (e.g. .venv). The extension creates the venv and selects it automatically.",
+          "description": "Click the + button or run 'Ansible: Create Environment' from Command Palette. Enter a name (e.g. .venv). The extension creates the venv and selects it automatically.",
           "command": "ansibleDevToolsEnvManagers.create"
         },
         {
@@ -440,7 +440,7 @@
         },
         {
           "title": "Output channel",
-          "description": "Review Ansible Environments logs."
+          "description": "Review Ansible logs."
         }
       ]
     }

--- a/.agents/skills/ux-walkthrough/walkthrough-modules.md
+++ b/.agents/skills/ux-walkthrough/walkthrough-modules.md
@@ -29,9 +29,9 @@ drive module order, exercises, and Canvas content. Do not parse the block below.
         { "title": "Build the extension", "description": "In the repo window: npm run compile && npm run build" },
         { "title": "Press F5 (Run Extension)", "description": "Opens Extension Development Host window." },
         { "title": "Open workspace folder", "description": "In dev host: File → Open Folder → your Ansible project path." },
-        { "title": "Open Ansible Environments", "description": "Click Ansible icon in Activity Bar.", "view": "ansibleDevToolsEnvManagers" },
+        { "title": "Open Ansible", "description": "Click Ansible icon in Activity Bar.", "view": "ansibleDevToolsEnvManagers" },
         { "title": "Scan sidebar views", "description": "Scroll through all tree views." },
-        { "title": "Check output channel", "description": "Output → Ansible Environments. Confirm no activation errors." }
+        { "title": "Check output channel", "description": "Output → Ansible. Confirm no activation errors." }
       ]
     },
     {
@@ -45,7 +45,7 @@ drive module order, exercises, and Canvas content. Do not parse the block below.
       "exercise": "Create a venv from the sidebar, install ansible-dev-tools, select the environment, and verify the Dev Tools tree populates.",
       "steps": [
         { "title": "Open Environment Managers", "command": "ansibleDevToolsEnvManagers.refresh", "view": "ansibleDevToolsEnvManagers" },
-        { "title": "Create virtual environment", "description": "Click + or Command Palette → 'Ansible Environments: Create Environment'. Enter a name (e.g. .venv).", "command": "ansibleDevToolsEnvManagers.create" },
+        { "title": "Create virtual environment", "description": "Click + or Command Palette → 'Ansible: Create Environment'. Enter a name (e.g. .venv).", "command": "ansibleDevToolsEnvManagers.create" },
         { "title": "Verify environment selected", "description": "Confirm the new venv appears in Environment Managers and the Python status bar updates.", "view": "ansibleDevToolsEnvManagers" },
         { "title": "Install ansible-dev-tools", "description": "In Dev Tools Packages view, click 'Install ansible-dev-tools'. Verify tree populates.", "command": "ansibleDevToolsPackages.install", "view": "ansibleDevToolsPackages" },
         { "title": "Inspect Dev Tools", "description": "Verify expected packages appear (ansible-lint, ansible-navigator, etc.).", "command": "ansibleDevToolsPackages.refresh", "view": "ansibleDevToolsPackages" },
@@ -214,7 +214,7 @@ drive module order, exercises, and Canvas content. Do not parse the block below.
         { "title": "Disable AI features", "description": "Toggle enableAiFeatures off; verify core views." },
         { "title": "Empty/error states", "description": "Note messaging when data or tools missing." },
         { "title": "Settings review", "description": "Search ansible in Settings." },
-        { "title": "Output channel", "description": "Review Ansible Environments logs." }
+        { "title": "Output channel", "description": "Review Ansible logs." }
       ]
     }
   ]

--- a/.sdlc/ux-reports/2026-06-24-bthornto.md
+++ b/.sdlc/ux-reports/2026-06-24-bthornto.md
@@ -1,0 +1,62 @@
+---
+title: UX Walkthrough Report
+reviewer: Bradley A. Thornton
+date: 2026-06-24
+epic:
+extension_version: 0.0.1
+session_status: in_progress
+last_module:
+modules_completed: 0
+modules_total: 12
+issues_count:
+  blocker: 0
+  major: 0
+  minor: 0
+  enhancement: 0
+environment:
+  os: linux (Fedora)
+  editor: Cursor
+  launch_mode: F5 Extension Development Host
+  workspace: /var/home/bthornto/ansible-ux-walkthrough
+  venv_path:
+  ai_enabled: unknown
+  lightspeed_enabled: unknown
+---
+
+# UX Walkthrough Report
+
+## Executive summary
+
+<!-- Fill at session end. -->
+
+## Module findings
+
+---
+
+## Issues catalog
+
+| ID | Severity | Module | US/AC | Type | Summary |
+|----|----------|--------|-------|------|---------|
+
+## Value matrix
+
+| Module | Score (1–5) | Rationale |
+|--------|-------------|-----------|
+| setup | | |
+| environment | | |
+| editor-lsp | | |
+| collections-installed | | |
+| collections-remote | | |
+| creator | | |
+| playbooks | | |
+| execution-envs | | |
+| ai-authoring | | |
+| mcp-skills | | |
+| lightspeed | | |
+| cross-cutting | | |
+
+## Proposed Jira stories
+
+## Open questions for PM
+
+## Walkthrough content feedback

--- a/.sdlc/ux-reports/2026-06-25-bthornto.md
+++ b/.sdlc/ux-reports/2026-06-25-bthornto.md
@@ -1,0 +1,106 @@
+---
+title: UX Walkthrough Report
+reviewer: bthornto
+date: 2026-06-25
+epic:
+extension_version: 0.0.1
+session_status: in_progress
+last_module: environment
+modules_completed: 2
+modules_total: 12
+issues_count:
+  blocker: 0
+  major: 3
+  minor: 4
+  enhancement: 0
+environment:
+  os: Fedora 44 (linux 7.0.12)
+  editor: Cursor
+  ai_features: true
+  lightspeed: false
+  launch_mode: F5 Extension Development Host
+  workspace: ~/ansible-ux-walkthrough
+  venv_path:
+---
+
+# UX Walkthrough Report
+
+## Executive summary
+
+<!-- 3–5 sentences on overall release-readiness impression. Fill at session end. -->
+
+## Module findings
+
+### Module: setup — Setup & First Impressions
+
+**Maps to:** AC-8
+
+| Question | Response |
+|----------|----------|
+| Expectation — What did you expect? | A lot to explore, lots of entries in the sidebar |
+| Outcome — Did it work? (yes / partial / no) | partial — sidebar loaded but EE discovery was in an infinite retry loop, AIForge skills showed URL/auth error |
+| User mental model — What would end users expect? | They wouldn't know where to begin. The volume of views is overwhelming for a first-time user. AIForge auth error adds confusion. |
+| Issues found | UX-001: EE discovery infinite retry loop; UX-002: No clear starting point in sidebar; UX-003: AIForge skills error on first run |
+| Value (1–5) | 5 — the breadth of capabilities feels extensive |
+
+**Notes:** ~26 `ExecutionEnvService: Loaded 0 execution environments` log lines in rapid succession (~300-400ms intervals) suggest a retry loop without backoff or max-retry limit.
+
+### Module: environment — Environment & Tool Management
+
+**Maps to:** US-1, US-2 / AC-1
+
+| Question | Response |
+|----------|----------|
+| Expectation — What did you expect? | (session paused before full reflection) |
+| Outcome — Did it work? (yes / partial / no) | yes — venv created, devtools installed, packages visible after manual refresh |
+| User mental model — What would end users expect? | Status bar should be visible without opening a file first. Clicking it should open a diagnostics webview, not a QuickPick mixing versions with actions. |
+| Issues found | UX-004: DevTools view no auto-refresh; UX-005: Python status bar hidden until file opened; UX-006: Ansible status bar QuickPick mixes data with actions |
+| Value (1–5) | (session paused) |
+
+**Notes:** Terminal fallback (ADR-019) worked — `python3 -m venv .venv2` ran correctly. The `source activate` matched the created venv. DevTools installed via `pip install ansible-dev-tools` in the terminal. Reviewer suggests replacing the status bar QuickPick with a dedicated diagnostics webview showing versions, venv info, and a refresh button.
+
+---
+
+## Issues catalog
+
+| ID | Severity | Module | US/AC | Type | Summary |
+|----|----------|--------|-------|------|---------|
+| UX-001 | major | setup | AC-8 | bug | ExecutionEnvService polls in infinite retry loop (~300ms intervals) when no EEs found, spamming output channel |
+| UX-002 | minor | setup | AC-8 | ux-gap | Sidebar has 10 views with no guided starting point — new users don't know where to begin |
+| UX-003 | minor | setup | AC-8 | expectation-mismatch | AIForge skills view shows URL/auth configuration error on first run when not configured |
+| UX-004 | major | environment | US-1/AC-1 | bug | Dev Tools Packages view does not auto-refresh after terminal-based pip install completes |
+| UX-005 | major | environment | US-1/AC-1 | ux-gap | Python status bar item not visible until a playbook file is opened |
+| UX-006 | minor | environment | US-1/AC-1 | ux-gap | Ansible status bar QuickPick mixes package versions with actions — confusing UI, should be a diagnostics webview |
+
+Severity: `blocker` | `major` | `minor` | `enhancement`
+
+Type: `bug` | `ux-gap` | `expectation-mismatch` | `missing-feature` | `polish`
+
+## Value matrix
+
+| Module | Score (1–5) | Rationale |
+|--------|-------------|-----------|
+| setup | 5 | Breadth of capabilities feels extensive |
+| environment | | |
+| editor-lsp | | |
+| collections-installed | | |
+| collections-remote | | |
+| creator | | |
+| playbooks | | |
+| execution-envs | | |
+| ai-authoring | | |
+| mcp-skills | | |
+| lightspeed | | |
+| cross-cutting | | |
+
+## Proposed Jira stories
+
+<!-- One block per issue with severity blocker, major, or minor. -->
+
+## Open questions for PM
+
+<!-- Branding, positioning, scope, Lightspeed relationship, etc. -->
+
+## Walkthrough content feedback
+
+<!-- Step instructions that confused reviewers — feed back into walkthrough-modules.json for Phase 2 -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to Ansible Environments
+# Contributing to Ansible
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Ansible Environments
+# Ansible
 
 A VS Code extension for managing Ansible development environments, leveraging the [Microsoft Python Environments extension](https://github.com/microsoft/vscode-python-environments) API.
 
@@ -22,7 +22,7 @@ src/                # Extension host (views, panels, commands)
 
 ### Sidebar Views
 
-The extension adds an **Ansible Environments** panel to the Activity Bar with seven tree views:
+The extension adds an **Ansible** panel to the Activity Bar with seven tree views:
 
 #### Environment Managers
 
@@ -123,7 +123,7 @@ The extension includes a standalone MCP server (`@ansible/mcp-server`) that expo
 **Automatic Configuration:**
 
 1. Open the Command Palette (`Ctrl+Shift+P` / `Cmd+Shift+P`)
-2. Run: **Ansible Environments: Configure Cursor MCP**
+2. Run: **Ansible: Configure Cursor MCP**
 3. Choose Global or Workspace configuration
 4. Restart Cursor
 

--- a/docs/src/content/docs/editor/vscode-extension.mdx
+++ b/docs/src/content/docs/editor/vscode-extension.mdx
@@ -18,7 +18,7 @@ The extension automatically installs two dependencies:
 
 ## Sidebar views
 
-The extension adds an **Ansible Environments** activity bar with the following tree views:
+The extension adds an **Ansible** activity bar with the following tree views:
 
 | View | Description |
 |------|-------------|

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ansible",
-  "displayName": "Ansible Environments",
+  "displayName": "Ansible",
   "description": "A VS Code extension for managing Ansible development environments using the Microsoft Python Environments extension API",
   "version": "0.0.1",
   "publisher": "redhat",
@@ -229,14 +229,14 @@
     "mcpServerDefinitionProviders": [
       {
         "id": "ansibleEnvironments",
-        "label": "Ansible Environments"
+        "label": "Ansible"
       }
     ],
     "viewsContainers": {
       "activitybar": [
         {
           "id": "ansible-environments",
-          "title": "Ansible Environments",
+          "title": "Ansible",
           "icon": "resources/ansible-icon.svg"
         }
       ]
@@ -440,11 +440,11 @@
       },
       {
         "command": "ansible-environments.configureCursorMcp",
-        "title": "Ansible Environments: Configure Cursor MCP"
+        "title": "Ansible: Configure Cursor MCP"
       },
       {
         "command": "ansible-environments.showMcpStatus",
-        "title": "Ansible Environments: Show MCP Status"
+        "title": "Ansible: Show MCP Status"
       },
       {
         "command": "ansibleMcpTools.refresh",
@@ -607,13 +607,13 @@
       {
         "command": "ansibleEnvironments.selectLlmModel",
         "title": "Select LLM Provider & Model",
-        "category": "Ansible Environments",
+        "category": "Ansible",
         "icon": "$(hubot)"
       },
       {
         "command": "ansibleEnvironments.showLlmStatus",
         "title": "Show LLM Status",
-        "category": "Ansible Environments",
+        "category": "Ansible",
         "icon": "$(info)"
       },
       {
@@ -963,7 +963,7 @@
       ]
     },
     "configuration": {
-      "title": "Ansible Environments",
+      "title": "Ansible",
       "properties": {
         "ansibleEnvironments.enableAiFeatures": {
           "type": "boolean",

--- a/packages/mcp-server/src/handlers.ts
+++ b/packages/mcp-server/src/handlers.ts
@@ -1527,7 +1527,7 @@ export class McpToolHandler {
                     text:
                         `To create a virtual environment named "${name}", use the VS Code command:\n\n` +
                         '1. Open the Command Palette (Ctrl+Shift+P)\n' +
-                        '2. Run "Ansible Environments: Create Environment"\n' +
+                        '2. Run "Ansible: Create Environment"\n' +
                         `3. Enter "${name}" when prompted\n\n` +
                         'The extension will create the venv and select it automatically.\n\n' +
                         'Alternatively, run in a terminal:\n' +

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @ansible/mcp-server — public API for the Ansible Environments MCP implementation.
+ * @ansible/mcp-server — public API for the Ansible MCP implementation.
  */
 
 export { McpToolHandler } from './handlers';

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Ansible Environments MCP Server
+ * Ansible MCP Server
  *
  * Standalone MCP server that exposes Ansible tools for AI agents.
  * Can be used with Cursor, VS Code Copilot, or any MCP-compatible client.
@@ -58,7 +58,7 @@ const server = new Server(
 );
 
 // Best practices resource content
-const BEST_PRACTICES_RESOURCE = `# Ansible Environments Extension - Best Practices
+const BEST_PRACTICES_RESOURCE = `# Ansible Extension - Best Practices
 
 ## Installing Collections
 
@@ -112,9 +112,8 @@ Call \`get_agent_onboarding\` for a complete guide to available tools, skills, a
 const RESOURCES = [
     {
         uri: 'ansible://best-practices',
-        name: 'Ansible Environments Best Practices',
-        description:
-            'Guidelines for using the Ansible Environments extension and MCP tools correctly',
+        name: 'Ansible Best Practices',
+        description: 'Guidelines for using the Ansible extension and MCP tools correctly',
         mimeType: 'text/markdown',
     },
 ];
@@ -212,7 +211,7 @@ process.on('SIGTERM', () => {
 // Start the server
 /** Initializes services and connects the MCP server over stdio transport. */
 async function main() {
-    console.error('[MCP Server] Starting Ansible Environments MCP server...');
+    console.error('[MCP Server] Starting Ansible MCP server...');
 
     try {
         // Configure skill sources from environment

--- a/packages/services/src/DevToolsService.ts
+++ b/packages/services/src/DevToolsService.ts
@@ -22,10 +22,15 @@ export interface DevToolPackage {
  */
 export type PackageInstaller = () => Promise<void>;
 
+interface CommandResult {
+    exitCode: number | undefined;
+    success: boolean;
+}
+
 interface TerminalServiceLike {
     getInstance(): {
         createActivatedTerminal(opts: { name: string; show: boolean }): Promise<{
-            sendCommand(cmd: string, opts: { waitForCompletion: boolean }): Promise<unknown>;
+            sendCommand(cmd: string, opts: { waitForCompletion: boolean }): Promise<CommandResult>;
         }>;
     };
 }
@@ -194,11 +199,25 @@ export class DevToolsService {
             name: 'Install ansible-dev-tools',
             show: true,
         });
-        await managed.sendCommand('pip install ansible-dev-tools', {
+        const result = await managed.sendCommand('pip install ansible-dev-tools', {
             waitForCompletion: true,
         });
         log('DevToolsService: terminal install complete, refreshing packages');
         await this.refresh();
+
+        if (!this.hasPackages() && result.exitCode === undefined) {
+            log('DevToolsService: shell integration unavailable, polling for packages');
+            const maxAttempts = 12;
+            const interval = 5000;
+            for (let i = 0; i < maxAttempts; i++) {
+                await new Promise((r) => setTimeout(r, interval));
+                await this.refresh();
+                if (this.hasPackages()) {
+                    log(`DevToolsService: packages found after ${String(i + 1)} poll(s)`);
+                    break;
+                }
+            }
+        }
     }
 
     /**

--- a/packages/services/src/ExecutionEnvService.ts
+++ b/packages/services/src/ExecutionEnvService.ts
@@ -304,7 +304,7 @@ export class ExecutionEnvService {
             return this._loadingPromise;
         }
 
-        if (this._loaded && this._executionEnvironments.length > 0) {
+        if (this._loaded) {
             return this._executionEnvironments;
         }
 

--- a/packages/services/src/SkillRegistry.ts
+++ b/packages/services/src/SkillRegistry.ts
@@ -152,13 +152,20 @@ interface CachedIndex {
 // ---------------------------------------------------------------------------
 
 let _cachedGhToken: string | undefined | null;
+let _tokenRejected = false;
 
 /**
  * Resolve a GitHub token from the environment or gh CLI.
+ * Returns undefined when the token was previously rejected (401)
+ * to avoid noisy retry loops.
  *
  * @returns Token string or undefined when no auth is available.
  */
 function _resolveGitHubToken(): string | undefined {
+    if (_tokenRejected) {
+        return undefined;
+    }
+
     if (_cachedGhToken !== undefined) {
         return _cachedGhToken ?? undefined;
     }
@@ -189,10 +196,22 @@ function _resolveGitHubToken(): string | undefined {
 }
 
 /**
+ * Mark the cached token as rejected so subsequent requests
+ * skip auth rather than retrying with a known-bad token.
+ */
+function _markTokenRejected(): void {
+    if (_cachedGhToken) {
+        log('SkillRegistry: GitHub token rejected, disabling auth for this session');
+    }
+    _tokenRejected = true;
+}
+
+/**
  * Reset the cached GitHub token (for tests).
  */
 export function _resetGitHubToken(): void {
     _cachedGhToken = undefined;
+    _tokenRejected = false;
 }
 
 // ---------------------------------------------------------------------------
@@ -510,7 +529,9 @@ export class SkillRegistry {
             this._skills.set(skill.id, skill);
         }
 
-        this._writeCache(source.id, skills, format, source.url);
+        if (skills.length > 0 || source.type === 'local') {
+            this._writeCache(source.id, skills, format, source.url);
+        }
         log(
             `SkillRegistry: loaded ${String(skills.length)} skills from ${source.id}` +
                 (format ? ` (${format} format)` : ''),
@@ -551,6 +572,17 @@ export class SkillRegistry {
         const repoPath = this._githubRepoPath(source.url);
         if (!repoPath) {
             return 'generic';
+        }
+
+        const rawBase = this._githubRawBase(source.url);
+        if (rawBase) {
+            const rawLolaCheck = await this._httpGet(
+                `${rawBase}/main/lola-market.yml`,
+                this._getAuthHeaders(),
+            );
+            if (rawLolaCheck) {
+                return 'lola';
+            }
         }
 
         const apiHeaders = this._githubApiHeaders();
@@ -1368,7 +1400,23 @@ export class SkillRegistry {
                     return;
                 }
 
+                const isAuthRetryable =
+                    headers?.Authorization &&
+                    (res.statusCode === 401 ||
+                        (res.statusCode === 404 && url.includes('raw.githubusercontent.com')));
+                if (isAuthRetryable) {
+                    _markTokenRejected();
+                    const rest = Object.fromEntries(
+                        Object.entries(headers).filter(([k]) => k !== 'Authorization'),
+                    );
+                    void this._httpGet(url, Object.keys(rest).length > 0 ? rest : undefined).then(
+                        resolve,
+                    );
+                    return;
+                }
+
                 if (res.statusCode !== 200) {
+                    log(`SkillRegistry: HTTP ${String(res.statusCode)} for ${url}`);
                     resolve(undefined);
                     return;
                 }
@@ -1383,10 +1431,12 @@ export class SkillRegistry {
                 });
             });
 
-            req.on('error', () => {
+            req.on('error', (err) => {
+                log(`SkillRegistry: request error for ${url}: ${String(err)}`);
                 resolve(undefined);
             });
             req.setTimeout(10000, () => {
+                log(`SkillRegistry: request timeout for ${url}`);
                 req.destroy();
                 resolve(undefined);
             });

--- a/packages/services/test/services/ExecutionEnvService.test.ts
+++ b/packages/services/test/services/ExecutionEnvService.test.ts
@@ -271,6 +271,21 @@ describe('ExecutionEnvService', () => {
             expect(second).toEqual(first);
             expect(containerMocks.listImages).not.toHaveBeenCalled();
         });
+
+        it('caches empty result without re-querying container engine', async () => {
+            containerMocks.detectEngine.mockResolvedValue('podman');
+            containerMocks.listImages.mockResolvedValue([]);
+
+            const svc = ExecutionEnvService.getInstance();
+            const first = await svc.loadExecutionEnvironments();
+            expect(first).toHaveLength(0);
+            expect(containerMocks.listImages).toHaveBeenCalledTimes(1);
+
+            vi.clearAllMocks();
+            const second = await svc.loadExecutionEnvironments();
+            expect(second).toHaveLength(0);
+            expect(containerMocks.listImages).not.toHaveBeenCalled();
+        });
     });
 
     describe('loadDetails', () => {

--- a/resources/callback_plugins/vscode_progress.py
+++ b/resources/callback_plugins/vscode_progress.py
@@ -1,5 +1,5 @@
 """
-VS Code Ansible Environments - Progress Callback Plugin
+VS Code Ansible - Progress Callback Plugin
 
 This callback plugin sends playbook execution events to a Unix socket
 for real-time progress display in VS Code. It runs alongside the

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -71,7 +71,7 @@ import { PythonStatusBar } from '@src/statusBar/pythonStatusBar';
 import { AnsibleStatusBar } from '@src/statusBar/ansibleStatusBar';
 
 // Create output channel for extension logs
-export const outputChannel = vscode.window.createOutputChannel('Ansible Environments');
+export const outputChannel = vscode.window.createOutputChannel('Ansible');
 
 let _logFilePath: string | undefined;
 let _logStream: fs.WriteStream | undefined;
@@ -179,7 +179,7 @@ async function openChatWithPrompt(prompt: string): Promise<void> {
 }
 
 /**
- * Activate the Ansible Environments extension and register providers and commands.
+ * Activate the Ansible extension and register providers and commands.
  * @param context - VS Code extension activation context
  */
 export function activate(context: vscode.ExtensionContext) {
@@ -203,8 +203,8 @@ export function activate(context: vscode.ExtensionContext) {
     setCollectionsLogFunction(log);
     setCollectionSourcesLogFunction(log);
 
-    log('Ansible Environments extension is now active');
-    console.log('Ansible Environments extension is now active');
+    log('Ansible extension is now active');
+    console.log('Ansible extension is now active');
 
     // Helper to update MCP status context
     const updateMcpStatusContext = () => {
@@ -235,7 +235,7 @@ export function activate(context: vscode.ExtensionContext) {
 
     // Check if workspace is open
     if (!vscode.workspace.workspaceFolders || vscode.workspace.workspaceFolders.length === 0) {
-        vscode.window.showWarningMessage('Ansible Environments requires an open workspace folder.');
+        vscode.window.showWarningMessage('Ansible requires an open workspace folder.');
         return;
     }
 

--- a/src/mcp/cursorConfig.ts
+++ b/src/mcp/cursorConfig.ts
@@ -6,11 +6,11 @@ import * as os from 'os';
 let _outputChannel: vscode.OutputChannel | undefined;
 
 /**
- * Append a timestamped message to the Ansible Environments output channel.
+ * Append a timestamped message to the Ansible output channel.
  * @param message - Log message to record
  */
 function log(message: string): void {
-    _outputChannel ??= vscode.window.createOutputChannel('Ansible Environments');
+    _outputChannel ??= vscode.window.createOutputChannel('Ansible');
     _outputChannel.appendLine(`[${new Date().toISOString()}] ${message}`);
 }
 
@@ -218,7 +218,7 @@ async function configureViaMcpJson(context: vscode.ExtensionContext): Promise<vo
         }
 
         const update = await vscode.window.showWarningMessage(
-            'Ansible Environments MCP is already configured with a different path. Update it?',
+            'Ansible MCP is already configured with a different path. Update it?',
             'Update',
             'Cancel',
         );
@@ -260,7 +260,7 @@ async function configureViaMcpJson(context: vscode.ExtensionContext): Promise<vo
 // -------------------------------------------------------------------------
 
 /**
- * Configure Cursor to use the Ansible Environments MCP server.
+ * Configure Cursor to use the Ansible MCP server.
  * Tries the Cursor extension API first; falls back to mcp.json.
  * @param context - Extension context used to resolve the MCP server path
  */
@@ -275,9 +275,7 @@ export async function configureCursorMcp(context: vscode.ExtensionContext): Prom
     }
 
     if (registerViaCursorApi(serverPath)) {
-        vscode.window.showInformationMessage(
-            'Ansible Environments MCP server registered and ready.',
-        );
+        vscode.window.showInformationMessage('Ansible MCP server registered and ready.');
         return;
     }
 
@@ -336,7 +334,7 @@ export function showCursorMcpStatus(context: vscode.ExtensionContext): void {
     const cursorApi = getCursorMcpApi();
 
     const lines: string[] = [
-        '## Ansible Environments MCP Server Status\n',
+        '## Ansible MCP Server Status\n',
         `**Server Path:** \`${escapeHtml(serverPath)}\``,
         `**Server Exists:** ${fs.existsSync(serverPath) ? 'Yes' : 'No'}`,
         `**Cursor Extension API:** ${cursorApi ? 'Available' : 'Not available'}\n`,
@@ -417,7 +415,7 @@ export function showCursorMcpStatus(context: vscode.ExtensionContext): void {
         .join('\n')}
 
     <div style="margin-top: 30px;">
-        <p>To configure, run: <strong>Ansible Environments: Configure Cursor MCP</strong></p>
+        <p>To configure, run: <strong>Ansible: Configure Cursor MCP</strong></p>
     </div>
 </body>
 </html>`;

--- a/src/mcp/vscodeProvider.ts
+++ b/src/mcp/vscodeProvider.ts
@@ -1,7 +1,7 @@
 /**
  * VS Code MCP Provider
  *
- * Registers the Ansible Environments MCP server with VS Code's
+ * Registers the Ansible MCP server with VS Code's
  * language model API (for Copilot integration).
  *
  * Based on: https://github.com/microsoft/vscode-extension-samples/tree/main/mcp-extension-sample
@@ -15,7 +15,7 @@ import * as path from 'path';
 /**
  * Register the MCP server with VS Code.
  *
- * This makes the Ansible Environments tools available to VS Code Copilot
+ * This makes the Ansible tools available to VS Code Copilot
  * and other AI features that support MCP.
  *
  * @param context Extension context for subscriptions and paths
@@ -25,12 +25,12 @@ export function registerMcpServerProvider(context: vscode.ExtensionContext): voi
         !vscode.lm ||
         typeof (vscode.lm as any).registerMcpServerDefinitionProvider !== 'function'
     ) {
-        console.log('Ansible Environments: VS Code MCP API not available');
+        console.log('Ansible: VS Code MCP API not available');
         return;
     }
 
     if (!(vscode as any).McpStdioServerDefinition) {
-        console.log('Ansible Environments: McpStdioServerDefinition not available');
+        console.log('Ansible: McpStdioServerDefinition not available');
         return;
     }
 
@@ -47,9 +47,7 @@ export function registerMcpServerProvider(context: vscode.ExtensionContext): voi
                 const workspaceFolder = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
 
                 if (!workspaceFolder) {
-                    console.log(
-                        'Ansible Environments: No workspace folder, MCP server not available',
-                    );
+                    console.log('Ansible: No workspace folder, MCP server not available');
                     return [];
                 }
 
@@ -68,7 +66,7 @@ export function registerMcpServerProvider(context: vscode.ExtensionContext): voi
 
                 return [
                     new (vscode as any).McpStdioServerDefinition(
-                        'Ansible Environments',
+                        'Ansible',
                         'node',
                         [serverPath],
                         env,
@@ -79,7 +77,7 @@ export function registerMcpServerProvider(context: vscode.ExtensionContext): voi
     );
 
     context.subscriptions.push(didChangeEmitter);
-    console.log('Ansible Environments: MCP server provider registered');
+    console.log('Ansible: MCP server provider registered');
 }
 
 /* eslint-enable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unnecessary-condition */

--- a/src/services/LlmService.ts
+++ b/src/services/LlmService.ts
@@ -390,7 +390,7 @@ export class LlmService {
     </ul>
     
     <p style="margin-top: 20px;">
-        <em>Use command "Ansible Environments: Select LLM Provider & Model" to change.</em>
+        <em>Use command "Ansible: Select LLM Provider & Model" to change.</em>
     </p>
 </body>
 </html>`;
@@ -573,7 +573,7 @@ export class LlmService {
             return {
                 success: false,
                 content: '',
-                error: 'No language model available. Use "Ansible Environments: Select LLM Provider & Model" to configure.',
+                error: 'No language model available. Use "Ansible: Select LLM Provider & Model" to configure.',
             };
         }
 

--- a/src/services/TerminalService.ts
+++ b/src/services/TerminalService.ts
@@ -185,27 +185,46 @@ export class TerminalService {
         command: string,
         timeout: number,
     ): Promise<CommandResult> {
-        terminal.sendText(command);
-
-        const shellIntegration = (
-            terminal as {
-                shellIntegration?: {
-                    onDidEndCommandExecution?: (
-                        cb: (e: { exitCode: number | undefined }) => void,
-                    ) => { dispose(): void };
+        interface ShellIntegrationTerminal {
+            shellIntegration?: {
+                onDidEndCommandExecution?: (cb: (e: { exitCode: number | undefined }) => void) => {
+                    dispose(): void;
                 };
-            }
-        ).shellIntegration;
+            };
+        }
 
-        const onDidEndCommandExecution = shellIntegration?.onDidEndCommandExecution;
-        if (onDidEndCommandExecution) {
+        const getShellIntegration = () =>
+            (terminal as ShellIntegrationTerminal).shellIntegration?.onDidEndCommandExecution;
+
+        let onDidEnd = getShellIntegration();
+
+        if (!onDidEnd) {
+            const ready = await new Promise<boolean>((resolve) => {
+                const d = vscode.window.onDidChangeTerminalShellIntegration((e) => {
+                    if (e.terminal === terminal) {
+                        d.dispose();
+                        resolve(true);
+                    }
+                });
+                setTimeout(() => {
+                    d.dispose();
+                    resolve(false);
+                }, 5000);
+            });
+            if (ready) {
+                onDidEnd = getShellIntegration();
+            }
+        }
+
+        if (onDidEnd) {
+            const endListener = onDidEnd;
             return new Promise((resolve) => {
                 const timeoutId = setTimeout(() => {
                     listener.dispose();
                     resolve({ output: '', exitCode: undefined, success: false });
                 }, timeout);
 
-                const listener = onDidEndCommandExecution((e: { exitCode: number | undefined }) => {
+                const listener = endListener((e: { exitCode: number | undefined }) => {
                     clearTimeout(timeoutId);
                     listener.dispose();
                     resolve({
@@ -214,9 +233,12 @@ export class TerminalService {
                         success: e.exitCode === 0,
                     });
                 });
+
+                terminal.sendText(command);
             });
         }
 
+        terminal.sendText(command);
         return { output: '', exitCode: undefined, success: true };
     }
 

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,7 +1,7 @@
 /**
  * Service layer exports
  *
- * These services contain the core business logic for the Ansible Environments extension.
+ * These services contain the core business logic for the Ansible extension.
  * They are designed to be independent of VS Code UI components and can be used by:
  * - TreeView providers (for UI rendering)
  * - Commands (for user actions)

--- a/src/statusBar/pythonStatusBar.ts
+++ b/src/statusBar/pythonStatusBar.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { PythonEnvironmentService } from '@src/services/PythonEnvironmentService';
-import { isAnsibleEditor, type AnsibleEnvironmentInfo } from '@src/statusBar/statusBarUtils';
+import type { AnsibleEnvironmentInfo } from '@src/statusBar/statusBarUtils';
 import { log } from '@src/extension';
 
 const COMMAND_ID = 'ansible.statusBar.pythonClick';
@@ -8,9 +8,9 @@ const COMMAND_ID = 'ansible.statusBar.pythonClick';
 /**
  * Status bar item displaying the active Python environment for Ansible.
  *
- * Visible only when an Ansible file is open. Clicking opens a QuickPick
- * with environment details and actions (change, refresh) instead of relying
- * on hover tooltips which are unreliable across platforms.
+ * Always visible when a workspace is open. Uses the active Ansible editor's
+ * URI for environment resolution, falling back to the first workspace folder.
+ * Clicking opens a QuickPick with environment details and actions.
  *
  * Exposes {@link getEnvironmentInfo} for telemetry consumption.
  */
@@ -55,13 +55,10 @@ export class PythonStatusBar implements vscode.Disposable {
      * Python environment and active editor.
      */
     public async update(): Promise<void> {
-        if (!isAnsibleEditor(vscode.window.activeTextEditor)) {
-            this._item.hide();
-            return;
-        }
-
         try {
-            const activeUri = vscode.window.activeTextEditor?.document.uri;
+            const activeUri =
+                vscode.window.activeTextEditor?.document.uri ??
+                vscode.workspace.workspaceFolders?.[0]?.uri;
             const env = await this._envService.getEnvironment(activeUri);
             if (env) {
                 this._cachedDisplayName = env.displayName || env.name;

--- a/src/views/SkillsProvider.ts
+++ b/src/views/SkillsProvider.ts
@@ -176,7 +176,11 @@ export class SkillsProvider implements vscode.TreeDataProvider<TreeNode> {
                 .filter((s) => s.source === element.source.id);
 
             if (skills.length === 0) {
-                return [new MessageNode('No skills loaded — check URL and auth', 'warning')];
+                const url = element.source.url;
+                const hint = url
+                    ? `Browse available skills at ${url}`
+                    : 'Configure access in Settings.';
+                return [new MessageNode(`No skills loaded. ${hint}`, 'info')];
             }
 
             const modules = new Map<string, SkillEntry[]>();
@@ -210,22 +214,23 @@ export class SkillsProvider implements vscode.TreeDataProvider<TreeNode> {
         return [];
     }
 
-    /** Show a warning notification for each source that loaded zero skills. */
+    /**
+     * Show an informational notification for user-added sources that loaded
+     * zero skills. Default sources (like ai-forge) are silently hidden from
+     * the tree and do not trigger a notification.
+     */
     private _notifyEmptySources(): void {
         const sources = this._registry.getSources();
         const allSkills = this._registry.getAllSkills();
+        const defaultSourceIds = new Set(['builtin', 'ai-forge']);
 
         for (const source of sources) {
-            if (source.type === 'builtin') continue;
+            if (defaultSourceIds.has(source.id)) continue;
             const count = allSkills.filter((s) => s.source === source.id).length;
             if (count === 0) {
-                const isGitHub = source.url.includes('github.com');
-                const hint = isGitHub
-                    ? 'Check the URL points to a valid GitHub repo with skills.'
-                    : 'The URL may not point to a supported skill repository.';
                 void vscode.window
-                    .showWarningMessage(
-                        `Skill source "${source.id}" loaded 0 skills. ${hint}`,
+                    .showInformationMessage(
+                        `Skill source "${source.id}" loaded 0 skills. The URL may not point to a supported skill repository.`,
                         'Open Settings',
                     )
                     .then((choice) => {

--- a/test/integration/activation.test.ts
+++ b/test/integration/activation.test.ts
@@ -13,7 +13,7 @@ interface ExtensionManifest {
     };
 }
 
-suite('Ansible Environments Extension', () => {
+suite('Ansible Extension', () => {
     suiteSetup(async () => {
         const ext = vscode.extensions.getExtension(EXTENSION_ID);
         if (ext && !ext.isActive) {

--- a/test/ui/languageServer.spec.ts
+++ b/test/ui/languageServer.spec.ts
@@ -33,7 +33,7 @@ describe('Ansible Language Server e2e', () => {
             // The extension logs "Ansible Language Server started" to the output channel.
             // Check the extension host log or registered commands for evidence.
             const outputDoc = vscode.workspace.textDocuments.find(
-                (d) => d.uri.scheme === 'output' && d.uri.path.includes('Ansible Environments'),
+                (d) => d.uri.scheme === 'output' && d.uri.path.includes('Ansible'),
             );
             return outputDoc?.getText() ?? '';
         });

--- a/test/ui/smoke.spec.ts
+++ b/test/ui/smoke.spec.ts
@@ -6,7 +6,7 @@ describe('VS Code UI smoke test', () => {
         await expect(browser.sessionId).toBeDefined();
     });
 
-    it('should show the Ansible Environments activity bar icon', async () => {
+    it('should show the Ansible activity bar icon', async () => {
         const workbench = await browser.getWorkbench();
         const activityBar = workbench.getActivityBar();
         const viewControls = await activityBar.getViewControls();
@@ -14,9 +14,9 @@ describe('VS Code UI smoke test', () => {
 
         // The view container may be collapsed under "Additional Views" if
         // a previous spec changed the activity bar state in the same session.
-        const visible = titles.includes('Ansible Environments');
+        const visible = titles.includes('Ansible');
         if (visible) {
-            await expect(titles).toContain('Ansible Environments');
+            await expect(titles).toContain('Ansible');
             return;
         }
 
@@ -31,7 +31,7 @@ describe('VS Code UI smoke test', () => {
                 };
             };
             return (pkg.contributes?.viewsContainers?.activitybar ?? []).some(
-                (c) => c.title === 'Ansible Environments',
+                (c) => c.title === 'Ansible',
             );
         });
         await expect(contributed).toBe(true);

--- a/test/unit/statusBar/pythonStatusBar.test.ts
+++ b/test/unit/statusBar/pythonStatusBar.test.ts
@@ -49,6 +49,11 @@ vi.mock('vscode', () => ({
         registerCommand: mockRegisterCommand,
         executeCommand: mockExecuteCommand,
     },
+    workspace: {
+        workspaceFolders: [
+            { uri: { fsPath: '/mock/workspace', toString: () => 'file:///mock/workspace' } },
+        ],
+    },
     StatusBarAlignment: { Right: 2 },
     ThemeColor: class MockThemeColor {
         /**
@@ -160,10 +165,10 @@ describe('PythonStatusBar', () => {
         expect(envService.onDidChangeEnvironment).toHaveBeenCalled();
     });
 
-    it('hides when active editor is not ansible', async () => {
+    it('shows even when active editor is not ansible', async () => {
         const vscode = await import('vscode');
         (vscode.window as unknown as { activeTextEditor: unknown }).activeTextEditor = {
-            document: { languageId: 'typescript' },
+            document: { languageId: 'typescript', uri: { fsPath: '/mock/file.ts' } },
         };
 
         const ctx = createMockContext();
@@ -175,7 +180,26 @@ describe('PythonStatusBar', () => {
         await bar.update();
 
         const item = mockCreateStatusBarItem.mock.results[0].value as MockStatusBarItem;
-        expect(item.hide).toHaveBeenCalled();
+        expect(item.show).toHaveBeenCalled();
+    });
+
+    it('shows using workspace folder when no editor is active', async () => {
+        const vscode = await import('vscode');
+        (vscode.window as unknown as { activeTextEditor: unknown }).activeTextEditor = undefined;
+
+        const ctx = createMockContext();
+        const envService = createMockEnvService();
+        const bar = new PythonStatusBar(
+            ctx as unknown as ExtensionContext,
+            envService as unknown as PythonEnvironmentService,
+        );
+        await bar.update();
+
+        const item = mockCreateStatusBarItem.mock.results[0].value as MockStatusBarItem;
+        expect(item.show).toHaveBeenCalled();
+        expect(envService.getEnvironment).toHaveBeenCalledWith(
+            expect.objectContaining({ fsPath: '/mock/workspace' }),
+        );
     });
 
     it('shows env display name when environment is available', async () => {


### PR DESCRIPTION
## Summary
- Fix bugs found during UX walkthrough: EE discovery loop, DevTools refresh, SkillRegistry auth, Python status bar visibility
- Rename extension display name from "Ansible Environments" to "Ansible" everywhere (settings namespace unchanged)

## Changes
- **EE discovery**: cache empty results to prevent infinite retry loop when no container engine is available
- **DevTools**: poll for packages when shell integration is unavailable after terminal pip install
- **SkillRegistry**: retry GitHub requests without auth on 401/404, detect repo format via `raw.githubusercontent.com` before API fallback, skip caching empty results
- **SkillsProvider**: informational message for empty sources, suppress toasts for default sources
- **Python status bar**: show immediately on activation using workspace folder URI fallback instead of gating on ansible file focus
- **TerminalService**: register command completion listener before sending text, wait for shell integration readiness
- **Rename**: displayName, activity bar, command palette, output channel, MCP server, docs, tests — all "Ansible Environments" → "Ansible"

## Quality of life
- AI-authored additions: UX walkthrough report updates, skill catalog corrections

## Test plan
- [x] `npm run ci` passes (compile + lint + test:coverage + build)
- [ ] `npm run test:ui` passes (rename affects smoke test assertions)

related: #2940

Made with [Cursor](https://cursor.com)