### PR TITLE
chore: webview coverage exclusions + unit tests for lightspeed webviews

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -58,6 +58,7 @@ esbuild
 eslintcache
 ffdx
 fqcn
+fqcns
 geckodriver
 genai
 haaaad

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,7 @@
 # cspell: ignore multicriteria
 # sonar does not support cobertura coverage xml format, only lcov.info
 # Disable insecure os command execution inside tests
-sonar.coverage.exclusions=out/server/external,out/server/node_modules
+sonar.coverage.exclusions=out/server/external,out/server/node_modules,webviews/lightspeed/src/explanation.ts,webviews/lightspeed/src/hello-world.ts,webviews/lightspeed/src/playbook-generation.ts,webviews/lightspeed/src/role-generation.ts,webviews/lightspeed/src/HelloWorld.vue,webviews/lightspeed/src/explorer.ts
 sonar.debug=true
 sonar.issue.ignore.multicriteria.e1.resourceKey=**/test/**/*
 sonar.issue.ignore.multicriteria.e1.ruleKey=typescript:S4721

--- a/test/unit/webviews/lightspeed/components/CollectionSelector.test.ts
+++ b/test/unit/webviews/lightspeed/components/CollectionSelector.test.ts
@@ -152,4 +152,31 @@ describe("CollectionSelector", () => {
 
     expect(wrapper.emitted("update:collectionName")).toBeTruthy();
   });
+
+  it("filters fqcns on complete", async () => {
+    const wrapper = mount(CollectionSelector, {
+      props: { collectionName: "" },
+    });
+
+    const handler = vi
+      .mocked(vscodeApi.on)
+      .mock.calls.find((call) => call[0] === "getCollectionList")?.[1];
+    void handler?.([
+      { fqcn: "my.one", path: "/a" },
+      { fqcn: "other.two", path: "/b" },
+    ]);
+    await flushPromises();
+
+    const ac = wrapper.findComponent({ name: "AutoComplete" });
+
+    // empty query -> all fqcns
+    ac.vm.$emit("complete", { query: "" });
+    await flushPromises();
+    expect(ac.props("suggestions")).toEqual(["my.one", "other.two"]);
+
+    // prefix query -> filtered to fqcns starting with "my"
+    ac.vm.$emit("complete", { query: "my" });
+    await flushPromises();
+    expect(ac.props("suggestions")).toEqual(["my.one"]);
+  });
 });

--- a/test/unit/webviews/lightspeed/components/ErrorBox.test.ts
+++ b/test/unit/webviews/lightspeed/components/ErrorBox.test.ts
@@ -94,14 +94,14 @@ describe("ErrorBox", () => {
 
     expect(wrapper.find("#errorContainer").exists()).toBe(true);
     const entries = wrapper.findAllComponents({ name: "ErrorBoxEntry" });
-    expect(entries.length).toBe(1);
+    expect(entries).toHaveLength(1);
     expect(entries[0].props("message")).toBe("boom");
   });
 
   it("renders one entry per item in a non-empty model", () => {
     const messages = ["a", "b", "c", "d"];
     const wrapper = mount(ErrorBox, { props: { errorMessages: messages } });
-    expect(wrapper.findAllComponents({ name: "ErrorBoxEntry" }).length).toBe(
+    expect(wrapper.findAllComponents({ name: "ErrorBoxEntry" })).toHaveLength(
       messages.length,
     );
   });

--- a/test/unit/webviews/lightspeed/components/ErrorBox.test.ts
+++ b/test/unit/webviews/lightspeed/components/ErrorBox.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { mount } from "@vue/test-utils";
+import { mount, flushPromises } from "@vue/test-utils";
 import ErrorBox from "@webviews/lightspeed/src/components/ErrorBox.vue";
 import { vscodeApi } from "@webviews/lightspeed/src/utils/vscode";
 
@@ -81,5 +81,28 @@ describe("ErrorBox", () => {
       },
     });
     expect(wrapper.find("ul#errorContainer").exists()).toBe(true);
+  });
+
+  it("renders an entry and container when a message arrives from vscode", async () => {
+    const wrapper = mount(ErrorBox, { props: { errorMessages: [] } });
+
+    const handler = vi
+      .mocked(vscodeApi.on)
+      .mock.calls.find((call) => call[0] === "errorMessage")?.[1];
+    void handler?.("boom");
+    await flushPromises();
+
+    expect(wrapper.find("#errorContainer").exists()).toBe(true);
+    const entries = wrapper.findAllComponents({ name: "ErrorBoxEntry" });
+    expect(entries.length).toBe(1);
+    expect(entries[0].props("message")).toBe("boom");
+  });
+
+  it("renders one entry per item in a non-empty model", () => {
+    const messages = ["a", "b", "c", "d"];
+    const wrapper = mount(ErrorBox, { props: { errorMessages: messages } });
+    expect(wrapper.findAllComponents({ name: "ErrorBoxEntry" }).length).toBe(
+      messages.length,
+    );
   });
 });

--- a/test/unit/webviews/lightspeed/components/ProviderConfigForm.test.ts
+++ b/test/unit/webviews/lightspeed/components/ProviderConfigForm.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import ProviderConfigForm from "@webviews/lightspeed/src/components/ProviderConfigForm.vue";
+import type { ProviderInfo } from "@webviews/lightspeed/src/components/llmProviderState";
+
+function makeProvider(): ProviderInfo {
+  return {
+    type: "wca",
+    name: "wca",
+    displayName: "WCA",
+    description: "",
+    defaultEndpoint: "",
+    configSchema: [
+      {
+        key: "apiKey",
+        label: "API Key",
+        type: "password",
+        required: true,
+        placeholder: "",
+        description: "Your secret API key",
+      },
+      {
+        key: "apiEndpoint",
+        label: "Endpoint",
+        type: "text",
+        required: false,
+        placeholder: "https://...",
+        description: "",
+      },
+    ],
+  };
+}
+
+function mountForm(hasChanges = false) {
+  return mount(ProviderConfigForm, {
+    props: {
+      provider: makeProvider(),
+      getConfigValue: (_t: string, key: string) =>
+        key === "apiKey" ? "secret" : "endpoint",
+      hasChanges,
+    },
+  });
+}
+
+describe("ProviderConfigForm", () => {
+  it("renders one .config-field per configSchema entry", () => {
+    const wrapper = mountForm();
+    expect(wrapper.findAll(".config-field").length).toBe(2);
+  });
+
+  it("renders a required indicator only for required fields", () => {
+    const wrapper = mountForm();
+    expect(wrapper.findAll(".required-indicator").length).toBe(1);
+  });
+
+  it("renders a field description when present", () => {
+    const wrapper = mountForm();
+    const descriptions = wrapper.findAll(".field-description");
+    expect(descriptions.length).toBe(1);
+    expect(descriptions[0].text()).toContain("Your secret API key");
+  });
+
+  it("renders password fields with type=password", () => {
+    const wrapper = mountForm();
+    const apiKeyInput = wrapper.find("#apiKey-wca");
+    expect(apiKeyInput.attributes("type")).toBe("password");
+    const endpointInput = wrapper.find("#apiEndpoint-wca");
+    expect(endpointInput.attributes("type")).toBe("text");
+  });
+
+  it("emits update:field with key and value on input", async () => {
+    const wrapper = mountForm();
+    const endpointInput = wrapper.find("#apiEndpoint-wca");
+    await endpointInput.setValue("https://example.com");
+    const emitted = wrapper.emitted("update:field");
+    expect(emitted).toBeTruthy();
+    expect(emitted?.[0]).toEqual(["apiEndpoint", "https://example.com"]);
+  });
+
+  it("emits save and cancel on the respective buttons", async () => {
+    const wrapper = mountForm();
+    await wrapper.find(".save-btn").trigger("click");
+    await wrapper.find(".cancel-btn").trigger("click");
+    expect(wrapper.emitted("save")).toBeTruthy();
+    expect(wrapper.emitted("cancel")).toBeTruthy();
+  });
+
+  it("shows has-changes and unsaved indicator when hasChanges is true", () => {
+    const wrapper = mountForm(true);
+    expect(wrapper.find(".save-btn").classes()).toContain("has-changes");
+    expect(wrapper.find(".unsaved-indicator").exists()).toBe(true);
+  });
+
+  it("hides the unsaved indicator when hasChanges is false", () => {
+    const wrapper = mountForm(false);
+    expect(wrapper.find(".save-btn").classes()).not.toContain("has-changes");
+    expect(wrapper.find(".unsaved-indicator").exists()).toBe(false);
+  });
+});

--- a/test/unit/webviews/lightspeed/components/ProviderConfigForm.test.ts
+++ b/test/unit/webviews/lightspeed/components/ProviderConfigForm.test.ts
@@ -45,18 +45,18 @@ function mountForm(hasChanges = false) {
 describe("ProviderConfigForm", () => {
   it("renders one .config-field per configSchema entry", () => {
     const wrapper = mountForm();
-    expect(wrapper.findAll(".config-field").length).toBe(2);
+    expect(wrapper.findAll(".config-field")).toHaveLength(2);
   });
 
   it("renders a required indicator only for required fields", () => {
     const wrapper = mountForm();
-    expect(wrapper.findAll(".required-indicator").length).toBe(1);
+    expect(wrapper.findAll(".required-indicator")).toHaveLength(1);
   });
 
   it("renders a field description when present", () => {
     const wrapper = mountForm();
     const descriptions = wrapper.findAll(".field-description");
-    expect(descriptions.length).toBe(1);
+    expect(descriptions).toHaveLength(1);
     expect(descriptions[0].text()).toContain("Your secret API key");
   });
 

--- a/test/unit/webviews/lightspeed/components/SavedFiles.test.ts
+++ b/test/unit/webviews/lightspeed/components/SavedFiles.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+import SavedFiles from "@webviews/lightspeed/src/components/SavedFiles.vue";
+import { vscodeApi } from "@webviews/lightspeed/src/utils/vscode";
+import { RoleFileType } from "@src/interfaces/lightspeed";
+
+// NOTE: the `roleLocation` v-if block in SavedFiles.vue is dead code -- the ref
+// is initialised to "" and never reassigned, so those two template conditions
+// stay intentionally uncovered.
+
+describe("SavedFiles", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("posts writeRoleInWorkspace on mount with the mapped file payload", async () => {
+    vi.mocked(vscodeApi.postAndReceive).mockResolvedValueOnce([]);
+
+    mount(SavedFiles, {
+      props: {
+        files: [
+          {
+            path: "tasks/main.yml",
+            file_type: RoleFileType.Task,
+            content: "x",
+          },
+          {
+            path: "defaults/main.yml",
+            file_type: RoleFileType.Default,
+            content: "y",
+          },
+        ],
+        roleName: "myrole",
+        collectionName: "ns.coll",
+      },
+    });
+    await flushPromises();
+
+    expect(vscodeApi.postAndReceive).toHaveBeenCalledWith(
+      "writeRoleInWorkspace",
+      {
+        files: [
+          ["tasks/main.yml", "x", RoleFileType.Task],
+          ["defaults/main.yml", "y", RoleFileType.Default],
+        ],
+        collectionName: "ns.coll",
+        roleName: "myrole",
+      },
+    );
+  });
+
+  it("renders one SavedFilesEntry per resolved entry", async () => {
+    vi.mocked(vscodeApi.postAndReceive).mockResolvedValueOnce([
+      { longPath: "/a/tasks/main.yml", command: "open-a" },
+      { longPath: "/a/defaults/main.yml", command: "open-b" },
+    ]);
+
+    const wrapper = mount(SavedFiles, {
+      props: {
+        files: [],
+        roleName: "myrole",
+        collectionName: "ns.coll",
+      },
+    });
+    await flushPromises();
+
+    expect(wrapper.findAllComponents({ name: "SavedFilesEntry" }).length).toBe(
+      2,
+    );
+  });
+});

--- a/test/unit/webviews/lightspeed/components/SavedFiles.test.ts
+++ b/test/unit/webviews/lightspeed/components/SavedFiles.test.ts
@@ -64,7 +64,7 @@ describe("SavedFiles", () => {
     });
     await flushPromises();
 
-    expect(wrapper.findAllComponents({ name: "SavedFilesEntry" }).length).toBe(
+    expect(wrapper.findAllComponents({ name: "SavedFilesEntry" })).toHaveLength(
       2,
     );
   });

--- a/test/unit/webviews/lightspeed/components/lightspeed/FinalPreviewAsync.test.ts
+++ b/test/unit/webviews/lightspeed/components/lightspeed/FinalPreviewAsync.test.ts
@@ -12,8 +12,8 @@ describe("FinalPreviewAsync", () => {
       "The following role was generated for you",
     );
     expect(
-      wrapper.findAllComponents({ name: "GeneratedFileEntry" }).length,
-    ).toBe(0);
+      wrapper.findAllComponents({ name: "GeneratedFileEntry" }),
+    ).toHaveLength(0);
   });
 
   it("renders one GeneratedFileEntry per file with the file prop", () => {
@@ -31,7 +31,7 @@ describe("FinalPreviewAsync", () => {
       },
     });
     const entries = wrapper.findAllComponents({ name: "GeneratedFileEntry" });
-    expect(entries.length).toBe(2);
+    expect(entries).toHaveLength(2);
     expect(entries[0].props("file")).toEqual(files[0]);
     expect(entries[1].props("file")).toEqual(files[1]);
   });

--- a/test/unit/webviews/lightspeed/components/lightspeed/FinalPreviewAsync.test.ts
+++ b/test/unit/webviews/lightspeed/components/lightspeed/FinalPreviewAsync.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import FinalPreviewAsync from "@webviews/lightspeed/src/components/lightspeed/FinalPreviewAsync.vue";
+import { RoleFileType } from "@src/interfaces/lightspeed";
+
+describe("FinalPreviewAsync", () => {
+  it("renders the heading and an empty list when response is undefined", () => {
+    const wrapper = mount(FinalPreviewAsync, {
+      props: { response: undefined },
+    });
+    expect(wrapper.find("h4").text()).toContain(
+      "The following role was generated for you",
+    );
+    expect(
+      wrapper.findAllComponents({ name: "GeneratedFileEntry" }).length,
+    ).toBe(0);
+  });
+
+  it("renders one GeneratedFileEntry per file with the file prop", () => {
+    const files = [
+      { path: "a.yml", file_type: RoleFileType.Task, content: "a" },
+      { path: "b.yml", file_type: RoleFileType.Default, content: "b" },
+    ];
+    const wrapper = mount(FinalPreviewAsync, {
+      props: {
+        response: {
+          files,
+          generationId: "gen-1",
+          name: "myrole",
+        },
+      },
+    });
+    const entries = wrapper.findAllComponents({ name: "GeneratedFileEntry" });
+    expect(entries.length).toBe(2);
+    expect(entries[0].props("file")).toEqual(files[0]);
+    expect(entries[1].props("file")).toEqual(files[1]);
+  });
+});

--- a/test/unit/webviews/lightspeed/components/lightspeed/OutlineReview.test.ts
+++ b/test/unit/webviews/lightspeed/components/lightspeed/OutlineReview.test.ts
@@ -99,4 +99,55 @@ describe("OutlineReview", () => {
     const textarea = wrapper.find("#outline-field");
     expect(textarea.attributes("rows")).toBe("12"); // 10 lines + 2
   });
+
+  // These tests attach to document.body so the component's
+  // document.querySelector("#outline-field") resolves; each unmounts to keep a
+  // single #outline-field in the document at a time.
+  it("emits outlineUpdate with reapplied line numbers on input", async () => {
+    const wrapper = mount(OutlineReview, {
+      props: { outline: "1. a\n2. b", type: "playbook" as const },
+      attachTo: document.body,
+    });
+    const textarea = wrapper.find("#outline-field");
+    const el = textarea.element as HTMLTextAreaElement;
+    el.value = "1. Install nginx\nConfigure";
+    el.selectionStart = el.value.length;
+    await textarea.trigger("input");
+
+    const emitted = wrapper.emitted("outlineUpdate");
+    expect(emitted).toBeTruthy();
+    expect(emitted?.[0]?.[0]).toBe("1. Install nginx\n2. Configure");
+    wrapper.unmount();
+  });
+
+  it("removes a line that is only a bare line number", async () => {
+    const wrapper = mount(OutlineReview, {
+      props: { outline: "1. a\n2.\n3. c", type: "playbook" as const },
+      attachTo: document.body,
+    });
+    const textarea = wrapper.find("#outline-field");
+    const el = textarea.element as HTMLTextAreaElement;
+    el.value = "1. a\n2.\n3. c";
+    el.selectionStart = 7; // end of the bare "2."
+    await textarea.trigger("input");
+
+    const emitted = wrapper.emitted("outlineUpdate");
+    expect(emitted?.[0]?.[0]).toBe("1. a\n2. c");
+    wrapper.unmount();
+  });
+
+  it("handles the cursor sitting right after a newline", async () => {
+    const wrapper = mount(OutlineReview, {
+      props: { outline: "1. a\n2. b", type: "playbook" as const },
+      attachTo: document.body,
+    });
+    const textarea = wrapper.find("#outline-field");
+    const el = textarea.element as HTMLTextAreaElement;
+    el.value = "1. a\n2. b";
+    el.selectionStart = 5; // char before is "\n"
+    await textarea.trigger("input");
+
+    expect(wrapper.emitted("outlineUpdate")).toBeTruthy();
+    wrapper.unmount();
+  });
 });

--- a/test/unit/webviews/lightspeed/components/lightspeed/OutlineReview.test.ts
+++ b/test/unit/webviews/lightspeed/components/lightspeed/OutlineReview.test.ts
@@ -108,16 +108,19 @@ describe("OutlineReview", () => {
       props: { outline: "1. a\n2. b", type: "playbook" as const },
       attachTo: document.body,
     });
-    const textarea = wrapper.find("#outline-field");
-    const el = textarea.element as HTMLTextAreaElement;
-    el.value = "1. Install nginx\nConfigure";
-    el.selectionStart = el.value.length;
-    await textarea.trigger("input");
+    try {
+      const textarea = wrapper.find("#outline-field");
+      const el = textarea.element as HTMLTextAreaElement;
+      el.value = "1. Install nginx\nConfigure";
+      el.selectionStart = el.value.length;
+      await textarea.trigger("input");
 
-    const emitted = wrapper.emitted("outlineUpdate");
-    expect(emitted).toBeTruthy();
-    expect(emitted?.[0]?.[0]).toBe("1. Install nginx\n2. Configure");
-    wrapper.unmount();
+      const emitted = wrapper.emitted("outlineUpdate");
+      expect(emitted).toBeTruthy();
+      expect(emitted?.[0]?.[0]).toBe("1. Install nginx\n2. Configure");
+    } finally {
+      wrapper.unmount();
+    }
   });
 
   it("removes a line that is only a bare line number", async () => {
@@ -125,15 +128,18 @@ describe("OutlineReview", () => {
       props: { outline: "1. a\n2.\n3. c", type: "playbook" as const },
       attachTo: document.body,
     });
-    const textarea = wrapper.find("#outline-field");
-    const el = textarea.element as HTMLTextAreaElement;
-    el.value = "1. a\n2.\n3. c";
-    el.selectionStart = 7; // end of the bare "2."
-    await textarea.trigger("input");
+    try {
+      const textarea = wrapper.find("#outline-field");
+      const el = textarea.element as HTMLTextAreaElement;
+      el.value = "1. a\n2.\n3. c";
+      el.selectionStart = 7; // end of the bare "2."
+      await textarea.trigger("input");
 
-    const emitted = wrapper.emitted("outlineUpdate");
-    expect(emitted?.[0]?.[0]).toBe("1. a\n2. c");
-    wrapper.unmount();
+      const emitted = wrapper.emitted("outlineUpdate");
+      expect(emitted?.[0]?.[0]).toBe("1. a\n2. c");
+    } finally {
+      wrapper.unmount();
+    }
   });
 
   it("handles the cursor sitting right after a newline", async () => {
@@ -141,13 +147,16 @@ describe("OutlineReview", () => {
       props: { outline: "1. a\n2. b", type: "playbook" as const },
       attachTo: document.body,
     });
-    const textarea = wrapper.find("#outline-field");
-    const el = textarea.element as HTMLTextAreaElement;
-    el.value = "1. a\n2. b";
-    el.selectionStart = 5; // char before is "\n"
-    await textarea.trigger("input");
+    try {
+      const textarea = wrapper.find("#outline-field");
+      const el = textarea.element as HTMLTextAreaElement;
+      el.value = "1. a\n2. b";
+      el.selectionStart = 5; // char before is "\n"
+      await textarea.trigger("input");
 
-    expect(wrapper.emitted("outlineUpdate")).toBeTruthy();
-    wrapper.unmount();
+      expect(wrapper.emitted("outlineUpdate")).toBeTruthy();
+    } finally {
+      wrapper.unmount();
+    }
   });
 });

--- a/test/unit/webviews/lightspeed/components/lightspeed/PromptField.test.ts
+++ b/test/unit/webviews/lightspeed/components/lightspeed/PromptField.test.ts
@@ -96,4 +96,31 @@ describe("PromptField", () => {
       "Current prompt text",
     );
   });
+
+  it("sorts received recent prompts and filters them on complete", async () => {
+    const wrapper = mount(PromptField, { props: { prompt: "" } });
+
+    const handler = vi
+      .mocked(vscodeApi.on)
+      .mock.calls.find((call) => call[0] === "getRecentPrompts")?.[1];
+    void handler?.(["b", "a"]);
+    await flushPromises();
+
+    const ac = wrapper.findComponent({ name: "AutoComplete" });
+
+    // empty query -> full (sorted) list
+    ac.vm.$emit("complete", { query: "" });
+    await flushPromises();
+    expect(ac.props("suggestions")).toEqual(["a", "b"]);
+
+    // matching query -> filtered list
+    ac.vm.$emit("complete", { query: "a" });
+    await flushPromises();
+    expect(ac.props("suggestions")).toEqual(["a"]);
+
+    // whitespace-only query -> full list
+    ac.vm.$emit("complete", { query: "   " });
+    await flushPromises();
+    expect(ac.props("suggestions")).toEqual(["a", "b"]);
+  });
 });

--- a/test/unit/webviews/lightspeed/components/lightspeed/StatusBoxCollectionName.test.ts
+++ b/test/unit/webviews/lightspeed/components/lightspeed/StatusBoxCollectionName.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import StatusBoxCollectionName from "@webviews/lightspeed/src/components/lightspeed/StatusBoxCollectionName.vue";
+
+describe("StatusBoxCollectionName", () => {
+  it("renders the collection name", () => {
+    const wrapper = mount(StatusBoxCollectionName, {
+      props: { collectionName: "ns.coll" },
+    });
+    expect(wrapper.text()).toContain('Collection name: "ns.coll"');
+  });
+
+  it("emits restartWizard when the edit anchor is clicked", async () => {
+    const wrapper = mount(StatusBoxCollectionName, {
+      props: { collectionName: "ns.coll" },
+    });
+    await wrapper.find("#backAnchorCollectionName").trigger("click");
+    expect(wrapper.emitted("restartWizard")).toBeTruthy();
+  });
+});

--- a/test/unit/webviews/lightspeed/utils/outlineLineNumbers.test.ts
+++ b/test/unit/webviews/lightspeed/utils/outlineLineNumbers.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import {
+  removeLine,
+  reapplyLineNumbers,
+  calculateNewCursorPosition,
+  countNewlinesBeforePosition,
+} from "@webviews/lightspeed/src/utils/outlineLineNumbers";
+
+function makeTextarea(value: string): HTMLTextAreaElement {
+  const ta = document.createElement("textarea");
+  ta.value = value;
+  return ta;
+}
+
+describe("outlineLineNumbers (webview copy)", () => {
+  describe("removeLine", () => {
+    it("keeps the remainder when a next newline exists", () => {
+      // value: "1. a\n2.\n3. c" -> cursor at end of bare "2." (index 7)
+      const ta = makeTextarea("1. a\n2.\n3. c");
+      const originalPosition = 7;
+      const previousNewLineIndex = ta.value.lastIndexOf(
+        "\n",
+        originalPosition - 1,
+      );
+      removeLine(ta, originalPosition, previousNewLineIndex);
+      expect(ta.value).toBe("1. a\n3. c");
+    });
+
+    it("drops the trailing line when there is no next newline (last line)", () => {
+      // value: "1. a\n2." -> cursor at end (index 7), no newline after
+      const ta = makeTextarea("1. a\n2.");
+      const originalPosition = 7;
+      const previousNewLineIndex = ta.value.lastIndexOf(
+        "\n",
+        originalPosition - 1,
+      );
+      removeLine(ta, originalPosition, previousNewLineIndex);
+      expect(ta.value).toBe("1. a");
+    });
+  });
+
+  describe("reapplyLineNumbers", () => {
+    it("renumbers each line, preserving content after an existing number", () => {
+      const ta = makeTextarea("1. a\nb\n3. c");
+      reapplyLineNumbers(ta);
+      expect(ta.value).toBe("1. a\n2. b\n3. c");
+    });
+  });
+
+  describe("calculateNewCursorPosition", () => {
+    it("jumps past the inserted number when the previous char is a newline", () => {
+      const text = "x\ny";
+      // text[originalPosition - 1] === "\n" -> originalPosition = 2
+      expect(calculateNewCursorPosition(text, 2, 1, 1)).toBe(2 + 1 + 2);
+    });
+
+    it("snaps to after the number when the cursor sits inside the number region", () => {
+      // originalPosition - previousNewLineIndex < numDigits + 3
+      // 5 - 4 = 1 < 1 + 3 = 4 -> returns previousNewLineIndex + numDigits + 3
+      const text = "1. a\nb";
+      expect(calculateNewCursorPosition(text, 5, 4, 1)).toBe(4 + 1 + 3);
+    });
+
+    it("returns the original position in the fall-through case", () => {
+      // not preceded by newline, and outside the number region
+      const text = "1. abcdefg";
+      expect(calculateNewCursorPosition(text, 9, 0, 1)).toBe(9);
+    });
+  });
+
+  describe("countNewlinesBeforePosition", () => {
+    it("returns 0 (|| [] branch) when there are no newlines", () => {
+      expect(countNewlinesBeforePosition("no newlines here", 5)).toBe(0);
+    });
+
+    it("counts the newlines before the given position", () => {
+      expect(countNewlinesBeforePosition("a\nb\nc", 5)).toBe(2);
+    });
+  });
+});

--- a/test/unit/webviews/lightspeed/utils/vscode.test.ts
+++ b/test/unit/webviews/lightspeed/utils/vscode.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// This suite opts OUT of the global vscodeApi mock (test/unit/webviews/vitestSetup.ts)
+// by re-importing the *real* module with vi.importActual after controlling the
+// global acquireVsCodeApi factory. Because the module exports a singleton created
+// at import time, we use vi.resetModules() + importActual to obtain a fresh
+// instance that reflects the current global state.
+
+type VscodeModule = typeof import("@webviews/lightspeed/src/utils/vscode");
+
+interface FakeApi {
+  postMessage: ReturnType<typeof vi.fn>;
+  getState: ReturnType<typeof vi.fn>;
+  setState: ReturnType<typeof vi.fn>;
+}
+
+function makeFakeApi(state: unknown = undefined): FakeApi {
+  return {
+    postMessage: vi.fn(),
+    getState: vi.fn(() => state),
+    setState: vi.fn(),
+  };
+}
+
+async function loadFresh(
+  acquire: (() => FakeApi) | undefined,
+): Promise<VscodeModule["vscodeApi"]> {
+  vi.resetModules();
+  if (acquire === undefined) {
+    delete (globalThis as Record<string, unknown>).acquireVsCodeApi;
+  } else {
+    (globalThis as Record<string, unknown>).acquireVsCodeApi = acquire;
+  }
+  const mod = await vi.importActual<VscodeModule>(
+    "@webviews/lightspeed/src/utils/vscode",
+  );
+  return mod.vscodeApi;
+}
+
+describe("vscodeApi (real WebviewApi)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    delete (globalThis as Record<string, unknown>).acquireVsCodeApi;
+  });
+
+  it("logs an error and no-ops when acquireVsCodeApi is missing", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const api = await loadFresh(undefined);
+
+    expect(errorSpy).toHaveBeenCalledWith("acquireVsCodeApi is not a function");
+    // post / postMessage are no-ops (must not throw)
+    expect(() => api.post("foo", { a: 1 })).not.toThrow();
+    expect(() => api.postMessage({ hello: "world" })).not.toThrow();
+    // getState returns undefined without an underlying api
+    expect(api.getState()).toBeUndefined();
+    errorSpy.mockRestore();
+  });
+
+  it("post(type, data) forwards { type, data } to postMessage", async () => {
+    const fake = makeFakeApi();
+    const api = await loadFresh(() => fake);
+
+    api.post("myType", { value: 42 });
+
+    expect(fake.postMessage).toHaveBeenCalledWith({
+      type: "myType",
+      data: { value: 42 },
+    });
+  });
+
+  it("postMessage forwards the raw message to the underlying api", async () => {
+    const fake = makeFakeApi();
+    const api = await loadFresh(() => fake);
+
+    api.postMessage({ command: "ping" });
+
+    expect(fake.postMessage).toHaveBeenCalledWith({ command: "ping" });
+  });
+
+  it("on() registers a success listener fired by a window 'message' event", async () => {
+    const fake = makeFakeApi();
+    const api = await loadFresh(() => fake);
+
+    const success = vi.fn();
+    api.on("evt", success);
+
+    window.dispatchEvent(
+      new MessageEvent("message", { data: { type: "evt", data: "payload" } }),
+    );
+
+    expect(success).toHaveBeenCalledWith("payload");
+  });
+
+  it("off() removes a previously registered listener", async () => {
+    const fake = makeFakeApi();
+    const api = await loadFresh(() => fake);
+
+    const success = vi.fn();
+    api.on("evt", success);
+    api.off("evt");
+
+    window.dispatchEvent(
+      new MessageEvent("message", { data: { type: "evt", data: "payload" } }),
+    );
+
+    expect(success).not.toHaveBeenCalled();
+  });
+
+  it("ignores messages with no matching type", async () => {
+    const fake = makeFakeApi();
+    const api = await loadFresh(() => fake);
+
+    const success = vi.fn();
+    api.on("evt", success);
+
+    // No type key at all -> _runListener early returns
+    window.dispatchEvent(
+      new MessageEvent("message", { data: { data: "payload" } }),
+    );
+
+    expect(success).not.toHaveBeenCalled();
+  });
+
+  it("postAndReceive resolves when a matching vscode-webview message arrives", async () => {
+    vi.useFakeTimers();
+    const fake = makeFakeApi();
+    const api = await loadFresh(() => fake);
+
+    const promise = api.postAndReceive<string>("evt", { q: 1 });
+
+    // wrong origin is ignored ...
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        origin: "https://evil.example",
+        data: { type: "evt", data: "nope" },
+      }),
+    );
+    // ... wrong type is ignored ...
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        origin: "vscode-webview://abc",
+        data: { type: "other", data: "nope" },
+      }),
+    );
+    // ... correct origin + type resolves.
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        origin: "vscode-webview://abc",
+        data: { type: "evt", data: "result" },
+      }),
+    );
+
+    await expect(promise).resolves.toBe("result");
+    // the initial post + the periodic interval post both target postMessage
+    expect(fake.postMessage).toHaveBeenCalledWith({
+      type: "evt",
+      data: { q: 1 },
+    });
+  });
+
+  it("postAndReceive rejects with Timeout and fires the fail listener", async () => {
+    vi.useFakeTimers();
+    const fake = makeFakeApi();
+    const api = await loadFresh(() => fake);
+
+    const fail = vi.fn();
+    api.on("evt", vi.fn(), fail);
+
+    const promise = api.postAndReceive("evt", {});
+    const assertion = expect(promise).rejects.toThrow("Timeout");
+    await vi.advanceTimersByTimeAsync(10_000);
+    await assertion;
+
+    expect(fail).toHaveBeenCalledWith(expect.any(Error));
+  });
+
+  it("postAndReceive rejects when acquireVsCodeApi is not available", async () => {
+    const api = await loadFresh(undefined);
+    await expect(api.postAndReceive("evt", {})).rejects.toThrow(
+      "acquireVsCodeApi is not available",
+    );
+  });
+
+  it("getState / setState proxy through to the underlying api", async () => {
+    const fake = makeFakeApi("savedState");
+    const api = await loadFresh(() => fake);
+
+    expect(api.getState()).toBe("savedState");
+
+    const returned = api.setState("newState");
+    expect(returned).toBe("newState");
+    expect(fake.setState).toHaveBeenCalledWith("newState");
+  });
+});

--- a/test/unit/webviews/lightspeed/utils/vscode.test.ts
+++ b/test/unit/webviews/lightspeed/utils/vscode.test.ts
@@ -83,14 +83,14 @@ describe("vscodeApi (real WebviewApi)", () => {
     expect(fake.postMessage).toHaveBeenCalledWith({ command: "ping" });
   });
 
-  it("on() registers a success listener fired by a window 'message' event", async () => {
+  it("on() registers a success listener fired by a globalThis 'message' event", async () => {
     const fake = makeFakeApi();
     const api = await loadFresh(() => fake);
 
     const success = vi.fn();
     api.on("evt", success);
 
-    window.dispatchEvent(
+    globalThis.dispatchEvent(
       new MessageEvent("message", { data: { type: "evt", data: "payload" } }),
     );
 
@@ -105,7 +105,7 @@ describe("vscodeApi (real WebviewApi)", () => {
     api.on("evt", success);
     api.off("evt");
 
-    window.dispatchEvent(
+    globalThis.dispatchEvent(
       new MessageEvent("message", { data: { type: "evt", data: "payload" } }),
     );
 
@@ -120,7 +120,7 @@ describe("vscodeApi (real WebviewApi)", () => {
     api.on("evt", success);
 
     // No type key at all -> _runListener early returns
-    window.dispatchEvent(
+    globalThis.dispatchEvent(
       new MessageEvent("message", { data: { data: "payload" } }),
     );
 
@@ -134,22 +134,23 @@ describe("vscodeApi (real WebviewApi)", () => {
 
     const promise = api.postAndReceive<string>("evt", { q: 1 });
 
-    // wrong origin is ignored ...
-    window.dispatchEvent(
+    // postAndReceive's receive handler checks e.origin.startsWith("vscode-webview://"),
+    // so a non-vscode-webview origin with matching type is ignored.
+    globalThis.dispatchEvent(
       new MessageEvent("message", {
         origin: "https://evil.example",
         data: { type: "evt", data: "nope" },
       }),
     );
-    // ... wrong type is ignored ...
-    window.dispatchEvent(
+    // wrong type is also ignored by the receive handler's type check.
+    globalThis.dispatchEvent(
       new MessageEvent("message", {
         origin: "vscode-webview://abc",
         data: { type: "other", data: "nope" },
       }),
     );
-    // ... correct origin + type resolves.
-    window.dispatchEvent(
+    // correct origin + type resolves.
+    globalThis.dispatchEvent(
       new MessageEvent("message", {
         origin: "vscode-webview://abc",
         data: { type: "evt", data: "result" },

--- a/test/unit/webviews/lightspeed/utils/vscode.test.ts
+++ b/test/unit/webviews/lightspeed/utils/vscode.test.ts
@@ -48,7 +48,9 @@ describe("vscodeApi (real WebviewApi)", () => {
   });
 
   it("logs an error and no-ops when acquireVsCodeApi is missing", async () => {
-    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const errorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
     const api = await loadFresh(undefined);
 
     expect(errorSpy).toHaveBeenCalledWith("acquireVsCodeApi is not a function");

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -144,7 +144,15 @@ export default defineConfig({
       cleanOnRerun: true,
       clean: true,
       enabled: !isFiltered,
-      exclude: [],
+      exclude: [
+        // Pure bootstrap/demo webview entrypoints (createApp().mount() glue / demo)
+        "webviews/lightspeed/src/explanation.ts",
+        "webviews/lightspeed/src/hello-world.ts",
+        "webviews/lightspeed/src/playbook-generation.ts",
+        "webviews/lightspeed/src/role-generation.ts",
+        "webviews/lightspeed/src/HelloWorld.vue",
+        "webviews/lightspeed/src/explorer.ts",
+      ],
       include: [
         "src/**/**.{js,jsx,ts,tsx}",
         ...(skipAlsTests


### PR DESCRIPTION
## Summary

Part 1 of the SonarQube coverage push for the `webviews/lightspeed/` Vue app (follows #2882, #2884, #2893, #2959, #2960, #2961, #2962). Pairs a small config change with `vue`-project component tests.

### Config — exclude bootstrap/demo entrypoints
These 6 files are pure `createApp().mount()` glue or a developer demo — testing them only asserts that Vue mounts (already covered by component tests). Excluded from coverage in **both** `vitest.config.ts` and `sonar-project.properties` (additive — existing exclusions preserved):
`explanation.ts`, `hello-world.ts`, `playbook-generation.ts`, `role-generation.ts`, `HelloWorld.vue`, `explorer.ts`.

### Tests added/extended
| File | Before |
|---|---|
| `utils/vscode.ts` (was fully mocked out) | 0% |
| `utils/outlineLineNumbers.ts` | 63% |
| `components/lightspeed/FinalPreviewAsync.vue` | 0% |
| `components/lightspeed/StatusBoxCollectionName.vue` | 0% |
| `components/SavedFiles.vue` | 4% |
| `components/lightspeed/OutlineReview.vue` | 10% |
| `components/lightspeed/PromptField.vue` | 67% |
| `components/ErrorBox.vue` | 67% |
| `components/CollectionSelector.vue` | 70% |
| `components/ProviderConfigForm.vue` | 83% |

Highlight: `utils/vscode.ts` (the `WebviewApi` postMessage/postAndReceive/listener logic) was at 0% purely because the test setup module-mocks it everywhere — added a dedicated test that opts out of the mock and drives the real class with fake timers.

## Notes
- `SavedFiles.vue`'s `roleLocation` v-if is dead code (the ref is never reassigned); left intentionally uncovered with a comment.
- `WebviewApi` custom `typeKey`/`dataKey` option branches are unreachable (only the no-arg singleton is exported), so those are not tested.

## Testing
Config + test-only change — no production Vue/TS source modified.

```
npx vitest run --project vue
# Test Files 26 passed (26) · Tests 217 passed (217)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- add coverage exclusions and new/expanded webview tests: Updated Sonar/Vitest coverage to skip bootstrap/demo webview entrypoints and expanded unit test coverage for the Lightspeed webview components/utilities (including async Vue updates and message/IPC behavior). This was needed to improve SonarQube coverage without changing production Vue/TypeScript code.

- Excluded demo entrypoints from `vitest.config.ts` and `sonar-project.properties` coverage.
- Added/extended Vitest unit tests for `vscodeApi`, `outlineLineNumbers`, and multiple Lightspeed Vue components (e.g., previews, selectors, error handling, outline review, prompts, saved files, provider config).

Original commit message: add coverage exclusions and new/expanded webview tests
Commit message: fix an ESLint `no-empty-function` issue in a webview test
Commit message: add `fqcns` to the cspell dictionary for webview tests
Commit message: switch assertions to `toHaveLength` to satisfy SonarCloud rule `typescript:S5906`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->