### PR TITLE
chore(ci): refine SonarCloud config and coverage upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,16 @@ jobs:
           fail_ci_if_error: true
           use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
 
+      - name: Upload coverage for SonarCloud
+        if: ${{ !cancelled() && hashFiles('coverage/**/lcov.info') != '' }}
+        uses: ansible/actions/upload-artifact@b2b0657c2e1d083cf979eba2fd04ae79e5ab3900 # v1.1.2
+        with:
+          name: sonar-coverage-node${{ matrix.node-version }}-${{ github.run_attempt }}
+          path: |
+            coverage/**/lcov.info
+          if-no-files-found: ignore
+          retention-days: 7
+
   lint:
     runs-on: ubuntu-latest
     steps:
@@ -143,6 +153,16 @@ jobs:
           disable_search: true
           fail_ci_if_error: false
           use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
+
+      - name: Upload WDIO coverage for SonarCloud
+        if: ${{ !cancelled() && hashFiles('coverage/wdio/lcov.info') != '' }}
+        uses: ansible/actions/upload-artifact@b2b0657c2e1d083cf979eba2fd04ae79e5ab3900 # v1.1.2
+        with:
+          name: sonar-coverage-wdio-${{ github.run_attempt }}
+          path: |
+            coverage/**/lcov.info
+          if-no-files-found: ignore
+          retention-days: 7
 
   docs:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ lib/
 docs/.astro/
 docs/dist/
 packages/common/src/skills/*.content.ts
+**/*.tgz

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,16 +1,30 @@
 codecov:
   require_ci_to_pass: false
   notify:
-    after_n_builds: 3
-    wait_for_ci: false
+    after_n_builds: 5
+    wait_for_ci: true
 comment:
   layout: "condensed_header, condensed_files, condensed_footer"
   require_changes: "coverage_drop OR uncovered_patch"
-  after_n_builds: 3
+  after_n_builds: 5
 coverage:
   status:
     patch: false
     project: true
+flag_management:
+  default_rules:
+    carryforward: false
+  individual_flags:
+    - name: unit-node22
+      carryforward: false
+    - name: unit-node24
+      carryforward: false
+    - name: unit-node26
+      carryforward: false
+    - name: wdio
+      carryforward: false
+    - name: wsl-fedora
+      carryforward: false
 github_checks:
   annotations: true
 ignore:

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,10 +1,15 @@
 # cspell: ignore multicriteria
 # sonar does not support cobertura coverage xml format, only lcov.info
-# Disable insecure os command execution inside tests
-sonar.debug=true
-sonar.log.level.app=DEBUG
+#
+# Branch analysis: SonarCloud treats the default branch automatically.
+# Do not hardcode sonar.branch.name or sonar.branch.target here — a static
+# target would break other branch scans. For additional long-lived branches,
+# set the pattern (Project > Branches) to: ^(next|(branch|release)-.*)$
+sonar.debug=false
+sonar.log.level.app=INFO
+sonar.javascript.lcov.reportPaths=coverage/lcov.info,coverage/wdio/lcov.info
 sonar.organization=ansible
 sonar.projectKey=ansible_vscode-ansible
 sonar.sources=src/,packages/common/src/,packages/language-server/src/,packages/lightspeed/src/,packages/mcp-server/src/,packages/services/src/,packages/ui/src/,packages/lightspeed/webviews/src/
-sonar.tests=test/,packages/language-server/test/,packages/lightspeed/test/,packages/mcp-server/test/,packages/services/test/,packages/ui/test/
-sonar.verbose=true
+sonar.tests=test/,packages/common/test/,packages/language-server/test/,packages/lightspeed/test/,packages/mcp-server/test/,packages/services/test/,packages/ui/test/
+sonar.verbose=false


### PR DESCRIPTION
## Summary

Combines the SonarCloud-relevant improvements from #2977 and #2979 into a
focused, merge-ready PR, plus fixes Codecov carry-forward inflation discovered
during review. Credits @ssbarnea for the original SonarCloud work.

## Changes

### SonarCloud configuration (from #2977 / #2979)

- **LCOV report paths**: configure explicit comma-separated paths
  (`coverage/lcov.info,coverage/wdio/lcov.info`) instead of glob patterns —
  SonarScanner's wildcard handling for this property is inconsistent
  ([Copilot review on #2977](https://github.com/ansible/vscode-ansible/pull/2977#pullrequestreview-4604030468))
- **Test scope**: add `packages/common/test/` to `sonar.tests` (was missing)
- **Branch-analysis docs**: document long-lived branch pattern for SonarCloud
  without hardcoding `sonar.branch.name`/`sonar.branch.target`, which would
  break PR scans
- **Log verbosity**: reduce from `DEBUG`/`verbose=true` to `INFO`/`false` —
  `DEBUG` is only useful when diagnosing scanner issues
- **Coverage artifact upload**: upload LCOV files from `build-and-test` and
  `ui` jobs via `ansible/actions/upload-artifact@b2b0657c # v1.1.2`
  (gitleaks-secured wrapper around `actions/upload-artifact`)
- **`.gitignore`**: ignore `**/*.tgz` packaging artifacts

### Codecov carry-forward fix

After merging #2983 (honest coverage), we observed coverage jumping from an
honest ~39% to an inflated 87.67% after late-arriving WSL uploads triggered
re-computation. Root cause: Codecov's default `carryforward: true` was merging
stale (pre-#2983) inflated coverage data for flags that hadn't yet uploaded
fresh results.

- **Disable carry-forward** for all 5 flags (`unit-node22/24/26`, `wdio`,
  `wsl-fedora`) — each flag uploads fresh data on every CI run, so
  carry-forward is unnecessary and was actively harmful
- **Increase `after_n_builds`** from 3 to 5 to match actual upload count
  (3 build-and-test matrix + 1 wdio + 1 wsl)
- **Enable `wait_for_ci`** so Codecov waits for all uploads before computing
  the final merged report

## What was NOT included from #2979

- Job consolidation (we intentionally have separate lint/test/integration/ui/package jobs)
- WSL workflow deletion (we recently added WSL CI with retry logic in #2981)
- `package.json` script changes
- `prek.toml` changes (disabling skillmark/actionlint)

## Test plan

- [ ] CI passes (no source code changes — config only)
- [ ] Codecov reports honest coverage (~39%) after all 5 uploads complete
- [ ] SonarCloud scan on `next` picks up LCOV reports after merge
- [ ] Coverage artifacts appear in Actions run summary

Supersedes #2977.

Co-authored-by: Sorin Sbarnea <ssbarnea@users.noreply.github.com>