### PR TITLE
chore: branch-coverage unit tests for inlineSuggestions and ansibleCreatorUtils

### DIFF
--- a/test/unit/lightspeed/inlineSuggestions.test.ts
+++ b/test/unit/lightspeed/inlineSuggestions.test.ts
@@ -311,7 +311,7 @@ describe("getCompletionState (via provideInlineCompletionItems)", () => {
       ctx(h.InlineCompletionTriggerKind.Invoke),
     );
     expect(Array.isArray(res)).toBe(true);
-    expect(res.length).toBe(1);
+    expect(res).toHaveLength(1);
     // cached path does not issue a new completion request
     expect(
       h.lightSpeedManager.providerManager.completionRequest,
@@ -362,7 +362,7 @@ describe("WCA provider apiEndpoint matrix", () => {
     );
     // falls through to the Default path -> a real suggestion is produced
     expect(h.window.showErrorMessage).not.toHaveBeenCalled();
-    expect(res.length).toBe(1);
+    expect(res).toHaveLength(1);
   });
 });
 
@@ -399,7 +399,7 @@ describe("getInlineSuggestionState valid-prompt dispatch", () => {
       singleTaskPos(),
       ctx(h.InlineCompletionTriggerKind.Automatic),
     );
-    expect(res.length).toBe(1);
+    expect(res).toHaveLength(1);
     expect(
       h.lightSpeedManager.providerManager.completionRequest,
     ).toHaveBeenCalled();
@@ -412,7 +412,7 @@ describe("getInlineSuggestionState valid-prompt dispatch", () => {
       multiTaskPos(),
       ctx(h.InlineCompletionTriggerKind.Automatic),
     );
-    expect(res.length).toBe(1);
+    expect(res).toHaveLength(1);
     expect(
       h.lightSpeedManager.providerManager.completionRequest,
     ).toHaveBeenCalled();
@@ -477,7 +477,7 @@ describe("onDoSingleTasksSuggestion happy path", () => {
       singleTaskPos(),
       ctx(h.InlineCompletionTriggerKind.Automatic),
     );
-    expect(res.length).toBe(1);
+    expect(res).toHaveLength(1);
     expect(res[0]).toBeInstanceOf(h.InlineCompletionItem);
     expect(res[0].command.command).toBe(
       LightSpeedCommands.LIGHTSPEED_SUGGESTION_MARKER,
@@ -493,8 +493,8 @@ describe("onDoSingleTasksSuggestion happy path", () => {
     expect(details[0].suggestionId).toBe("resp-sid");
     // activity tracker first-insert
     expect(
-      Object.keys(h.lightSpeedManager.lightSpeedActivityTracker).length,
-    ).toBe(1);
+      Object.keys(h.lightSpeedManager.lightSpeedActivityTracker),
+    ).toHaveLength(1);
   });
 });
 
@@ -535,7 +535,7 @@ describe("isDocumentChangedImmediately", () => {
       singleTaskPos(),
       ctx(h.InlineCompletionTriggerKind.Automatic),
     );
-    expect(res.length).toBe(1);
+    expect(res).toHaveLength(1);
   });
 
   it("waitWindow > 0 returns empty when the document changes during the wait", async () => {
@@ -855,8 +855,8 @@ describe("additional branch coverage", () => {
   it("reuses the existing activity tracker entry for the same document", async () => {
     await arm(singleTaskPos());
     expect(
-      Object.keys(h.lightSpeedManager.lightSpeedActivityTracker).length,
-    ).toBe(1);
+      Object.keys(h.lightSpeedManager.lightSpeedActivityTracker),
+    ).toHaveLength(1);
     // reset the displayed state via a NotForMe pass, then request again
     await provide(
       makeDoc(["x"], { languageId: "plaintext" }),
@@ -866,8 +866,8 @@ describe("additional branch coverage", () => {
     await arm(new h.Position(1, 4));
     // same documentUri -> the tracker entry is reused, not re-inserted
     expect(
-      Object.keys(h.lightSpeedManager.lightSpeedActivityTracker).length,
-    ).toBe(1);
+      Object.keys(h.lightSpeedManager.lightSpeedActivityTracker),
+    ).toHaveLength(1);
   });
 
   it("single-task: prediction with no leading whitespace", async () => {
@@ -881,7 +881,7 @@ describe("additional branch coverage", () => {
       singleTaskPos(),
       ctx(h.InlineCompletionTriggerKind.Automatic),
     );
-    expect(res.length).toBe(1);
+    expect(res).toHaveLength(1);
   });
 
   it("multi-task: prediction with no leading whitespace", async () => {
@@ -896,7 +896,7 @@ describe("additional branch coverage", () => {
       multiTaskPos(),
       ctx(h.InlineCompletionTriggerKind.Automatic),
     );
-    expect(res.length).toBe(1);
+    expect(res).toHaveLength(1);
   });
 
   it("handles a prompt and cursor with no leading whitespace", async () => {

--- a/test/unit/lightspeed/inlineSuggestions.test.ts
+++ b/test/unit/lightspeed/inlineSuggestions.test.ts
@@ -591,7 +591,7 @@ describe("requestSuggestion error path", () => {
 
   it("handles a non-Error rejection from completionRequest", async () => {
     h.lightSpeedManager.providerManager.completionRequest.mockRejectedValue(
-      "stringly-typed failure",
+      "plain string failure",
     );
     const res = await provide(
       singleTaskDoc(),
@@ -600,7 +600,7 @@ describe("requestSuggestion error path", () => {
     );
     expect(res).toEqual([]);
     expect(h.window.showErrorMessage).toHaveBeenCalledWith(
-      "Error in inline suggestions: stringly-typed failure",
+      "Error in inline suggestions: plain string failure",
     );
   });
 });

--- a/test/unit/lightspeed/inlineSuggestions.test.ts
+++ b/test/unit/lightspeed/inlineSuggestions.test.ts
@@ -1,0 +1,971 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { UserAction, LightSpeedCommands } from "@src/definitions/lightspeed";
+
+// ---------------------------------------------------------------------------
+// Stable mock surface (hoisted so the SUT and the test share the same object
+// identities across vi.resetModules() re-imports).
+// ---------------------------------------------------------------------------
+const h = vi.hoisted(() => {
+  class Position {
+    line: number;
+    character: number;
+    constructor(line: number, character: number) {
+      this.line = line;
+      this.character = character;
+    }
+  }
+  class Range {
+    start: Position;
+    end: Position;
+    constructor(start: Position, end: Position) {
+      this.start = start;
+      this.end = end;
+    }
+    get isEmpty() {
+      return (
+        this.start.line === this.end.line &&
+        this.start.character === this.end.character
+      );
+    }
+  }
+  class InlineCompletionItem {
+    insertText: string;
+    command: unknown;
+    constructor(insertText: string) {
+      this.insertText = insertText;
+      this.command = undefined;
+    }
+  }
+
+  const window = {
+    activeTextEditor: undefined as unknown,
+    showInformationMessage: vi.fn(),
+    showErrorMessage: vi.fn(),
+  };
+  const commands = { executeCommand: vi.fn() };
+  const InlineCompletionTriggerKind = { Invoke: 0, Automatic: 1 };
+
+  const lightSpeedManager = {
+    apiInstance: {
+      isSuggestionFeedbackInProgress: vi.fn(() => false),
+      cancelSuggestionFeedbackInProgress: vi.fn(),
+      feedbackRequest: vi.fn(),
+    },
+    providerManager: {
+      completionRequest: vi.fn(),
+    },
+    settingsManager: {
+      settings: {
+        lightSpeedService: {
+          suggestions: { enabled: true, waitWindow: 0 },
+          provider: "wca",
+          apiEndpoint: "https://api.example",
+        },
+      },
+    },
+    statusBarProvider: {
+      statusBar: { hide: vi.fn(), show: vi.fn(), text: "" },
+      getLightSpeedStatusBarText: vi.fn(async () => "LS"),
+      updateLightSpeedStatusbar: vi.fn(),
+      setLightSpeedStatusBarTooltip: vi.fn(),
+    },
+    contentMatchesProvider: { suggestionDetails: [] as unknown[] },
+    lightSpeedActivityTracker: {} as Record<string, unknown>,
+    currentModelValue: undefined as unknown,
+    inlineSuggestionsEnabled: true,
+  };
+
+  const data = {
+    shouldRequestInlineSuggestions: vi.fn(() => true),
+    shouldTriggerMultiTaskSuggestion: vi.fn(() => false),
+  };
+  const prompt = {
+    shouldRequestForPromptPosition: vi.fn(() => true),
+    getContentWithMultiLinePromptForMultiTasksSuggestions: vi.fn(
+      (c: string) => c,
+    ),
+  };
+
+  return {
+    Position,
+    Range,
+    InlineCompletionItem,
+    InlineCompletionTriggerKind,
+    window,
+    commands,
+    lightSpeedManager,
+    data,
+    prompt,
+  };
+});
+
+vi.mock("vscode", () => ({
+  InlineCompletionTriggerKind: h.InlineCompletionTriggerKind,
+  InlineCompletionItem: h.InlineCompletionItem,
+  Position: h.Position,
+  Range: h.Range,
+  window: h.window,
+  commands: h.commands,
+}));
+
+vi.mock("@src/extension", () => ({ lightSpeedManager: h.lightSpeedManager }));
+
+vi.mock("@src/features/lightspeed/utils/data", () => h.data);
+
+vi.mock(
+  "@src/features/lightspeed/utils/multiLinePromptForMultiTasks",
+  () => h.prompt,
+);
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+type TextLine = { text: string; isEmptyOrWhitespace: boolean };
+
+interface DocOptions {
+  languageId?: string;
+  uri?: string;
+  getTextOverride?: string;
+}
+
+function makeDoc(lines: string[], opts: DocOptions = {}) {
+  const languageId = opts.languageId ?? "ansible";
+  const uri = opts.uri ?? "file:///test/playbook.yml";
+  return {
+    languageId,
+    uri: { toString: () => uri },
+    lineAt: (posOrLine: number | { line: number }): TextLine => {
+      const line = typeof posOrLine === "number" ? posOrLine : posOrLine.line;
+      const text = lines[line] ?? "";
+      return { text, isEmptyOrWhitespace: text.trim() === "" };
+    },
+    getText: (range?: { end: { line: number; character: number } }) => {
+      if (opts.getTextOverride !== undefined) {
+        return opts.getTextOverride;
+      }
+      if (!range) {
+        return lines.join("\n");
+      }
+      const collected: string[] = [];
+      for (let i = 0; i <= range.end.line; i++) {
+        const text = lines[i] ?? "";
+        collected.push(
+          i === range.end.line ? text.slice(0, range.end.character) : text,
+        );
+      }
+      return collected.join("\n");
+    },
+  };
+}
+
+const ctx = (kind: number) => ({ triggerKind: kind });
+const token = (cancelled = false) => ({ isCancellationRequested: cancelled });
+
+// A valid single-task scenario: prompt line is a `- name:` task, cursor sits on
+// the (empty) following line aligned to the same column.
+function singleTaskDoc(over: DocOptions = {}) {
+  return makeDoc(["    - name: install foo", "    "], over);
+}
+const singleTaskPos = () => new h.Position(1, 4);
+
+// A valid multi-task scenario: prompt line is a comment.
+function multiTaskDoc(over: DocOptions = {}) {
+  return makeDoc(["  # install nginx", "  "], over);
+}
+const multiTaskPos = () => new h.Position(1, 2);
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let sut: any;
+
+function resetMockState() {
+  const m = h.lightSpeedManager;
+  m.apiInstance.isSuggestionFeedbackInProgress.mockReturnValue(false);
+  m.providerManager.completionRequest.mockReset();
+  m.providerManager.completionRequest.mockResolvedValue({
+    predictions: ["  - name: created task"],
+    suggestionId: "resp-sid",
+    model: "model-a",
+  });
+  m.statusBarProvider.getLightSpeedStatusBarText.mockResolvedValue("LS");
+  m.settingsManager.settings.lightSpeedService = {
+    suggestions: { enabled: true, waitWindow: 0 },
+    provider: "wca",
+    apiEndpoint: "https://api.example",
+  };
+  m.contentMatchesProvider.suggestionDetails = [];
+  m.lightSpeedActivityTracker = {};
+  m.currentModelValue = undefined;
+  m.inlineSuggestionsEnabled = true;
+
+  h.window.activeTextEditor = undefined;
+
+  h.data.shouldRequestInlineSuggestions.mockReturnValue(true);
+  h.data.shouldTriggerMultiTaskSuggestion.mockReturnValue(false);
+  h.prompt.shouldRequestForPromptPosition.mockReturnValue(true);
+  h.prompt.getContentWithMultiLinePromptForMultiTasksSuggestions.mockImplementation(
+    (c: string) => c,
+  );
+}
+
+async function provide(
+  doc: unknown,
+  position: unknown,
+  context: unknown,
+  tok: unknown = token(),
+) {
+  const provider = new sut.LightSpeedInlineSuggestionProvider();
+  return provider.provideInlineCompletionItems(doc, position, context, tok);
+}
+
+// Drive a successful single-task suggestion to "arm" the module-private state
+// (suggestionDisplayed = true, inlineSuggestionData.suggestionId set,
+// insertTexts populated, displayTime set). Returns the produced items.
+async function arm(position = singleTaskPos()) {
+  const items = await provide(
+    singleTaskDoc(),
+    position,
+    ctx(h.InlineCompletionTriggerKind.Automatic),
+  );
+  return items;
+}
+
+const ansibleEditor = () => ({
+  document: {
+    languageId: "ansible",
+    lineAt: () => ({ text: "", isEmptyOrWhitespace: true }),
+  },
+});
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  resetMockState();
+  vi.resetModules();
+  sut = await import("@src/features/lightspeed/inlineSuggestions");
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+// ---------------------------------------------------------------------------
+
+describe("getCompletionState (via provideInlineCompletionItems)", () => {
+  it("RequestInProgress: cancels feedback when suggestion feedback is in progress", async () => {
+    h.lightSpeedManager.apiInstance.isSuggestionFeedbackInProgress.mockReturnValue(
+      true,
+    );
+    const res = await provide(
+      singleTaskDoc(),
+      singleTaskPos(),
+      ctx(h.InlineCompletionTriggerKind.Automatic),
+    );
+    expect(res).toEqual([]);
+    expect(
+      h.lightSpeedManager.apiInstance.cancelSuggestionFeedbackInProgress,
+    ).toHaveBeenCalled();
+  });
+
+  it("NotForMe: hides the status bar for non-ansible documents", async () => {
+    const res = await provide(
+      makeDoc(["hello"], { languageId: "plaintext" }),
+      new h.Position(0, 0),
+      ctx(h.InlineCompletionTriggerKind.Automatic),
+    );
+    expect(res).toEqual([]);
+    expect(
+      h.lightSpeedManager.statusBarProvider.statusBar.hide,
+    ).toHaveBeenCalled();
+  });
+
+  it("CancellationRequested: returns empty when the token is cancelled", async () => {
+    const res = await provide(
+      singleTaskDoc(),
+      singleTaskPos(),
+      ctx(h.InlineCompletionTriggerKind.Automatic),
+      token(true),
+    );
+    expect(res).toEqual([]);
+  });
+
+  it("LightspeedIsDisabled: refreshes the status bar when suggestions are disabled", async () => {
+    h.lightSpeedManager.settingsManager.settings.lightSpeedService.suggestions.enabled = false;
+    const res = await provide(
+      singleTaskDoc(),
+      singleTaskPos(),
+      ctx(h.InlineCompletionTriggerKind.Automatic),
+    );
+    expect(res).toEqual([]);
+    expect(
+      h.lightSpeedManager.statusBarProvider.updateLightSpeedStatusbar,
+    ).toHaveBeenCalled();
+  });
+
+  it("CacheSuggestion: returns the cached item when the position has not changed", async () => {
+    const pos = singleTaskPos();
+    await arm(pos);
+    h.lightSpeedManager.providerManager.completionRequest.mockClear();
+    // same position object -> positionHasChanged is false
+    const res = await provide(
+      singleTaskDoc(),
+      pos,
+      ctx(h.InlineCompletionTriggerKind.Invoke),
+    );
+    expect(Array.isArray(res)).toBe(true);
+    expect(res.length).toBe(1);
+    // cached path does not issue a new completion request
+    expect(
+      h.lightSpeedManager.providerManager.completionRequest,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("RefusedSuggestion: hides the suggestion when displayed and position changed", async () => {
+    await arm(singleTaskPos());
+    h.commands.executeCommand.mockClear();
+    const res = await provide(
+      singleTaskDoc(),
+      new h.Position(5, 4),
+      ctx(h.InlineCompletionTriggerKind.Automatic),
+    );
+    expect(res).toEqual([]);
+    expect(h.commands.executeCommand).toHaveBeenCalledWith(
+      LightSpeedCommands.LIGHTSPEED_SUGGESTION_HIDE,
+    );
+  });
+});
+
+describe("WCA provider apiEndpoint matrix", () => {
+  it("URLMisconfigured: wca provider with a blank apiEndpoint shows an error", async () => {
+    h.lightSpeedManager.settingsManager.settings.lightSpeedService.provider =
+      "wca";
+    h.lightSpeedManager.settingsManager.settings.lightSpeedService.apiEndpoint =
+      "   ";
+    const res = await provide(
+      singleTaskDoc(),
+      singleTaskPos(),
+      ctx(h.InlineCompletionTriggerKind.Automatic),
+    );
+    expect(res).toEqual([]);
+    expect(h.window.showErrorMessage).toHaveBeenCalledWith(
+      "Ansible Lightspeed URL is empty. Please provide a URL.",
+    );
+  });
+
+  it("LLM provider with a blank apiEndpoint falls through (no URL error)", async () => {
+    h.lightSpeedManager.settingsManager.settings.lightSpeedService.provider =
+      "google";
+    h.lightSpeedManager.settingsManager.settings.lightSpeedService.apiEndpoint =
+      "";
+    const res = await provide(
+      singleTaskDoc(),
+      singleTaskPos(),
+      ctx(h.InlineCompletionTriggerKind.Automatic),
+    );
+    // falls through to the Default path -> a real suggestion is produced
+    expect(h.window.showErrorMessage).not.toHaveBeenCalled();
+    expect(res.length).toBe(1);
+  });
+});
+
+describe("getInlineSuggestionState rejection paths", () => {
+  it("UnexpectedPrompt when the current line is non-empty and trigger is Invoke", async () => {
+    const doc = makeDoc(["    - name: install foo", "    not empty"]);
+    const res = await provide(
+      doc,
+      new h.Position(1, 4),
+      ctx(h.InlineCompletionTriggerKind.Invoke),
+    );
+    expect(res).toEqual([]);
+    expect(h.window.showInformationMessage).toHaveBeenCalled();
+  });
+
+  it("CancellationRequested when indentation mismatches and trigger is Automatic", async () => {
+    // prompt indented 4 spaces, cursor at column 2 -> mismatch
+    const doc = makeDoc(["    - name: install foo", "  "]);
+    const res = await provide(
+      doc,
+      new h.Position(1, 2),
+      ctx(h.InlineCompletionTriggerKind.Automatic),
+    );
+    expect(res).toEqual([]);
+    // automatic trigger -> no information message
+    expect(h.window.showInformationMessage).not.toHaveBeenCalled();
+  });
+});
+
+describe("getInlineSuggestionState valid-prompt dispatch", () => {
+  it("DoSingleTaskSuggestion when a single-task prompt matches", async () => {
+    const res = await provide(
+      singleTaskDoc(),
+      singleTaskPos(),
+      ctx(h.InlineCompletionTriggerKind.Automatic),
+    );
+    expect(res.length).toBe(1);
+    expect(
+      h.lightSpeedManager.providerManager.completionRequest,
+    ).toHaveBeenCalled();
+  });
+
+  it("DoMultiTasksSuggestion when a multi-task comment matches", async () => {
+    h.data.shouldTriggerMultiTaskSuggestion.mockReturnValue(true);
+    const res = await provide(
+      multiTaskDoc(),
+      multiTaskPos(),
+      ctx(h.InlineCompletionTriggerKind.Automatic),
+    );
+    expect(res.length).toBe(1);
+    expect(
+      h.lightSpeedManager.providerManager.completionRequest,
+    ).toHaveBeenCalled();
+  });
+
+  it("ShouldNotTriggerSuggestion when the prompt is not valid", async () => {
+    h.prompt.shouldRequestForPromptPosition.mockReturnValue(false);
+    const res = await provide(
+      singleTaskDoc(),
+      singleTaskPos(),
+      ctx(h.InlineCompletionTriggerKind.Automatic),
+    );
+    expect(res).toEqual([]);
+    expect(
+      h.lightSpeedManager.providerManager.completionRequest,
+    ).not.toHaveBeenCalled();
+  });
+});
+
+describe("onUnexpectedPrompt information messages", () => {
+  it("shows the positioning hint when there is no prompt match", async () => {
+    const doc = makeDoc(["just some text", "    "]);
+    await provide(
+      doc,
+      new h.Position(1, 4),
+      ctx(h.InlineCompletionTriggerKind.Invoke),
+    );
+    expect(h.window.showInformationMessage).toHaveBeenCalledWith(
+      expect.stringContaining("Cursor should be positioned"),
+    );
+  });
+
+  it("shows the positioning hint when the current line is not whitespace", async () => {
+    const doc = makeDoc(["    - name: install foo", "    text"]);
+    await provide(
+      doc,
+      new h.Position(1, 4),
+      ctx(h.InlineCompletionTriggerKind.Invoke),
+    );
+    expect(h.window.showInformationMessage).toHaveBeenCalledWith(
+      expect.stringContaining("Cursor should be positioned"),
+    );
+  });
+
+  it("shows the column hint when the indentation does not match", async () => {
+    const doc = makeDoc(["    - name: install foo", "  "]);
+    await provide(
+      doc,
+      new h.Position(1, 2),
+      ctx(h.InlineCompletionTriggerKind.Invoke),
+    );
+    expect(h.window.showInformationMessage).toHaveBeenCalledWith(
+      expect.stringContaining("Cursor must be in column 4"),
+    );
+  });
+});
+
+describe("onDoSingleTasksSuggestion happy path", () => {
+  it("produces an inline completion item and records suggestion details", async () => {
+    const res = await provide(
+      singleTaskDoc(),
+      singleTaskPos(),
+      ctx(h.InlineCompletionTriggerKind.Automatic),
+    );
+    expect(res.length).toBe(1);
+    expect(res[0]).toBeInstanceOf(h.InlineCompletionItem);
+    expect(res[0].command.command).toBe(
+      LightSpeedCommands.LIGHTSPEED_SUGGESTION_MARKER,
+    );
+    // model-update branch: currentModelValue updated to the response model
+    expect(h.lightSpeedManager.currentModelValue).toBe("model-a");
+    expect(
+      h.lightSpeedManager.statusBarProvider.setLightSpeedStatusBarTooltip,
+    ).toHaveBeenCalled();
+    // suggestionDetails populated with the response suggestionId
+    const details = h.lightSpeedManager.contentMatchesProvider
+      .suggestionDetails as Array<{ suggestionId: string }>;
+    expect(details[0].suggestionId).toBe("resp-sid");
+    // activity tracker first-insert
+    expect(
+      Object.keys(h.lightSpeedManager.lightSpeedActivityTracker).length,
+    ).toBe(1);
+  });
+});
+
+describe("empty predictions early return", () => {
+  it("single-task returns empty when there are no predictions", async () => {
+    h.lightSpeedManager.providerManager.completionRequest.mockResolvedValue({
+      predictions: [],
+      suggestionId: "x",
+    });
+    const res = await provide(
+      singleTaskDoc(),
+      singleTaskPos(),
+      ctx(h.InlineCompletionTriggerKind.Automatic),
+    );
+    expect(res).toEqual([]);
+  });
+
+  it("multi-task returns empty when there are no predictions", async () => {
+    h.data.shouldTriggerMultiTaskSuggestion.mockReturnValue(true);
+    h.lightSpeedManager.providerManager.completionRequest.mockResolvedValue({
+      predictions: [],
+      suggestionId: "x",
+    });
+    const res = await provide(
+      multiTaskDoc(),
+      multiTaskPos(),
+      ctx(h.InlineCompletionTriggerKind.Automatic),
+    );
+    expect(res).toEqual([]);
+  });
+});
+
+describe("isDocumentChangedImmediately", () => {
+  it("waitWindow 0 proceeds with the suggestion", async () => {
+    h.lightSpeedManager.settingsManager.settings.lightSpeedService.suggestions.waitWindow = 0;
+    const res = await provide(
+      singleTaskDoc(),
+      singleTaskPos(),
+      ctx(h.InlineCompletionTriggerKind.Automatic),
+    );
+    expect(res.length).toBe(1);
+  });
+
+  it("waitWindow > 0 returns empty when the document changes during the wait", async () => {
+    vi.useFakeTimers();
+    h.lightSpeedManager.settingsManager.settings.lightSpeedService.suggestions.waitWindow = 50;
+    const p = provide(
+      singleTaskDoc(),
+      singleTaskPos(),
+      ctx(h.InlineCompletionTriggerKind.Automatic),
+    );
+    await vi.advanceTimersByTimeAsync(10);
+    sut.setDocumentChanged(true);
+    await vi.advanceTimersByTimeAsync(60);
+    const res = await p;
+    expect(res).toEqual([]);
+    expect(
+      h.lightSpeedManager.providerManager.completionRequest,
+    ).not.toHaveBeenCalled();
+  });
+});
+
+describe("loadFile YAML parse failure", () => {
+  it("shows an error and rethrows when the document is invalid YAML", async () => {
+    const doc = singleTaskDoc({ getTextOverride: "{" });
+    await expect(
+      provide(
+        doc,
+        singleTaskPos(),
+        ctx(h.InlineCompletionTriggerKind.Automatic),
+      ),
+    ).rejects.toThrow();
+    expect(h.window.showErrorMessage).toHaveBeenCalledWith(
+      expect.stringContaining("Ansible Lightspeed expects valid YAML"),
+    );
+  });
+});
+
+describe("requestSuggestion error path", () => {
+  it("handles an Error rejection from completionRequest", async () => {
+    h.lightSpeedManager.providerManager.completionRequest.mockRejectedValue(
+      new Error("boom"),
+    );
+    const res = await provide(
+      singleTaskDoc(),
+      singleTaskPos(),
+      ctx(h.InlineCompletionTriggerKind.Automatic),
+    );
+    expect(res).toEqual([]);
+    expect(h.window.showErrorMessage).toHaveBeenCalledWith(
+      "Error in inline suggestions: boom",
+    );
+  });
+
+  it("handles a non-Error rejection from completionRequest", async () => {
+    h.lightSpeedManager.providerManager.completionRequest.mockRejectedValue(
+      "stringly-typed failure",
+    );
+    const res = await provide(
+      singleTaskDoc(),
+      singleTaskPos(),
+      ctx(h.InlineCompletionTriggerKind.Automatic),
+    );
+    expect(res).toEqual([]);
+    expect(h.window.showErrorMessage).toHaveBeenCalledWith(
+      "Error in inline suggestions: stringly-typed failure",
+    );
+  });
+});
+
+describe("requestInlineSuggest model branches", () => {
+  it("no model on the response leaves currentModelValue unchanged", async () => {
+    h.lightSpeedManager.currentModelValue = "preset";
+    h.lightSpeedManager.providerManager.completionRequest.mockResolvedValue({
+      predictions: ["  - name: t"],
+      suggestionId: "s",
+      model: undefined,
+    });
+    await provide(
+      singleTaskDoc(),
+      singleTaskPos(),
+      ctx(h.InlineCompletionTriggerKind.Automatic),
+    );
+    expect(h.lightSpeedManager.currentModelValue).toBe("preset");
+    expect(
+      h.lightSpeedManager.statusBarProvider.setLightSpeedStatusBarTooltip,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("equal model does not trigger a tooltip update", async () => {
+    h.lightSpeedManager.currentModelValue = "model-a";
+    await provide(
+      singleTaskDoc(),
+      singleTaskPos(),
+      ctx(h.InlineCompletionTriggerKind.Automatic),
+    );
+    expect(h.lightSpeedManager.currentModelValue).toBe("model-a");
+    expect(
+      h.lightSpeedManager.statusBarProvider.setLightSpeedStatusBarTooltip,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("different model updates the value and the tooltip", async () => {
+    h.lightSpeedManager.currentModelValue = "old-model";
+    await provide(
+      singleTaskDoc(),
+      singleTaskPos(),
+      ctx(h.InlineCompletionTriggerKind.Automatic),
+    );
+    expect(h.lightSpeedManager.currentModelValue).toBe("model-a");
+    expect(
+      h.lightSpeedManager.statusBarProvider.setLightSpeedStatusBarTooltip,
+    ).toHaveBeenCalled();
+  });
+});
+
+describe("command handler language/editor guards", () => {
+  it("inlineSuggestionTriggerHandler does nothing without an active editor", async () => {
+    h.window.activeTextEditor = undefined;
+    await sut.inlineSuggestionTriggerHandler();
+    expect(h.commands.executeCommand).not.toHaveBeenCalledWith(
+      "editor.action.inlineSuggest.trigger",
+    );
+  });
+
+  it("inlineSuggestionTriggerHandler does nothing for a non-ansible editor", async () => {
+    h.window.activeTextEditor = { document: { languageId: "plaintext" } };
+    await sut.inlineSuggestionTriggerHandler();
+    expect(h.commands.executeCommand).not.toHaveBeenCalledWith(
+      "editor.action.inlineSuggest.trigger",
+    );
+  });
+
+  it("inlineSuggestionTriggerHandler triggers for an ansible editor", async () => {
+    h.window.activeTextEditor = ansibleEditor();
+    await sut.inlineSuggestionTriggerHandler();
+    expect(h.commands.executeCommand).toHaveBeenCalledWith(
+      "editor.action.inlineSuggest.trigger",
+    );
+  });
+
+  it("inlineSuggestionReplaceMarker does nothing for a non-ansible editor", async () => {
+    const edit = vi.fn();
+    h.window.activeTextEditor = {
+      document: { languageId: "plaintext" },
+      edit,
+    };
+    await sut.inlineSuggestionReplaceMarker(new h.Position(1, 0));
+    expect(edit).not.toHaveBeenCalled();
+  });
+
+  it("inlineSuggestionHideHandler does nothing for a non-ansible editor", async () => {
+    h.window.activeTextEditor = { document: { languageId: "plaintext" } };
+    await sut.inlineSuggestionHideHandler();
+    expect(h.commands.executeCommand).not.toHaveBeenCalledWith(
+      "editor.action.inlineSuggest.hide",
+    );
+  });
+});
+
+describe("inlineSuggestionReplaceMarker whitespace cleanup", () => {
+  function markerEditor(currentLineText: string) {
+    const edit = vi.fn(async (cb: (b: unknown) => void) => {
+      cb({ delete: vi.fn() });
+    });
+    return {
+      document: {
+        languageId: "ansible",
+        lineAt: () => ({ text: currentLineText }),
+      },
+      selection: { active: { line: 3 } },
+      edit,
+    };
+  }
+
+  it("performs a second edit when the trailing line is all whitespace", async () => {
+    const editor = markerEditor("     ");
+    h.window.activeTextEditor = editor;
+    await sut.inlineSuggestionReplaceMarker(new h.Position(2, 0));
+    expect(editor.edit).toHaveBeenCalledTimes(2);
+  });
+
+  it("performs a single edit when the trailing line has content", async () => {
+    const editor = markerEditor("  key: value");
+    h.window.activeTextEditor = editor;
+    await sut.inlineSuggestionReplaceMarker(new h.Position(2, 0));
+    expect(editor.edit).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("inlineSuggestionHideHandler action switch", () => {
+  beforeEach(async () => {
+    h.window.activeTextEditor = ansibleEditor();
+    await arm();
+    h.lightSpeedManager.apiInstance.feedbackRequest.mockClear();
+  });
+
+  it("REJECTED action sends a feedback request", async () => {
+    await sut.inlineSuggestionHideHandler(UserAction.REJECTED, "sid-1");
+    expect(h.lightSpeedManager.apiInstance.feedbackRequest).toHaveBeenCalled();
+  });
+
+  it("IGNORED action sends a feedback request", async () => {
+    await sut.inlineSuggestionHideHandler(UserAction.IGNORED, "sid-1");
+    expect(h.lightSpeedManager.apiInstance.feedbackRequest).toHaveBeenCalled();
+  });
+
+  it("unknown action hits the default branch and still sends feedback", async () => {
+    await sut.inlineSuggestionHideHandler(99 as unknown as UserAction, "sid-1");
+    expect(h.lightSpeedManager.apiInstance.feedbackRequest).toHaveBeenCalled();
+  });
+
+  it("falls back to the stored suggestionId when none is provided", async () => {
+    await sut.inlineSuggestionHideHandler();
+    expect(h.lightSpeedManager.apiInstance.feedbackRequest).toHaveBeenCalled();
+  });
+});
+
+describe("inlineSuggestionHideHandler empty early return", () => {
+  it("returns after hiding when there is no suggestionId", async () => {
+    h.window.activeTextEditor = ansibleEditor();
+    await sut.inlineSuggestionHideHandler();
+    expect(h.commands.executeCommand).toHaveBeenCalledWith(
+      "editor.action.inlineSuggest.hide",
+    );
+    expect(
+      h.lightSpeedManager.apiInstance.feedbackRequest,
+    ).not.toHaveBeenCalled();
+  });
+});
+
+describe("inlineSuggestionCommitHandler", () => {
+  it("commits and exits early when there is no suggestionId", async () => {
+    await sut.inlineSuggestionCommitHandler();
+    expect(h.commands.executeCommand).toHaveBeenCalledWith(
+      "editor.action.inlineSuggest.commit",
+    );
+  });
+
+  it("commits and proceeds when a suggestionId is set", async () => {
+    h.window.activeTextEditor = undefined;
+    await arm();
+    h.commands.executeCommand.mockClear();
+    await sut.inlineSuggestionCommitHandler();
+    expect(h.commands.executeCommand).toHaveBeenCalledWith(
+      "editor.action.inlineSuggest.commit",
+    );
+  });
+});
+
+describe("rejectPendingSuggestion / ignorePendingSuggestion", () => {
+  it("rejectPendingSuggestion sends REJECTED feedback when armed and pending", async () => {
+    h.window.activeTextEditor = ansibleEditor();
+    await arm();
+    h.lightSpeedManager.apiInstance.feedbackRequest.mockClear();
+    await sut.rejectPendingSuggestion();
+    expect(h.lightSpeedManager.apiInstance.feedbackRequest).toHaveBeenCalled();
+  });
+
+  it("rejectPendingSuggestion does nothing when feedback is in progress", async () => {
+    h.window.activeTextEditor = ansibleEditor();
+    await arm();
+    h.lightSpeedManager.apiInstance.feedbackRequest.mockClear();
+    h.lightSpeedManager.apiInstance.isSuggestionFeedbackInProgress.mockReturnValue(
+      true,
+    );
+    await sut.rejectPendingSuggestion();
+    expect(
+      h.lightSpeedManager.apiInstance.feedbackRequest,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("rejectPendingSuggestion does nothing when inline suggestions are disabled", async () => {
+    h.window.activeTextEditor = ansibleEditor();
+    await arm();
+    h.lightSpeedManager.apiInstance.feedbackRequest.mockClear();
+    h.lightSpeedManager.inlineSuggestionsEnabled = false;
+    await sut.rejectPendingSuggestion();
+    expect(
+      h.lightSpeedManager.apiInstance.feedbackRequest,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("rejectPendingSuggestion resets when displayed but not pending", async () => {
+    // armed, but active editor is non-ansible so inlineSuggestionPending() is false
+    await arm();
+    h.lightSpeedManager.apiInstance.feedbackRequest.mockClear();
+    h.window.activeTextEditor = { document: { languageId: "plaintext" } };
+    await sut.rejectPendingSuggestion();
+    expect(
+      h.lightSpeedManager.apiInstance.feedbackRequest,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("rejectPendingSuggestion does nothing when nothing is displayed", async () => {
+    await sut.rejectPendingSuggestion();
+    expect(
+      h.lightSpeedManager.apiInstance.feedbackRequest,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("ignorePendingSuggestion sends IGNORED feedback when armed and pending", async () => {
+    await arm();
+    h.lightSpeedManager.apiInstance.feedbackRequest.mockClear();
+    await sut.ignorePendingSuggestion();
+    expect(h.lightSpeedManager.apiInstance.feedbackRequest).toHaveBeenCalled();
+  });
+
+  it("ignorePendingSuggestion does nothing when nothing is displayed", async () => {
+    await sut.ignorePendingSuggestion();
+    expect(
+      h.lightSpeedManager.apiInstance.feedbackRequest,
+    ).not.toHaveBeenCalled();
+  });
+});
+
+describe("additional branch coverage", () => {
+  it("reuses the existing activity tracker entry for the same document", async () => {
+    await arm(singleTaskPos());
+    expect(
+      Object.keys(h.lightSpeedManager.lightSpeedActivityTracker).length,
+    ).toBe(1);
+    // reset the displayed state via a NotForMe pass, then request again
+    await provide(
+      makeDoc(["x"], { languageId: "plaintext" }),
+      new h.Position(0, 0),
+      ctx(h.InlineCompletionTriggerKind.Automatic),
+    );
+    await arm(new h.Position(1, 4));
+    // same documentUri -> the tracker entry is reused, not re-inserted
+    expect(
+      Object.keys(h.lightSpeedManager.lightSpeedActivityTracker).length,
+    ).toBe(1);
+  });
+
+  it("single-task: prediction with no leading whitespace", async () => {
+    h.lightSpeedManager.providerManager.completionRequest.mockResolvedValue({
+      predictions: ["- name: no leading"],
+      suggestionId: "resp-sid",
+      model: "model-a",
+    });
+    const res = await provide(
+      singleTaskDoc(),
+      singleTaskPos(),
+      ctx(h.InlineCompletionTriggerKind.Automatic),
+    );
+    expect(res.length).toBe(1);
+  });
+
+  it("multi-task: prediction with no leading whitespace", async () => {
+    h.data.shouldTriggerMultiTaskSuggestion.mockReturnValue(true);
+    h.lightSpeedManager.providerManager.completionRequest.mockResolvedValue({
+      predictions: ["- name: no leading"],
+      suggestionId: "resp-sid",
+      model: "model-a",
+    });
+    const res = await provide(
+      multiTaskDoc(),
+      multiTaskPos(),
+      ctx(h.InlineCompletionTriggerKind.Automatic),
+    );
+    expect(res.length).toBe(1);
+  });
+
+  it("handles a prompt and cursor with no leading whitespace", async () => {
+    // prompt line has zero indentation and the current line is non-whitespace
+    const doc = makeDoc(["- name: install foo", "z"]);
+    await provide(
+      doc,
+      new h.Position(1, 1),
+      ctx(h.InlineCompletionTriggerKind.Invoke),
+    );
+    expect(h.window.showInformationMessage).toHaveBeenCalledWith(
+      expect.stringContaining("Cursor should be positioned"),
+    );
+  });
+});
+
+describe("inlineSuggestionTextDocumentChangeHandler", () => {
+  it("handles an accepted match and fetches training matches", async () => {
+    h.window.activeTextEditor = ansibleEditor();
+    const items = await arm();
+    const accepted = items[0].insertText as string;
+    h.lightSpeedManager.apiInstance.feedbackRequest.mockClear();
+    h.commands.executeCommand.mockClear();
+
+    await sut.inlineSuggestionTextDocumentChangeHandler({
+      document: { languageId: "ansible" },
+      contentChanges: [{ text: accepted }],
+    });
+    // flush the async forEach callback
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(h.lightSpeedManager.apiInstance.feedbackRequest).toHaveBeenCalled();
+    expect(h.commands.executeCommand).toHaveBeenCalledWith(
+      LightSpeedCommands.LIGHTSPEED_FETCH_TRAINING_MATCHES,
+    );
+  });
+
+  it("does nothing for a non-matching change", async () => {
+    h.window.activeTextEditor = ansibleEditor();
+    await arm();
+    h.lightSpeedManager.apiInstance.feedbackRequest.mockClear();
+    h.commands.executeCommand.mockClear();
+
+    await sut.inlineSuggestionTextDocumentChangeHandler({
+      document: { languageId: "ansible" },
+      contentChanges: [{ text: "something unrelated" }],
+    });
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(
+      h.lightSpeedManager.apiInstance.feedbackRequest,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when inline suggestions are disabled (guard false)", async () => {
+    h.window.activeTextEditor = ansibleEditor();
+    const items = await arm();
+    const accepted = items[0].insertText as string;
+    h.lightSpeedManager.apiInstance.feedbackRequest.mockClear();
+    h.lightSpeedManager.inlineSuggestionsEnabled = false;
+
+    await sut.inlineSuggestionTextDocumentChangeHandler({
+      document: { languageId: "ansible" },
+      contentChanges: [{ text: accepted }],
+    });
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(
+      h.lightSpeedManager.apiInstance.feedbackRequest,
+    ).not.toHaveBeenCalled();
+  });
+});

--- a/test/unit/lightspeed/views/ansibleCreatorUtils.test.ts
+++ b/test/unit/lightspeed/views/ansibleCreatorUtils.test.ts
@@ -13,7 +13,9 @@ vi.mock("vscode", () => {
       return { path: joined, fsPath: joined, toString: () => joined };
     },
   };
-  return { Uri, Webview: class {} };
+  // eslint-disable-next-line @typescript-eslint/no-extraneous-class
+  class Webview {}
+  return { Uri, Webview };
 });
 
 // Real semver for everything; just make the named exports overridable so we can
@@ -43,7 +45,9 @@ vi.mock("@src/features/utils/commandRunner", () => ({
 vi.mock("@src/settings", () => ({
   SettingsManager: class {
     settings = {};
-    async initialize() {}
+    async initialize() {
+      /* no-op */
+    }
   },
 }));
 

--- a/test/unit/lightspeed/views/ansibleCreatorUtils.test.ts
+++ b/test/unit/lightspeed/views/ansibleCreatorUtils.test.ts
@@ -1,0 +1,528 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import * as semver from "semver";
+
+// Use an elaborate vscode mock so Uri.parse/joinPath behave like the real API
+// (the shared mocks/vscode.ts returns undefined from Uri.parse which breaks the
+// collection path logic in runInitCommand).
+vi.mock("vscode", () => {
+  const Uri = {
+    parse: (s: string) => ({ path: s, fsPath: s, toString: () => s }),
+    joinPath: (base: { path?: string; fsPath?: string }, ...segs: string[]) => {
+      const joined = [base.path ?? base.fsPath ?? "", ...segs].join("/");
+      return { path: joined, fsPath: joined, toString: () => joined };
+    },
+  };
+  return { Uri, Webview: class {} };
+});
+
+// Real semver for everything; just make the named exports overridable so we can
+// force gte() to throw for the catch-arm test.
+vi.mock("semver", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("semver")>();
+  return {
+    ...actual,
+    default: actual,
+    valid: vi.fn(actual.valid),
+    coerce: vi.fn(actual.coerce),
+    gte: vi.fn(actual.gte),
+  };
+});
+
+vi.mock("@src/features/contentCreator/utils", () => ({
+  getADEVersion: vi.fn(),
+  getCreatorVersion: vi.fn(),
+  getBinDetail: vi.fn(),
+  runCommand: vi.fn(),
+}));
+
+vi.mock("@src/features/utils/commandRunner", () => ({
+  withInterpreter: vi.fn(),
+}));
+
+vi.mock("@src/settings", () => ({
+  SettingsManager: class {
+    settings = {};
+    async initialize() {}
+  },
+}));
+
+// Import after mocks
+import { AnsibleCreatorOperations } from "@src/features/lightspeed/vue/views/ansibleCreatorUtils";
+import {
+  getADEVersion,
+  getCreatorVersion,
+  getBinDetail,
+  runCommand,
+} from "@src/features/contentCreator/utils";
+import { withInterpreter } from "@src/features/utils/commandRunner";
+import type {
+  AnsibleCollectionFormInterface,
+  AnsibleProjectFormInterface,
+  RoleFormInterface,
+  PluginFormInterface,
+} from "@src/features/contentCreator/types";
+
+type Web = { postMessage: ReturnType<typeof vi.fn> };
+
+function makeWeb(): Web {
+  return { postMessage: vi.fn() };
+}
+
+// Returns the commandOutput of the last execution-log postMessage.
+function lastOutput(web: Web): string {
+  const calls = web.postMessage.mock.calls;
+  return calls[calls.length - 1][0].arguments.commandOutput as string;
+}
+
+function lastArgs(web: Web): Record<string, unknown> {
+  const calls = web.postMessage.mock.calls;
+  return calls[calls.length - 1][0].arguments as Record<string, unknown>;
+}
+
+// The command string handed to withInterpreter (the assembled ansible-creator cmd).
+function interpreterCmd(callIndex = 0): string {
+  return vi.mocked(withInterpreter).mock.calls[callIndex][1] as string;
+}
+
+function rolePayload(o: Partial<RoleFormInterface> = {}): RoleFormInterface {
+  return {
+    roleName: "myrole",
+    collectionPath: "",
+    verbosity: "off",
+    isOverwritten: false,
+    ...o,
+  };
+}
+
+function pluginPayload(
+  o: Partial<PluginFormInterface> = {},
+): PluginFormInterface {
+  return {
+    pluginName: "myplugin",
+    pluginType: "module",
+    collectionPath: "",
+    verbosity: "off",
+    isOverwritten: false,
+    ...o,
+  };
+}
+
+function collectionPayload(
+  o: Partial<AnsibleCollectionFormInterface> = {},
+): AnsibleCollectionFormInterface {
+  return {
+    namespaceName: "ns",
+    collectionName: "col",
+    initPath: "/tmp/init",
+    verbosity: "off",
+    logToFile: false,
+    logFilePath: "",
+    logFileAppend: false,
+    logLevel: "debug",
+    isOverwritten: false,
+    isEditableModeInstall: false,
+    ...o,
+  };
+}
+
+function projectPayload(
+  o: Partial<AnsibleProjectFormInterface> = {},
+): AnsibleProjectFormInterface {
+  return {
+    destinationPath: "/tmp/proj",
+    namespaceName: "ns",
+    collectionName: "col",
+    verbosity: "off",
+    logToFile: false,
+    logFilePath: "",
+    logFileAppend: false,
+    logLevel: "debug",
+    isOverwritten: false,
+    ...o,
+  };
+}
+
+describe("AnsibleCreatorOperations", () => {
+  let ops: AnsibleCreatorOperations;
+
+  beforeEach(() => {
+    // clearAllMocks wipes call history but keeps the base vi.fn(actual.*)
+    // implementations, so real semver behavior is restored after a per-test
+    // mockImplementationOnce override is consumed.
+    vi.clearAllMocks();
+    vi.mocked(getCreatorVersion).mockResolvedValue("25.5.0");
+    vi.mocked(getADEVersion).mockResolvedValue("25.4.0");
+    vi.mocked(getBinDetail).mockResolvedValue("ade 25.4.0");
+    vi.mocked(runCommand).mockResolvedValue({
+      output: "creator-output\n",
+      status: "passed",
+    } as never);
+    vi.mocked(withInterpreter).mockImplementation(
+      async (_settings: unknown, command: string) =>
+        ({ command, env: { TEST: "1" } }) as never,
+    );
+    ops = new AnsibleCreatorOperations();
+  });
+
+  describe("checkVersionWithError", () => {
+    const call = (cur: string, req: string) =>
+      (
+        ops as unknown as {
+          checkVersionWithError: (
+            c: string,
+            r: string,
+          ) => { isGte: boolean; userMessage?: string };
+        }
+      ).checkVersionWithError(cur, req);
+
+    it("returns isGte true for a valid semver that satisfies the requirement", () => {
+      expect(call("25.5.0", "25.4.0")).toEqual({ isGte: true });
+    });
+
+    it("coerces a non-strict version like 'v25.4'", () => {
+      expect(call("v25.4", "25.0.0")).toEqual({ isGte: true });
+    });
+
+    it("returns userMessage for an un-parseable version", () => {
+      expect(call("garbage", "1.0.0")).toEqual({
+        isGte: false,
+        userMessage: "Invalid version format: garbage.\n",
+      });
+    });
+
+    it("hits the catch arm when semver.gte throws", () => {
+      vi.mocked(semver.gte).mockImplementationOnce(() => {
+        throw new Error("boom");
+      });
+      expect(call("1.2.3", "1.0.0")).toEqual({
+        isGte: false,
+        userMessage: "Invalid version format: 1.2.3.\n",
+      });
+    });
+  });
+
+  describe("runRoleAddCommand", () => {
+    it("reports failure and skips runCommand when ansible-creator is missing", async () => {
+      vi.mocked(getCreatorVersion).mockResolvedValue("failed");
+      const web = makeWeb();
+      await ops.runRoleAddCommand(rolePayload(), web);
+      expect(runCommand).not.toHaveBeenCalled();
+      expect(lastArgs(web).status).toBe("failed");
+      expect(lastOutput(web)).toContain("ansible-creator is not installed");
+    });
+
+    it("adds --overwrite and the correct verbosity flag, defaulting the collection path", async () => {
+      const web = makeWeb();
+      await ops.runRoleAddCommand(
+        rolePayload({ isOverwritten: true, verbosity: "high" }),
+        web,
+      );
+      expect(interpreterCmd()).toContain("--overwrite");
+      expect(interpreterCmd()).toContain(" -vvv");
+      // default destination path used
+      expect(lastArgs(web).projectUrl).toContain(
+        "/.ansible/collections/ansible_collections",
+      );
+    });
+
+    it.each([
+      ["off", ""],
+      ["low", " -v"],
+      ["medium", " -vv"],
+      ["high", " -vvv"],
+      ["bogus", ""],
+    ])(
+      "maps verbosity %s -> %s and uses --no-overwrite",
+      async (verbosity, flag) => {
+        const web = makeWeb();
+        await ops.runRoleAddCommand(
+          rolePayload({ verbosity, isOverwritten: false }),
+          web,
+        );
+        const cmd = interpreterCmd();
+        expect(cmd).toContain("--no-overwrite");
+        if (flag) {
+          expect(cmd).toContain(flag);
+        }
+      },
+    );
+
+    it("runs the command when the version gate passes", async () => {
+      const web = makeWeb();
+      await ops.runRoleAddCommand(rolePayload(), web);
+      expect(runCommand).toHaveBeenCalledTimes(1);
+      expect(lastArgs(web).status).toBe("passed");
+      expect(lastOutput(web)).toContain("creator-output");
+    });
+
+    it("emits the minimum-version message when the gate fails without a userMessage", async () => {
+      vi.mocked(getCreatorVersion).mockResolvedValue("25.3.0");
+      const web = makeWeb();
+      await ops.runRoleAddCommand(rolePayload(), web);
+      expect(runCommand).not.toHaveBeenCalled();
+      expect(lastArgs(web).status).toBe("failed");
+      expect(lastOutput(web)).toContain(
+        "Minimum ansible-creator version needed to add the role",
+      );
+    });
+
+    it("appends the userMessage when the version is un-parseable", async () => {
+      vi.mocked(getCreatorVersion).mockResolvedValue("garbage");
+      const web = makeWeb();
+      await ops.runRoleAddCommand(rolePayload(), web);
+      expect(runCommand).not.toHaveBeenCalled();
+      expect(lastOutput(web)).toContain("Invalid version format: garbage.");
+      expect(lastOutput(web)).not.toContain("Minimum ansible-creator version");
+    });
+  });
+
+  describe("runPluginAddCommand", () => {
+    it("reports failure and skips runCommand when ansible-creator is missing", async () => {
+      vi.mocked(getCreatorVersion).mockResolvedValue(undefined as never);
+      const web = makeWeb();
+      await ops.runPluginAddCommand(pluginPayload(), web);
+      expect(runCommand).not.toHaveBeenCalled();
+      expect(lastArgs(web).status).toBe("failed");
+      expect(lastOutput(web)).toContain("ansible-creator is not installed");
+    });
+
+    it.each(["lookup", "filter", "action", "module", "test"])(
+      "passes the version gate for plugin type %s",
+      async (pluginType) => {
+        const web = makeWeb();
+        await ops.runPluginAddCommand(
+          pluginPayload({ pluginType, isOverwritten: true, verbosity: "low" }),
+          web,
+        );
+        expect(runCommand).toHaveBeenCalledTimes(1);
+        const cmd = interpreterCmd();
+        expect(cmd).toContain(`add plugin ${pluginType}`);
+        expect(cmd).toContain("--overwrite");
+        expect(cmd).toContain(" -v");
+        expect(lastArgs(web).status).toBe("passed");
+      },
+    );
+
+    it("emits the minimum-version message for a plugin when the gate fails", async () => {
+      vi.mocked(getCreatorVersion).mockResolvedValue("24.0.0");
+      const web = makeWeb();
+      await ops.runPluginAddCommand(pluginPayload({ pluginType: "test" }), web);
+      expect(runCommand).not.toHaveBeenCalled();
+      expect(lastOutput(web)).toContain(
+        "Minimum ansible-creator version needed to add the test plugin",
+      );
+    });
+  });
+
+  describe("runInitCommand", () => {
+    it("builds an init-collection command and posts collectionUrl", async () => {
+      const web = makeWeb();
+      await ops.runInitCommand(
+        collectionPayload({ initPath: "/tmp/init" }),
+        web,
+      );
+      const cmd = interpreterCmd();
+      expect(cmd).toContain("init collection ns.col");
+      expect(lastArgs(web).collectionUrl).toBe("/tmp/init");
+      expect(lastArgs(web).projectUrl).toBeUndefined();
+    });
+
+    it("joins namespace/collection when initPath ends with the collections root", async () => {
+      const web = makeWeb();
+      await ops.runInitCommand(
+        collectionPayload({
+          initPath: "/home/collections/ansible_collections",
+        }),
+        web,
+      );
+      expect(lastArgs(web).collectionUrl).toBe(
+        "/home/collections/ansible_collections/ns/col",
+      );
+    });
+
+    it("builds an init-playbook command and posts projectUrl", async () => {
+      const web = makeWeb();
+      await ops.runInitCommand(
+        projectPayload({ destinationPath: "/tmp/proj" }),
+        web,
+      );
+      const cmd = interpreterCmd();
+      expect(cmd).toContain("init playbook ns.col");
+      expect(lastArgs(web).projectUrl).toBe("/tmp/proj");
+      expect(lastArgs(web).collectionUrl).toBeUndefined();
+    });
+
+    it("falls back to homedir when project destinationPath is empty", async () => {
+      const web = makeWeb();
+      await ops.runInitCommand(projectPayload({ destinationPath: "" }), web);
+      expect(typeof lastArgs(web).projectUrl).toBe("string");
+      expect(lastArgs(web).projectUrl).not.toBe("");
+    });
+
+    it("creator-missing early return for a collection payload", async () => {
+      vi.mocked(getCreatorVersion).mockResolvedValue("failed");
+      const web = makeWeb();
+      await ops.runInitCommand(collectionPayload(), web);
+      expect(runCommand).not.toHaveBeenCalled();
+      expect(lastArgs(web).collectionUrl).toBeDefined();
+      expect(lastArgs(web).projectUrl).toBeUndefined();
+      expect(lastArgs(web).status).toBe("failed");
+    });
+
+    it("creator-missing early return for a project payload", async () => {
+      vi.mocked(getCreatorVersion).mockResolvedValue("failed");
+      const web = makeWeb();
+      await ops.runInitCommand(projectPayload(), web);
+      expect(runCommand).not.toHaveBeenCalled();
+      expect(lastArgs(web).projectUrl).toBeDefined();
+      expect(lastArgs(web).collectionUrl).toBeUndefined();
+    });
+
+    it.each([
+      ["25.5.0", true, "--overwrite"],
+      ["24.0.0", true, "--force"],
+      ["25.5.0", false, "--no-overwrite"],
+    ])(
+      "overwrite matrix version=%s isOverwritten=%s -> %s",
+      async (version, isOverwritten, expected) => {
+        vi.mocked(getCreatorVersion).mockResolvedValue(version);
+        const web = makeWeb();
+        await ops.runInitCommand(projectPayload({ isOverwritten }), web);
+        expect(interpreterCmd()).toContain(expected);
+      },
+    );
+
+    it("adds no overwrite flag when version is old and not overwritten", async () => {
+      vi.mocked(getCreatorVersion).mockResolvedValue("24.0.0");
+      const web = makeWeb();
+      await ops.runInitCommand(projectPayload({ isOverwritten: false }), web);
+      const cmd = interpreterCmd();
+      expect(cmd).not.toContain("--overwrite");
+      expect(cmd).not.toContain("--force");
+      expect(cmd).not.toContain("--no-overwrite");
+    });
+
+    it("omits log flags when logToFile is false", async () => {
+      const web = makeWeb();
+      await ops.runInitCommand(projectPayload({ logToFile: false }), web);
+      expect(interpreterCmd()).not.toContain("--lf=");
+    });
+
+    it("uses an explicit log file path for a collection (--la=<append>)", async () => {
+      const web = makeWeb();
+      await ops.runInitCommand(
+        collectionPayload({
+          logToFile: true,
+          logFilePath: "/var/log/c.log",
+          logFileAppend: true,
+        }),
+        web,
+      );
+      const cmd = interpreterCmd();
+      expect(cmd).toContain("--lf=/var/log/c.log");
+      expect(cmd).toContain("--la=true");
+    });
+
+    it("defaults the log file path to tmpdir and uses boolean --la for a project", async () => {
+      const web = makeWeb();
+      await ops.runInitCommand(
+        projectPayload({
+          logToFile: true,
+          logFilePath: "",
+          logFileAppend: false,
+        }),
+        web,
+      );
+      const cmd = interpreterCmd();
+      expect(cmd).toContain("ansible-creator.log");
+      expect(cmd).toContain("--la=false");
+    });
+
+    it("installs in editable mode when ADE version is high enough", async () => {
+      vi.mocked(getADEVersion).mockResolvedValue("25.4.0");
+      const web = makeWeb();
+      await ops.runInitCommand(
+        collectionPayload({ isEditableModeInstall: true }),
+        web,
+      );
+      // second withInterpreter call is the ADE command with --im=cfg
+      const adeCmd = vi.mocked(withInterpreter).mock.calls[1][1] as string;
+      expect(adeCmd).toContain("--im=cfg");
+      // runCommand called for both creator and ADE
+      expect(runCommand).toHaveBeenCalledTimes(2);
+    });
+
+    it("reports the editable-mode failure when ADE version is too low", async () => {
+      vi.mocked(getADEVersion).mockResolvedValue("1.0.0");
+      const web = makeWeb();
+      await ops.runInitCommand(
+        collectionPayload({ isEditableModeInstall: true }),
+        web,
+      );
+      expect(lastOutput(web)).toContain(
+        "Collection could not be installed in editable mode",
+      );
+      // only the creator command ran
+      expect(runCommand).toHaveBeenCalledTimes(1);
+    });
+
+    it("skips the ADE block when editable mode is disabled", async () => {
+      const web = makeWeb();
+      await ops.runInitCommand(
+        collectionPayload({ isEditableModeInstall: false }),
+        web,
+      );
+      expect(getADEVersion).not.toHaveBeenCalled();
+      expect(runCommand).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("isADEPresent", () => {
+    it("posts ADEPresence false when ade is not found", async () => {
+      vi.mocked(getBinDetail).mockResolvedValue("failed");
+      const web = makeWeb();
+      await ops.isADEPresent(web as never);
+      expect(web.postMessage).toHaveBeenCalledWith({
+        command: "ADEPresence",
+        arguments: false,
+      });
+    });
+
+    it("posts ADEPresence true when ade is found", async () => {
+      vi.mocked(getBinDetail).mockResolvedValue("ade 25.4.0");
+      const web = makeWeb();
+      await ops.isADEPresent(web as never);
+      expect(web.postMessage).toHaveBeenCalledWith({
+        command: "ADEPresence",
+        arguments: true,
+      });
+    });
+  });
+
+  describe("version-syntax command builders", () => {
+    it("getCollectionCreatorCommand uses new syntax on a recent version", async () => {
+      vi.mocked(getCreatorVersion).mockResolvedValue("25.5.0");
+      const cmd = await ops.getCollectionCreatorCommand("ns", "col", "/tmp");
+      expect(cmd).toBe("ansible-creator init collection ns.col /tmp --no-ansi");
+    });
+
+    it("getCollectionCreatorCommand uses legacy syntax on an old version", async () => {
+      vi.mocked(getCreatorVersion).mockResolvedValue("24.0.0");
+      const cmd = await ops.getCollectionCreatorCommand("ns", "col", "/tmp");
+      expect(cmd).toContain("--init-path=/tmp");
+    });
+
+    it("getPlaybookCreatorCommand uses new syntax on a recent version", async () => {
+      vi.mocked(getCreatorVersion).mockResolvedValue("25.5.0");
+      const cmd = await ops.getPlaybookCreatorCommand("ns", "col", "/tmp");
+      expect(cmd).toBe("ansible-creator init playbook ns.col /tmp --no-ansi");
+    });
+
+    it("getPlaybookCreatorCommand uses legacy syntax on an old version", async () => {
+      vi.mocked(getCreatorVersion).mockResolvedValue("24.0.0");
+      const cmd = await ops.getPlaybookCreatorCommand("ns", "col", "/tmp");
+      expect(cmd).toContain("--scm-org=ns");
+      expect(cmd).toContain("--scm-project=col");
+    });
+  });
+});

--- a/test/unit/lightspeed/views/ansibleCreatorUtils.test.ts
+++ b/test/unit/lightspeed/views/ansibleCreatorUtils.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import * as semver from "semver";
+import type { Webview } from "vscode";
 
 // Use an elaborate vscode mock so Uri.parse/joinPath behave like the real API
 // (the shared mocks/vscode.ts returns undefined from Uri.parse which breaks the
@@ -62,10 +63,12 @@ import type {
   PluginFormInterface,
 } from "@src/features/contentCreator/types";
 
-type Web = { postMessage: ReturnType<typeof vi.fn> };
+// Intersect with Webview so the fake is assignable to the SUT's
+// vscode.Webview parameters, while keeping postMessage typed as a vi mock.
+type Web = Webview & { postMessage: ReturnType<typeof vi.fn> };
 
 function makeWeb(): Web {
-  return { postMessage: vi.fn() };
+  return { postMessage: vi.fn() } as unknown as Web;
 }
 
 // Returns the commandOutput of the last execution-log postMessage.
@@ -152,7 +155,7 @@ describe("AnsibleCreatorOperations", () => {
     vi.clearAllMocks();
     vi.mocked(getCreatorVersion).mockResolvedValue("25.5.0");
     vi.mocked(getADEVersion).mockResolvedValue("25.4.0");
-    vi.mocked(getBinDetail).mockResolvedValue("ade 25.4.0");
+    vi.mocked(getBinDetail).mockResolvedValue("ade 25.4.0" as never);
     vi.mocked(runCommand).mockResolvedValue({
       output: "creator-output\n",
       status: "passed",
@@ -489,7 +492,7 @@ describe("AnsibleCreatorOperations", () => {
     });
 
     it("posts ADEPresence true when ade is found", async () => {
-      vi.mocked(getBinDetail).mockResolvedValue("ade 25.4.0");
+      vi.mocked(getBinDetail).mockResolvedValue("ade 25.4.0" as never);
       const web = makeWeb();
       await ops.isADEPresent(web as never);
       expect(web.postMessage).toHaveBeenCalledWith({


### PR DESCRIPTION
## Summary

Continues the SonarQube coverage push for lightspeed code (follows #2882, #2884, #2893, #2959, #2960, #2961). Tackles the two branch-heaviest files — both ~100% line coverage but very low branch coverage.

| File | Branch before | Branch after |
|---|---|---|
| `lightspeed/inlineSuggestions.ts` | 11.8% | ~91.3% |
| `lightspeed/vue/views/ansibleCreatorUtils.ts` | 0% | ~94.8% |

## What's covered
**inlineSuggestions.ts** (55 tests): `getCompletionState` state machine, WCA apiEndpoint matrix, `getInlineSuggestionState` reject/dispatch, `onUnexpectedPrompt` messages, single/multi suggestion happy + empty-prediction paths, `isDocumentChangedImmediately` (fake timers), `loadFile` YAML failure, `requestSuggestion` error arms, `requestInlineSuggest` model branches, command-handler guards, `inlineSuggestionReplaceMarker` whitespace cleanup, hide-handler action switch, commit handler, reject/ignore-pending matrix, and the accepted-match text-change path.

**ansibleCreatorUtils.ts** (43 tests, real module — not scaffolding's mock): `checkVersionWithError`, `runRoleAddCommand` / `runPluginAddCommand` (creator-missing, overwrite × verbosity matrix, version gating, plugin-type lookup), `runInitCommand` (collection-vs-project, 3-way overwrite, logToFile, ADE editable mode), `isADEPresent`, creator-command version-syntax ternaries.

## Remaining uncovered (intentional — defensive/unreachable)
A handful of inverse arms in `inlineSuggestions.ts` are not naturally producible: `onUnexpectedPrompt` non-Invoke branches (only dispatched on Invoke), `loadFile` empty-range/non-Error arms (never reached at line 0,0 / yaml only throws Error), and `!editor` guards that follow a `languageId === "ansible"` check (editor is necessarily defined). `suggestionDisplayed`/`suggestionId` are always set/cleared together, so "displayed-but-no-id" arms can't occur. Both files are comfortably above the 90% target.

## Testing
Test-only change — no production source modified.

```
npx vitest run --project ext test/unit/lightspeed/inlineSuggestions.test.ts test/unit/lightspeed/views/ansibleCreatorUtils.test.ts
# Test Files 2 passed (2) · Tests 98 passed (98)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Added branch-coverage Vitest tests for `lightspeed/inlineSuggestions.ts` and `lightspeed/vue/views/ansibleCreatorUtils.ts`, targeting guarded paths, version gates, command handlers, error handling, and feedback flows that were previously low-branch-coverage.
- Original commit message: broaden branch coverage for Lightspeed inline suggestions and Ansible creator utilities, then fix type/lint/cspell issues and SonarCloud assertion expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->