### PR TITLE
chore: unit tests for lightSpeedOAuthProvider to raise coverage

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -120,6 +120,7 @@ towerhost
 tsdown
 typedarrays
 unrs
+unstub
 uuidv
 vite
 vitest

--- a/test/unit/lightspeed/lightSpeedOAuthProvider.test.ts
+++ b/test/unit/lightspeed/lightSpeedOAuthProvider.test.ts
@@ -1,0 +1,707 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  vi,
+  type Mock,
+} from "vitest";
+import * as vscode from "vscode";
+import {
+  LightSpeedAuthenticationProvider,
+  isSupportedCallback,
+} from "@src/features/lightspeed/lightSpeedOAuthProvider";
+import * as webUtils from "@src/features/lightspeed/utils/webUtils";
+import { lightSpeedManager } from "@src/extension";
+import { LightSpeedCommands } from "@src/definitions/lightspeed";
+
+// The SUT imports `lightSpeedManager` at module load and uses it inside
+// createSession (`currentModelValue` + `lightspeedAuthenticatedUser.getUserInfo`).
+vi.mock("@src/extension", () => ({
+  lightSpeedManager: {
+    currentModelValue: undefined,
+    lightspeedAuthenticatedUser: { getUserInfo: vi.fn() },
+  },
+}));
+
+// Override getBaseUri while keeping the real auth-id constants, secret keys,
+// helpers (getUserTypeLabel, calculate/coerce expiry, UriEventHandler) intact.
+vi.mock("@src/features/lightspeed/utils/webUtils", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("@src/features/lightspeed/utils/webUtils")
+    >();
+  return { ...actual, getBaseUri: vi.fn() };
+});
+
+const getBaseUriMock = webUtils.getBaseUri as unknown as Mock;
+const { SESSIONS_SECRET_KEY, ACCOUNT_SECRET_KEY } = webUtils;
+const getUserInfoMock = lightSpeedManager.lightspeedAuthenticatedUser
+  .getUserInfo as unknown as Mock;
+
+type AnyProvider = LightSpeedAuthenticationProvider & {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [key: string]: any;
+};
+
+const fetchMock = vi.fn();
+
+interface FakeResponseOptions {
+  ok?: boolean;
+  status?: number;
+  body?: unknown;
+}
+
+function fakeResponse({
+  ok = true,
+  status = 200,
+  body = {},
+}: FakeResponseOptions = {}) {
+  return { ok, status, json: () => Promise.resolve(body) };
+}
+
+let consoleErrorSpy: Mock;
+let secretsGet: Mock;
+let secretsStore: Mock;
+let logger: { debug: Mock; trace: Mock; info: Mock };
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let context: any;
+let provider: AnyProvider;
+
+function makeProvider(
+  packageJSON: unknown = { publisher: "redhat", name: "ansible" },
+) {
+  secretsGet = vi.fn();
+  secretsStore = vi.fn();
+  context = {
+    secrets: { get: secretsGet, store: secretsStore },
+    extension: { packageJSON },
+  };
+  logger = { debug: vi.fn(), trace: vi.fn(), info: vi.fn() };
+  return new LightSpeedAuthenticationProvider(
+    context,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    {} as any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    logger as any,
+    "auth-lightspeed",
+    "Ansible Lightspeed",
+  ) as AnyProvider;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  fetchMock.mockReset();
+  vi.stubGlobal("fetch", fetchMock);
+
+  consoleErrorSpy = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {}) as unknown as Mock;
+
+  // vscode env extensions the alias mock lacks.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (vscode.env as any).uriScheme = "vscode";
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (vscode.env as any).asExternalUri = vi.fn(async () => ({
+    toString: () => "vscode://redhat.ansible/cb",
+  }));
+  (vscode.Uri.parse as unknown as Mock).mockImplementation((s: string) => ({
+    raw: s,
+    with: () => ({ raw: s, scheme: "https" }),
+    toString: () => s,
+  }));
+
+  getBaseUriMock.mockResolvedValue("https://lightspeed.example");
+
+  provider = makeProvider();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("isSupportedCallback", () => {
+  it("accepts the vscode desktop scheme", () => {
+    expect(isSupportedCallback({ scheme: "vscode" } as never)).toBe(true);
+  });
+
+  it("accepts openshift devspaces hosts", () => {
+    expect(
+      isSupportedCallback({
+        scheme: "https",
+        authority: "foo.openshiftapps.com",
+      } as never),
+    ).toBe(true);
+  });
+
+  it("accepts github codespaces hosts", () => {
+    expect(isSupportedCallback({ authority: "foo.github.dev" } as never)).toBe(
+      true,
+    );
+  });
+
+  it("rejects an unrelated http host", () => {
+    expect(
+      isSupportedCallback({
+        scheme: "http",
+        authority: "example.com",
+      } as never),
+    ).toBe(false);
+  });
+});
+
+describe("redirect URI helpers", () => {
+  it("computes/sets the external redirect URI from packageJSON", async () => {
+    await provider.setExternalRedirectUri();
+    expect(provider._externalRedirectUri).toBe("vscode://redhat.ansible/cb");
+    expect(vscode.Uri.parse).toHaveBeenCalledWith("vscode://redhat.ansible");
+  });
+
+  it("falls back to empty publisher/name when packageJSON is empty", async () => {
+    const p = makeProvider({});
+    await LightSpeedAuthenticationProvider.getExternalRedirectUri(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (p as any).context,
+    );
+    expect(vscode.Uri.parse).toHaveBeenCalledWith("vscode://.");
+  });
+});
+
+describe("createSession", () => {
+  it("creates a session for a licensed admin user", async () => {
+    const account = {
+      type: "oauth",
+      accessToken: "AT",
+      refreshToken: "RT",
+      expiresAtTimestampInSeconds: 123,
+    };
+    vi.spyOn(provider, "login").mockResolvedValue(account);
+    getUserInfoMock.mockResolvedValue({
+      external_username: "u",
+      rh_org_has_subscription: true,
+      rh_user_is_org_admin: true,
+    });
+    const fireSpy = vi.spyOn(provider._sessionChangeEmitter, "fire");
+
+    const session = await provider.createSession([]);
+
+    expect(session.account.label).toBe("u (licensed)");
+    expect(session.rhOrgHasSubscription).toBe(true);
+    expect(session.rhUserIsOrgAdmin).toBe(true);
+    expect(secretsStore).toHaveBeenCalledWith(
+      SESSIONS_SECRET_KEY,
+      expect.any(String),
+    );
+    expect(fireSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ added: [expect.anything()] }),
+    );
+    expect(fireSpy.mock.calls[0][0].added).toHaveLength(1);
+  });
+
+  it("throws when login yields no account", async () => {
+    vi.spyOn(provider, "login").mockResolvedValue(undefined);
+    await expect(provider.createSession([])).rejects.toThrow(
+      "Ansible Lightspeed login failure",
+    );
+    expect(consoleErrorSpy).toHaveBeenCalled();
+  });
+
+  it("uses username fallback and unlicensed label", async () => {
+    vi.spyOn(provider, "login").mockResolvedValue({
+      type: "oauth",
+      accessToken: "AT",
+      refreshToken: "RT",
+      expiresAtTimestampInSeconds: 1,
+    });
+    getUserInfoMock.mockResolvedValue({
+      username: "only-username",
+      rh_org_has_subscription: false,
+    });
+    const session = await provider.createSession([]);
+    expect(session.account.label).toBe("only-username (unlicensed)");
+    expect(session.rhOrgHasSubscription).toBe(false);
+    expect(session.rhUserIsOrgAdmin).toBe(false);
+  });
+
+  it("uses an empty name when no username is provided", async () => {
+    vi.spyOn(provider, "login").mockResolvedValue({
+      type: "oauth",
+      accessToken: "AT",
+      refreshToken: "RT",
+      expiresAtTimestampInSeconds: 1,
+    });
+    getUserInfoMock.mockResolvedValue({});
+    const session = await provider.createSession([]);
+    expect(session.account.label).toBe(" (unlicensed)");
+  });
+});
+
+describe("removeSession", () => {
+  it("removes a stored session and fires a removed event", async () => {
+    secretsGet.mockResolvedValue(
+      JSON.stringify([{ id: "a" }, { id: "target" }]),
+    );
+    const fireSpy = vi.spyOn(provider._sessionChangeEmitter, "fire");
+
+    await provider.removeSession("target");
+
+    expect(secretsStore).toHaveBeenCalledWith(
+      SESSIONS_SECRET_KEY,
+      expect.any(String),
+    );
+    expect(fireSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ removed: [{ id: "target" }] }),
+    );
+  });
+
+  it("stores without firing when the id is absent", async () => {
+    secretsGet.mockResolvedValue(JSON.stringify([{ id: "a" }]));
+    const fireSpy = vi.spyOn(provider._sessionChangeEmitter, "fire");
+
+    await provider.removeSession("missing");
+
+    expect(secretsStore).toHaveBeenCalled();
+    expect(fireSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns early when there are no stored sessions", async () => {
+    secretsGet.mockResolvedValue(undefined);
+    await provider.removeSession("x");
+    expect(secretsStore).not.toHaveBeenCalled();
+  });
+});
+
+describe("getSessions / setMockSession / onDidChangeSessions", () => {
+  it("parses stored sessions", async () => {
+    secretsGet.mockResolvedValue(JSON.stringify([{ id: "a" }]));
+    const sessions = await provider.getSessions();
+    expect(sessions).toEqual([{ id: "a" }]);
+  });
+
+  it("returns an empty array when nothing is stored", async () => {
+    secretsGet.mockResolvedValue(undefined);
+    expect(await provider.getSessions()).toEqual([]);
+  });
+
+  it("writes a synthetic session and fires an added event", async () => {
+    secretsGet.mockResolvedValue(undefined);
+    const fireSpy = vi.spyOn(provider._sessionChangeEmitter, "fire");
+
+    await provider.setMockSession({
+      accessToken: "tok",
+      accountId: "id-1",
+      accountLabel: "Mock User",
+    });
+
+    expect(secretsStore).toHaveBeenCalledWith(
+      SESSIONS_SECRET_KEY,
+      expect.any(String),
+    );
+    expect(fireSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        added: [expect.objectContaining({ id: "id-1" })],
+      }),
+    );
+  });
+
+  it("exposes the session-change event", () => {
+    expect(typeof provider.onDidChangeSessions).toBe("function");
+  });
+});
+
+describe("initialize / dispose", () => {
+  function stubRegistrations() {
+    (
+      vscode.authentication.registerAuthenticationProvider as unknown as Mock
+    ).mockReturnValue({ dispose: vi.fn() });
+    (vscode.window.registerUriHandler as unknown as Mock).mockReturnValue({
+      dispose: vi.fn(),
+    });
+  }
+
+  it("is idempotent once registered", () => {
+    stubRegistrations();
+    provider.initialize();
+    const first = provider._disposable;
+    provider.initialize();
+    expect(provider._disposable).toBe(first);
+    expect(logger.debug).toHaveBeenCalledWith(
+      "[ansible-lightspeed-oauth] Auth provider already registered",
+    );
+  });
+
+  it("removes the active session on dispose when authenticated", async () => {
+    stubRegistrations();
+    (vscode.authentication.getSession as unknown as Mock).mockResolvedValue({
+      id: "acc-1",
+    });
+    const removeSpy = vi
+      .spyOn(provider, "removeSession")
+      .mockResolvedValue(undefined);
+    provider.initialize();
+    const disp = provider._disposable;
+
+    await provider.dispose();
+
+    expect(removeSpy).toHaveBeenCalledWith("acc-1");
+    expect(disp.dispose).toHaveBeenCalled();
+    expect(provider._disposable).toBeUndefined();
+  });
+
+  it("disposes without removing a session when not authenticated", async () => {
+    stubRegistrations();
+    (vscode.authentication.getSession as unknown as Mock).mockResolvedValue(
+      undefined,
+    );
+    const removeSpy = vi.spyOn(provider, "removeSession");
+    provider.initialize();
+    const disp = provider._disposable;
+
+    await provider.dispose();
+
+    expect(removeSpy).not.toHaveBeenCalled();
+    expect(disp.dispose).toHaveBeenCalled();
+  });
+
+  it("is a no-op when never initialized", async () => {
+    const removeSpy = vi.spyOn(provider, "removeSession");
+    await provider.dispose();
+    expect(removeSpy).not.toHaveBeenCalled();
+    expect(vscode.authentication.getSession).not.toHaveBeenCalled();
+  });
+});
+
+describe("login", () => {
+  it("throws when the base URI is not configured", async () => {
+    getBaseUriMock.mockResolvedValue("");
+    await expect(provider.login([])).rejects.toThrow(
+      "Please enter the Ansible Lightspeed URL",
+    );
+  });
+
+  it("resolves an account from the redirect callback", async () => {
+    const account = {
+      type: "oauth",
+      accessToken: "AT",
+      refreshToken: "RT",
+      expiresAtTimestampInSeconds: 999,
+    };
+    const reqSpy = vi
+      .spyOn(provider, "requestOAuthAccountFromCode")
+      .mockResolvedValue(account);
+
+    // Replace the UriEventHandler with a binding-safe emitter, since the alias
+    // mock's EventEmitter.event method is not auto-bound.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const listeners: Array<(u: any) => void> = [];
+    provider._uriHandler = {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      event: (l: any) => {
+        listeners.push(l);
+        return { dispose: () => {} };
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      fire: (u: any) => listeners.forEach((l) => l(u)),
+    };
+
+    getBaseUriMock.mockResolvedValue("https://ls.example");
+    (vscode.window.withProgress as unknown as Mock).mockImplementation(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      async (_opts: any, task: any) => {
+        const token = {
+          onCancellationRequested: () => ({ dispose: () => {} }),
+        };
+        const p = task({ report: vi.fn() }, token);
+        provider._uriHandler.fire({ query: "code=the-code" });
+        return p;
+      },
+    );
+
+    const result = await provider.login([]);
+
+    expect(result).toBe(account);
+    expect(vscode.env.openExternal).toHaveBeenCalled();
+    expect(reqSpy).toHaveBeenCalledWith("the-code");
+  });
+});
+
+describe("handleUriForCode", () => {
+  it("rejects when no code is present", async () => {
+    const adapter = provider.handleUriForCode([]);
+    const resolve = vi.fn();
+    const reject = vi.fn();
+    await adapter({ query: "" }, resolve, reject);
+    expect(reject).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining("No code received"),
+      }),
+    );
+    expect(resolve).not.toHaveBeenCalled();
+  });
+
+  it("rejects when the account cannot be formed", async () => {
+    vi.spyOn(provider, "requestOAuthAccountFromCode").mockResolvedValue(
+      undefined,
+    );
+    const adapter = provider.handleUriForCode([]);
+    const resolve = vi.fn();
+    const reject = vi.fn();
+    await adapter({ query: "code=abc" }, resolve, reject);
+    expect(reject).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "Unable to form account" }),
+    );
+  });
+
+  it("resolves with the account on success", async () => {
+    const account = { type: "oauth", accessToken: "AT" };
+    vi.spyOn(provider, "requestOAuthAccountFromCode").mockResolvedValue(
+      account,
+    );
+    const adapter = provider.handleUriForCode([]);
+    const resolve = vi.fn();
+    const reject = vi.fn();
+    await adapter({ query: "code=abc" }, resolve, reject);
+    expect(resolve).toHaveBeenCalledWith(account);
+    expect(reject).not.toHaveBeenCalled();
+  });
+});
+
+describe("requestOAuthAccountFromCode", () => {
+  it("throws and logs on a non-2xx response", async () => {
+    fetchMock.mockResolvedValue(fakeResponse({ ok: false, status: 403 }));
+    await expect(provider.requestOAuthAccountFromCode("c")).rejects.toThrow(
+      "Request failed with status code: 403",
+    );
+    expect(consoleErrorSpy).toHaveBeenCalled();
+  });
+
+  it("defaults missing tokens to empty strings and stores the account", async () => {
+    fetchMock.mockResolvedValue(fakeResponse({ ok: true, body: {} }));
+    const account = await provider.requestOAuthAccountFromCode("c");
+    expect(account.accessToken).toBe("");
+    expect(account.refreshToken).toBe("");
+    expect(secretsStore).toHaveBeenCalledWith(
+      ACCOUNT_SECRET_KEY,
+      expect.any(String),
+    );
+  });
+
+  it("rethrows fetch errors and logs error metadata", async () => {
+    const err = Object.assign(new Error("network down"), {
+      code: "ECONNREFUSED",
+      cause: "boom",
+    });
+    fetchMock.mockRejectedValue(err);
+    await expect(provider.requestOAuthAccountFromCode("c")).rejects.toThrow(
+      "network down",
+    );
+    const lastCall = consoleErrorSpy.mock.calls.at(-1);
+    expect(lastCall?.[1]).toMatchObject({
+      name: "Error",
+      message: "network down",
+      cause: "boom",
+      code: "ECONNREFUSED",
+    });
+  });
+});
+
+describe("requestTokenAfterExpiry", () => {
+  const currentAccount = {
+    type: "oauth",
+    accessToken: "old",
+    refreshToken: "r",
+    expiresAtTimestampInSeconds: 1,
+  };
+
+  beforeEach(() => {
+    (vscode.window.withProgress as unknown as Mock).mockImplementation(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      async (_opts: any, task: any) => task(),
+    );
+  });
+
+  it("returns a refreshed account and stores it", async () => {
+    fetchMock.mockResolvedValue(
+      fakeResponse({
+        ok: true,
+        body: { access_token: "new", refresh_token: "nr", expires_in: 3600 },
+      }),
+    );
+    const account = await provider.requestTokenAfterExpiry(currentAccount);
+    expect(account.accessToken).toBe("new");
+    expect(account.refreshToken).toBe("nr");
+    expect(secretsStore).toHaveBeenCalledWith(
+      ACCOUNT_SECRET_KEY,
+      expect.any(String),
+    );
+  });
+
+  it("falls back to the current tokens when the response omits them", async () => {
+    fetchMock.mockResolvedValue(fakeResponse({ ok: true, body: {} }));
+    const account = await provider.requestTokenAfterExpiry(currentAccount);
+    expect(account.accessToken).toBe("old");
+    expect(account.refreshToken).toBe("r");
+  });
+
+  it("throws on a non-2xx response", async () => {
+    fetchMock.mockResolvedValue(fakeResponse({ ok: false, status: 500 }));
+    await expect(
+      provider.requestTokenAfterExpiry(currentAccount),
+    ).rejects.toThrow("Request failed with status code: 500");
+  });
+
+  it("rethrows fetch errors", async () => {
+    fetchMock.mockRejectedValue(new Error("refresh boom"));
+    await expect(
+      provider.requestTokenAfterExpiry(currentAccount),
+    ).rejects.toThrow("refresh boom");
+  });
+});
+
+describe("refreshAccessToken", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const session = { id: "sess-1" } as any;
+  const nowSeconds = () => Math.floor(Date.now() / 1000);
+
+  it("throws when no account is stored", async () => {
+    secretsGet.mockResolvedValue(undefined);
+    await expect(provider.refreshAccessToken(session)).rejects.toThrow(
+      "Unable to fetch account",
+    );
+  });
+
+  it("returns the current token when it is still valid", async () => {
+    const account = {
+      type: "oauth",
+      accessToken: "valid-token",
+      refreshToken: "r",
+      expiresAtTimestampInSeconds: nowSeconds() + 100000,
+    };
+    secretsGet.mockImplementation(async (key: string) =>
+      key === ACCOUNT_SECRET_KEY ? JSON.stringify(account) : undefined,
+    );
+    const reqSpy = vi.spyOn(provider, "requestTokenAfterExpiry");
+
+    const token = await provider.refreshAccessToken(session);
+
+    expect(token).toBe("valid-token");
+    expect(reqSpy).not.toHaveBeenCalled();
+  });
+
+  it("refreshes, updates sessions and fires a changed event", async () => {
+    const expired = {
+      type: "oauth",
+      accessToken: "old",
+      refreshToken: "r",
+      expiresAtTimestampInSeconds: nowSeconds() - 100,
+    };
+    const sessions = [
+      {
+        id: "sess-1",
+        accessToken: "old",
+        account: { id: "sess-1", label: "u" },
+        scopes: [],
+      },
+    ];
+    secretsGet.mockImplementation(async (key: string) => {
+      if (key === ACCOUNT_SECRET_KEY) return JSON.stringify(expired);
+      if (key === SESSIONS_SECRET_KEY) return JSON.stringify(sessions);
+      return undefined;
+    });
+    vi.spyOn(provider, "requestTokenAfterExpiry").mockResolvedValue({
+      type: "oauth",
+      accessToken: "fresh",
+      refreshToken: "r2",
+      expiresAtTimestampInSeconds: nowSeconds() + 100000,
+    });
+    const fireSpy = vi.spyOn(provider._sessionChangeEmitter, "fire");
+
+    const token = await provider.refreshAccessToken(session);
+
+    expect(token).toBe("fresh");
+    expect(secretsStore).toHaveBeenCalledWith(
+      ACCOUNT_SECRET_KEY,
+      expect.any(String),
+    );
+    expect(secretsStore).toHaveBeenCalledWith(
+      SESSIONS_SECRET_KEY,
+      expect.any(String),
+    );
+    expect(fireSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ changed: [expect.anything()] }),
+    );
+  });
+
+  it("prompts to reconnect when the refresh fails", async () => {
+    const expired = {
+      type: "oauth",
+      accessToken: "old",
+      refreshToken: "r",
+      expiresAtTimestampInSeconds: nowSeconds() - 100,
+    };
+    secretsGet.mockImplementation(async (key: string) =>
+      key === ACCOUNT_SECRET_KEY ? JSON.stringify(expired) : undefined,
+    );
+    vi.spyOn(provider, "requestTokenAfterExpiry").mockResolvedValue(undefined);
+    const removeSpy = vi
+      .spyOn(provider, "removeSession")
+      .mockResolvedValue(undefined);
+    (vscode.window.showWarningMessage as unknown as Mock).mockResolvedValue(
+      "Reconnect",
+    );
+
+    await provider.refreshAccessToken(session);
+
+    expect(removeSpy).toHaveBeenCalledWith("sess-1");
+    expect(vscode.commands.executeCommand).toHaveBeenCalledWith(
+      LightSpeedCommands.LIGHTSPEED_AUTH_REQUEST,
+    );
+  });
+
+  it("does not execute a command when the reconnect prompt is dismissed", async () => {
+    const expired = {
+      type: "oauth",
+      accessToken: "old",
+      refreshToken: "r",
+      expiresAtTimestampInSeconds: nowSeconds() - 100,
+    };
+    secretsGet.mockImplementation(async (key: string) =>
+      key === ACCOUNT_SECRET_KEY ? JSON.stringify(expired) : undefined,
+    );
+    vi.spyOn(provider, "requestTokenAfterExpiry").mockResolvedValue(undefined);
+    vi.spyOn(provider, "removeSession").mockResolvedValue(undefined);
+    (vscode.window.showWarningMessage as unknown as Mock).mockResolvedValue(
+      undefined,
+    );
+
+    await provider.refreshAccessToken(session);
+
+    expect(vscode.commands.executeCommand).not.toHaveBeenCalled();
+  });
+
+  it("returns the refreshed token without a changed event when no sessions are stored", async () => {
+    const expired = {
+      type: "oauth",
+      accessToken: "old",
+      refreshToken: "r",
+      expiresAtTimestampInSeconds: nowSeconds() - 100,
+    };
+    secretsGet.mockImplementation(async (key: string) =>
+      key === ACCOUNT_SECRET_KEY ? JSON.stringify(expired) : undefined,
+    );
+    vi.spyOn(provider, "requestTokenAfterExpiry").mockResolvedValue({
+      type: "oauth",
+      accessToken: "fresh",
+      refreshToken: "r2",
+      expiresAtTimestampInSeconds: nowSeconds() + 100000,
+    });
+    const fireSpy = vi.spyOn(provider._sessionChangeEmitter, "fire");
+
+    const token = await provider.refreshAccessToken(session);
+
+    expect(token).toBe("fresh");
+    expect(fireSpy).not.toHaveBeenCalled();
+  });
+});

--- a/test/unit/lightspeed/lightSpeedOAuthProvider.test.ts
+++ b/test/unit/lightspeed/lightSpeedOAuthProvider.test.ts
@@ -90,8 +90,37 @@ function makeProvider(
   ) as AnyProvider;
 }
 
+// Subscribe through the public event so tests verify the real notification
+// path (onDidChangeSessions) rather than spying on the internal emitter.
+type SessionChangeEvent = {
+  added?: readonly unknown[];
+  removed?: readonly unknown[];
+  changed?: readonly unknown[];
+};
+function captureSessionChanges(): SessionChangeEvent[] {
+  const events: SessionChangeEvent[] = [];
+  // The shared MockEventEmitter.event is an unbound prototype method, so a
+  // detached `onDidChangeSessions(listener)` call would bind `this` to the
+  // provider instead of the emitter. Install a minimal bound emitter so the
+  // public event path actually delivers payloads through onDidChangeSessions.
+  const listeners: Array<(e: SessionChangeEvent) => void> = [];
+  provider._sessionChangeEmitter = {
+    event: (listener: (e: SessionChangeEvent) => void) => {
+      listeners.push(listener);
+      return { dispose: () => {} };
+    },
+    fire: (e: SessionChangeEvent) => listeners.forEach((l) => l(e)),
+  };
+  provider.onDidChangeSessions((e: SessionChangeEvent) => {
+    events.push(e);
+  });
+  return events;
+}
+
 beforeEach(() => {
-  vi.clearAllMocks();
+  // resetAllMocks (not clearAllMocks) so prior mockResolvedValue/
+  // mockImplementation state on shared fakes does not leak between tests.
+  vi.resetAllMocks();
   fetchMock.mockReset();
   vi.stubGlobal("fetch", fetchMock);
 
@@ -183,7 +212,7 @@ describe("createSession", () => {
       rh_org_has_subscription: true,
       rh_user_is_org_admin: true,
     });
-    const fireSpy = vi.spyOn(provider._sessionChangeEmitter, "fire");
+    const events = captureSessionChanges();
 
     const session = await provider.createSession([]);
 
@@ -194,10 +223,8 @@ describe("createSession", () => {
       SESSIONS_SECRET_KEY,
       expect.any(String),
     );
-    expect(fireSpy).toHaveBeenCalledWith(
-      expect.objectContaining({ added: [expect.anything()] }),
-    );
-    expect(fireSpy.mock.calls[0][0].added).toHaveLength(1);
+    expect(events).toHaveLength(1);
+    expect(events[0].added).toHaveLength(1);
   });
 
   it("throws when login yields no account", async () => {
@@ -243,7 +270,7 @@ describe("removeSession", () => {
     secretsGet.mockResolvedValue(
       JSON.stringify([{ id: "a" }, { id: "target" }]),
     );
-    const fireSpy = vi.spyOn(provider._sessionChangeEmitter, "fire");
+    const events = captureSessionChanges();
 
     await provider.removeSession("target");
 
@@ -251,19 +278,22 @@ describe("removeSession", () => {
       SESSIONS_SECRET_KEY,
       expect.any(String),
     );
-    expect(fireSpy).toHaveBeenCalledWith(
-      expect.objectContaining({ removed: [{ id: "target" }] }),
-    );
+    // The persisted list must no longer contain the removed id (a regression
+    // that re-saved the original array would otherwise pass).
+    const [, storedSessions] = secretsStore.mock.calls[0];
+    expect(JSON.parse(storedSessions)).toEqual([{ id: "a" }]);
+    expect(events).toHaveLength(1);
+    expect(events[0].removed).toEqual([{ id: "target" }]);
   });
 
   it("stores without firing when the id is absent", async () => {
     secretsGet.mockResolvedValue(JSON.stringify([{ id: "a" }]));
-    const fireSpy = vi.spyOn(provider._sessionChangeEmitter, "fire");
+    const events = captureSessionChanges();
 
     await provider.removeSession("missing");
 
     expect(secretsStore).toHaveBeenCalled();
-    expect(fireSpy).not.toHaveBeenCalled();
+    expect(events).toHaveLength(0);
   });
 
   it("returns early when there are no stored sessions", async () => {
@@ -287,7 +317,7 @@ describe("getSessions / setMockSession / onDidChangeSessions", () => {
 
   it("writes a synthetic session and fires an added event", async () => {
     secretsGet.mockResolvedValue(undefined);
-    const fireSpy = vi.spyOn(provider._sessionChangeEmitter, "fire");
+    const events = captureSessionChanges();
 
     await provider.setMockSession({
       accessToken: "tok",
@@ -299,11 +329,8 @@ describe("getSessions / setMockSession / onDidChangeSessions", () => {
       SESSIONS_SECRET_KEY,
       expect.any(String),
     );
-    expect(fireSpy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        added: [expect.objectContaining({ id: "id-1" })],
-      }),
-    );
+    expect(events).toHaveLength(1);
+    expect(events[0].added).toEqual([expect.objectContaining({ id: "id-1" })]);
   });
 
   it("exposes the session-change event", () => {
@@ -616,7 +643,7 @@ describe("refreshAccessToken", () => {
       refreshToken: "r2",
       expiresAtTimestampInSeconds: nowSeconds() + 100000,
     });
-    const fireSpy = vi.spyOn(provider._sessionChangeEmitter, "fire");
+    const events = captureSessionChanges();
 
     const token = await provider.refreshAccessToken(session);
 
@@ -629,9 +656,8 @@ describe("refreshAccessToken", () => {
       SESSIONS_SECRET_KEY,
       expect.any(String),
     );
-    expect(fireSpy).toHaveBeenCalledWith(
-      expect.objectContaining({ changed: [expect.anything()] }),
-    );
+    expect(events).toHaveLength(1);
+    expect(events[0].changed).toHaveLength(1);
   });
 
   it("prompts to reconnect when the refresh fails", async () => {
@@ -697,11 +723,11 @@ describe("refreshAccessToken", () => {
       refreshToken: "r2",
       expiresAtTimestampInSeconds: nowSeconds() + 100000,
     });
-    const fireSpy = vi.spyOn(provider._sessionChangeEmitter, "fire");
+    const events = captureSessionChanges();
 
     const token = await provider.refreshAccessToken(session);
 
     expect(token).toBe("fresh");
-    expect(fireSpy).not.toHaveBeenCalled();
+    expect(events).toHaveLength(0);
   });
 });

--- a/test/unit/lightspeed/lightSpeedOAuthProvider.test.ts
+++ b/test/unit/lightspeed/lightSpeedOAuthProvider.test.ts
@@ -40,10 +40,12 @@ const { SESSIONS_SECRET_KEY, ACCOUNT_SECRET_KEY } = webUtils;
 const getUserInfoMock = lightSpeedManager.lightspeedAuthenticatedUser
   .getUserInfo as unknown as Mock;
 
-type AnyProvider = LightSpeedAuthenticationProvider & {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  [key: string]: any;
-};
+// These tests deliberately reach into private members of the provider
+// (_sessionChangeEmitter, _disposable, login, handleUriForCode, ...). vitest
+// transpiles without type info, but vue-tsc --noEmit in CI enforces private
+// access, so alias to any for those reaches.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyProvider = any;
 
 const fetchMock = vi.fn();
 
@@ -133,7 +135,7 @@ beforeEach(() => {
   (vscode.env as any).uriScheme = "vscode";
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (vscode.env as any).asExternalUri = vi.fn(async () => ({
-    toString: () => "vscode://redhat.ansible/cb",
+    toString: (): string => "vscode://redhat.ansible/cb",
   }));
   (vscode.Uri.parse as unknown as Mock).mockImplementation((s: string) => ({
     raw: s,

--- a/test/unit/lightspeed/lightSpeedOAuthProvider.test.ts
+++ b/test/unit/lightspeed/lightSpeedOAuthProvider.test.ts
@@ -44,8 +44,8 @@ const getUserInfoMock = lightSpeedManager.lightspeedAuthenticatedUser
 
 // These tests deliberately reach into private members of the provider
 // (_sessionChangeEmitter, _disposable, login, handleUriForCode, ...). vitest
-// transpiles without type info, but vue-tsc --noEmit in CI enforces private
-// access, so alias to any for those reaches.
+// compiles without type info, but vue-tsc --noEmit in CI enforces private
+// access, so alias to a record for those reaches.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyProvider = Record<string, any>;
 

--- a/test/unit/lightspeed/lightSpeedOAuthProvider.test.ts
+++ b/test/unit/lightspeed/lightSpeedOAuthProvider.test.ts
@@ -15,6 +15,8 @@ import {
 import * as webUtils from "@src/features/lightspeed/utils/webUtils";
 import { lightSpeedManager } from "@src/extension";
 import { LightSpeedCommands } from "@src/definitions/lightspeed";
+import type { SettingsManager } from "@src/settings";
+import type { Log } from "@src/utils/logger";
 
 // The SUT imports `lightSpeedManager` at module load and uses it inside
 // createSession (`currentModelValue` + `lightspeedAuthenticatedUser.getUserInfo`).
@@ -45,7 +47,7 @@ const getUserInfoMock = lightSpeedManager.lightspeedAuthenticatedUser
 // transpiles without type info, but vue-tsc --noEmit in CI enforces private
 // access, so alias to any for those reaches.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-type AnyProvider = any;
+type AnyProvider = Record<string, any>;
 
 const fetchMock = vi.fn();
 
@@ -82,14 +84,12 @@ function makeProvider(
   };
   logger = { debug: vi.fn(), trace: vi.fn(), info: vi.fn() };
   return new LightSpeedAuthenticationProvider(
-    context,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    {} as any,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    logger as any,
+    context as unknown as vscode.ExtensionContext,
+    {} as unknown as SettingsManager,
+    logger as unknown as Log,
     "auth-lightspeed",
     "Ansible Lightspeed",
-  ) as AnyProvider;
+  ) as unknown as AnyProvider;
 }
 
 // Subscribe through the public event so tests verify the real notification
@@ -109,7 +109,7 @@ function captureSessionChanges(): SessionChangeEvent[] {
   provider._sessionChangeEmitter = {
     event: (listener: (e: SessionChangeEvent) => void) => {
       listeners.push(listener);
-      return { dispose: () => {} };
+      return { dispose: () => undefined };
     },
     fire: (e: SessionChangeEvent) => listeners.forEach((l) => l(e)),
   };
@@ -128,7 +128,7 @@ beforeEach(() => {
 
   consoleErrorSpy = vi
     .spyOn(console, "error")
-    .mockImplementation(() => {}) as unknown as Mock;
+    .mockImplementation(() => undefined) as unknown as Mock;
 
   // vscode env extensions the alias mock lacks.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -193,8 +193,7 @@ describe("redirect URI helpers", () => {
   it("falls back to empty publisher/name when packageJSON is empty", async () => {
     const p = makeProvider({});
     await LightSpeedAuthenticationProvider.getExternalRedirectUri(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (p as any).context,
+      p.context as unknown as vscode.ExtensionContext,
     );
     expect(vscode.Uri.parse).toHaveBeenCalledWith("vscode://.");
   });
@@ -283,7 +282,7 @@ describe("removeSession", () => {
     // The persisted list must no longer contain the removed id (a regression
     // that re-saved the original array would otherwise pass).
     const [, storedSessions] = secretsStore.mock.calls[0];
-    expect(JSON.parse(storedSessions)).toEqual([{ id: "a" }]);
+    expect(JSON.parse(storedSessions as string)).toEqual([{ id: "a" }]);
     expect(events).toHaveLength(1);
     expect(events[0].removed).toEqual([{ id: "target" }]);
   });
@@ -423,16 +422,13 @@ describe("login", () => {
 
     // Replace the UriEventHandler with a binding-safe emitter, since the alias
     // mock's EventEmitter.event method is not auto-bound.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const listeners: Array<(u: any) => void> = [];
+    const listeners: Array<(u: { query: string }) => void> = [];
     provider._uriHandler = {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      event: (l: any) => {
+      event: (l: (u: { query: string }) => void) => {
         listeners.push(l);
-        return { dispose: () => {} };
+        return { dispose: () => undefined };
       },
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      fire: (u: any) => listeners.forEach((l) => l(u)),
+      fire: (u: { query: string }) => listeners.forEach((l) => l(u)),
     };
 
     getBaseUriMock.mockResolvedValue("https://ls.example");
@@ -440,7 +436,7 @@ describe("login", () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       async (_opts: any, task: any) => {
         const token = {
-          onCancellationRequested: () => ({ dispose: () => {} }),
+          onCancellationRequested: () => ({ dispose: () => undefined }),
         };
         const p = task({ report: vi.fn() }, token);
         provider._uriHandler.fire({ query: "code=the-code" });


### PR DESCRIPTION
## Summary

Continues the SonarQube coverage push for lightspeed code (follows #2882, #2884, #2893, #2959). Adds a greenfield vitest suite for `src/features/lightspeed/lightSpeedOAuthProvider.ts`, the single largest coverage gap in the directory.

**Coverage: 66.9% → ~98.8% line / ~96.9% branch** (39 tests).

## What's covered
- `isSupportedCallback` (desktop / openshiftapps / github.dev / negative)
- redirect-URI helpers incl. `publisher ?? ""` / `name ?? ""` fallbacks
- `createSession` — licensed / unlicensed / username fallback / empty name / login-failure
- `removeSession` — existing / absent id / no stored sessions
- `initialize` / `dispose` — authenticated / unauthenticated / uninitialized
- `login` — missing base_uri throw + full redirect success path
- `handleUriForCode` — no code / account-not-formed / success
- `requestOAuthAccountFromCode` — non-ok / missing-tokens / fetch-throws
- `requestTokenAfterExpiry` — ok / missing-tokens / non-ok / throws
- `refreshAccessToken` — no account / valid / refresh-success / Reconnect / dismissed / no-sessions

## Not covered
`login`'s 60s `setTimeout` timeout-rejection and `onCancellationRequested` race arms (timer/cancellation races that can't be triggered deterministically alongside the real event plumbing). The happy redirect path is fully covered.

## Testing
Test-only change — no production source modified.

```
npx vitest run --project ext test/unit/lightspeed/lightSpeedOAuthProvider.test.ts
# Test Files 1 passed (1) · Tests 39 passed (39)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a comprehensive Vitest unit test suite for the Lightspeed OAuth flow, covering supported-redirect detection, session creation/removal and persistence, and initialize/dispose lifecycle.
  * Validated token exchange and refresh behaviors, including expiry handling, error propagation, and reconnect prompts when refresh fails.
  * Confirmed session-change event emission semantics and redirect URI fallback/user labeling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->