### PR TITLE
chore(docs): add npm run help, ADR-021, and script audit skill

### DIFF
--- a/.agents/skills/audit-npm-scripts/SKILL.md
+++ b/.agents/skills/audit-npm-scripts/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: audit-npm-scripts
+description: >
+    Audit npm scripts for drift between package.json, scripts/help.mjs,
+    and documentation (CLAUDE.md, README.md). Use this skill when adding,
+    removing, or renaming npm scripts, or when reviewing a PR that changes
+    build commands.
+user-invocable: true
+triggers: [audit scripts, sync scripts, script drift, npm scripts]
+---
+
+# Audit npm Scripts
+
+Detect and fix drift between the four sources of truth for npm scripts:
+
+1. **`package.json`** `scripts` — the canonical definitions
+2. **`scripts/help.mjs`** `catalog` — categorized descriptions for `npm run help`
+3. **`CLAUDE.md`** — agent-facing documentation
+4. **`README.md`** — contributor-facing documentation
+
+## When to Run
+
+- After adding, removing, or renaming an npm script
+- As part of PR self-review (submit-pr skill, Step 3)
+- When a contributor reports that docs don't match available commands
+
+## Audit Steps
+
+### 1. Extract scripts from all sources
+
+Read the four files and extract the script names from each:
+
+- `package.json`: keys of `scripts` object (exclude `pre*` lifecycle hooks
+  and `vscode:prepublish`)
+- `scripts/help.mjs`: script names in the `catalog` array entries
+- `CLAUDE.md`: script names mentioned in code blocks or inline code in the
+  "Common Commands" section
+- `README.md`: script names mentioned in the development/build sections
+
+### 2. Compare and report
+
+For each script in `package.json`, check:
+
+- **Missing from help.mjs** — the script won't appear in `npm run help`
+- **Missing from CLAUDE.md** — agents won't know about it
+- **Missing from README.md** — contributors won't know about it
+
+For each script in `help.mjs` that's NOT in `package.json`:
+
+- **Stale entry** — the script was removed but help.mjs wasn't updated
+
+For each script mentioned in CLAUDE.md or README.md that's NOT in
+`package.json`:
+
+- **Stale documentation** — references a script that no longer exists
+
+### 3. Fix drift
+
+For each finding:
+
+- **Missing from help.mjs**: Add the script to the appropriate category
+  in `scripts/help.mjs` with a concise description
+- **Missing from docs**: Add the script to the relevant section of
+  CLAUDE.md and/or README.md
+- **Stale entries**: Remove references to scripts that no longer exist
+
+### 4. Verify
+
+Run `npm run help` and confirm the output is complete and accurate.
+
+## Output Format
+
+Report findings as a checklist:
+
+```text
+npm scripts audit:
+  [x] package.json has 27 scripts (25 user-facing, 2 lifecycle hooks)
+  [x] help.mjs covers 25/25 user-facing scripts
+  [ ] CLAUDE.md missing: test:lightspeed:ui, build:lightspeed:webviews
+  [x] README.md is current
+  [ ] help.mjs has stale entry: test:e2e (removed from package.json)
+
+Fixes applied:
+  - Added test:lightspeed:ui to CLAUDE.md Testing section
+  - Added build:lightspeed:webviews to CLAUDE.md Build section
+  - Removed test:e2e from help.mjs
+```

--- a/.sdlc/adrs/ADR-021-npm-scripts-over-task-runners.md
+++ b/.sdlc/adrs/ADR-021-npm-scripts-over-task-runners.md
@@ -1,0 +1,180 @@
+# ADR-021: npm Scripts Over External Task Runners
+
+## Status
+
+Accepted
+
+## Date
+
+2026-06-29
+
+## Context
+
+As the project grows, contributors have noted that npm scripts have
+poor UX compared to dedicated task runners:
+
+- **No built-in docs** — `package.json` doesn't support comments,
+  so script purpose must be documented externally
+- **No discoverability** — `npm run` lists scripts but without
+  descriptions, making it hard to find the right command
+- **No dependency graph** — scripts chain with `&&`, which is
+  sequential and fragile. There's no way to express "run B only
+  after A succeeds" or "run A and B in parallel" declaratively
+- **Painful chaining** — long `&&` chains are hard to read, offer
+  no error recovery, and break across platforms (bash vs cmd)
+
+Several external task runners address these issues:
+
+- **Task** (taskfile.dev) — Go binary, YAML config, dependency
+  graph, parallel execution, file-change detection
+- **just** — Rust binary, Makefile-like syntax, cross-platform
+- **Makefile** — ubiquitous but not cross-platform, arcane syntax
+- **Turborepo / Nx** — monorepo-oriented, heavy, opinionated
+
+The question: should we adopt an external task runner now, or stay
+with npm scripts and mitigate the UX gaps?
+
+## Decision
+
+**We will continue using npm scripts as the sole build orchestrator,
+with targeted UX improvements, and revisit when complexity exceeds
+the mitigations.**
+
+The mitigations are:
+
+1. **`npm run help`** — a categorized, described script listing
+   maintained in `scripts/help.mjs`
+2. **`audit-npm-scripts` agent skill** — an AI skill that detects
+   drift between scripts, `help.mjs`, and documentation (CLAUDE.md,
+   README), then fixes it automatically
+3. **prek for linting orchestration** — pre-commit hooks absorb
+   linting complexity that would otherwise require multiple npm
+   scripts
+
+## Alternatives Considered
+
+### Alternative 1: Task (taskfile.dev)
+
+**Description**: Replace npm scripts with a `Taskfile.yml` that
+defines tasks with dependencies, descriptions, and parallel execution.
+
+**Pros**:
+
+- Built-in `task --list` with descriptions
+- Dependency graph between tasks
+- Parallel execution with `deps:`
+- File-change detection (`sources:` / `generates:`)
+- Cross-platform (Go binary)
+
+**Cons**:
+
+- Adds a Go binary dependency — not installable via npm
+- Every contributor must install it (`go install` or `brew`)
+- CI workflows need an extra setup step
+- Two config systems to maintain (Taskfile + package.json scripts
+  that VS Code and npm lifecycle hooks still need)
+- The project already added `prek` and `uv` as non-npm prerequisites;
+  each additional tool adds friction
+
+**Why not chosen**: The project has ~27 scripts — manageable without
+a DAG. The `prek` integration already absorbed linting complexity.
+Adding another binary dependency compounds the contributor onboarding
+cost. The `npm run help` + audit skill mitigations close the
+discoverability gap without adding infrastructure.
+
+### Alternative 2: npm-run-all2 (run-s / run-p)
+
+**Description**: Install `npm-run-all2` to replace `&&` chains with
+`run-s` (sequential) and `run-p` (parallel) commands.
+
+**Pros**:
+
+- Pure npm dependency — no external binary
+- Cleaner sequential chains: `run-s compile lint test`
+- Enables safe parallel execution: `run-p lint:* test`
+- Cross-platform (no shell dependency)
+
+**Cons**:
+
+- Adds a runtime dependency for build orchestration
+- Marginal improvement over `&&` for the current script count
+- Still no descriptions, dependency graph, or file detection
+
+**Why not chosen**: The improvement is marginal for ~27 scripts.
+If `&&` chains grow beyond 4-5 steps or parallel execution becomes
+necessary, this is the lowest-friction next step.
+
+### Alternative 3: Turborepo / Nx
+
+**Description**: Adopt a monorepo build system with caching,
+dependency-aware task scheduling, and remote caching.
+
+**Pros**:
+
+- Understands package dependency graph
+- Intelligent caching (skip unchanged packages)
+- Remote cache for CI speedup
+- Built for monorepos
+
+**Cons**:
+
+- Significant setup and learning curve
+- Opinionated about project structure
+- Overkill for 6 packages with a simple build order
+- Heavy dependency tree
+
+**Why not chosen**: The monorepo has 6 packages with a
+straightforward build order. Turborepo/Nx solve problems at a scale
+we haven't reached. Revisit if the package count exceeds 10 or
+cross-package build dependencies become complex.
+
+## Consequences
+
+### Positive
+
+- Zero new dependencies or binary prerequisites
+- Contributors use familiar `npm run` commands
+- The `help` script and audit skill close the discoverability and
+  drift gaps that motivated the discussion
+- The decision is explicitly documented, preventing repeated debates
+
+### Negative
+
+- `&&` chains remain fragile for long pipelines
+- No file-change detection (every `npm run ci` rebuilds everything)
+- No parallel execution within a single script
+
+### Neutral
+
+- The decision has a clear re-evaluation trigger: if the script count
+  exceeds ~40, if `&&` chains exceed 5 steps, or if build times
+  exceed 5 minutes due to unnecessary rebuilds, revisit this ADR
+
+## Implementation Notes
+
+- `scripts/help.mjs` maintains a categorized description map that
+  must stay in sync with `package.json`
+- The `audit-npm-scripts` agent skill automates drift detection
+  between `help.mjs`, `package.json`, `CLAUDE.md`, and `README.md`
+- If `npm-run-all2` is adopted later, it replaces `&&` chains without
+  changing the overall approach — this ADR remains valid
+
+## Related Decisions
+
+- ADR-007: npm exec over npx (established npm as the canonical tool)
+- ADR-006: esbuild bundler (build system choice)
+
+## References
+
+- [Task (taskfile.dev)](https://taskfile.dev)
+- [npm-run-all2](https://github.com/bcomnes/npm-run-all2)
+- [Turborepo](https://turbo.build/repo)
+- [just](https://github.com/casey/just)
+
+---
+
+## Revision History
+
+| Date       | Author          | Change           |
+| ---------- | --------------- | ---------------- |
+| 2026-06-29 | Bradley Thornton | Initial proposal |

--- a/package.json
+++ b/package.json
@@ -1167,7 +1167,8 @@
     "test:lightspeed": "npm run test -w packages/lightspeed",
     "test:lightspeed:ui": "wdio run wdio.lightspeed.conf.ts",
     "build:lightspeed:webviews": "npm run build:webviews -w packages/lightspeed",
-    "pretest:wdio": "npx tsx tools/ensure-chromedriver.mts && node scripts/install-test-extensions.mjs"
+    "pretest:wdio": "npx tsx tools/ensure-chromedriver.mts && node scripts/install-test-extensions.mjs",
+    "help": "node scripts/help.mjs"
   },
   "devDependencies": {
     "@commitlint/cli": "^21.1.0",

--- a/scripts/help.mjs
+++ b/scripts/help.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+
+/**
+ * Print a categorized, described list of npm scripts.
+ *
+ * Keep this map in sync with package.json — the audit-npm-scripts
+ * agent skill checks for drift automatically.
+ */
+
+import { readFileSync } from "node:fs";
+
+const pkg = JSON.parse(readFileSync("package.json", "utf-8"));
+
+const catalog = [
+  ["Build & Development", {
+    compile: "TypeScript compilation (includes skill codegen)",
+    build: "esbuild production bundle (extension + LS + MCP)",
+    "build:production": "esbuild bundle with minification",
+    watch: "TypeScript watch mode",
+    "watch:bundle": "esbuild watch mode",
+  }],
+  ["Testing", {
+    test: "Run all unit tests (vitest)",
+    "test:coverage": "Unit tests with coverage thresholds",
+    "test:watch": "Unit tests in watch mode",
+    "test:integration": "VS Code integration tests",
+    "test:ui": "WebDriverIO UI tests (smoke + language server)",
+    "test:lightspeed": "Lightspeed unit tests",
+    "test:lightspeed:ui": "Lightspeed WebDriverIO UI tests",
+  }],
+  ["Linting", {
+    lint: "ESLint on the full project",
+    "lint:prek": "prek hooks (skillmark, cspell, markdownlint, actionlint)",
+  }],
+  ["Quality Gates", {
+    check: "compile + lint + test (iterative development)",
+    ci: "Full CI: compile + lint + prek + test:coverage + build",
+  }],
+  ["Packaging", {
+    package: "Create .vsix package",
+    "package:install": "Package, install in VS Code, clean up",
+  }],
+  ["Documentation", {
+    "docs:dev": "Start docs dev server (Starlight)",
+    "docs:build": "Build docs site for production",
+    "docs:preview": "Preview built docs site",
+  }],
+  ["Webviews", {
+    "build:lightspeed:webviews": "Build Lightspeed Vue webviews",
+  }],
+  ["Utilities", {
+    help: "Show this help message",
+  }],
+];
+
+const documented = new Set();
+
+for (const [category, scripts] of catalog) {
+  console.log(`\n  \x1b[1m${category}\x1b[0m`);
+  for (const [name, desc] of Object.entries(scripts)) {
+    if (!pkg.scripts[name]) continue;
+    documented.add(name);
+    console.log(`    ${name.padEnd(26)} ${desc}`);
+  }
+}
+
+const undocumented = Object.keys(pkg.scripts).filter(
+  (s) => !documented.has(s) && !s.startsWith("pre") && s !== "vscode:prepublish",
+);
+if (undocumented.length > 0) {
+  console.log(`\n  \x1b[2mUndocumented\x1b[0m`);
+  for (const s of undocumented) {
+    console.log(`    ${s.padEnd(26)} ${pkg.scripts[s]}`);
+  }
+}
+
+console.log(`\n  Run: npm run <name>       Full CI gate: npm run ci`);


### PR DESCRIPTION
## Summary

- Address npm script UX feedback: no docs, no discoverability, no way to list commands with descriptions
- Document the decision to stay with npm scripts over external task runners, with clear re-evaluation triggers

## Changes

### `npm run help` (`scripts/help.mjs`)
- Categorized, color-coded script listing with descriptions
- Detects undocumented scripts and lists them separately
- Categories: Build, Testing, Linting, Quality Gates, Packaging, Documentation, Webviews, Utilities

### ADR-021: npm Scripts Over External Task Runners
- Evaluates Task (taskfile.dev), npm-run-all2, and Turborepo/Nx
- Decision: stay the course with targeted mitigations
- Re-evaluation triggers: >40 scripts, >5 step chains, >5min builds

### `audit-npm-scripts` agent skill
- Detects drift between `package.json`, `help.mjs`, `CLAUDE.md`, and `README.md`
- Triggered when scripts are added/removed/renamed, or during PR review
- Fixes drift automatically and reports a checklist summary

## Quality of life
- AI-authored additions: ADR-021, audit-npm-scripts skill, help.mjs

## Test plan
- [x] `npm run ci` passes
- [x] `npm run help` displays complete categorized output


Made with [Cursor](https://cursor.com)