### PR TITLE
chore(ci): refine SonarCloud coverage and branch config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ lib/
 docs/.astro/
 docs/dist/
 packages/common/src/skills/*.content.ts
+**/*.tgz

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,10 +1,16 @@
 # cspell: ignore multicriteria
 # sonar does not support cobertura coverage xml format, only lcov.info
 # Disable insecure os command execution inside tests
-sonar.debug=true
-sonar.log.level.app=DEBUG
+#
+# Branch analysis: SonarCloud treats main as the main branch automatically.
+# Do not hardcode sonar.branch.name or sonar.branch.target here — a static
+# target would break other branch scans. For additional long-lived branches,
+# set the pattern (Project > Branches) to: ^(next|(branch|release)-.*)$
+sonar.debug=false
+sonar.log.level.app=INFO
+sonar.javascript.lcov.reportPaths=**/coverage/**/lcov.info
 sonar.organization=ansible
 sonar.projectKey=ansible_vscode-ansible
 sonar.sources=src/,packages/common/src/,packages/language-server/src/,packages/lightspeed/src/,packages/mcp-server/src/,packages/services/src/,packages/ui/src/,packages/lightspeed/webviews/src/
-sonar.tests=test/,packages/language-server/test/,packages/lightspeed/test/,packages/mcp-server/test/,packages/services/test/,packages/ui/test/
-sonar.verbose=true
+sonar.tests=test/,packages/common/test/,packages/language-server/test/,packages/lightspeed/test/,packages/mcp-server/test/,packages/services/test/,packages/ui/test/
+sonar.verbose=false


### PR DESCRIPTION
## Summary
- Improve SonarCloud configuration for the `next` branch: coverage paths, test scope, branch-analysis documentation, and quieter admin log levels.

## Changes
- Add `sonar.javascript.lcov.reportPaths=**/coverage/**/lcov.info` so JS/TS coverage is picked up from Vitest and WDIO outputs
- Include `packages/common/test/` in `sonar.tests`
- Document long-lived branch pattern for SonarCloud (`next`, `branch-*`, `release-*`) without hardcoding `sonar.branch.name` / `sonar.branch.target`
- Align log settings (`sonar.debug=false`, `sonar.log.level.app=INFO`, `sonar.verbose=false`)
- Ignore `**/*.tgz` in `.gitignore`

## Quality of life
- None (config-only change)

## Test plan
- [x] `npm run compile && npm run lint && npm run lint:knip && npm run test:coverage && npm run build` passes locally
- [ ] SonarCloud scan on `next` picks up lcov reports after merge


Made with [Cursor](https://cursor.com)