### PR TITLE
fix(deps): update wdio-vscode-service for Windows compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -70,7 +70,7 @@
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.61.0",
         "vitest": "^3.1.1",
-        "wdio-vscode-service": "github:cidrblock/wdio-vscode-service#323db15"
+        "wdio-vscode-service": "github:cidrblock/wdio-vscode-service#f8f4d79"
       },
       "engines": {
         "node": ">=22.18.0",
@@ -26989,7 +26989,7 @@
     },
     "node_modules/wdio-vscode-service": {
       "version": "8.0.0",
-      "resolved": "git+ssh://git@github.com/cidrblock/wdio-vscode-service.git#323db156201b07e3d17490273dd1cc1ea01c1aa5",
+      "resolved": "git+ssh://git@github.com/cidrblock/wdio-vscode-service.git#f8f4d79acb797cc32c436d61af83f661a854decb",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1214,7 +1214,7 @@
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.61.0",
     "vitest": "^3.1.1",
-    "wdio-vscode-service": "github:cidrblock/wdio-vscode-service#323db15"
+    "wdio-vscode-service": "github:cidrblock/wdio-vscode-service#f8f4d79"
   },
   "dependencies": {
     "@ansible/common": "*",


### PR DESCRIPTION
## Summary
- Update wdio-vscode-service SHA pin to include cross-platform `chmod` fix for Windows compatibility

## Changes
- Pin `wdio-vscode-service` to `f8f4d79` which replaces the Unix-only `chmod +x` command with `node -e "...fs.chmodSync(...)..."` so `npm install` succeeds on Windows (including Win11-ARM)

## Test plan
- [x] `npm run ci` passes (compile + lint + test:coverage + build)
- [x] Vuln count unchanged (3 moderate — markdownlint-cli2 transitive, no fix available)

Made with [Cursor](https://cursor.com)