### PR TITLE
chore: unit tests for lightspeed webview wizard apps and provider state

### DIFF
--- a/test/unit/webviews/lightspeed/ExplanationApp.test.ts
+++ b/test/unit/webviews/lightspeed/ExplanationApp.test.ts
@@ -3,6 +3,12 @@ import { mount, flushPromises } from "@vue/test-utils";
 import ExplanationApp from "@webviews/lightspeed/src/ExplanationApp.vue";
 import { vscodeApi } from "@webviews/lightspeed/src/utils/vscode";
 
+function getHandler(name: string) {
+  return vi
+    .mocked(vscodeApi.on)
+    .mock.calls.find((call) => call[0] === name)?.[1];
+}
+
 describe("ExplanationApp", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -266,6 +272,91 @@ describe("ExplanationApp", () => {
 
       const feedbackBox = wrapper.findComponent({ name: "FeedbackBox" });
       expect(feedbackBox.props("telemetryEnabled")).toBe(false);
+    });
+  });
+
+  describe("role explanation - empty content fallback", () => {
+    it("shows the no-explanation fallback when explainRole returns empty content", async () => {
+      const wrapper = mount(ExplanationApp);
+
+      void getHandler("setRoleData")?.({
+        files: [{ path: "tasks/main.yml", content: "- debug: msg=hello" }],
+        roleName: "my_role",
+      });
+      await flushPromises();
+
+      void getHandler("explainRole")?.({ content: "" });
+      await flushPromises();
+
+      expect(wrapper.html()).toContain("No explanation provided");
+    });
+  });
+
+  describe("watcher guard branches (no fetch triggered)", () => {
+    it("does not fetch a playbook explanation when fileName is missing", async () => {
+      mount(ExplanationApp);
+      vi.mocked(vscodeApi.post).mockClear();
+
+      // content truthy but fileName falsy -> watch short-circuits, no fetch.
+      void getHandler("setPlaybookData")?.({
+        content: "- hosts: all\n  tasks: []",
+        fileName: "",
+      });
+      await flushPromises();
+
+      expect(vscodeApi.post).not.toHaveBeenCalledWith(
+        "explainPlaybook",
+        expect.anything(),
+      );
+    });
+
+    it("does not fetch a playbook explanation when content is empty", async () => {
+      const wrapper = mount(ExplanationApp);
+      vi.mocked(vscodeApi.post).mockClear();
+
+      void getHandler("setPlaybookData")?.({
+        content: "",
+        fileName: "/path/to/playbook.yml",
+      });
+      await flushPromises();
+
+      expect(vscodeApi.post).not.toHaveBeenCalledWith(
+        "explainPlaybook",
+        expect.anything(),
+      );
+      // Still in the initial loading state (fetch never ran).
+      expect(wrapper.find(".codicon-loading").exists()).toBe(true);
+    });
+
+    it("does not fetch a role explanation when files is empty", async () => {
+      mount(ExplanationApp);
+      vi.mocked(vscodeApi.post).mockClear();
+
+      // files.length === 0 -> watch short-circuits.
+      void getHandler("setRoleData")?.({ files: [], roleName: "my_role" });
+      await flushPromises();
+
+      expect(vscodeApi.post).not.toHaveBeenCalledWith(
+        "explainRole",
+        expect.anything(),
+      );
+    });
+
+    it("does not fetch a role explanation when roleName is missing", async () => {
+      mount(ExplanationApp);
+      vi.mocked(vscodeApi.post).mockClear();
+
+      // files present but roleName falsy -> watch short-circuits.
+      void getHandler("setRoleData")?.({
+        files: [{ path: "tasks/main.yml", content: "- debug: msg=hi" }],
+        roleName: "",
+      });
+      await flushPromises();
+
+      expect(vscodeApi.post).not.toHaveBeenCalledWith(
+        "explainRole",
+        expect.anything(),
+      );
     });
   });
 });

--- a/test/unit/webviews/lightspeed/PlaybookGenApp.test.ts
+++ b/test/unit/webviews/lightspeed/PlaybookGenApp.test.ts
@@ -2,6 +2,13 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { mount, flushPromises } from "@vue/test-utils";
 import PlaybookGenApp from "@webviews/lightspeed/src/PlaybookGenApp.vue";
 import { vscodeApi } from "@webviews/lightspeed/src/utils/vscode";
+import { WizardGenerationActionType } from "@src/definitions/lightspeed";
+
+function getHandler(name: string) {
+  return vi
+    .mocked(vscodeApi.on)
+    .mock.calls.find((call) => call[0] === name)?.[1];
+}
 
 describe("PlaybookGenApp", () => {
   beforeEach(() => {
@@ -241,6 +248,236 @@ describe("PlaybookGenApp", () => {
       await flushPromises();
 
       expect(wrapper.findComponent({ name: "ErrorBox" }).exists()).toBe(true);
+    });
+  });
+
+  describe("analyze action", () => {
+    it("posts generatePlaybook and shows the spinner when prompt is filled", async () => {
+      const wrapper = mount(PlaybookGenApp);
+
+      const input = wrapper.find("input");
+      await input.setValue("make a playbook");
+      await flushPromises();
+
+      const analyze = wrapper
+        .findAll("vscode-button")
+        .find((b) => b.text() === "Analyze");
+      await analyze?.trigger("click");
+      await flushPromises();
+
+      expect(vscodeApi.post).toHaveBeenCalledWith("generatePlaybook", {
+        text: "make a playbook",
+        outline: "",
+      });
+      // loadingNewResponse becomes true -> spinner replaces page content.
+      expect(wrapper.find(".progress-spinner").exists()).toBe(true);
+    });
+  });
+
+  describe("generatePlaybook handler", () => {
+    it("accepts array warnings (push branch) and advances to page 2", async () => {
+      const wrapper = mount(PlaybookGenApp);
+
+      // Exercises the Array.isArray(warnings) push branch. Note: the page
+      // watcher resets errorMessages on transition, so the warning text is
+      // not visible afterwards - we only verify the branch runs and advances.
+      void getHandler("generatePlaybook")?.({
+        playbook: "- hosts: all",
+        outline: "1. step",
+        warnings: ["w1"],
+      });
+      await flushPromises();
+
+      expect(wrapper.find("#page-number").text()).toBe("2 of 3");
+      expect(wrapper.findComponent({ name: "OutlineReview" }).exists()).toBe(
+        true,
+      );
+      expect(wrapper.findComponent({ name: "StatusBoxPrompt" }).exists()).toBe(
+        true,
+      );
+    });
+
+    it("ignores non-array warnings but still advances", async () => {
+      const wrapper = mount(PlaybookGenApp);
+
+      void getHandler("generatePlaybook")?.({
+        playbook: "- hosts: all",
+        outline: "1. step",
+        warnings: "not-an-array",
+      });
+      await flushPromises();
+
+      expect(wrapper.find("#page-number").text()).toBe("2 of 3");
+      expect(wrapper.text()).not.toContain("not-an-array");
+    });
+  });
+
+  describe("nextPage with an existing response", () => {
+    it("only increments the page without re-posting generatePlaybook", async () => {
+      const wrapper = mount(PlaybookGenApp);
+
+      void getHandler("generatePlaybook")?.({
+        playbook: "- hosts: all",
+        outline: "1. step",
+      });
+      await flushPromises();
+
+      vi.mocked(vscodeApi.post).mockClear();
+      const continueButton = wrapper
+        .findAll("vscode-button")
+        .find((b) => b.text() === "Continue");
+      await continueButton?.trigger("click");
+      await flushPromises();
+
+      expect(wrapper.find("#page-number").text()).toBe("3 of 3");
+      expect(vscodeApi.post).not.toHaveBeenCalledWith(
+        "generatePlaybook",
+        expect.anything(),
+      );
+    });
+  });
+
+  describe("openEditor", () => {
+    it("opens the editor and sends a CLOSE_ACCEPT feedback event", async () => {
+      const wrapper = mount(PlaybookGenApp);
+
+      void getHandler("generatePlaybook")?.({
+        playbook: "- hosts: all\n  tasks: []",
+        outline: "1. step",
+      });
+      await flushPromises();
+
+      const continueButton = wrapper
+        .findAll("vscode-button")
+        .find((b) => b.text() === "Continue");
+      await continueButton?.trigger("click");
+      await flushPromises();
+
+      vi.mocked(vscodeApi.post).mockClear();
+      const openButton = wrapper
+        .findAll("vscode-button")
+        .find((b) => b.text() === "Open editor");
+      await openButton?.trigger("click");
+      await flushPromises();
+
+      expect(vscodeApi.post).toHaveBeenCalledWith("openEditor", {
+        content: "- hosts: all\n  tasks: []",
+      });
+      expect(vscodeApi.post).toHaveBeenCalledWith("feedback", {
+        request: expect.objectContaining({
+          playbookGenerationAction: expect.objectContaining({
+            action: WizardGenerationActionType.CLOSE_ACCEPT,
+          }),
+        }),
+      });
+    });
+
+    it("is a no-op when the playbook content is falsy", async () => {
+      const wrapper = mount(PlaybookGenApp);
+
+      // Empty playbook -> response.value.playbook is falsy.
+      void getHandler("generatePlaybook")?.({
+        playbook: "",
+        outline: "1. step",
+      });
+      await flushPromises();
+
+      const continueButton = wrapper
+        .findAll("vscode-button")
+        .find((b) => b.text() === "Continue");
+      await continueButton?.trigger("click");
+      await flushPromises();
+
+      vi.mocked(vscodeApi.post).mockClear();
+      const openButton = wrapper
+        .findAll("vscode-button")
+        .find((b) => b.text() === "Open editor");
+      await openButton?.trigger("click");
+      await flushPromises();
+
+      expect(vscodeApi.post).not.toHaveBeenCalledWith(
+        "openEditor",
+        expect.anything(),
+      );
+    });
+  });
+
+  describe("errorMessage handler", () => {
+    it("stops loading and renders the error text", async () => {
+      const wrapper = mount(PlaybookGenApp);
+
+      void getHandler("errorMessage")?.("Boom failed");
+      await flushPromises();
+
+      expect(wrapper.find(".progress-spinner").exists()).toBe(false);
+      expect(wrapper.text()).toContain("Boom failed");
+    });
+  });
+
+  describe("watchers", () => {
+    it("resets a previous response when the prompt changes, re-triggering generation", async () => {
+      const wrapper = mount(PlaybookGenApp);
+
+      // Receive a response (page 2, response defined).
+      void getHandler("generatePlaybook")?.({
+        playbook: "- hosts: all",
+        outline: "1. step",
+      });
+      await flushPromises();
+
+      // Go back to page 1 where the prompt field is editable.
+      const backButton = wrapper
+        .findAll("vscode-button")
+        .find((b) => b.text() === "Back");
+      await backButton?.trigger("click");
+      await flushPromises();
+
+      // Change the prompt -> watch(prompt) clears the response + outline.
+      await wrapper.find("input").setValue("a brand new prompt");
+      await flushPromises();
+
+      vi.mocked(vscodeApi.post).mockClear();
+      const analyze = wrapper
+        .findAll("vscode-button")
+        .find((b) => b.text() === "Analyze");
+      await analyze?.trigger("click");
+      await flushPromises();
+
+      // Because response was cleared, nextPage posts a fresh generation
+      // with the outline reset to "".
+      expect(vscodeApi.post).toHaveBeenCalledWith("generatePlaybook", {
+        text: "a brand new prompt",
+        outline: "",
+      });
+    });
+
+    it("clears the response when the outline diverges from the response outline", async () => {
+      const wrapper = mount(PlaybookGenApp);
+
+      void getHandler("generatePlaybook")?.({
+        playbook: "- hosts: all",
+        outline: "original outline",
+      });
+      await flushPromises();
+
+      // Edit the outline to something different -> watch(outline) clears response.
+      await wrapper
+        .findComponent({ name: "OutlineReview" })
+        .vm.$emit("outlineUpdate", "a different outline");
+      await flushPromises();
+
+      vi.mocked(vscodeApi.post).mockClear();
+      const continueButton = wrapper
+        .findAll("vscode-button")
+        .find((b) => b.text() === "Continue");
+      await continueButton?.trigger("click");
+      await flushPromises();
+
+      // response was cleared, so Continue triggers a fresh generation.
+      expect(vscodeApi.post).toHaveBeenCalledWith("generatePlaybook", {
+        text: "",
+        outline: "a different outline",
+      });
     });
   });
 });

--- a/test/unit/webviews/lightspeed/RoleGenApp.test.ts
+++ b/test/unit/webviews/lightspeed/RoleGenApp.test.ts
@@ -356,7 +356,9 @@ describe("RoleGenApp", () => {
       // page 2 role-name textfield (a vscode-textfield custom element) reflects
       // the response name via its v-model bound value property.
       const field = wrapper.find("vscode-textfield");
-      expect((field.element as HTMLInputElement).value).toBe("my_role");
+      expect((field.element as unknown as HTMLInputElement).value).toBe(
+        "my_role",
+      );
       expect(wrapper.findComponent({ name: "OutlineReview" }).exists()).toBe(
         true,
       );
@@ -370,7 +372,7 @@ describe("RoleGenApp", () => {
 
       // Editing the role name to a different value clears the response.
       const field = wrapper.find("vscode-textfield");
-      (field.element as HTMLInputElement).value = "renamed_role";
+      (field.element as unknown as HTMLInputElement).value = "renamed_role";
       await field.trigger("input");
       await flushPromises();
 

--- a/test/unit/webviews/lightspeed/RoleGenApp.test.ts
+++ b/test/unit/webviews/lightspeed/RoleGenApp.test.ts
@@ -209,8 +209,8 @@ describe("RoleGenApp", () => {
 
       expect(wrapper.find("#page-number").text()).toBe("3 of 3");
       expect(
-        wrapper.findAllComponents({ name: "GeneratedFileEntry" }).length,
-      ).toBe(2);
+        wrapper.findAllComponents({ name: "GeneratedFileEntry" }),
+      ).toHaveLength(2);
       expect(
         wrapper.findComponent({ name: "CollectionSelector" }).exists(),
       ).toBe(true);
@@ -410,8 +410,8 @@ describe("RoleGenApp", () => {
       await flushPromises();
 
       expect(
-        wrapper.findAllComponents({ name: "GeneratedFileEntry" }).length,
-      ).toBe(2);
+        wrapper.findAllComponents({ name: "GeneratedFileEntry" }),
+      ).toHaveLength(2);
       expect(
         wrapper.findComponent({ name: "CollectionSelector" }).exists(),
       ).toBe(true);

--- a/test/unit/webviews/lightspeed/RoleGenApp.test.ts
+++ b/test/unit/webviews/lightspeed/RoleGenApp.test.ts
@@ -2,6 +2,30 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { mount, flushPromises } from "@vue/test-utils";
 import RoleGenApp from "@webviews/lightspeed/src/RoleGenApp.vue";
 import { vscodeApi } from "@webviews/lightspeed/src/utils/vscode";
+import { WizardGenerationActionType } from "@src/definitions/lightspeed";
+
+function getHandler(name: string) {
+  return vi
+    .mocked(vscodeApi.on)
+    .mock.calls.find((call) => call[0] === name)?.[1];
+}
+
+const sampleResponse = {
+  name: "my_role",
+  files: [{ path: "tasks/main.yml", content: "- debug: msg=hello" }],
+  outline: "1. step",
+};
+
+// Drive RoleGenApp to page 3 with a generated response.
+async function goToPage3(wrapper: ReturnType<typeof mount>) {
+  void getHandler("generateRole")?.(sampleResponse);
+  await flushPromises();
+  const continueButton = wrapper
+    .findAll("vscode-button")
+    .find((b) => b.text() === "Continue");
+  await continueButton?.trigger("click");
+  await flushPromises();
+}
 
 describe("RoleGenApp", () => {
   beforeEach(() => {
@@ -296,6 +320,204 @@ describe("RoleGenApp", () => {
       await flushPromises();
 
       expect(wrapper.findComponent({ name: "ErrorBox" }).exists()).toBe(true);
+    });
+  });
+
+  describe("analyze action", () => {
+    it("posts generateRole and shows the spinner when prompt is filled", async () => {
+      const wrapper = mount(RoleGenApp);
+
+      await wrapper.find("input").setValue("make a role");
+      await flushPromises();
+
+      const analyze = wrapper
+        .findAll("vscode-button")
+        .find((b) => b.text() === "Analyze");
+      await analyze?.trigger("click");
+      await flushPromises();
+
+      expect(vscodeApi.post).toHaveBeenCalledWith("generateRole", {
+        name: "",
+        text: "make a role",
+        outline: "",
+      });
+      expect(wrapper.find(".progress-spinner").exists()).toBe(true);
+    });
+  });
+
+  describe("generateRole handler", () => {
+    it("populates the role name field on page 2 and stops loading", async () => {
+      const wrapper = mount(RoleGenApp);
+
+      void getHandler("generateRole")?.(sampleResponse);
+      await flushPromises();
+
+      expect(wrapper.find(".progress-spinner").exists()).toBe(false);
+      // page 2 role-name textfield (a vscode-textfield custom element) reflects
+      // the response name via its v-model bound value property.
+      const field = wrapper.find("vscode-textfield");
+      expect((field.element as HTMLInputElement).value).toBe("my_role");
+      expect(wrapper.findComponent({ name: "OutlineReview" }).exists()).toBe(
+        true,
+      );
+    });
+
+    it("clears the response when the role name is edited (watch fires)", async () => {
+      const wrapper = mount(RoleGenApp);
+
+      void getHandler("generateRole")?.(sampleResponse);
+      await flushPromises();
+
+      // Editing the role name to a different value clears the response.
+      const field = wrapper.find("vscode-textfield");
+      (field.element as HTMLInputElement).value = "renamed_role";
+      await field.trigger("input");
+      await flushPromises();
+
+      vi.mocked(vscodeApi.post).mockClear();
+      const continueButton = wrapper
+        .findAll("vscode-button")
+        .find((b) => b.text() === "Continue");
+      await continueButton?.trigger("click");
+      await flushPromises();
+
+      // response cleared -> Continue posts a fresh generation with the new name.
+      expect(vscodeApi.post).toHaveBeenCalledWith("generateRole", {
+        name: "renamed_role",
+        text: "",
+        outline: "1. step",
+      });
+    });
+  });
+
+  describe("page 3 - files and saving", () => {
+    it("renders one GeneratedFileEntry per file and disables Save with no collection", async () => {
+      const wrapper = mount(RoleGenApp);
+      void getHandler("generateRole")?.({
+        ...sampleResponse,
+        files: [
+          { path: "tasks/main.yml", content: "a" },
+          { path: "defaults/main.yml", content: "b" },
+        ],
+      });
+      await flushPromises();
+      const continueButton = wrapper
+        .findAll("vscode-button")
+        .find((b) => b.text() === "Continue");
+      await continueButton?.trigger("click");
+      await flushPromises();
+
+      expect(
+        wrapper.findAllComponents({ name: "GeneratedFileEntry" }).length,
+      ).toBe(2);
+      expect(
+        wrapper.findComponent({ name: "CollectionSelector" }).exists(),
+      ).toBe(true);
+
+      const saveButton = wrapper
+        .findAll("vscode-button")
+        .find((b) => b.text() === "Save files");
+      expect(saveButton?.attributes("disabled")).toBeDefined();
+    });
+
+    it("saves files, sends CLOSE_ACCEPT feedback and shows SavedFiles", async () => {
+      const wrapper = mount(RoleGenApp);
+      await goToPage3(wrapper);
+
+      // Populate the collection list so the AutoComplete renders, then choose
+      // one. The mock AutoComplete forwards its id to a real <input>.
+      void getHandler("getCollectionList")?.([
+        { fqcn: "namespace.collection" },
+      ]);
+      await flushPromises();
+      await wrapper.find("input").setValue("namespace.collection");
+      await flushPromises();
+
+      vi.mocked(vscodeApi.post).mockClear();
+      const saveButton = wrapper
+        .findAll("vscode-button")
+        .find((b) => b.text() === "Save files");
+      // disabled reflects as the string "false" on the custom element once a
+      // collection is selected (i.e. the button is enabled).
+      expect(saveButton?.attributes("disabled")).toBe("false");
+      await saveButton?.trigger("click");
+      await flushPromises();
+
+      expect(vscodeApi.post).toHaveBeenCalledWith("feedback", {
+        request: expect.objectContaining({
+          roleGenerationAction: expect.objectContaining({
+            action: WizardGenerationActionType.CLOSE_ACCEPT,
+          }),
+        }),
+      });
+      expect(wrapper.findComponent({ name: "SavedFiles" }).exists()).toBe(true);
+    });
+
+    it("runs the collectionName watcher when the collection changes", async () => {
+      const wrapper = mount(RoleGenApp);
+      await goToPage3(wrapper);
+
+      void getHandler("getCollectionList")?.([
+        { fqcn: "namespace.collection" },
+        { fqcn: "other.collection" },
+      ]);
+      await flushPromises();
+
+      // Changing the collection name pre-save exercises the watch(collectionName)
+      // callback (filesWereSaved is false, so it stays false and Save enables).
+      await wrapper.find("input").setValue("namespace.collection");
+      await flushPromises();
+
+      const saveButton = wrapper
+        .findAll("vscode-button")
+        .find((b) => b.text() === "Save files");
+      expect(saveButton?.attributes("disabled")).toBe("false");
+      expect(
+        wrapper.findComponent({ name: "CollectionSelector" }).exists(),
+      ).toBe(true);
+    });
+  });
+
+  describe("errorMessage handler", () => {
+    it("stops loading and renders the error text", async () => {
+      const wrapper = mount(RoleGenApp);
+      void getHandler("errorMessage")?.("Role boom");
+      await flushPromises();
+
+      expect(wrapper.find(".progress-spinner").exists()).toBe(false);
+      expect(wrapper.text()).toContain("Role boom");
+    });
+  });
+
+  describe("watch(prompt)", () => {
+    it("clears role name, outline and response when the prompt changes", async () => {
+      const wrapper = mount(RoleGenApp);
+
+      void getHandler("generateRole")?.(sampleResponse);
+      await flushPromises();
+
+      const backButton = wrapper
+        .findAll("vscode-button")
+        .find((b) => b.text() === "Back");
+      await backButton?.trigger("click");
+      await flushPromises();
+
+      await wrapper.find("input").setValue("a totally new role prompt");
+      await flushPromises();
+
+      vi.mocked(vscodeApi.post).mockClear();
+      const analyze = wrapper
+        .findAll("vscode-button")
+        .find((b) => b.text() === "Analyze");
+      await analyze?.trigger("click");
+      await flushPromises();
+
+      // roleName + outline were reset by watch(prompt).
+      expect(vscodeApi.post).toHaveBeenCalledWith("generateRole", {
+        name: "",
+        text: "a totally new role prompt",
+        outline: "",
+      });
     });
   });
 });

--- a/test/unit/webviews/lightspeed/RoleGenApp.test.ts
+++ b/test/unit/webviews/lightspeed/RoleGenApp.test.ts
@@ -423,7 +423,7 @@ describe("RoleGenApp", () => {
     });
 
     it("saves files, sends CLOSE_ACCEPT feedback and shows SavedFiles", async () => {
-      const wrapper = mount(RoleGenApp);
+      const wrapper: ReturnType<typeof mount> = mount(RoleGenApp);
       await goToPage3(wrapper);
 
       // Populate the collection list so the AutoComplete renders, then choose
@@ -456,7 +456,7 @@ describe("RoleGenApp", () => {
     });
 
     it("runs the collectionName watcher when the collection changes", async () => {
-      const wrapper = mount(RoleGenApp);
+      const wrapper: ReturnType<typeof mount> = mount(RoleGenApp);
       await goToPage3(wrapper);
 
       void getHandler("getCollectionList")?.([

--- a/test/unit/webviews/lightspeed/components/llmProviderState.test.ts
+++ b/test/unit/webviews/lightspeed/components/llmProviderState.test.ts
@@ -263,7 +263,7 @@ describe("useProviderSettings", () => {
     it("handles a failed connectionResult by setting status false and logging", () => {
       const consoleSpy = vi
         .spyOn(console, "error")
-        .mockImplementation(() => {});
+        .mockImplementation(() => undefined);
       const c = mountComposable();
       sendMessage(c, {
         command: "providerSettings",

--- a/test/unit/webviews/lightspeed/components/llmProviderState.test.ts
+++ b/test/unit/webviews/lightspeed/components/llmProviderState.test.ts
@@ -1,0 +1,308 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mount } from "@vue/test-utils";
+import { defineComponent, h } from "vue";
+import { useProviderSettings } from "@webviews/lightspeed/src/components/llmProviderState";
+import { vscodeApi } from "@webviews/lightspeed/src/utils/vscode";
+
+type ProviderSettings = ReturnType<typeof useProviderSettings>;
+
+interface MountedComposable {
+  api: ProviderSettings;
+  handleMessage: (event: MessageEvent) => void;
+  unmount: () => void;
+}
+
+const mockProviders = [
+  {
+    type: "google",
+    name: "google",
+    displayName: "Google Gemini",
+    description: "Test provider",
+    defaultEndpoint: "https://default.example.com",
+    configSchema: [
+      {
+        key: "apiEndpoint",
+        label: "Endpoint",
+        type: "string",
+        required: true,
+        placeholder: "",
+        description: "",
+      },
+      {
+        key: "apiKey",
+        label: "API Key",
+        type: "password",
+        required: true,
+        placeholder: "",
+        description: "",
+      },
+    ],
+  },
+  {
+    type: "wca",
+    name: "wca",
+    displayName: "IBM watsonx",
+    description: "Test provider",
+    defaultEndpoint: "https://wca.example.com",
+    configSchema: [
+      {
+        key: "apiEndpoint",
+        label: "Endpoint",
+        type: "string",
+        required: true,
+        placeholder: "",
+        description: "",
+      },
+    ],
+  },
+];
+
+// Mount the composable inside a throwaway component so onMounted runs.
+// We capture the window "message" handler by spying on addEventListener,
+// which also prevents leaking real listeners across tests.
+function mountComposable(): MountedComposable {
+  let captured: ((event: MessageEvent) => void) | null = null;
+  const addEventListenerSpy = vi
+    .spyOn(window, "addEventListener")
+    .mockImplementation((event, handler) => {
+      if (event === "message") {
+        captured = handler as (event: MessageEvent) => void;
+      }
+    });
+
+  let api!: ProviderSettings;
+  const wrapper = mount(
+    defineComponent({
+      setup() {
+        api = useProviderSettings();
+        return () => h("div");
+      },
+    }),
+  );
+
+  addEventListenerSpy.mockRestore();
+
+  return {
+    api,
+    handleMessage: (event: MessageEvent) => captured?.(event),
+    unmount: () => wrapper.unmount(),
+  };
+}
+
+function sendMessage(c: MountedComposable, data: unknown) {
+  c.handleMessage({ data } as MessageEvent);
+}
+
+describe("useProviderSettings", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("requests provider settings and registers a message listener on mount", () => {
+    const c = mountComposable();
+    expect(vscodeApi.postMessage).toHaveBeenCalledWith({
+      command: "getProviderSettings",
+    });
+    expect(c.handleMessage).toBeDefined();
+    c.unmount();
+  });
+
+  describe("setConfigValue", () => {
+    it("lazily creates the provider config object before setting a value", () => {
+      const c = mountComposable();
+      // No config exists for "google" yet.
+      expect(c.api.getConfigValue("google", "apiKey")).toBe("");
+
+      c.api.setConfigValue("google", "apiKey", "secret");
+
+      expect(c.api.getConfigValue("google", "apiKey")).toBe("secret");
+      c.unmount();
+    });
+  });
+
+  describe("showSaveIndicator", () => {
+    it("shows the indicator then hides it after 2000ms", () => {
+      vi.useFakeTimers();
+      const c = mountComposable();
+
+      expect(c.api.saveIndicatorVisible.value).toBe(false);
+
+      // setActiveProvider triggers showSaveIndicator internally.
+      c.api.setActiveProvider("google");
+      expect(c.api.saveIndicatorVisible.value).toBe(true);
+
+      vi.advanceTimersByTime(1999);
+      expect(c.api.saveIndicatorVisible.value).toBe(true);
+
+      vi.advanceTimersByTime(1);
+      expect(c.api.saveIndicatorVisible.value).toBe(false);
+      c.unmount();
+    });
+  });
+
+  describe("toggleEdit", () => {
+    it("initializes config from schema using the endpoint default", () => {
+      const c = mountComposable();
+      c.api.providers.value = mockProviders;
+
+      c.api.toggleEdit("google");
+
+      expect(c.api.editingProvider.value).toBe("google");
+      // apiEndpoint defaults to defaultEndpoint, other fields empty.
+      expect(c.api.getConfigValue("google", "apiEndpoint")).toBe(
+        "https://default.example.com",
+      );
+      expect(c.api.getConfigValue("google", "apiKey")).toBe("");
+      // Snapshot stored -> no unsaved changes right after opening.
+      expect(c.api.hasUnsavedChanges("google")).toBe(false);
+      c.unmount();
+    });
+
+    it("restores the original config when closing the edit panel", () => {
+      const c = mountComposable();
+      c.api.providers.value = mockProviders;
+
+      c.api.toggleEdit("google");
+      c.api.setConfigValue("google", "apiKey", "changed");
+      expect(c.api.hasUnsavedChanges("google")).toBe(true);
+
+      // Toggling the same provider closes and restores.
+      c.api.toggleEdit("google");
+
+      expect(c.api.editingProvider.value).toBeNull();
+      expect(c.api.getConfigValue("google", "apiKey")).toBe("");
+      c.unmount();
+    });
+
+    it("discards another provider's unsaved changes when switching", () => {
+      const c = mountComposable();
+      c.api.providers.value = mockProviders;
+
+      c.api.toggleEdit("google");
+      c.api.setConfigValue("google", "apiKey", "dirty");
+
+      // Switch to a different provider without saving google.
+      c.api.toggleEdit("wca");
+
+      expect(c.api.editingProvider.value).toBe("wca");
+      expect(c.api.getConfigValue("google", "apiKey")).toBe("");
+      c.unmount();
+    });
+  });
+
+  describe("saveProviderConfig", () => {
+    it("returns early for an unknown provider with no config", () => {
+      const c = mountComposable();
+      c.api.providers.value = mockProviders;
+      vi.mocked(vscodeApi.postMessage).mockClear();
+
+      c.api.saveProviderConfig("does-not-exist");
+
+      expect(vscodeApi.postMessage).not.toHaveBeenCalled();
+      c.unmount();
+    });
+
+    it("sends saveProviderSettings and resets connection status when config changed", () => {
+      const c = mountComposable();
+      sendMessage(c, {
+        command: "providerSettings",
+        providers: mockProviders,
+        currentProvider: "google",
+        providerConfigs: {
+          google: { apiEndpoint: "https://default.example.com", apiKey: "old" },
+          wca: { apiEndpoint: "https://wca.example.com" },
+        },
+        connectionStatuses: { google: true, wca: false },
+      });
+
+      expect(c.api.isConnected("google")).toBe(true);
+
+      c.api.toggleEdit("google");
+      c.api.setConfigValue("google", "apiKey", "new-key");
+      expect(c.api.hasUnsavedChanges("google")).toBe(true);
+
+      vi.mocked(vscodeApi.postMessage).mockClear();
+      c.api.saveProviderConfig("google");
+
+      expect(vscodeApi.postMessage).toHaveBeenCalledWith({
+        command: "saveProviderSettings",
+        provider: "google",
+        config: expect.objectContaining({ apiKey: "new-key" }),
+      });
+      expect(c.api.isConnected("google")).toBe(false);
+      c.unmount();
+    });
+  });
+
+  describe("handleMessage", () => {
+    it("ignores non-record data", () => {
+      const c = mountComposable();
+      expect(c.api.isLoading.value).toBe(true);
+
+      sendMessage(c, "not-an-object");
+      sendMessage(c, null);
+
+      expect(c.api.isLoading.value).toBe(true);
+      c.unmount();
+    });
+
+    it("ignores messages without a string command", () => {
+      const c = mountComposable();
+      expect(c.api.isLoading.value).toBe(true);
+
+      sendMessage(c, { foo: "bar" });
+
+      expect(c.api.isLoading.value).toBe(true);
+      c.unmount();
+    });
+
+    it("handles a failed connectionResult by setting status false and logging", () => {
+      const consoleSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      const c = mountComposable();
+      sendMessage(c, {
+        command: "providerSettings",
+        providers: mockProviders,
+        currentProvider: "google",
+        providerConfigs: { google: {}, wca: {} },
+        connectionStatuses: { google: true, wca: false },
+      });
+
+      sendMessage(c, {
+        command: "connectionResult",
+        provider: "google",
+        connected: false,
+        error: "Invalid key",
+      });
+
+      expect(c.api.isConnected("google")).toBe(false);
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Connection failed for google"),
+      );
+      consoleSpy.mockRestore();
+      c.unmount();
+    });
+  });
+
+  describe("hasUnsavedChanges false branches", () => {
+    it("returns false for an unknown provider (no provider info)", () => {
+      const c = mountComposable();
+      c.api.providers.value = mockProviders;
+      expect(c.api.hasUnsavedChanges("unknown")).toBe(false);
+      c.unmount();
+    });
+
+    it("returns false when there is no current/original config", () => {
+      const c = mountComposable();
+      c.api.providers.value = mockProviders;
+      // providers known but configs never initialized -> current/original undefined.
+      expect(c.api.hasUnsavedChanges("google")).toBe(false);
+      c.unmount();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Part 2 (final) of the SonarQube coverage push for the `webviews/lightspeed/` Vue app (follows #2882, #2884, #2893, #2959, #2960, #2961, #2962, #2963). Covers the wizard apps and the provider-settings composable.

| File | Before (line / branch) |
|---|---|
| `components/llmProviderState.ts` | 88% / 68% |
| `PlaybookGenApp.vue` | 74% / 70% |
| `RoleGenApp.vue` | 75% / 80% |
| `ExplanationApp.vue` | 93% / 85% |

## What's covered
- **llmProviderState** (`useProviderSettings`, new test): setConfigValue lazy-init, save-indicator timer cycle, `toggleEdit` (schema init / close-restore / switch-discard), `saveProviderConfig` (guard + connection reset), `handleMessage` (malformed ignore + connectionResult failure), `hasUnsavedChanges` false branches.
- **PlaybookGenApp**: analyze→generate page transitions, `generatePlaybook` handler, `openEditor` + feedback, errorMessage handler, prompt/outline watchers.
- **RoleGenApp**: generate flow, role-name + collection selection, save-flow feedback, watchers.
- **ExplanationApp**: playbook/role empty-content fallbacks and watcher short-circuit branches.

## Notes (defensive/unreachable branches, left intentionally)
- `ExplanationApp` early-return guards in `fetchPlaybookExplanation`/`fetchRoleExplanation` are unreachable — their `watch` callers already guard the same conditions; the reachable watcher short-circuits are covered instead.
- `RoleGenApp` `watch(collectionName)` reset-after-save branch is unreachable (CollectionSelector is hidden by `v-if="!filesWereSaved"` once saved).

## Testing
Test-only change — no production source modified.

```
npx vitest run --project vue test/unit/webviews/lightspeed/components/llmProviderState.test.ts \
  test/unit/webviews/lightspeed/PlaybookGenApp.test.ts \
  test/unit/webviews/lightspeed/RoleGenApp.test.ts \
  test/unit/webviews/lightspeed/ExplanationApp.test.ts
# Test Files 4 passed (4) · Tests 79 passed (79)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Added unit tests for Lightspeed webview Vue apps and `useProviderSettings` to close SonarQube coverage gaps.  
- Covers provider config initialization/saving, save-indicator timing, message handling, unsaved-change branches, and wizard flows for playbook/role generation and explanation fallbacks.  
- Original commit message: add unit tests for `webviews/lightspeed/` Vue app coverage

_AI-assisted._

<!-- end of auto-generated comment: release notes by coderabbit.ai -->