### PR TITLE
chore: branch-coverage unit tests for lightspeedUser and api

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -120,6 +120,7 @@ towerhost
 tsdown
 typedarrays
 unrs
+unstub
 uuidv
 vite
 vitest

--- a/test/unit/lightspeed/api.test.ts
+++ b/test/unit/lightspeed/api.test.ts
@@ -1,0 +1,579 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  vi,
+  type Mock,
+} from "vitest";
+import * as vscode from "vscode";
+import { LightSpeedAPI, getFetch } from "@src/features/lightspeed/api";
+import type { LightspeedUser } from "@src/features/lightspeed/lightspeedUser";
+import type { SettingsManager } from "@src/settings";
+import type {
+  CompletionRequestParams,
+  FeedbackRequestParams,
+  ContentMatchesRequestParams,
+  ExplanationRequestParams,
+  PlaybookGenerationRequestParams,
+  RoleGenerationRequestParams,
+  RoleExplanationRequestParams,
+} from "@src/interfaces/lightspeed";
+
+// Shared mocks created in the hoisted scope so the vi.mock factories below can
+// reference them (vi.mock is hoisted above imports).
+const h = vi.hoisted(() => ({
+  getBaseUri: vi.fn(),
+  mapError: vi.fn(),
+  inlineHide: vi.fn(),
+  trialProvider: { showPopup: vi.fn() },
+}));
+
+// Keep the real webUtils constants (auth ids etc.) and override getBaseUri only.
+vi.mock("@src/features/lightspeed/utils/webUtils", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("@src/features/lightspeed/utils/webUtils")
+    >();
+  return { ...actual, getBaseUri: h.getBaseUri };
+});
+
+vi.mock("@src/features/lightspeed/handleApiError", () => ({
+  mapError: h.mapError,
+}));
+
+vi.mock("@src/features/lightspeed/inlineSuggestions", () => ({
+  inlineSuggestionHideHandler: h.inlineHide,
+}));
+
+vi.mock("@src/features/lightspeed/utils/oneClickTrial", () => ({
+  getOneClickTrialProvider: () => h.trialProvider,
+  OneClickTrialProvider: class {},
+}));
+
+type MockResponse = {
+  ok: boolean;
+  status: number;
+  json: Mock;
+};
+
+function makeRes(opts: {
+  ok?: boolean;
+  status?: number;
+  json?: unknown;
+}): MockResponse {
+  return {
+    ok: opts.ok ?? true,
+    status: opts.status ?? 200,
+    json: vi.fn().mockResolvedValue(opts.json ?? {}),
+  };
+}
+
+const showInfo = vscode.window.showInformationMessage as unknown as Mock;
+const showError = vscode.window.showErrorMessage as unknown as Mock;
+
+interface MkApiOpts {
+  provider?: string;
+  authed?: boolean;
+  optOut?: boolean;
+  token?: string | undefined;
+  packageJSON?: { version?: string };
+}
+
+function mkApi(opts?: MkApiOpts) {
+  const settingsManager = {
+    settings: {
+      lightSpeedService: {
+        provider: opts?.provider ?? "wca",
+      },
+    },
+  } as unknown as SettingsManager;
+
+  const user = {
+    isAuthenticated: vi.fn().mockResolvedValue(opts?.authed ?? true),
+    orgOptOutTelemetry: vi.fn().mockResolvedValue(opts?.optOut ?? false),
+    getLightspeedUserAccessToken: vi
+      .fn()
+      .mockResolvedValue("token" in (opts ?? {}) ? opts?.token : "tok"),
+  } as unknown as LightspeedUser & {
+    isAuthenticated: Mock;
+    orgOptOutTelemetry: Mock;
+    getLightspeedUserAccessToken: Mock;
+  };
+
+  const context = {
+    extension: { packageJSON: opts?.packageJSON ?? { version: "9.9.9" } },
+  } as unknown as vscode.ExtensionContext;
+
+  const logger = {
+    info: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    trace: vi.fn(),
+  };
+
+  const api = new LightSpeedAPI(
+    settingsManager,
+    user,
+    context,
+    logger as unknown as never,
+  );
+  return { api, user, settingsManager, logger };
+}
+
+let fetchMock: Mock;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  fetchMock = vi.fn();
+  vi.stubGlobal("fetch", fetchMock);
+  h.getBaseUri.mockResolvedValue("https://base");
+  h.mapError.mockReturnValue({ code: "mapped", message: "Mapped error" });
+  h.trialProvider.showPopup.mockResolvedValue(false);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("getFetch", () => {
+  it("falls back to globalThis.fetch when electron is unavailable", () => {
+    // electron require resolves to a path string (no .net.fetch) -> fallback.
+    expect(getFetch()).toBe(fetchMock);
+  });
+});
+
+describe("LightSpeedAPI.lightspeedPost (via completionRequest)", () => {
+  it("throws an auth error for the WCA provider when no token is available", async () => {
+    const { api } = mkApi({ provider: "wca", token: undefined });
+    const result = await api.completionRequest({
+      prompt: "p",
+      suggestionId: "s1",
+    } as unknown as CompletionRequestParams);
+
+    // The thrown error is caught by completionRequest and mapped.
+    expect(h.mapError).toHaveBeenCalledTimes(1);
+    expect((h.mapError.mock.calls[0][0] as Error).message).toBe(
+      "Ansible Lightspeed authentication failed.",
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(result).toEqual({});
+  });
+
+  it("adds an Authorization header when a token is present", async () => {
+    const { api } = mkApi({ provider: "wca", token: "tok" });
+    fetchMock.mockResolvedValue(
+      makeRes({ json: { predictions: [{ prediction: "x" }] } }),
+    );
+
+    await api.completionRequest({
+      prompt: "p",
+      suggestionId: "s1",
+    } as unknown as CompletionRequestParams);
+
+    const headers = fetchMock.mock.calls[0][1].headers as Record<
+      string,
+      string
+    >;
+    expect(headers.Authorization).toBe("Bearer tok");
+  });
+
+  it("omits the Authorization header for a non-WCA provider with no token", async () => {
+    const { api } = mkApi({ provider: "ollama", token: undefined });
+    fetchMock.mockResolvedValue(
+      makeRes({ json: { predictions: [{ prediction: "x" }] } }),
+    );
+
+    await api.completionRequest({
+      prompt: "p",
+      suggestionId: "s1",
+    } as unknown as CompletionRequestParams);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const headers = fetchMock.mock.calls[0][1].headers as Record<
+      string,
+      string
+    >;
+    expect(headers.Authorization).toBeUndefined();
+  });
+});
+
+describe("LightSpeedAPI.completionRequest", () => {
+  it("returns the predictions payload on success", async () => {
+    const { api } = mkApi();
+    fetchMock.mockResolvedValue(
+      makeRes({ json: { predictions: [{ prediction: "do thing" }] } }),
+    );
+
+    const result = await api.completionRequest({
+      prompt: "p",
+      suggestionId: "s1",
+    } as unknown as CompletionRequestParams);
+
+    expect(result).toEqual({ predictions: [{ prediction: "do thing" }] });
+    // The feedback for this suggestion is still pending, so the finally branch
+    // treats it as cancelled and does NOT call the hide handler.
+    expect(h.inlineHide).not.toHaveBeenCalled();
+  });
+
+  it("calls inlineSuggestionHideHandler when the feedback was cancelled mid-flight", async () => {
+    const { api } = mkApi();
+    const res = makeRes({ json: { predictions: [{ prediction: "x" }] } });
+    // Cancel the pending feedback while awaiting json() so that, by the time the
+    // finally block runs, the suggestion is no longer tracked.
+    res.json.mockImplementation(async () => {
+      api.cancelSuggestionFeedback("s1");
+      return { predictions: [{ prediction: "x" }] };
+    });
+    fetchMock.mockResolvedValue(res);
+
+    await api.completionRequest({
+      prompt: "p",
+      suggestionId: "s1",
+    } as unknown as CompletionRequestParams);
+
+    expect(h.inlineHide).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    ["204 status", { ok: true, status: 204, json: {} }],
+    ["empty predictions", { ok: true, status: 200, json: { predictions: [] } }],
+    [
+      "null first prediction",
+      { ok: true, status: 200, json: { predictions: [null] } },
+    ],
+  ])("shows an info message for %s and returns {}", async (_label, resOpts) => {
+    const { api } = mkApi();
+    fetchMock.mockResolvedValue(makeRes(resOpts));
+
+    const result = await api.completionRequest({
+      prompt: "p",
+      suggestionId: "s1",
+    } as unknown as CompletionRequestParams);
+
+    expect(showInfo).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({});
+  });
+
+  it("shows an error message on a non-ok response when the trial popup is not shown", async () => {
+    const { api } = mkApi();
+    h.trialProvider.showPopup.mockResolvedValue(false);
+    fetchMock.mockResolvedValue(makeRes({ ok: false, status: 500, json: {} }));
+
+    const result = await api.completionRequest({
+      prompt: "p",
+      suggestionId: "s1",
+    } as unknown as CompletionRequestParams);
+
+    expect(showError).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({});
+  });
+
+  it("does not show an error message when the trial popup is shown", async () => {
+    const { api } = mkApi();
+    h.trialProvider.showPopup.mockResolvedValue(true);
+    fetchMock.mockResolvedValue(makeRes({ ok: false, status: 403, json: {} }));
+
+    await api.completionRequest({
+      prompt: "p",
+      suggestionId: "s1",
+    } as unknown as CompletionRequestParams);
+
+    expect(showError).not.toHaveBeenCalled();
+  });
+
+  it('pushes "" to the feedback queue when no suggestionId is supplied', async () => {
+    const { api } = mkApi();
+    let inProgressDuringRequest = false;
+    const res = makeRes({ json: { predictions: [{ prediction: "x" }] } });
+    res.json.mockImplementation(async () => {
+      inProgressDuringRequest = api.isSuggestionFeedbackInProgress();
+      return { predictions: [{ prediction: "x" }] };
+    });
+    fetchMock.mockResolvedValue(res);
+
+    await api.completionRequest({
+      prompt: "p",
+    } as unknown as CompletionRequestParams);
+
+    expect(inProgressDuringRequest).toBe(true);
+  });
+});
+
+describe("LightSpeedAPI.cancelSuggestionFeedback", () => {
+  it("returns true when the suggestion is found and false otherwise", () => {
+    const { api } = mkApi();
+    (
+      api as unknown as { _suggestionFeedbacks: string[] }
+    )._suggestionFeedbacks.push("abc");
+    expect(api.cancelSuggestionFeedback("abc")).toBe(true);
+    expect(api.cancelSuggestionFeedback("abc")).toBe(false);
+  });
+});
+
+describe("LightSpeedAPI.feedbackRequest", () => {
+  it("returns {} without fetching when unauthenticated and not showing auth errors", async () => {
+    const { api } = mkApi({ authed: false });
+
+    const result = await api.feedbackRequest({
+      inlineSuggestion: { latency: 1 },
+    } as unknown as FeedbackRequestParams);
+
+    expect(result).toEqual({});
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("strips inlineSuggestion on org opt-out and returns early when nothing remains", async () => {
+    const { api } = mkApi({ authed: true, optOut: true });
+    const inputData = {
+      inlineSuggestion: { latency: 1 },
+    } as unknown as FeedbackRequestParams;
+
+    const result = await api.feedbackRequest(inputData);
+
+    expect(result).toEqual({});
+    expect(inputData.inlineSuggestion).toBeUndefined();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("shows a thank-you message on success when showInfoMessage is true", async () => {
+    const { api } = mkApi({ authed: true });
+    fetchMock.mockResolvedValue(makeRes({ json: {} }));
+
+    await api.feedbackRequest(
+      { sentimentFeedback: { value: 5 } } as unknown as FeedbackRequestParams,
+      false,
+      true,
+    );
+
+    expect(showInfo).toHaveBeenCalledWith("Thanks for your feedback!");
+  });
+
+  it("shows an error message on failure when showInfoMessage is true", async () => {
+    const { api } = mkApi({ authed: true });
+    fetchMock.mockResolvedValue(makeRes({ ok: false, status: 400, json: {} }));
+
+    await api.feedbackRequest(
+      { sentimentFeedback: { value: 5 } } as unknown as FeedbackRequestParams,
+      false,
+      true,
+    );
+
+    expect(showError).toHaveBeenCalledTimes(1);
+  });
+
+  it("logs to console.error on failure when showInfoMessage is false", async () => {
+    const { api } = mkApi({ authed: true });
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    fetchMock.mockResolvedValue(makeRes({ ok: false, status: 400, json: {} }));
+
+    await api.feedbackRequest(
+      { sentimentFeedback: { value: 5 } } as unknown as FeedbackRequestParams,
+      false,
+      false,
+    );
+
+    expect(consoleError).toHaveBeenCalledTimes(1);
+    expect(showError).not.toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+});
+
+describe("LightSpeedAPI.contentMatchesRequest", () => {
+  it("shows an error and returns {} when unauthenticated", async () => {
+    const { api } = mkApi({ authed: false });
+
+    const result = await api.contentMatchesRequest({
+      suggestions: ["x"],
+    } as unknown as ContentMatchesRequestParams);
+
+    expect(showError).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({});
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns the data on success", async () => {
+    const { api } = mkApi({ authed: true });
+    fetchMock.mockResolvedValue(makeRes({ json: { contentmatches: [] } }));
+
+    const result = await api.contentMatchesRequest({
+      suggestions: ["x"],
+    } as unknown as ContentMatchesRequestParams);
+
+    expect(result).toEqual({ contentmatches: [] });
+  });
+
+  it("returns a mapped IError on a non-ok response", async () => {
+    const { api } = mkApi({ authed: true });
+    fetchMock.mockResolvedValue(makeRes({ ok: false, status: 500, json: {} }));
+
+    const result = await api.contentMatchesRequest({
+      suggestions: ["x"],
+    } as unknown as ContentMatchesRequestParams);
+
+    expect(result).toEqual({ code: "mapped", message: "Mapped error" });
+  });
+});
+
+describe("LightSpeedAPI.explanationRequest", () => {
+  it("returns the data on success", async () => {
+    const { api } = mkApi();
+    fetchMock.mockResolvedValue(makeRes({ json: { content: "explained" } }));
+
+    const result = await api.explanationRequest({
+      content: "yaml",
+    } as unknown as ExplanationRequestParams);
+
+    expect(result).toEqual({ content: "explained" });
+  });
+
+  it("returns a mapped IError on a non-ok response", async () => {
+    const { api } = mkApi();
+    fetchMock.mockResolvedValue(makeRes({ ok: false, status: 500, json: {} }));
+
+    const result = await api.explanationRequest({
+      content: "yaml",
+    } as unknown as ExplanationRequestParams);
+
+    expect(result).toEqual({ code: "mapped", message: "Mapped error" });
+  });
+});
+
+describe("LightSpeedAPI.playbookGenerationRequest", () => {
+  it("returns the data on success", async () => {
+    const { api } = mkApi();
+    fetchMock.mockResolvedValue(makeRes({ json: { playbook: "yaml" } }));
+
+    const result = await api.playbookGenerationRequest({
+      text: "do thing",
+    } as unknown as PlaybookGenerationRequestParams);
+
+    expect(result).toEqual({ playbook: "yaml" });
+  });
+
+  it("returns a mapped IError on a non-ok response", async () => {
+    const { api } = mkApi();
+    fetchMock.mockResolvedValue(makeRes({ ok: false, status: 500, json: {} }));
+
+    const result = await api.playbookGenerationRequest({
+      text: "do thing",
+    } as unknown as PlaybookGenerationRequestParams);
+
+    expect(result).toEqual({ code: "mapped", message: "Mapped error" });
+  });
+});
+
+describe("LightSpeedAPI.roleGenerationRequest", () => {
+  it("backfills name from role when name is missing", async () => {
+    const { api } = mkApi();
+    fetchMock.mockResolvedValue(makeRes({ json: { role: "r" } }));
+
+    const result = await api.roleGenerationRequest({
+      text: "t",
+    } as unknown as RoleGenerationRequestParams);
+
+    expect(result).toEqual({ role: "r", name: "r" });
+  });
+
+  it("does not backfill when name is already present", async () => {
+    const { api } = mkApi();
+    fetchMock.mockResolvedValue(makeRes({ json: { name: "n" } }));
+
+    const result = await api.roleGenerationRequest({
+      text: "t",
+    } as unknown as RoleGenerationRequestParams);
+
+    expect(result).toEqual({ name: "n" });
+  });
+
+  it("returns a mapped IError on a non-ok response", async () => {
+    const { api } = mkApi();
+    fetchMock.mockResolvedValue(makeRes({ ok: false, status: 500, json: {} }));
+
+    const result = await api.roleGenerationRequest({
+      text: "t",
+    } as unknown as RoleGenerationRequestParams);
+
+    expect(result).toEqual({ code: "mapped", message: "Mapped error" });
+  });
+});
+
+describe("LightSpeedAPI.roleExplanationRequest", () => {
+  it("returns the data on success", async () => {
+    const { api } = mkApi();
+    fetchMock.mockResolvedValue(makeRes({ json: { content: "role doc" } }));
+
+    const result = await api.roleExplanationRequest({
+      files: [],
+    } as unknown as RoleExplanationRequestParams);
+
+    expect(result).toEqual({ content: "role doc" });
+  });
+
+  it("returns a mapped IError on a non-ok response", async () => {
+    const { api } = mkApi();
+    fetchMock.mockResolvedValue(makeRes({ ok: false, status: 500, json: {} }));
+
+    const result = await api.roleExplanationRequest({
+      files: [],
+    } as unknown as RoleExplanationRequestParams);
+
+    expect(result).toEqual({ code: "mapped", message: "Mapped error" });
+  });
+});
+
+describe("LightSpeedAPI.getStatus", () => {
+  it("reports connected when completionRequest resolves", async () => {
+    const { api } = mkApi();
+    vi.spyOn(api, "completionRequest").mockResolvedValue({} as never);
+
+    const status = await api.getStatus();
+
+    expect(status.connected).toBe(true);
+    expect(status.modelInfo?.name).toBe("WCA");
+  });
+
+  it("reports the error message when completionRequest throws an Error", async () => {
+    const { api } = mkApi();
+    vi.spyOn(api, "completionRequest").mockRejectedValue(new Error("boom"));
+
+    const status = await api.getStatus();
+
+    expect(status).toEqual({ connected: false, error: "boom" });
+  });
+
+  it("uses a fallback message when completionRequest throws a non-Error", async () => {
+    const { api } = mkApi();
+    vi.spyOn(api, "completionRequest").mockRejectedValue("nope");
+
+    const status = await api.getStatus();
+
+    expect(status).toEqual({
+      connected: false,
+      error: "WCA connection failed",
+    });
+  });
+});
+
+describe("LightSpeedAPI constructor", () => {
+  it("uses an empty extension version when packageJSON has no version", async () => {
+    const { api } = mkApi({ packageJSON: {} });
+    fetchMock.mockResolvedValue(
+      makeRes({ json: { predictions: [{ prediction: "x" }] } }),
+    );
+
+    await api.completionRequest({
+      prompt: "p",
+      suggestionId: "s1",
+    } as unknown as CompletionRequestParams);
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body as string) as {
+      metadata: { ansibleExtensionVersion: string };
+    };
+    expect(body.metadata.ansibleExtensionVersion).toBe("");
+  });
+});

--- a/test/unit/lightspeed/api.test.ts
+++ b/test/unit/lightspeed/api.test.ts
@@ -49,7 +49,7 @@ vi.mock("@src/features/lightspeed/inlineSuggestions", () => ({
 
 vi.mock("@src/features/lightspeed/utils/oneClickTrial", () => ({
   getOneClickTrialProvider: () => h.trialProvider,
-  OneClickTrialProvider: class {},
+  OneClickTrialProvider: vi.fn(),
 }));
 
 type MockResponse = {
@@ -77,7 +77,7 @@ interface MkApiOpts {
   provider?: string;
   authed?: boolean;
   optOut?: boolean;
-  token?: string | undefined;
+  token?: string;
   packageJSON?: { version?: string };
 }
 
@@ -368,7 +368,7 @@ describe("LightSpeedAPI.feedbackRequest", () => {
     const { api } = mkApi({ authed: true });
     const consoleError = vi
       .spyOn(console, "error")
-      .mockImplementation(() => {});
+      .mockImplementation(() => undefined);
     fetchMock.mockResolvedValue(makeRes({ ok: false, status: 400, json: {} }));
 
     await api.feedbackRequest(

--- a/test/unit/lightspeed/lightspeedUser.test.ts
+++ b/test/unit/lightspeed/lightspeedUser.test.ts
@@ -1,10 +1,20 @@
-import { describe, it, expect, beforeEach, vi, type Mock } from "vitest";
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  vi,
+  type Mock,
+} from "vitest";
 import * as vscode from "vscode";
 import {
   LightspeedUser,
   AuthProviderType,
 } from "@src/features/lightspeed/lightspeedUser";
 import * as webUtils from "@src/features/lightspeed/utils/webUtils";
+import { LightSpeedAuthenticationProvider } from "@src/features/lightspeed/lightSpeedOAuthProvider";
+import { LightSpeedCommands } from "@src/definitions/lightspeed";
 
 // Override getBaseUri while keeping the real auth-id constants the module
 // relies on at import time (AuthProviderType is built from them).
@@ -192,5 +202,618 @@ describe("LightspeedUser.setLightspeedUser (provider-order wiring)", () => {
     expect(getSessionMock).toHaveBeenCalled();
     expect(priv(user)._session).toBeUndefined();
     expect(priv(user)._userType).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Additional coverage for branch-heavy paths in LightspeedUser.
+// ---------------------------------------------------------------------------
+
+const getExtensionMock = vscode.extensions.getExtension as unknown as Mock;
+const executeCommandMock = vscode.commands.executeCommand as unknown as Mock;
+const showWarningMock = vscode.window.showWarningMessage as unknown as Mock;
+
+interface AnyUser {
+  _userType: AuthProviderType | undefined;
+  _session: vscode.AuthenticationSession | undefined;
+  _userDetails: unknown;
+  _markdownUserDetails: string | undefined;
+  _extensionHost: string;
+  _getUserInfoCache: {
+    locked: boolean;
+    token: string;
+    time: number;
+    userInfo?: unknown;
+  };
+  _updateUserInformation(
+    createIfNone: boolean,
+    session: vscode.AuthenticationSession,
+  ): Promise<boolean>;
+  setLightspeedUser(
+    createIfNone: boolean,
+    useProviderType?: AuthProviderType,
+  ): Promise<void>;
+}
+
+const P = (u: LightspeedUser) => u as unknown as AnyUser;
+
+const fullUserInfo = () => ({
+  username: "u",
+  external_username: "ext",
+  rh_user_has_seat: true,
+  rh_org_has_subscription: true,
+  rh_user_is_org_admin: true,
+  org_telemetry_opt_out: false,
+});
+
+function mkRes(opts: { ok?: boolean; status?: number; json?: unknown }) {
+  return {
+    ok: opts.ok ?? true,
+    status: opts.status ?? 200,
+    json: vi.fn().mockResolvedValue("json" in opts ? opts.json : {}),
+  };
+}
+
+function mkUser(opts?: {
+  enabled?: boolean;
+  provider?: string;
+  extensionKind?: number;
+  navigatorDefined?: boolean;
+  authProvider?: { removeSession?: Mock; refreshAccessToken?: Mock };
+}) {
+  const logger = {
+    info: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    trace: vi.fn(),
+  };
+  const settingsManager = {
+    settings: {
+      lightSpeedService: {
+        enabled: opts?.enabled ?? true,
+        provider: opts?.provider ?? "wca",
+      },
+    },
+  };
+  const context = {
+    extension: {
+      extensionKind: opts?.extensionKind ?? vscode.ExtensionKind.UI,
+      packageJSON: {},
+    },
+  };
+  const authProvider = opts?.authProvider ?? {
+    removeSession: vi.fn(),
+    refreshAccessToken: vi.fn(),
+  };
+  // navigator must be controlled before construction (host detection happens
+  // in the constructor).
+  vi.stubGlobal("navigator", opts?.navigatorDefined ? {} : undefined);
+  const user = new LightspeedUser(
+    context as unknown as vscode.ExtensionContext,
+    settingsManager as unknown as never,
+    authProvider as unknown as never,
+    logger as unknown as never,
+  );
+  vi.unstubAllGlobals();
+  return { user, logger, authProvider, settingsManager };
+}
+
+describe("LightspeedUser constructor extension host detection", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("detects the Remote host (no navigator, Workspace extension kind)", () => {
+    const { user } = mkUser({
+      extensionKind: vscode.ExtensionKind.Workspace,
+      navigatorDefined: false,
+    });
+    expect(P(user)._extensionHost).toBe("Remote");
+  });
+
+  it("detects the WebWorker host when navigator is defined", () => {
+    const { user } = mkUser({ navigatorDefined: true });
+    expect(P(user)._extensionHost).toBe("WebWorker");
+  });
+});
+
+describe("LightspeedUser.setLightspeedUser (explicit provider type)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getBaseUriMock.mockResolvedValue("https://x");
+  });
+
+  it("uses RHSSO scopes, records the user type and returns early on success", async () => {
+    const { user } = mkUser();
+    const session = fakeSession("s");
+    getSessionMock.mockResolvedValue(session);
+    vi.spyOn(user, "getUserInfo").mockResolvedValue(fullUserInfo());
+    vi.spyOn(user, "getUserInfoFromMarkdown").mockResolvedValue("md");
+
+    await P(user).setLightspeedUser(true, AuthProviderType.rhsso);
+
+    expect(P(user)._userType).toBe(AuthProviderType.rhsso);
+    expect(P(user)._session).toBe(session);
+    expect(getSessionMock.mock.calls[0][1]).toEqual(["api.lightspeed"]);
+    expect(getSessionMock.mock.calls[0][2]).toEqual({ createIfNone: true });
+  });
+});
+
+describe("LightspeedUser.getUserInfo", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getBaseUriMock.mockResolvedValue("https://x");
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("returns a cached result on the second call without re-fetching", async () => {
+    const { user } = mkUser();
+    const f = vi.fn().mockResolvedValue(mkRes({ json: fullUserInfo() }));
+    vi.stubGlobal("fetch", f);
+
+    const a = await user.getUserInfo("tok");
+    const b = await user.getUserInfo("tok");
+
+    expect(f).toHaveBeenCalledTimes(1);
+    expect(b).toBe(a);
+  });
+
+  it("rejects with LightspeedAccessDenied on a 401 and resets the lock", async () => {
+    const { user } = mkUser();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(mkRes({ ok: false, status: 401 })),
+    );
+
+    await expect(user.getUserInfo("tok")).rejects.toThrow(/Access Denied/);
+    expect(P(user)._getUserInfoCache.locked).toBe(false);
+  });
+
+  it("rejects with a generic message on a 500", async () => {
+    const { user } = mkUser();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(mkRes({ ok: false, status: 500 })),
+    );
+
+    await expect(user.getUserInfo("tok")).rejects.toThrow(
+      "Request failed with status code: 500",
+    );
+  });
+
+  it("throws when the payload is not an object", async () => {
+    const { user } = mkUser();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(mkRes({ ok: true, status: 200, json: null })),
+    );
+
+    await expect(user.getUserInfo("tok")).rejects.toThrow(
+      "Unexpected userinfo payload",
+    );
+  });
+});
+
+describe("LightspeedUser.getUserInfoFromMarkdown", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getBaseUriMock.mockResolvedValue("https://x");
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("returns the content on success", async () => {
+    const { user } = mkUser();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(mkRes({ json: { content: "md-body" } })),
+    );
+    await expect(user.getUserInfoFromMarkdown("tok")).resolves.toBe("md-body");
+  });
+
+  it("rejects with LightspeedAccessDenied on a 401", async () => {
+    const { user } = mkUser();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(mkRes({ ok: false, status: 401 })),
+    );
+    await expect(user.getUserInfoFromMarkdown("tok")).rejects.toThrow(
+      /Access Denied/,
+    );
+  });
+
+  it("rejects with a generic message on a 500", async () => {
+    const { user } = mkUser();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(mkRes({ ok: false, status: 500 })),
+    );
+    await expect(user.getUserInfoFromMarkdown("tok")).rejects.toThrow(
+      "Request failed with status code: 500",
+    );
+  });
+});
+
+describe("LightspeedUser.getAuthProviderOrder", () => {
+  let savedPrefer: string | undefined;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    savedPrefer = process.env.LIGHTSPEED_PREFER_RHSSO_AUTH;
+    delete process.env.LIGHTSPEED_PREFER_RHSSO_AUTH;
+  });
+  afterEach(() => {
+    if (savedPrefer === undefined) {
+      delete process.env.LIGHTSPEED_PREFER_RHSSO_AUTH;
+    } else {
+      process.env.LIGHTSPEED_PREFER_RHSSO_AUTH = savedPrefer;
+    }
+    vi.unstubAllGlobals();
+  });
+
+  it("returns [lightspeed] when the redhat-account extension is absent", async () => {
+    getExtensionMock.mockReturnValue(undefined);
+    const { user } = mkUser();
+    await expect(user.getAuthProviderOrder()).resolves.toEqual([
+      AuthProviderType.lightspeed,
+    ]);
+  });
+
+  it("prefers RHSSO when LIGHTSPEED_PREFER_RHSSO_AUTH=true", async () => {
+    getExtensionMock.mockReturnValue({});
+    process.env.LIGHTSPEED_PREFER_RHSSO_AUTH = "true";
+    const { user } = mkUser();
+    await expect(user.getAuthProviderOrder()).resolves.toEqual([
+      AuthProviderType.rhsso,
+      AuthProviderType.lightspeed,
+    ]);
+  });
+
+  it("prefers the previously-used lightspeed provider first", async () => {
+    getExtensionMock.mockReturnValue({});
+    const { user } = mkUser();
+    P(user)._userType = AuthProviderType.lightspeed;
+    await expect(user.getAuthProviderOrder()).resolves.toEqual([
+      AuthProviderType.lightspeed,
+      AuthProviderType.rhsso,
+    ]);
+  });
+
+  it("prefers the previously-used rhsso provider first", async () => {
+    getExtensionMock.mockReturnValue({});
+    const { user } = mkUser();
+    P(user)._userType = AuthProviderType.rhsso;
+    await expect(user.getAuthProviderOrder()).resolves.toEqual([
+      AuthProviderType.rhsso,
+      AuthProviderType.lightspeed,
+    ]);
+  });
+
+  it("falls back to [lightspeed, rhsso] when resolving the base URI throws", async () => {
+    getExtensionMock.mockReturnValue({});
+    getBaseUriMock.mockRejectedValue(new Error("boom"));
+    const { user } = mkUser();
+    await expect(user.getAuthProviderOrder()).resolves.toEqual([
+      AuthProviderType.lightspeed,
+      AuthProviderType.rhsso,
+    ]);
+  });
+
+  it("prefers RHSSO on Remote prod with an unsupported callback", async () => {
+    getExtensionMock.mockReturnValue({});
+    getBaseUriMock.mockResolvedValue("https://c.ai.ansible.redhat.com");
+    vi.spyOn(
+      LightSpeedAuthenticationProvider,
+      "getExternalRedirectUri",
+    ).mockResolvedValue({
+      scheme: "https",
+      authority: "example.com",
+      toString: () => "https://example.com",
+    } as unknown as vscode.Uri);
+    const { user } = mkUser({
+      extensionKind: vscode.ExtensionKind.Workspace,
+      navigatorDefined: false,
+    });
+    await expect(user.getAuthProviderOrder()).resolves.toEqual([
+      AuthProviderType.rhsso,
+      AuthProviderType.lightspeed,
+    ]);
+  });
+
+  it("prefers lightspeed on Remote prod with a supported callback", async () => {
+    getExtensionMock.mockReturnValue({});
+    getBaseUriMock.mockResolvedValue("https://c.ai.ansible.redhat.com");
+    vi.spyOn(
+      LightSpeedAuthenticationProvider,
+      "getExternalRedirectUri",
+    ).mockResolvedValue({
+      scheme: "vscode",
+      authority: "",
+      toString: () => "vscode://callback",
+    } as unknown as vscode.Uri);
+    const { user } = mkUser({
+      extensionKind: vscode.ExtensionKind.Workspace,
+      navigatorDefined: false,
+    });
+    await expect(user.getAuthProviderOrder()).resolves.toEqual([
+      AuthProviderType.lightspeed,
+      AuthProviderType.rhsso,
+    ]);
+  });
+});
+
+describe("LightspeedUser.updateUserInformation", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("invokes _updateUserInformation when a session is present", async () => {
+    const { user } = mkUser();
+    const session = fakeSession("s");
+    P(user)._session = session;
+    const spy = vi
+      .spyOn(P(user), "_updateUserInformation")
+      .mockResolvedValue(true);
+    await user.updateUserInformation();
+    expect(spy).toHaveBeenCalledWith(false, session);
+  });
+
+  it("does nothing when there is no session", async () => {
+    const { user } = mkUser();
+    const spy = vi
+      .spyOn(P(user), "_updateUserInformation")
+      .mockResolvedValue(true);
+    await user.updateUserInformation();
+    expect(spy).not.toHaveBeenCalled();
+  });
+});
+
+describe("LightspeedUser._updateUserInformation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getBaseUriMock.mockResolvedValue("https://x");
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("sets details and returns true on full success", async () => {
+    const { user } = mkUser();
+    vi.spyOn(user, "getUserInfo").mockResolvedValue(fullUserInfo());
+    vi.spyOn(user, "getUserInfoFromMarkdown").mockResolvedValue("md");
+    const session = fakeSession("s");
+
+    const ok = await P(user)._updateUserInformation(false, session);
+
+    expect(ok).toBe(true);
+    expect(P(user)._userDetails).toBeDefined();
+    expect(P(user)._markdownUserDetails).toBe("md");
+  });
+
+  it("uses an empty markdown string when the markdown fetch throws", async () => {
+    const { user } = mkUser();
+    vi.spyOn(user, "getUserInfo").mockResolvedValue(fullUserInfo());
+    vi.spyOn(user, "getUserInfoFromMarkdown").mockRejectedValue(
+      new Error("md boom"),
+    );
+    const session = fakeSession("s");
+
+    const ok = await P(user)._updateUserInformation(false, session);
+
+    expect(ok).toBe(true);
+    expect(P(user)._markdownUserDetails).toBe("");
+  });
+
+  it("forces a new session on access-denied when createIfNone and a user type are set", async () => {
+    const { user } = mkUser();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(mkRes({ ok: false, status: 401 })),
+    );
+    P(user)._userType = AuthProviderType.rhsso;
+    const session = fakeSession("s");
+
+    const ok = await P(user)._updateUserInformation(true, session);
+
+    expect(ok).toBe(false);
+    expect(getSessionMock).toHaveBeenCalledWith(
+      AuthProviderType.rhsso,
+      ["api.lightspeed"],
+      { forceNewSession: true },
+    );
+  });
+
+  it("removes the lightspeed session on access-denied without createIfNone", async () => {
+    const authProvider = {
+      removeSession: vi.fn(),
+      refreshAccessToken: vi.fn(),
+    };
+    const { user } = mkUser({ authProvider });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(mkRes({ ok: false, status: 401 })),
+    );
+    P(user)._userType = AuthProviderType.lightspeed;
+    const session = fakeSession("sess-1");
+
+    const ok = await P(user)._updateUserInformation(false, session);
+
+    expect(ok).toBe(false);
+    expect(authProvider.removeSession).toHaveBeenCalledWith("sess-1");
+  });
+});
+
+describe("LightspeedUser.getLightspeedUserDetails", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns undefined when the service is disabled", async () => {
+    const { user } = mkUser({ enabled: false });
+    await expect(user.getLightspeedUserDetails(false)).resolves.toBeUndefined();
+  });
+
+  it("returns undefined for an LLM provider when not explicitly authenticating", async () => {
+    const { user } = mkUser({ provider: "ollama" });
+    await expect(user.getLightspeedUserDetails(false)).resolves.toBeUndefined();
+  });
+
+  it("returns cached details and refreshes on a provider-type mismatch", async () => {
+    const { user } = mkUser({ provider: "wca" });
+    const cached = {
+      rhOrgHasSubscription: true,
+      rhUserIsOrgAdmin: false,
+      displayName: "ext",
+      displayNameWithUserType: "ext (licensed)",
+      orgOptOutTelemetry: false,
+    };
+    P(user)._userDetails = cached;
+    P(user)._userType = AuthProviderType.lightspeed;
+    const spy = vi.spyOn(P(user), "setLightspeedUser").mockResolvedValue();
+
+    await expect(user.getLightspeedUserDetails(false)).resolves.toBe(cached);
+    expect(spy).not.toHaveBeenCalled();
+
+    await user.getLightspeedUserDetails(false, AuthProviderType.rhsso);
+    expect(spy).toHaveBeenCalled();
+  });
+});
+
+describe("LightspeedUser.getMarkdownLightspeedUserDetails", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns undefined when the service is disabled", async () => {
+    const { user } = mkUser({ enabled: false });
+    await expect(
+      user.getMarkdownLightspeedUserDetails(false),
+    ).resolves.toBeUndefined();
+  });
+
+  it("returns the cached markdown without refreshing", async () => {
+    const { user } = mkUser();
+    P(user)._markdownUserDetails = "cached-md";
+    P(user)._userType = AuthProviderType.lightspeed;
+    const spy = vi.spyOn(P(user), "setLightspeedUser").mockResolvedValue();
+
+    await expect(user.getMarkdownLightspeedUserDetails(false)).resolves.toBe(
+      "cached-md",
+    );
+    expect(spy).not.toHaveBeenCalled();
+  });
+});
+
+describe("LightspeedUser.getLightspeedUserContent", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns an empty string when no markdown details exist", async () => {
+    const { user } = mkUser();
+    vi.spyOn(P(user), "setLightspeedUser").mockResolvedValue();
+    await expect(user.getLightspeedUserContent()).resolves.toBe("");
+  });
+});
+
+describe("LightspeedUser.rhOrgHasSubscription", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns undefined when no user details are available", async () => {
+    const { user } = mkUser();
+    vi.spyOn(user, "getLightspeedUserDetails").mockResolvedValue(undefined);
+    await expect(user.rhOrgHasSubscription()).resolves.toBeUndefined();
+  });
+
+  it("returns true when the org has a subscription", async () => {
+    const { user } = mkUser();
+    vi.spyOn(user, "getLightspeedUserDetails").mockResolvedValue({
+      rhOrgHasSubscription: true,
+      displayNameWithUserType: "ext (licensed)",
+    } as never);
+    await expect(user.rhOrgHasSubscription()).resolves.toBe(true);
+  });
+
+  it("returns false when the org has no subscription", async () => {
+    const { user } = mkUser();
+    vi.spyOn(user, "getLightspeedUserDetails").mockResolvedValue({
+      rhOrgHasSubscription: false,
+      displayNameWithUserType: "ext (unlicensed)",
+    } as never);
+    await expect(user.rhOrgHasSubscription()).resolves.toBe(false);
+  });
+});
+
+describe("LightspeedUser.getLightspeedUserAccessToken", () => {
+  let savedTestToken: string | undefined;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    savedTestToken = process.env.TEST_LIGHTSPEED_ACCESS_TOKEN;
+    delete process.env.TEST_LIGHTSPEED_ACCESS_TOKEN;
+  });
+  afterEach(() => {
+    if (savedTestToken === undefined) {
+      delete process.env.TEST_LIGHTSPEED_ACCESS_TOKEN;
+    } else {
+      process.env.TEST_LIGHTSPEED_ACCESS_TOKEN = savedTestToken;
+    }
+  });
+
+  it("returns the TEST_LIGHTSPEED_ACCESS_TOKEN when set", async () => {
+    process.env.TEST_LIGHTSPEED_ACCESS_TOKEN = "env-token";
+    const { user } = mkUser();
+    await expect(user.getLightspeedUserAccessToken()).resolves.toBe(
+      "env-token",
+    );
+  });
+
+  it("returns undefined for an LLM provider", async () => {
+    const { user } = mkUser({ provider: "ollama" });
+    await expect(user.getLightspeedUserAccessToken()).resolves.toBeUndefined();
+  });
+
+  it("triggers the auth request command when the user selects Login", async () => {
+    const { user } = mkUser();
+    showWarningMock.mockResolvedValue("Login");
+    await user.getLightspeedUserAccessToken();
+    expect(executeCommandMock).toHaveBeenCalledWith(
+      LightSpeedCommands.LIGHTSPEED_AUTH_REQUEST,
+    );
+  });
+
+  it("opens settings when the user selects Disable Lightspeed", async () => {
+    const { user } = mkUser();
+    showWarningMock.mockResolvedValue("Disable Lightspeed");
+    await user.getLightspeedUserAccessToken();
+    expect(executeCommandMock).toHaveBeenCalledWith(
+      "workbench.action.openSettings",
+      "ansible.lightspeed.enabled",
+    );
+  });
+
+  it("refreshes the token via the provider for a lightspeed session", async () => {
+    const authProvider = {
+      removeSession: vi.fn(),
+      refreshAccessToken: vi.fn().mockResolvedValue("ls-token"),
+    };
+    const { user } = mkUser({ authProvider });
+    P(user)._session = fakeSession("s");
+    P(user)._userType = AuthProviderType.lightspeed;
+    await expect(user.getLightspeedUserAccessToken()).resolves.toBe("ls-token");
+    expect(authProvider.refreshAccessToken).toHaveBeenCalled();
+  });
+
+  it("returns the session access token for an rhsso session", async () => {
+    const { user } = mkUser();
+    const session = fakeSession("rh");
+    P(user)._session = session;
+    P(user)._userType = AuthProviderType.rhsso;
+    await expect(user.getLightspeedUserAccessToken()).resolves.toBe(
+      session.accessToken,
+    );
+  });
+});
+
+describe("LightspeedUser.isAuthenticated", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns true when a session is present", async () => {
+    const { user } = mkUser();
+    P(user)._session = fakeSession("s");
+    await expect(user.isAuthenticated()).resolves.toBe(true);
+  });
+
+  it("returns false when no session is present", async () => {
+    const { user } = mkUser();
+    await expect(user.isAuthenticated()).resolves.toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Continues the SonarQube coverage push for lightspeed code (follows #2882, #2884, #2893, #2959, #2960). Both files were already ~100% line coverage but low on **branch** coverage — these tests close those condition gaps.

| File | Before (line / branch) |
|---|---|
| `lightspeed/lightspeedUser.ts` | 100% / 27% |
| `lightspeed/api.ts` | 100% / 9% |

## What's covered
**lightspeedUser.ts** (29 cases added): host detection (Local/Remote/WebWorker), `getScopesForAuthProviderType` rhsso, `getUserInfo` cache-hit + 401/500/bad-payload, markdown variants, `getAuthProviderOrder` (no-ext / PREFER_RHSSO env / prior userType / getBaseUri-throws / remote-prod unsupported-callback), `setLightspeedUser`/`_updateUserInformation` (success / AccessDenied forceNewSession / removeSession), user-details caching, `rhOrgHasSubscription`, `getLightspeedUserAccessToken` (TEST env / LLM skip / Login / Disable / refresh), `isAuthenticated`.

**api.ts** (new file, 34 cases): `lightspeedPost` auth header / WCA-no-token, `completionRequest` success / 204-empty / non-ok ±showPopup / hide-handler finally, `cancelSuggestionFeedback`, `feedbackRequest` unauth / orgOptOut-strip / success / error, `contentMatchesRequest`, `explanation`/`playbook`/`role` generation ok+non-ok, `roleGeneration` name-backfill, `getStatus` connected / Error / non-Error, version fallback.

## Not covered
`getFetch`'s electron `net.fetch` branch (api.ts) — covering it requires hijacking `electron` module-wide, which breaks the other tests' global-fetch fallback. The fallback branch is covered; the electron arm (4 lines) is left as-is.

## Testing
Test-only change — no production source modified.

```
npx vitest run --project ext test/unit/lightspeed/lightspeedUser.test.ts test/unit/lightspeed/api.test.ts
# Test Files 2 passed (2) · Tests 83 passed (83)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Added Vitest branch-coverage tests for `lightspeedUser.ts` and `lightspeed/api.ts`, covering auth/provider selection, caching, request handling, status/error paths, and fallback behavior to close Lightspeed SonarQube gaps.
- Original commit message: add branch coverage tests for Lightspeed auth/API paths, fix ESLint issues, and resolve `unstub` cspell coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->