### PR TITLE
feat(ci): add user-story-driven WDIO feature coverage

### DIFF
--- a/.agents/skills/define-user-story/SKILL.md
+++ b/.agents/skills/define-user-story/SKILL.md
@@ -1,0 +1,185 @@
+---
+name: define-user-story
+description: >
+    Define a user story for new user-facing functionality and optionally
+    scaffold a WDIO test skeleton. Use when the submit-pr self-review
+    detects new user-facing capabilities, or when the user says
+    "define story", "add user story", or "new user story".
+argument-hint: "[description of the new functionality]"
+user-invocable: true
+metadata:
+    author: ansible-environments team
+    version: 1.0.0
+---
+
+# Define User Story
+
+Guide a developer through defining a user story for new or existing
+user-facing functionality, then add it to the canonical story catalog
+and optionally scaffold a WDIO test.
+
+## When to use
+
+- The `submit-pr` self-review (question 10) detected new user-facing
+  functionality without a matching story
+- A developer wants to document what a feature does from the user's
+  perspective
+- Coverage gaps need to be closed — `scripts/story-coverage.mjs`
+  reports uncovered areas
+
+## Workflow
+
+### Step 1: Context gathering
+
+Ask the developer:
+
+> **What can the user do now that they couldn't before?**
+>
+> Describe it from the user's perspective — not "I added a command
+> `ansibleFoo.bar`", but "the user can now see a visual diff of
+> their playbook changes before running".
+
+If the developer provides a command or implementation description,
+reframe it as a user outcome.
+
+### Step 2: Story drafting
+
+Generate the story in "As a... I want... so that..." format:
+
+```text
+As an Ansible developer, I want to [outcome]
+so that [benefit — why this matters to the user].
+```
+
+Rules:
+
+- The subject is always "an Ansible developer" (or "an automation
+  architect" for Content Designer features)
+- The "I want" describes a **user-visible outcome**, not an
+  implementation detail
+- The "so that" explains the **value** — why does this matter?
+- Do NOT mention commands, views, panels, or API calls in the story
+
+### Step 3: Acceptance criteria
+
+Generate 2–4 acceptance criteria from the developer's description.
+Each criterion should be independently verifiable in a WDIO test:
+
+```yaml
+criteria:
+  - The sidebar shows available playbook diffs
+  - Clicking a diff opens a side-by-side comparison
+  - Changes are highlighted with add/remove colors
+```
+
+Rules:
+
+- Each criterion maps to one `it()` block in a WDIO spec
+- Criteria describe **observable behavior**, not internal state
+- Avoid "should" — use declarative present tense
+
+### Step 4: Story ID and PRD mapping
+
+Assign an ID using the area prefix + next available number:
+
+| Area | Prefix | Covers |
+|------|--------|--------|
+| Environment management | `ENV-` | Python envs, tools, status bar |
+| Editor & Language Server | `LSP-` | Completion, hover, diagnostics, vault, schemas |
+| Collections | `COL-` | Installed + remote, docs, search, install |
+| Content scaffolding | `SCF-` | Creator forms, CLI preview |
+| Playbook execution | `PLB-` | Discovery, config, run, progress, AI analysis |
+| Execution environments | `EE-` | Discovery, inspection, AI summary |
+| AI authoring & MCP | `AI-` | Summaries, generation, discovery, LLM, MCP, skills |
+| Lightspeed | `LS-` | Auth, generation, explanation, inline suggest |
+| Cross-cutting | `XC-` | Activation, degradation, empty states |
+
+Read `.sdlc/user-stories.yaml` to find the highest existing number
+for the chosen prefix and increment it.
+
+Map to PRD references:
+
+- Check `docs/src/content/docs/roadmap/feature-ansible-ide-experience.md`
+  for the closest US- and AC- identifiers
+- If no PRD reference fits, use `[]` — the story stands on its own
+
+### Step 5: Add to catalog
+
+Append the new story to `.sdlc/user-stories.yaml`:
+
+```yaml
+  - id: PLB-007
+    title: Visual playbook diff before execution
+    story: >
+      As an Ansible developer, I want to see a visual diff of my
+      playbook changes before running, so that I can verify what
+      changed since the last successful run.
+    prd_refs: [US-6, AC-4]
+    requires_ai: false
+    criteria:
+      - The sidebar shows available playbook diffs
+      - Clicking a diff opens a side-by-side comparison
+      - Changes are highlighted with add/remove colors
+```
+
+Set `requires_ai: true` if the feature needs an AI provider.
+
+### Step 6: Optional WDIO test skeleton
+
+Ask the developer:
+
+> **Would you like me to scaffold a WDIO test for this story?**
+
+If yes, create a test file (or add to an existing one) with:
+
+```typescript
+/**
+ * @covers PLB-007
+ */
+describe('Playbook diff before execution', () => {
+    it.skip('should show available playbook diffs in the sidebar', async () => {
+        // TODO: implement — remove .skip when ready
+    });
+
+    it.skip('should open a side-by-side diff comparison', async () => {
+        // TODO: implement — remove .skip when ready
+    });
+
+    it.skip('should highlight changes with add/remove colors', async () => {
+        // TODO: implement — remove .skip when ready
+    });
+});
+```
+
+Place the file in `test/ui/` for core extension features or
+`packages/<pkg>/test/wdio/` for package-specific features.
+
+### Step 7: Verify coverage
+
+Run the coverage script to confirm the story is tracked:
+
+```bash
+node scripts/story-coverage.mjs --threshold 0
+```
+
+The new story should appear in the covered or uncovered list
+depending on whether the WDIO test has real assertions.
+
+## Integration with submit-pr
+
+This skill is invoked by `submit-pr` (question 10 in the
+self-review) when new user-facing functionality is detected.
+The typical flow:
+
+1. Developer runs `/submit-pr`
+2. Self-review detects a new `contributes.commands` entry or
+   new Panel/Provider class
+3. Agent prompts: "This PR adds user-facing functionality.
+   Would you like me to help define a user story?"
+4. If yes, this skill runs
+5. Story is added to the catalog and optionally a test skeleton
+   is created
+6. Developer continues with the PR submission
+
+The developer can decline — the CI catalog-completeness check
+will flag the gap, but it's not a hard gate.

--- a/.agents/skills/submit-pr/SKILL.md
+++ b/.agents/skills/submit-pr/SKILL.md
@@ -162,6 +162,19 @@ translate it:
    needs dispose, EventEmitter needs cleanup). TypeScript enforces
    structure; runtime contracts include semantics.
 
+10. **Does this PR add user-facing functionality without a user
+    story?** Scan the diff for signals of new user-facing
+    capabilities: new entries in `contributes.commands`,
+    `contributes.views`, or `contributes.configuration`; new `Panel`
+    or `Provider` classes in `src/panels/` or `src/views/`; new skill
+    `.md` files in `packages/common/src/skills/`; new
+    `registerCommand()` calls; or new MCP tools in
+    `packages/mcp-server/`. If any are found, check whether a
+    corresponding user story exists in `.sdlc/user-stories.yaml`.
+    If not, prompt the developer to define one via the
+    `define-user-story` skill. The developer can decline — the CI
+    story-coverage check will flag the gap.
+
 Only proceed to Step 3b after completing this review.
 
 ### Step 3b: Cold subagent review

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,20 @@ jobs:
       - name: Run Lightspeed UI tests
         run: xvfb-run --auto-servernum pnpm run test:lightspeed:ui
 
+      - name: Story coverage report
+        if: ${{ !cancelled() }}
+        run: node scripts/story-coverage.mjs --threshold 20 --lcov coverage/stories.lcov
+
+      - name: Upload story coverage to Codecov
+        if: ${{ !cancelled() && hashFiles('coverage/stories.lcov') != '' }}
+        uses: codecov/codecov-action@v7
+        with:
+          files: ./coverage/stories.lcov
+          flags: stories
+          disable_search: true
+          fail_ci_if_error: false
+          use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
+
   docs:
     runs-on: ubuntu-latest
     steps:

--- a/.sdlc/adrs/ADR-023-wdio-feature-coverage.md
+++ b/.sdlc/adrs/ADR-023-wdio-feature-coverage.md
@@ -77,25 +77,23 @@ not in uncovered lines.
   capabilities lack any automated E2E validation.
 - **Effort**: Building a custom feature-coverage system costs
   engineering time; the value depends on it being maintainable.
-- **Existing assets**: The `ux-walkthrough` skill already maintains a
-  curated workflow catalog with 12 modules and ~50 steps in
-  `walkthrough-modules.json`.
+- **Existing assets**: The PRD defines 19 user stories across 8
+  capability areas. The `ux-walkthrough` skill maintains a curated
+  workflow catalog. Both describe user-facing functionality from
+  different angles.
 
 ## Decision
 
 **We will retire V8 line coverage for WDIO tests and adopt a
-workflow-level feature coverage model that measures the percentage
-of user-facing workflows with E2E validation.**
+user-story-driven feature coverage model that measures the percentage
+of user-facing stories with E2E validation.**
 
 ### 1. Retire V8 line coverage upload
 
 Remove the WDIO coverage upload to Codecov from CI. Remove the
-`wdio` flag from `codecov.yml`. Remove the `WDIO_COVERAGE`
-environment variable from CI and the `coverage` blocks from
-`wdio.conf.ts` / `wdio.conf.wsl.ts` — the upstream
-`wdio-vscode-service@8` package does not support this option.
-V8 line-coverage data from bundled E2E tests must not be merged
-into aggregate coverage metrics.
+`wdio` flag from `codecov.yml`. Revert `wdio-vscode-service` from
+the fork to upstream v8 (which removes the coverage feature). This
+data must not be merged into aggregate coverage metrics.
 
 ### 2. Three-tier coverage model
 
@@ -110,47 +108,60 @@ exercises the primary user journey for that capability. Smoke
 coverage (from integration tests like `activation.test.ts`) confirms
 structural correctness but not behavioral quality.
 
-### 3. Workflow-grain feature catalog
+### 3. User-story-grain feature catalog
 
-The canonical catalog of user-facing workflows lives in
-`.agents/skills/ux-walkthrough/walkthrough-modules.json`. Each
-module represents a user journey — not an individual command:
+The canonical catalog of user-facing capabilities lives in
+`.sdlc/user-stories.yaml`. Each entry is a user story written
+from the user's perspective — not a command or view, but an
+outcome the user can achieve:
 
-| Module ID | Workflow | Example commands involved |
-|-----------|----------|--------------------------|
-| `setup` | Setup & first impressions | Activity bar, output channel |
-| `environment` | Environment & tool management | `create`, `select`, `install` |
-| `editor-lsp` | Editor & language server | Completion, hover, diagnostics, vault |
-| `collections-installed` | Installed collections & plugin docs | `search`, `showPluginDoc` |
-| `collections-remote` | Collection sources & installation | `filterGalaxy`, `install` |
-| `creator` | Content scaffolding | `openForm`, scaffold submit |
-| `playbooks` | Playbook execution & visualization | `run`, `runWithProgress`, `editConfig` |
-| `execution-envs` | Execution environment inspection | `showDetail`, `showPackageDetail` |
-| `ai-authoring` | AI-assisted content authoring | AI summary commands |
-| `mcp-skills` | MCP tools & AI skills | `useInChat`, `showMcpStatus` |
-| `lightspeed` | Ansible Lightspeed | Generation, explanation, inline suggest |
-| `cross-cutting` | Cross-cutting UX | Non-AI path, empty states, settings |
+| Prefix | Area | Example story |
+|--------|------|---------------|
+| `ENV-` | Environment management | "I want to create a virtual environment from the sidebar" |
+| `LSP-` | Editor & language server | "I want auto-completion for module options" |
+| `COL-` | Collections | "I want to install a collection from Galaxy with one click" |
+| `SCF-` | Content scaffolding | "I want to see the exact CLI command before scaffolding" |
+| `PLB-` | Playbook execution | "I want an AI explanation of why a task failed" |
+| `EE-`  | Execution environments | "I want to drill into an EE to see its contents" |
+| `AI-`  | AI authoring & MCP | "I want to describe what I need and get a generated role" |
+| `LS-`  | Lightspeed | "I want to generate a playbook via Lightspeed" |
+| `XC-`  | Cross-cutting UX | "I want helpful guidance when tools are missing" |
 
-This is approximately 12 modules with ~50 testable steps. The
-catalog already exists — this ADR promotes it from a dogfooding
-guide to the source of truth for E2E coverage measurement.
+Each story includes acceptance criteria that map directly to
+WDIO `it()` blocks, PRD traceability (`prd_refs`), and an
+`requires_ai` flag. The initial catalog contains ~54 stories
+derived from the PRD capability tables, the `ux-walkthrough`
+catalog, and existing WDIO tests.
+
+The `ux-walkthrough` catalog remains useful for dogfooding
+sessions but is no longer the coverage source of truth.
 
 ### 4. Traceability via test tags
 
-WDIO spec files declare which workflows they cover. The mechanism
-is a `@covers` annotation or equivalent metadata that maps each
-`describe`/`it` block to one or more module IDs from the catalog.
+WDIO spec files declare which stories they cover via `@covers`
+JSDoc annotations on `describe` blocks:
 
-A CI script (future implementation) loads the catalog, scans WDIO
-specs for coverage tags, and reports:
+```typescript
+/**
+ * @covers LSP-001
+ * @covers LSP-002
+ */
+describe('Ansible Language Server e2e', () => { ... });
+```
+
+The CI script `scripts/story-coverage.mjs` loads the story
+catalog, scans WDIO specs for `@covers` tags, cross-references
+them, and reports:
 
 ```text
-Feature coverage: 4/12 modules (33%)
-  E2E:       setup, editor-lsp, lightspeed, cross-cutting
-  Smoke:     environment, collections-installed
-  Uncovered: collections-remote, creator, playbooks, execution-envs,
-             ai-authoring, mcp-skills
+Coverage: 13/54 stories (24%)
+  Covered:   ENV-002, ENV-005, COL-007, LSP-001, LSP-002, LSP-003,
+             LSP-004, LS-001, LS-002, LS-003, LS-004, LS-006, XC-001
+  Uncovered: ENV-001, ENV-003, ..., PLB-005 (AI failure analysis), ...
 ```
+
+The script exits non-zero if coverage drops below a configurable
+threshold (initially 20%, ratcheted up as tests are added).
 
 ### 5. Registration parity as a separate concern
 
@@ -233,9 +244,10 @@ identifiers.
   when the test audience is developers, not product managers
 - Introduces a framework migration in the E2E test layer
 
-**Why not chosen**: The catalog already exists in
-`walkthrough-modules.json`. A Mocha tag helper achieves the same
-traceability with less migration effort.
+**Why not chosen**: The user-story catalog in
+`.sdlc/user-stories.yaml` combined with `@covers` JSDoc tags on
+Mocha `describe` blocks achieves the same traceability with less
+migration effort.
 
 ## Consequences
 
@@ -244,11 +256,13 @@ traceability with less migration effort.
 - Codecov reports honest aggregate coverage based solely on unit
   tests — no inflation from incidental code loading
 - Feature coverage becomes a visible, actionable metric — the team
-  can prioritize which workflows to add WDIO tests for
-- The `ux-walkthrough` catalog gains a dual purpose: dogfooding
-  guide and E2E coverage manifest
-- The three-tier model makes coverage gaps explicit rather than
-  hidden behind a misleading line percentage
+  can prioritize which user stories to add WDIO tests for
+- User stories are the natural language developers use for planning
+  work; adding a story is lower friction than updating a walkthrough
+- The `define-user-story` skill and submit-pr integration ensure
+  new functionality is tracked automatically
+- The coverage model makes gaps explicit rather than hidden behind
+  a misleading line percentage
 
 ### Negative
 
@@ -257,57 +271,72 @@ traceability with less migration effort.
   badge without context.
 - The feature coverage metric requires a custom CI script — there
   is no off-the-shelf WDIO plugin for this
-- Maintaining the catalog requires discipline: new features must
-  add a walkthrough module or step, or they will appear as
-  "uncovered" even if WDIO tests exist
+- Maintaining the story catalog requires discipline: new features
+  must add a user story, or they will appear as "uncovered" even
+  if WDIO tests exist. The submit-pr skill mitigates this by
+  detecting new user-facing functionality and prompting for a story
 
 ### Neutral
 
-- The `WDIO_COVERAGE` local debugging capability is preserved — a
-  developer can still run `WDIO_COVERAGE=1` to see which extension
-  code paths a test hits, for investigative purposes
-- The `wdio-vscode-service` fork's coverage feature
+- The `wdio-vscode-service` dependency reverted to upstream v8;
+  the fork's coverage feature
   ([PR #164](https://github.com/webdriverio-community/wdio-vscode-service/pull/164))
-  remains useful for projects that don't bundle their extensions,
-  where V8 coverage on source files would be accurate
+  was closed as the V8 coverage approach is fundamentally unsuitable
+  for bundled extensions
 
 ## Implementation Notes
 
-### Phase 1: Retire V8 upload (immediate)
+### Phase 1: Retire V8 upload (done)
 
-1. Remove the "Upload WDIO coverage to Codecov" step from the
-   `unit` job in `.github/workflows/ci.yml`
-2. Remove the `wdio` flag from `codecov.yml` flag_management
-3. Update `codecov.yml` `after_n_builds` from 5 to 4 (three
-   unit-node runs + one wsl-fedora)
-4. Comment on wdio-vscode-service
+1. Removed WDIO coverage upload steps from `.github/workflows/ci.yml`
+2. Removed the `wdio` flag from `codecov.yml` flag_management
+3. Removed `coverage/wdio/lcov.info` from `sonar-project.properties`
+4. Reverted `wdio-vscode-service` from the fork to upstream v8
+5. Removed `coverage` config from `wdio.conf.ts` and `wdio.conf.wsl.ts`
+6. Closed wdio-vscode-service
    [PR #164](https://github.com/webdriverio-community/wdio-vscode-service/pull/164)
-   explaining that V8 coverage on bundled code produces unreliable
-   results and linking to this ADR
+   with an explanation of why V8 coverage on bundled code is unsuitable
 
-### Phase 2: Feature coverage infrastructure (future)
+### Phase 2: User-story coverage infrastructure (done)
 
-1. Add a stable `coverage` field to each module in
-   `walkthrough-modules.json` with possible values: `e2e`, `smoke`,
-   `none`
-2. Add `@covers('module-id')` metadata to WDIO spec `describe`
-   blocks
-3. Create `scripts/feature-coverage.mjs` that:
-   - Loads `walkthrough-modules.json`
-   - Scans `test/ui/**/*.spec.ts` for `@covers` tags
-   - Cross-references integration tests for smoke tier
-   - Emits a markdown summary and exits non-zero if coverage drops
-     below a configured threshold
-4. Add a CI step that runs the feature coverage script and posts
-   the summary as a PR comment
+1. Derived ~54 user stories from the PRD capability tables, the
+   `ux-walkthrough` catalog, and existing WDIO tests. Stories live
+   in `.sdlc/user-stories.yaml`
+2. Added `@covers` JSDoc tags to all 4 existing WDIO spec files,
+   mapping each `describe` block to the stories it validates
+3. Created `scripts/story-coverage.mjs` that:
+   - Loads `.sdlc/user-stories.yaml`
+   - Scans `test/ui/**/*.spec.ts` and `packages/*/test/wdio/**/*.spec.ts`
+     for `@covers` tags
+   - Cross-references to compute coverage per story
+   - Emits a markdown summary table
+   - Exits non-zero if coverage drops below a configurable threshold
+4. Added a CI step in the `ui` job that runs the story coverage
+   script after WDIO tests complete
 
-### Catalog maintenance rule
+### Phase 3: Developer workflow integration (done)
+
+1. Created the `define-user-story` agent skill
+   (`.agents/skills/define-user-story/SKILL.md`) that walks
+   developers through defining a user story and optionally
+   scaffolding a WDIO test skeleton
+2. Added question 10 to the `submit-pr` skill's self-review
+   checklist: detects new user-facing functionality in the PR diff
+   and prompts the developer to define a story if none exists
+
+### Story maintenance rule
 
 When adding a new user-facing feature (command, view, panel, editor
-capability), add a corresponding module or step to
-`walkthrough-modules.json`. This is analogous to ADR-012's
+capability), add a corresponding user story to
+`.sdlc/user-stories.yaml`. This is analogous to ADR-012's
 requirement that every UI capability has an MCP tool equivalent —
-every UI capability must also have a catalog entry.
+every UI capability must also have a user story.
+
+The `submit-pr` skill's self-review (question 10) detects new
+user-facing functionality in the diff and prompts the developer to
+define a story via the `define-user-story` skill. The CI story
+coverage script flags any `@covers` tags that reference unknown
+story IDs.
 
 ## Related Decisions
 
@@ -317,9 +346,8 @@ every UI capability must also have a catalog entry.
   extension capabilities — this ADR applies the same "catalog
   completeness" principle to E2E test coverage
 - [ADR-014](ADR-014-internal-skills-as-prompt-source.md): Internal
-  skills as AI prompt source of truth — the `ux-walkthrough` skill
-  was built under this framework and is now promoted to E2E
-  coverage manifest
+  skills as AI prompt source of truth — the `define-user-story`
+  skill follows this framework
 
 ## References
 
@@ -327,7 +355,9 @@ every UI capability must also have a catalog entry.
 - [V8 code coverage documentation](https://v8.dev/blog/javascript-code-coverage)
 - [c8 — V8-to-Istanbul](https://github.com/bcoe/c8)
 - [Codecov flag management](https://docs.codecov.com/docs/flags)
-- [ux-walkthrough skill catalog](.agents/skills/ux-walkthrough/walkthrough-modules.json)
+- [User story catalog](../user-stories.yaml)
+- [Story coverage script](../../scripts/story-coverage.mjs)
+- [define-user-story skill](../../.agents/skills/define-user-story/SKILL.md)
 
 ---
 
@@ -336,3 +366,4 @@ every UI capability must also have a catalog entry.
 | Date       | Author          | Change           |
 | ---------- | --------------- | ---------------- |
 | 2026-06-30 | Bradley Thornton | Initial proposal |
+| 2026-06-30 | Bradley Thornton | Replace walkthrough-based model with user-story-based model |

--- a/.sdlc/user-stories.yaml
+++ b/.sdlc/user-stories.yaml
@@ -1,0 +1,754 @@
+# User stories for WDIO feature coverage tracking.
+# See ADR-023 for rationale and CI enforcement model.
+version: 1
+parent_prd: docs/src/content/docs/roadmap/feature-ansible-ide-experience.md
+
+# Commands that are mechanical (refresh, internal tree-item handlers) and
+# do not need a dedicated user story. They are exercised as part of
+# higher-level workflows.
+excluded_commands:
+  - ansibleDevToolsEnvManagers.refresh
+  - ansibleDevToolsPackages.refresh
+  - ansibleDevToolsCollections.refresh
+  - ansibleCollectionSources.refresh
+  - ansibleExecutionEnvironments.refresh
+  - ansibleCreator.refresh
+  - ansiblePlaybooks.refresh
+  - ansibleMcpTools.refresh
+  - ansibleSkills.refresh
+  - ansiblePlaybooks.goToPlay # navigation helper, covered by PLB-001
+  - ansiblePlaybooks.editDefaults # settings form, covered by PLB-002
+  - ansible.statusBar.ansibleClick # status bar detail, covered by ENV-004
+
+stories:
+  # ---------------------------------------------------------------------------
+  # ENV — Environment Management
+  # PRD: Section 1 (Environment and Tool Management), US-1, US-2, AC-1
+  # ---------------------------------------------------------------------------
+  - id: ENV-001
+    title: Discover Python environments
+    story: >
+      As an Ansible developer, I want to see all available Python
+      environments grouped by manager (venv, global, conda) so that
+      I can choose the right one for my project without inspecting
+      paths or running pip list.
+    prd_refs: [US-1, AC-1]
+    requires_ai: false
+    criteria:
+      - Environment Managers tree view populates with discovered environments
+      - Environments are grouped under their manager type
+      - Each environment shows its Python path or version
+
+  - id: ENV-002
+    title: Create virtual environment
+    story: >
+      As an Ansible developer, I want to create a new Python virtual
+      environment from the sidebar so that I can isolate my Ansible
+      tooling per project.
+    prd_refs: [US-1, AC-1]
+    requires_ai: false
+    criteria:
+      - Clicking create in Environment Managers creates a venv
+      - The new environment is auto-selected after creation
+      - The Python status bar updates to reflect the new environment
+
+  - id: ENV-003
+    title: Select Python environment
+    story: >
+      As an Ansible developer, I want to click an environment to
+      select it and have all Ansible tool paths resolve from that
+      environment automatically, so that I don't have to configure
+      tool paths individually.
+    prd_refs: [US-1, AC-1]
+    requires_ai: false
+    criteria:
+      - Clicking an environment in the tree selects it
+      - The Python status bar updates
+      - Subsequent Ansible tool invocations use the selected env's bin directory
+
+  - id: ENV-004
+    title: View installed dev tools and versions
+    story: >
+      As an Ansible developer, I want to see which ansible-dev-tools
+      packages are installed and their versions, so that I know whether
+      my toolchain is current.
+    prd_refs: [US-2, AC-1]
+    requires_ai: false
+    criteria:
+      - Dev Tools tree view shows installed packages with version numbers
+      - Packages include ansible-lint, ansible-navigator, ansible-creator, etc.
+
+  - id: ENV-005
+    title: Install ansible-dev-tools
+    story: >
+      As an Ansible developer, I want to install the ansible-dev-tools
+      meta-package with one click so that I get all required tools
+      without running pip commands.
+    prd_refs: [US-2, AC-1]
+    requires_ai: false
+    criteria:
+      - One-click install from the Dev Tools view
+      - The tree populates with package versions after install
+
+  - id: ENV-006
+    title: Upgrade dev tools
+    story: >
+      As an Ansible developer, I want to upgrade my Ansible
+      development tools when new versions are available, so that I
+      stay on supported versions.
+    prd_refs: [US-2, AC-1]
+    requires_ai: false
+    criteria:
+      - Upgrade action is available in Dev Tools view
+      - After upgrade, version numbers update in the tree
+
+  - id: ENV-007
+    title: Python environment status bar
+    story: >
+      As an Ansible developer, I want to see which Python environment
+      is active in the status bar and click it to see details or
+      switch environments, so that I always know my current context.
+    prd_refs: [US-1, AC-1]
+    requires_ai: false
+    criteria:
+      - Status bar shows the active Python environment
+      - Clicking it opens a QuickPick with environment info
+
+  # ---------------------------------------------------------------------------
+  # LSP — Editor & Language Server
+  # PRD: Assumption 1 (LSP baseline), AC-8; Walkthrough Module 2
+  # ---------------------------------------------------------------------------
+  - id: LSP-001
+    title: Ansible file detection
+    story: >
+      As an Ansible developer, I want my YAML files to be
+      automatically recognized as Ansible when they contain playbook
+      or task content, so that I get language features without manual
+      configuration.
+    prd_refs: [US-18, AC-8]
+    requires_ai: false
+    criteria:
+      - Opening a .ansible.yml file sets languageId to ansible
+      - Playbook heuristic detects ansible content in plain .yml files
+
+  - id: LSP-002
+    title: Syntax highlighting
+    story: >
+      As an Ansible developer, I want Ansible keywords, module names,
+      and Jinja2 template expressions to be syntax-highlighted, so
+      that I can visually parse playbook structure at a glance.
+    prd_refs: [US-18, AC-8]
+    requires_ai: false
+    criteria:
+      - Ansible files show keyword-aware syntax highlighting
+      - Jinja2 expressions are highlighted distinctly
+      - Semantic token provider activates for ansible documents
+
+  - id: LSP-003
+    title: Auto-completion for module names
+    story: >
+      As an Ansible developer, I want auto-completion to suggest
+      module names when I'm writing a task, so that I can find the
+      right module without memorizing FQCNs.
+    prd_refs: [US-3, US-18, AC-8]
+    requires_ai: false
+    criteria:
+      - Triggering completion at a task position offers module names
+      - Task keywords (name, register, when, become) also appear
+
+  - id: LSP-004
+    title: Auto-completion for module options
+    story: >
+      As an Ansible developer, I want auto-completion to suggest a
+      module's parameters after I specify the module name, so that I
+      can use correct parameter names and types without checking docs.
+    prd_refs: [US-3, US-18, AC-8]
+    requires_ai: false
+    criteria:
+      - Requesting completions under a module key returns its options
+      - Options come from ansible-doc (real schema, not training data)
+
+  - id: LSP-005
+    title: Hover documentation
+    story: >
+      As an Ansible developer, I want to hover over a module name or
+      keyword and see its documentation inline, so that I can
+      understand usage without leaving the editor.
+    prd_refs: [US-3, US-18, AC-8]
+    requires_ai: false
+    criteria:
+      - Hovering over an FQCN shows plugin synopsis and description
+      - Hovering over a keyword shows keyword documentation
+
+  - id: LSP-006
+    title: Diagnostics and linting
+    story: >
+      As an Ansible developer, I want to see YAML parse errors and
+      ansible-lint violations as squiggles in the editor as I type,
+      so that I catch problems before running the playbook.
+    prd_refs: [US-18, AC-8]
+    requires_ai: false
+    criteria:
+      - YAML syntax errors produce diagnostic squiggles
+      - ansible-lint findings appear as warnings or errors
+      - Syntax-check fallback works when lint is disabled
+
+  - id: LSP-007
+    title: Vault encrypt and decrypt
+    story: >
+      As an Ansible developer, I want to encrypt and decrypt
+      vault-encrypted content directly from the editor, so that I can
+      manage secrets without switching to the terminal.
+    prd_refs: [US-18, AC-8]
+    requires_ai: false
+    criteria:
+      - Vault command is available via command palette or context menu
+      - Encrypting selected text produces vault-encrypted output
+      - Decrypting vault-encrypted text reveals the original
+
+  - id: LSP-008
+    title: YAML and JSON schema validation
+    story: >
+      As an Ansible developer, I want schema validation for Ansible
+      config files (galaxy.yml, molecule.yml, execution-environment.yml,
+      requirements.yml), so that I get completion and error checking
+      in those files automatically.
+    prd_refs: [US-18, AC-8]
+    requires_ai: false
+    criteria:
+      - galaxy.yml files get schema-driven completion
+      - Invalid keys or values in config files produce diagnostics
+
+  # ---------------------------------------------------------------------------
+  # COL — Collections (Installed + Remote)
+  # PRD: Section 2 (Collection Discovery and Documentation), US-3, US-4, AC-2
+  # ---------------------------------------------------------------------------
+  - id: COL-001
+    title: Browse installed collections
+    story: >
+      As an Ansible developer, I want to browse my installed
+      collections in a tree organized by Collection, Plugin Type, and
+      Plugin, so that I can explore what's available in my environment.
+    prd_refs: [US-3, AC-2]
+    requires_ai: false
+    criteria:
+      - Collections tree view shows installed collections
+      - Each collection expands to show plugin types, then individual plugins
+      - Counts, versions, and descriptions are visible
+
+  - id: COL-002
+    title: Search plugins by keyword
+    story: >
+      As an Ansible developer, I want to search for plugins by
+      keyword across all my installed collections, so that I can find
+      the right module without knowing which collection it belongs to.
+    prd_refs: [US-3, AC-2]
+    requires_ai: false
+    criteria:
+      - Keyword search returns matching plugins across all collections
+      - Results show the plugin FQCN and a brief description
+
+  - id: COL-003
+    title: View plugin documentation
+    story: >
+      As an Ansible developer, I want to view rich, interactive
+      documentation for any installed plugin — including parameters,
+      examples, and return values — without leaving the editor.
+    prd_refs: [US-3, AC-2]
+    requires_ai: false
+    criteria:
+      - Clicking a plugin opens a documentation panel
+      - Panel shows synopsis, parameters with types and defaults, and examples
+      - Return values are documented
+
+  - id: COL-004
+    title: Generate sample tasks from plugin docs
+    story: >
+      As an Ansible developer, I want to generate a sample task from
+      a plugin's documentation with selectable detail levels (minimal,
+      documented, full), so that I can quickly scaffold a correct task
+      without typing it from scratch.
+    prd_refs: [US-3, US-10, AC-2]
+    requires_ai: false
+    criteria:
+      - Plugin Doc panel has a Sample Task tab
+      - Three detail levels are available
+      - Generated YAML uses correct parameter names and types
+
+  - id: COL-005
+    title: Search remote collections
+    story: >
+      As an Ansible developer, I want to search for collections on
+      Ansible Galaxy and my configured GitHub organizations so that I
+      can discover collections I haven't installed yet.
+    prd_refs: [US-4, AC-2]
+    requires_ai: false
+    criteria:
+      - Collection Sources view shows Galaxy and GitHub sources
+      - Search returns matching collections from remote sources
+
+  - id: COL-006
+    title: Browse uninstalled plugin documentation
+    story: >
+      As an Ansible developer, I want to read documentation for
+      plugins in collections I haven't installed yet, so that I can
+      evaluate whether a collection meets my needs before installing.
+    prd_refs: [US-4, AC-2]
+    requires_ai: false
+    criteria:
+      - Clicking a remote plugin opens its documentation panel
+      - Documentation is fetched from Galaxy or GitHub metadata
+
+  - id: COL-007
+    title: Install collection from sidebar
+    story: >
+      As an Ansible developer, I want to install a collection from
+      Galaxy or GitHub with one click from the sidebar, so that I can
+      add dependencies without using the command line.
+    prd_refs: [US-4, AC-2]
+    requires_ai: false
+    criteria:
+      - Install action is available on remote collection items
+      - After install, the collection appears in the installed collections tree
+
+  - id: COL-008
+    title: Manage collection sources
+    story: >
+      As an Ansible developer, I want to add and remove GitHub
+      organizations as collection sources, so that I can discover
+      internal or third-party collections alongside Galaxy.
+    prd_refs: [US-4, AC-2]
+    requires_ai: false
+    criteria:
+      - Add Source action prompts for a GitHub organization
+      - Added sources appear in the Collection Sources tree
+      - Sources can be removed
+
+  # ---------------------------------------------------------------------------
+  # SCF — Content Scaffolding
+  # PRD: Section 3 (Content Scaffolding), US-5, AC-3
+  # ---------------------------------------------------------------------------
+  - id: SCF-001
+    title: Scaffold new Ansible content
+    story: >
+      As an Ansible developer, I want to scaffold new collections,
+      playbook projects, roles, and plugins through an interactive
+      form, so that I always get the correct project structure without
+      memorizing CLI flags.
+    prd_refs: [US-5, AC-3]
+    requires_ai: false
+    criteria:
+      - Creator view shows available ansible-creator subcommands
+      - Opening a form presents fields for the selected scaffold type
+      - Submitting the form creates the correct directory structure
+
+  - id: SCF-002
+    title: Live CLI command preview
+    story: >
+      As an Ansible developer, I want to see the exact
+      ansible-creator command that will be run as I fill out the
+      scaffolding form, so that I can learn the CLI and verify what
+      will happen.
+    prd_refs: [US-5, AC-3]
+    requires_ai: false
+    criteria:
+      - The creator form shows a live command preview
+      - Changing form fields updates the preview in real time
+
+  - id: SCF-003
+    title: Auto-adapt to creator schema
+    story: >
+      As an Ansible developer, I want the scaffolding form to
+      automatically adapt when ansible-creator adds new subcommands,
+      so that I can use new scaffolding capabilities without waiting
+      for an extension update.
+    prd_refs: [US-5, AC-3]
+    requires_ai: false
+    criteria:
+      - Schema is read at runtime from the installed ansible-creator
+      - New subcommands appear in the Creator view automatically
+
+  # ---------------------------------------------------------------------------
+  # PLB — Playbook Execution & Visualization
+  # PRD: Section 4 (Playbook Execution), US-6, AC-4
+  # ---------------------------------------------------------------------------
+  - id: PLB-001
+    title: Discover playbooks in workspace
+    story: >
+      As an Ansible developer, I want to see all playbooks in my
+      workspace organized in a tree with folder structure, play names,
+      and host targets, so that I can quickly navigate my automation.
+    prd_refs: [US-6, AC-4]
+    requires_ai: false
+    criteria:
+      - Playbooks tree view discovers and displays workspace playbooks
+      - Tree shows folder hierarchy, play names, and target hosts
+
+  - id: PLB-002
+    title: Configure playbook execution parameters
+    story: >
+      As an Ansible developer, I want to configure execution
+      parameters (inventory, connection, privilege escalation, vault
+      password, verbosity) through a visual form, so that I can run
+      playbooks without constructing command lines.
+    prd_refs: [US-6, AC-4]
+    requires_ai: false
+    criteria:
+      - Edit Config opens a form with execution parameters
+      - Parameters include inventory, connection, vault, verbosity
+      - Configuration is saved per playbook
+
+  - id: PLB-003
+    title: Run playbook in terminal
+    story: >
+      As an Ansible developer, I want to run a playbook from the
+      sidebar and see its output in an integrated terminal, so that I
+      can execute automation without switching to an external terminal.
+    prd_refs: [US-6, AC-4]
+    requires_ai: false
+    criteria:
+      - Run action launches the playbook in an integrated terminal
+      - Terminal shows ansible-playbook output
+
+  - id: PLB-004
+    title: Real-time playbook progress visualization
+    story: >
+      As an Ansible developer, I want to see real-time progress
+      during playbook execution — which play, task, and host is
+      running, with live ok/changed/failed/skipped counts — so that I
+      can monitor execution without parsing terminal output.
+    prd_refs: [US-6, AC-4]
+    requires_ai: false
+    criteria:
+      - Progress viewer shows a tree of plays, tasks, and hosts
+      - Status updates in real time as tasks complete
+      - Summary stats (ok/changed/failed/skipped) update live
+
+  - id: PLB-005
+    title: AI explanation of playbook failure
+    story: >
+      As an Ansible developer, I want to get an AI-powered
+      explanation of why a playbook task failed, so that I can
+      understand the root cause without manually parsing error output.
+    prd_refs: [US-6, US-8, AC-4]
+    requires_ai: true
+    criteria:
+      - Failed tasks are highlighted in the progress viewer
+      - An analyze action invokes AI to explain the failure
+      - The explanation provides actionable root-cause information
+
+  - id: PLB-006
+    title: AI playbook summary
+    story: >
+      As an Ansible developer, I want to generate a natural-language
+      summary of what a playbook does with one click, so that I can
+      quickly understand unfamiliar automation.
+    prd_refs: [US-11, AC-4]
+    requires_ai: true
+    criteria:
+      - AI summary action is available on playbook tree items
+      - Summary describes the playbook's purpose and structure
+
+  # ---------------------------------------------------------------------------
+  # EE — Execution Environment Inspection
+  # PRD: Section 5 (Execution Environment Inspection), US-7, AC-5
+  # ---------------------------------------------------------------------------
+  - id: EE-001
+    title: Discover execution environment images
+    story: >
+      As an Ansible developer, I want to see which Execution
+      Environment container images are available, so that I can choose
+      the right environment for my automation.
+    prd_refs: [US-7, AC-5]
+    requires_ai: false
+    criteria:
+      - EE tree view discovers and lists available container images
+      - Images are discovered via ansible-navigator
+
+  - id: EE-002
+    title: Inspect EE contents
+    story: >
+      As an Ansible developer, I want to drill into an EE image to
+      see its installed collections, Python packages, and system
+      metadata, so that I understand what's available inside without
+      running the container.
+    prd_refs: [US-7, AC-5]
+    requires_ai: false
+    criteria:
+      - Expanding an EE shows its Ansible info, collections, and packages
+      - Detail panel shows Python and system package lists
+
+  - id: EE-003
+    title: AI EE summary
+    story: >
+      As an Ansible developer, I want an AI-generated summary of
+      what an Execution Environment is suited for, so that I can
+      quickly evaluate whether it fits my use case.
+    prd_refs: [US-7, US-11, AC-5]
+    requires_ai: true
+    criteria:
+      - AI summary action is available on EE tree items
+      - Summary describes the EE's capabilities and intended use
+
+  # ---------------------------------------------------------------------------
+  # AI — AI-Assisted Authoring, MCP, and Skills
+  # PRD: Section 6 (AI Content Authoring), Section 8 (MCP), US-8–11, AC-6
+  # ---------------------------------------------------------------------------
+  - id: AI-001
+    title: AI collection summary
+    story: >
+      As an Ansible developer, I want to generate a natural-language
+      summary of a collection with one click, so that I can quickly
+      understand what it provides without reading every plugin doc.
+    prd_refs: [US-11, AC-6]
+    requires_ai: true
+    criteria:
+      - AI summary action is available on collection tree items
+      - Summary describes the collection's purpose and key plugins
+
+  - id: AI-002
+    title: AI plugin explanation
+    story: >
+      As an Ansible developer, I want an AI-powered explanation of
+      a plugin with practical examples, so that I can understand how
+      to use it effectively beyond the raw documentation.
+    prd_refs: [US-9, US-11, AC-6]
+    requires_ai: true
+    criteria:
+      - AI explanation action is available on plugin tree items
+      - Explanation includes practical usage examples
+
+  - id: AI-003
+    title: Schema-driven task generation
+    story: >
+      As an Ansible developer, I want to generate Ansible tasks from
+      real plugin schemas through a guided, interactive conversation,
+      so that I produce valid YAML with correct parameter names and
+      types.
+    prd_refs: [US-10, AC-6]
+    requires_ai: true
+    criteria:
+      - AI builds tasks using the plugin's actual schema from ansible-doc
+      - Generated task uses correct parameter names, types, and defaults
+      - User can refine the task through conversational feedback
+
+  - id: AI-004
+    title: Natural language playbook generation
+    story: >
+      As an Ansible developer, I want to describe what I need in
+      natural language and have the AI generate a complete playbook
+      using my installed collections and real schemas, so that I go
+      from intent to working code in minutes.
+    prd_refs: [US-8, AC-6]
+    requires_ai: true
+    criteria:
+      - User describes desired outcome in natural language
+      - AI generates a playbook using real plugin schemas
+      - Generated content follows Ansible best practices (FQCN, etc.)
+
+  - id: AI-005
+    title: Natural language role generation
+    story: >
+      As an Ansible developer, I want to describe what I need and
+      have the AI scaffold and populate a complete role, so that I
+      get a properly structured role with validated task files.
+    prd_refs: [US-8, AC-6]
+    requires_ai: true
+    criteria:
+      - User describes role intent in natural language
+      - AI scaffolds role structure via ansible-creator
+      - Task files are populated with schema-validated content
+
+  - id: AI-006
+    title: AI plugin discovery
+    story: >
+      As an Ansible developer, I want to ask the AI "what module
+      should I use for X?" and get a recommendation based on my
+      installed plugins with full parameter guidance, so that I find
+      the right module without browsing docs manually.
+    prd_refs: [US-9, AC-6]
+    requires_ai: true
+    criteria:
+      - AI searches installed plugins based on the user's description
+      - Recommendation includes the plugin FQCN and key parameters
+      - Recommendation is based on the user's actual environment
+
+  - id: AI-007
+    title: Select LLM model and provider
+    story: >
+      As an Ansible developer, I want to choose which LLM model and
+      provider to use for AI features, so that I can use my preferred
+      or organization-approved AI service.
+    prd_refs: [US-18, AC-6]
+    requires_ai: true
+    criteria:
+      - Model selection offers available providers and models
+      - Selected model is used for subsequent AI operations
+
+  - id: AI-008
+    title: Browse and use MCP tools
+    story: >
+      As an Ansible developer, I want to browse the available
+      Ansible MCP tools and invoke them directly in my chat
+      conversation, so that my AI assistant has access to my real
+      Ansible environment.
+    prd_refs: [US-18, AC-8]
+    requires_ai: true
+    criteria:
+      - AI Tools tree view shows available MCP tools by category
+      - Use in Chat action sends the tool prompt to the active chat
+
+  - id: AI-009
+    title: Configure MCP for external AI clients
+    story: >
+      As an Ansible developer, I want to configure MCP integration
+      for my AI client (Cursor, etc.) through a guided setup, so that
+      external AI tools can access my Ansible environment context.
+    prd_refs: [US-18, AC-8]
+    requires_ai: true
+    criteria:
+      - MCP configuration action provides a guided setup flow
+      - Configuration is written for the target AI client
+      - MCP status view shows connection state
+
+  - id: AI-010
+    title: Browse AI skills
+    story: >
+      As an Ansible developer, I want to see what AI skills are
+      available (builtin and external) and understand what each one
+      does, so that I can leverage specialized AI capabilities for
+      different Ansible tasks.
+    prd_refs: [US-18, AC-8]
+    requires_ai: true
+    criteria:
+      - AI Skills tree view shows available skills
+      - Skills are categorized by source (builtin, external)
+      - Each skill shows a description of what it does
+
+  # ---------------------------------------------------------------------------
+  # LS — Ansible Lightspeed
+  # PRD: referenced in Section 6; Walkthrough Module 10
+  # ---------------------------------------------------------------------------
+  - id: LS-001
+    title: Sign in to Ansible Lightspeed
+    story: >
+      As an Ansible developer, I want to sign in to Ansible
+      Lightspeed through an OAuth flow, so that I can access
+      Lightspeed-powered features.
+    prd_refs: [AC-6]
+    requires_ai: false
+    requires_lightspeed: true
+    criteria:
+      - OAuth sign-in flow completes successfully
+      - Lightspeed commands become available after sign-in
+
+  - id: LS-002
+    title: Generate playbook via Lightspeed
+    story: >
+      As an Ansible developer, I want to generate a playbook using
+      Lightspeed's natural language interface, so that I can quickly
+      produce automation from a text description.
+    prd_refs: [US-8, AC-6]
+    requires_ai: false
+    requires_lightspeed: true
+    criteria:
+      - Playbook Generation command opens a webview panel
+      - User can enter a natural language description
+
+  - id: LS-003
+    title: Generate role via Lightspeed
+    story: >
+      As an Ansible developer, I want to generate a role using
+      Lightspeed so that I can scaffold a complete role from a text
+      description.
+    prd_refs: [US-8, AC-6]
+    requires_ai: false
+    requires_lightspeed: true
+    criteria:
+      - Role Generation command opens a webview panel
+
+  - id: LS-004
+    title: Explain playbook via Lightspeed
+    story: >
+      As an Ansible developer, I want to get a Lightspeed-powered
+      explanation of an existing playbook, so that I can understand
+      unfamiliar automation.
+    prd_refs: [US-11, AC-6]
+    requires_ai: false
+    requires_lightspeed: true
+    criteria:
+      - Playbook Explanation command opens a webview panel
+      - Explanation describes the playbook's structure and purpose
+
+  - id: LS-005
+    title: Inline code suggestions
+    story: >
+      As an Ansible developer, I want to see inline ghost-text
+      suggestions as I type in Ansible files, so that I can accept
+      AI-powered completions without opening a separate panel.
+    prd_refs: [US-8, AC-6]
+    requires_ai: false
+    requires_lightspeed: true
+    criteria:
+      - Ghost-text suggestions appear while typing in a task context
+      - Accepting a suggestion inserts the completed content
+
+  - id: LS-006
+    title: Lightspeed error resilience
+    story: >
+      As an Ansible developer, I want Lightspeed features to handle
+      API errors and timeouts gracefully without crashing the
+      extension, so that temporary service issues don't disrupt my
+      work.
+    prd_refs: [US-18, AC-8]
+    requires_ai: false
+    requires_lightspeed: true
+    criteria:
+      - API 401/403 errors are handled without extension crash
+      - Server timeouts are handled gracefully
+      - Extension remains functional after error conditions
+
+  # ---------------------------------------------------------------------------
+  # XC — Cross-Cutting UX
+  # PRD: US-18, US-19, AC-8; Walkthrough Module 11
+  # ---------------------------------------------------------------------------
+  - id: XC-001
+    title: Extension activation and sidebar
+    story: >
+      As an Ansible developer, I want the extension to activate
+      cleanly and show the Ansible sidebar with all expected views,
+      so that I can start working immediately after opening a project.
+    prd_refs: [US-18, AC-8]
+    requires_ai: false
+    criteria:
+      - Extension activates without errors
+      - Ansible icon appears in the activity bar
+      - Clicking the icon opens the sidebar with tree views
+
+  - id: XC-002
+    title: Graceful degradation without AI
+    story: >
+      As an Ansible developer, I want all core features (environment
+      management, collections, scaffolding, playbooks, editor) to
+      work fully without any AI provider configured, so that the
+      extension is valuable from the moment I install it.
+    prd_refs: [US-18, AC-8]
+    requires_ai: false
+    criteria:
+      - Core views populate and function without AI
+      - AI-only actions are hidden or show graceful fallback
+      - No errors when enableAiFeatures is false
+
+  - id: XC-003
+    title: Helpful empty and error states
+    story: >
+      As an Ansible developer, I want helpful guidance when tools are
+      missing, data is unavailable, or something goes wrong, so that
+      I know what to do next instead of seeing a blank view or
+      cryptic error.
+    prd_refs: [US-19, AC-8]
+    requires_ai: false
+    criteria:
+      - Empty tree views show a helpful message with next-step actions
+      - Missing tool warnings explain what to install
+      - Error states show actionable recovery guidance

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,6 +149,7 @@ src/
   adrs/             → Architecture Decision Records
   todos/            → Project work items (pending/complete)
   templates/        → ADR and todo templates
+  user-stories.yaml → User-facing feature catalog (WDIO coverage source of truth)
 .agents/
   skills/           → Agent skills for common workflows
 ```
@@ -216,3 +217,5 @@ the closing `---` is the instruction text. Prompt builders call
 | `manage-todos`          | Project work item tracking              |
 | `branching-strategy`    | Understanding next vs main              |
 | `review-contributor-pr` | Reviewing external contributions        |
+| `define-user-story`     | New user-facing functionality needs a story |
+| `ux-walkthrough`        | Team dogfooding — UX report for Jira    |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,18 @@ pnpm run test:integration
 pnpm run pretest:ui                  # Install chromedriver + test extensions (first time)
 pnpm run test:ui                     # Run WDIO smoke + language server tests
 pnpm run test:lightspeed:ui          # Run WDIO lightspeed tests
+
+# User story coverage (WDIO feature coverage)
+node scripts/story-coverage.mjs --threshold 0   # Report coverage
+node scripts/story-coverage.mjs --threshold 20   # CI gate (exits non-zero if below)
 ```
+
+### User Story Coverage
+
+WDIO tests track coverage against user stories in `.sdlc/user-stories.yaml`.
+Tag `describe` blocks with `@covers STORY-ID` (e.g., `@covers XC-002`).
+New user-facing functionality should have a user story added — use the
+`define-user-story` agent skill or add manually. See ADR-023.
 
 ### Linting
 
@@ -95,7 +106,7 @@ pnpm run docs:preview    # Preview built docs
 ## Testing Framework
 
 - **Vitest** for unit/integration tests — configured with projects: `ext`, `common`, `services`, `mcp`, `ls`, `lightspeed`, `ui`
-- **WebDriverIO** for UI/browser tests (`test/ui/`)
+- **WebDriverIO** for UI/browser tests (`test/ui/`), tracked against user stories in `.sdlc/user-stories.yaml`
 - **VS Code Test CLI** for extension integration tests (`test/integration/`)
 - Path aliases in tests: `@src/*` → `src/*`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,6 +81,30 @@ src/                # VS Code extension host (views, panels, commands)
 | `pnpm run package`         | Package VSIX (no install)              | Verify extension packaging works           |
 | `pnpm run package:install` | Package VSIX and install into VS Code  | Test the extension in your local VS Code   |
 | `pnpm run test:ui`         | WebDriverIO e2e tests                  | After UI/panel changes                     |
+| `pnpm run test:story-coverage` | User story WDIO coverage report    | After adding/modifying WDIO tests          |
+
+## User story coverage
+
+WDIO E2E tests are tracked against user stories defined in
+`.sdlc/user-stories.yaml`. Each story describes a user-facing
+outcome (not a command or view).
+
+When adding a new WDIO test, tag the `describe` block with the
+stories it covers:
+
+```typescript
+/**
+ * @covers PLB-005
+ */
+describe('Playbook failure analysis', () => { ... });
+```
+
+When adding new user-facing functionality, add a user story to
+`.sdlc/user-stories.yaml` (or use the `define-user-story` agent
+skill). CI runs `node scripts/story-coverage.mjs` after WDIO tests
+and will fail if coverage drops below the configured threshold.
+
+Check current coverage: `node scripts/story-coverage.mjs --threshold 0`
 
 ## PR process
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -10,7 +10,13 @@ comment:
 coverage:
   status:
     patch: false
-    project: true
+    project:
+      default:
+        flags: [unit-node22, unit-node24, unit-node26, wsl-fedora]
+      stories:
+        target: 20%
+        threshold: 0%
+        flags: [stories]
 flag_management:
   default_rules:
     carryforward: false
@@ -23,6 +29,8 @@ flag_management:
       carryforward: false
     - name: wsl-fedora
       carryforward: false
+    - name: stories
+      carryforward: true
 github_checks:
   annotations: true
 ignore:

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -106,7 +106,7 @@ export default defineConfig(
             'jsdoc/require-returns': 'error',
             'jsdoc/require-returns-description': 'error',
             'jsdoc/check-param-names': 'error',
-            'jsdoc/check-tag-names': 'error',
+            'jsdoc/check-tag-names': ['error', { definedTags: ['covers'] }],
             'jsdoc/no-types': 'error',
         },
         settings: {

--- a/package.json
+++ b/package.json
@@ -1171,7 +1171,8 @@
     "build:lightspeed:webviews": "pnpm --filter @ansible/lightspeed run build:webviews",
     "pretest:wdio": "pnpm exec tsx tools/ensure-chromedriver.mts && node scripts/install-test-extensions.mjs",
     "help": "node scripts/help.mjs",
-    "deps:check": "echo '=== Outdated ===' && pnpm outdated || true && echo '\n=== Audit ===' && pnpm audit || true"
+    "deps:check": "echo '=== Outdated ===' && pnpm outdated || true && echo '\n=== Audit ===' && pnpm audit || true",
+    "test:story-coverage": "node scripts/story-coverage.mjs --threshold 20"
   },
   "devDependencies": {
     "@commitlint/cli": "^21.2.0",

--- a/packages/lightspeed/test/wdio/lightspeed.spec.ts
+++ b/packages/lightspeed/test/wdio/lightspeed.spec.ts
@@ -72,6 +72,13 @@ async function closeAllEditors(): Promise<void> {
     });
 }
 
+/**
+ * @covers LS-001
+ * @covers LS-002
+ * @covers LS-003
+ * @covers LS-004
+ * @covers LS-006
+ */
 describe('Lightspeed with mock server', () => {
     before(async function () {
 

--- a/scripts/help.mjs
+++ b/scripts/help.mjs
@@ -28,6 +28,7 @@ const catalog = [
     "test:lightspeed": "Lightspeed unit tests",
     "test:lightspeed:ui": "Lightspeed WebDriverIO UI tests",
     "pretest:wdio": "Install Chromedriver and test dependency extensions",
+    "test:story-coverage": "User story WDIO coverage report (threshold gate)",
   }],
   ["Linting", {
     lint: "All linters via prek (eslint, cspell, markdownlint, etc.)",

--- a/scripts/story-coverage.mjs
+++ b/scripts/story-coverage.mjs
@@ -1,0 +1,260 @@
+#!/usr/bin/env node
+/**
+ * Computes user-story coverage from WDIO spec @covers tags.
+ *
+ * Reads .sdlc/user-stories.yaml for the canonical story list, scans
+ * all WDIO spec files for @covers annotations, cross-references them,
+ * and emits a markdown summary. Exits non-zero if coverage drops below
+ * the configured threshold.
+ *
+ * Usage:
+ *   node scripts/story-coverage.mjs [--threshold 20] [--output report.md] [--lcov coverage/stories.lcov]
+ */
+
+import { readFileSync, writeFileSync, mkdirSync, readdirSync, statSync } from 'fs';
+import { join, dirname, relative } from 'path';
+import { fileURLToPath } from 'url';
+import { parse as parseYaml } from 'yaml';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const STORIES_PATH = join(ROOT, '.sdlc', 'user-stories.yaml');
+
+const SPEC_GLOBS = [
+    join(ROOT, 'test', 'ui'),
+    join(ROOT, 'packages', 'lightspeed', 'test', 'wdio'),
+];
+
+// ---------------------------------------------------------------------------
+// CLI args
+// ---------------------------------------------------------------------------
+
+const args = process.argv.slice(2);
+let threshold = 20;
+let outputPath = '';
+let lcovPath = '';
+
+for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--threshold' && args[i + 1]) {
+        threshold = Number(args[++i]);
+        if (!Number.isFinite(threshold) || threshold < 0 || threshold > 100) {
+            console.error(`Invalid --threshold value: must be a number between 0 and 100`);
+            process.exit(1);
+        }
+    } else if (args[i] === '--output' && args[i + 1]) {
+        outputPath = args[++i];
+    } else if (args[i] === '--lcov' && args[i + 1]) {
+        lcovPath = args[++i];
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Load stories
+// ---------------------------------------------------------------------------
+
+const yamlText = readFileSync(STORIES_PATH, 'utf-8');
+const catalog = parseYaml(yamlText);
+
+if (!catalog?.stories?.length) {
+    console.error('No stories found in', STORIES_PATH);
+    process.exit(1);
+}
+
+/** @type {Map<string, { title: string, requires_ai: boolean }>} */
+const storyMap = new Map();
+for (const s of catalog.stories) {
+    storyMap.set(s.id, {
+        title: s.title,
+        requires_ai: s.requires_ai ?? false,
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Scan spec files for @covers tags
+// ---------------------------------------------------------------------------
+
+/**
+ * Recursively collects .spec.ts files from a directory.
+ * @param {string} dir
+ * @returns {string[]}
+ */
+function collectSpecs(dir) {
+    const results = [];
+    let entries;
+    try {
+        entries = readdirSync(dir);
+    } catch {
+        return results;
+    }
+    for (const entry of entries) {
+        const full = join(dir, entry);
+        if (statSync(full).isDirectory()) {
+            results.push(...collectSpecs(full));
+        } else if (entry.endsWith('.spec.ts')) {
+            results.push(full);
+        }
+    }
+    return results;
+}
+
+const COVERS_RE = /@covers\s+([\w-]+)/g;
+
+/** @type {Map<string, Set<string>>} story ID -> set of spec files */
+const coverageMap = new Map();
+
+/** @type {Map<string, Set<string>>} spec file -> set of story IDs */
+const specMap = new Map();
+
+const allSpecs = SPEC_GLOBS.flatMap(collectSpecs);
+
+for (const specPath of allSpecs) {
+    const content = readFileSync(specPath, 'utf-8');
+    const relPath = relative(ROOT, specPath);
+    const matches = [...content.matchAll(COVERS_RE)];
+
+    if (matches.length === 0) continue;
+
+    const storyIds = new Set(matches.map((m) => m[1]));
+    specMap.set(relPath, storyIds);
+
+    for (const id of storyIds) {
+        if (!coverageMap.has(id)) {
+            coverageMap.set(id, new Set());
+        }
+        coverageMap.get(id).add(relPath);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Compute coverage
+// ---------------------------------------------------------------------------
+
+const covered = [];
+const uncovered = [];
+const unknownTags = [];
+
+for (const [id, meta] of storyMap) {
+    if (coverageMap.has(id)) {
+        covered.push({ id, ...meta, specs: [...coverageMap.get(id)] });
+    } else {
+        uncovered.push({ id, ...meta });
+    }
+}
+
+for (const id of coverageMap.keys()) {
+    if (!storyMap.has(id)) {
+        unknownTags.push(id);
+    }
+}
+
+const total = storyMap.size;
+const coveredCount = covered.length;
+const pct = total > 0 ? Math.round((coveredCount / total) * 100) : 0;
+
+// ---------------------------------------------------------------------------
+// Build report
+// ---------------------------------------------------------------------------
+
+const lines = [];
+
+lines.push('# User Story Coverage Report');
+lines.push('');
+lines.push(`**Coverage: ${coveredCount}/${total} stories (${pct}%)**`);
+lines.push(`**Threshold: ${threshold}%**`);
+lines.push('');
+
+if (covered.length > 0) {
+    lines.push('## Covered stories');
+    lines.push('');
+    lines.push('| Story | Title | Spec files |');
+    lines.push('|-------|-------|------------|');
+    for (const s of covered.sort((a, b) => a.id.localeCompare(b.id))) {
+        lines.push(`| ${s.id} | ${s.title} | ${s.specs.join(', ')} |`);
+    }
+    lines.push('');
+}
+
+if (uncovered.length > 0) {
+    lines.push('## Uncovered stories');
+    lines.push('');
+    lines.push('| Story | Title | Requires AI |');
+    lines.push('|-------|-------|-------------|');
+    for (const s of uncovered.sort((a, b) => a.id.localeCompare(b.id))) {
+        lines.push(`| ${s.id} | ${s.title} | ${s.requires_ai ? 'yes' : 'no'} |`);
+    }
+    lines.push('');
+}
+
+if (unknownTags.length > 0) {
+    lines.push('## Unknown @covers tags');
+    lines.push('');
+    lines.push('These tags appear in spec files but have no matching story:');
+    lines.push('');
+    for (const id of unknownTags.sort()) {
+        lines.push(`- \`${id}\``);
+    }
+    lines.push('');
+}
+
+if (specMap.size > 0) {
+    lines.push('## Spec file index');
+    lines.push('');
+    lines.push('| Spec file | Stories covered |');
+    lines.push('|-----------|----------------|');
+    for (const [spec, ids] of [...specMap].sort((a, b) => a[0].localeCompare(b[0]))) {
+        lines.push(`| ${spec} | ${[...ids].sort().join(', ')} |`);
+    }
+    lines.push('');
+}
+
+const report = lines.join('\n');
+
+// ---------------------------------------------------------------------------
+// Output
+// ---------------------------------------------------------------------------
+
+console.log(report);
+
+if (outputPath) {
+    writeFileSync(outputPath, report, 'utf-8');
+    console.log(`Report written to ${outputPath}`);
+}
+
+// ---------------------------------------------------------------------------
+// Synthetic lcov for Codecov (optional)
+// ---------------------------------------------------------------------------
+
+if (lcovPath) {
+    const lcovDir = dirname(lcovPath);
+    mkdirSync(lcovDir, { recursive: true });
+
+    const sortedStories = [...storyMap.entries()].sort((a, b) => a[0].localeCompare(b[0]));
+
+    const sourceLines = sortedStories.map(([id, meta]) => `${id}: ${meta.title}`);
+    const sourcePath = join(lcovDir, 'user-stories.txt');
+    writeFileSync(sourcePath, sourceLines.join('\n') + '\n', 'utf-8');
+
+    const lcovLines = [`TN:user-story-coverage`, `SF:${sourcePath}`];
+    let linesHit = 0;
+    for (let i = 0; i < sortedStories.length; i++) {
+        const hit = coverageMap.has(sortedStories[i][0]) ? 1 : 0;
+        linesHit += hit;
+        lcovLines.push(`DA:${i + 1},${hit}`);
+    }
+    lcovLines.push(`LF:${sortedStories.length}`);
+    lcovLines.push(`LH:${linesHit}`);
+    lcovLines.push('end_of_record');
+
+    writeFileSync(lcovPath, lcovLines.join('\n') + '\n', 'utf-8');
+    console.log(`Synthetic lcov written to ${lcovPath}`);
+    console.log(`Source file written to ${sourcePath}`);
+}
+
+if (pct < threshold) {
+    console.error(
+        `\nCoverage ${pct}% is below threshold ${threshold}%. ` +
+            `Add WDIO tests with @covers tags for uncovered stories.`,
+    );
+    process.exit(1);
+}
+
+console.log(`\nCoverage ${pct}% meets threshold ${threshold}%.`);

--- a/test/ui/languageServer.spec.ts
+++ b/test/ui/languageServer.spec.ts
@@ -4,6 +4,12 @@ import type * as VsCode from 'vscode';
 
 const PLAYBOOK_FILENAME = 'playbook.ansible.yml';
 
+/**
+ * @covers LSP-001
+ * @covers LSP-002
+ * @covers LSP-003
+ * @covers XC-001
+ */
 describe('Ansible Language Server e2e', () => {
     it('should detect .ansible.yml file as ansible language', async () => {
         const workbench = await browser.getWorkbench();

--- a/test/ui/languageServerFullStack.spec.ts
+++ b/test/ui/languageServerFullStack.spec.ts
@@ -25,6 +25,13 @@ function shell(cmd: string, opts: Record<string, unknown> = {}): string {
     }).trim();
 }
 
+/**
+ * @covers ENV-002
+ * @covers ENV-005
+ * @covers COL-007
+ * @covers LSP-003
+ * @covers LSP-004
+ */
 describe('Language Server full stack e2e', function () {
     before(function () {
         this.timeout(600_000);

--- a/test/ui/noAiFallback.spec.ts
+++ b/test/ui/noAiFallback.spec.ts
@@ -1,0 +1,92 @@
+import { browser } from '@wdio/globals';
+import type * as VsCode from 'vscode';
+
+const CORE_VIEWS = [
+    'ansibleDevToolsEnvManagers',
+    'ansibleDevToolsPackages',
+    'ansibleDevToolsCollections',
+    'ansibleCollectionSources',
+    'ansibleExecutionEnvironments',
+    'ansibleCreator',
+    'ansiblePlaybooks',
+];
+
+const AI_GATED_VIEWS = ['ansibleMcpTools', 'ansibleSkills'];
+
+/**
+ * @covers XC-002
+ */
+describe('Graceful degradation without AI', () => {
+    before(async () => {
+        await browser.executeWorkbench(async (vscode: typeof VsCode) => {
+            const config = vscode.workspace.getConfiguration('ansibleEnvironments');
+            await config.update('enableAiFeatures', false, vscode.ConfigurationTarget.Global);
+        });
+        await browser.pause(1000);
+    });
+
+    after(async () => {
+        await browser.executeWorkbench(async (vscode: typeof VsCode) => {
+            const config = vscode.workspace.getConfiguration('ansibleEnvironments');
+            await config.update('enableAiFeatures', undefined, vscode.ConfigurationTarget.Global);
+        });
+    });
+
+    it('should register all core tree views when AI is disabled', async () => {
+        const contributed: string[] = await browser.executeWorkbench(
+            (vscode: typeof VsCode, viewIds: string[]) => {
+                const ext = vscode.extensions.getExtension('redhat.ansible');
+                if (!ext) return [];
+                const pkg = ext.packageJSON as {
+                    contributes?: { views?: Record<string, { id: string }[]> };
+                };
+                const allViews = Object.values(pkg.contributes?.views ?? {}).flat();
+                const ids = new Set(allViews.map((v) => v.id));
+                return viewIds.filter((id) => ids.has(id));
+            },
+            CORE_VIEWS,
+        );
+
+        expect(contributed).toEqual(CORE_VIEWS);
+    });
+
+    it('should hide AI-gated views when enableAiFeatures is false', async () => {
+        const aiSetting: boolean = await browser.executeWorkbench((vscode: typeof VsCode) => {
+            return vscode.workspace
+                .getConfiguration('ansibleEnvironments')
+                .get<boolean>('enableAiFeatures', true);
+        });
+
+        expect(aiSetting).toBe(false);
+
+        // AI Tools and AI Skills views have a "when" clause that hides them.
+        // Verify the when clause is present in the manifest.
+        const gatedCorrectly: boolean = await browser.executeWorkbench(
+            (vscode: typeof VsCode, viewIds: string[]) => {
+                const ext = vscode.extensions.getExtension('redhat.ansible');
+                if (!ext) return false;
+                const pkg = ext.packageJSON as {
+                    contributes?: {
+                        views?: Record<string, { id: string; when?: string }[]>;
+                    };
+                };
+                const allViews = Object.values(pkg.contributes?.views ?? {}).flat();
+                return viewIds.every((id) => {
+                    const view = allViews.find((v) => v.id === id);
+                    return view?.when?.includes('enableAiFeatures') ?? false;
+                });
+            },
+            AI_GATED_VIEWS,
+        );
+
+        expect(gatedCorrectly).toBe(true);
+    });
+
+    it('should keep the extension active and error-free', async () => {
+        const isActive: boolean = await browser.executeWorkbench((vscode: typeof VsCode) => {
+            const ext = vscode.extensions.getExtension('redhat.ansible');
+            return ext?.isActive === true;
+        });
+        expect(isActive).toBe(true);
+    });
+});

--- a/test/ui/smoke.spec.ts
+++ b/test/ui/smoke.spec.ts
@@ -1,6 +1,9 @@
 import { browser } from '@wdio/globals';
 import type * as VsCode from 'vscode';
 
+/**
+ * @covers XC-001
+ */
 describe('VS Code UI smoke test', () => {
     it('should launch a VS Code session', () => {
         expect(browser.sessionId).toBeDefined();


### PR DESCRIPTION
## Summary

E2E tests answer a fundamentally different question than unit tests. Unit tests ask "does this function behave correctly?" and line coverage is the right metric. E2E tests ask "can the user accomplish this task?" — and line coverage is not just unhelpful, it's actively misleading. Our WDIO tests were reporting 100% line coverage because esbuild bundles all source into a single file that V8 marks as fully covered on load. This inflated aggregate coverage from an honest 44% to a misleading 87%, masking the real gaps.

This PR retires V8 line coverage for WDIO tests and replaces it with a user-story-driven model. Instead of asking "which lines did the test touch?", we now ask "which user-facing outcomes have end-to-end validation?" The answer today is 14 out of 54 stories (26%) — an honest number that tells us exactly where to invest next.

Each user story describes something a user can accomplish ("I want to see auto-completion for module options"), not an implementation detail ("the completion provider returns items"). WDIO tests declare which stories they validate via `@covers` tags, and a CI script reports the gap.

Story coverage is also reported to Codecov as a synthetic lcov under a separate `stories` flag. This gives us a native `coverage/project/stories` GitHub status check with trend graphs and PR diffs, completely isolated from the real `coverage/project/default` line metrics.

## Developer workflow

The system is designed so that story coverage grows naturally as features ship, with agents helping at every step:

1. **Developer builds a new feature** — adds a command, view, panel, or MCP tool
2. **`/submit-pr` self-review** (question 10) detects new user-facing functionality in the diff and asks: "This PR adds user-facing capabilities — do you want to define a user story?"
3. **`/define-user-story` skill** walks the developer through writing the story from the user's perspective ("As an Ansible developer, I want to..."), generates acceptance criteria, assigns an ID, and appends it to `.sdlc/user-stories.yaml`
4. **Developer (or agent) writes a WDIO test** with `@covers STORY-ID` on the `describe` block, using acceptance criteria as `it()` blocks
5. **CI runs `scripts/story-coverage.mjs`** after WDIO tests, reports which stories are covered vs uncovered, gates on a threshold (currently 20%), and uploads a synthetic lcov to Codecov under a `stories` flag
6. **`pnpm run test:story-coverage`** lets anyone check coverage locally at any time

If a developer skips the story, the CI report makes the gap visible — it's not a hard block, but the uncovered story shows up in every subsequent PR's coverage report until someone addresses it.

## Changes

### New files
- `.sdlc/user-stories.yaml` — 54 user stories derived from the PRD and walkthrough catalog, organized by area (ENV, LSP, COL, SCF, PLB, EE, AI, LS, XC)
- `scripts/story-coverage.mjs` — CI script that scans WDIO specs for `@covers` tags, cross-references against the story catalog, produces a markdown report with threshold gating, and optionally emits a synthetic lcov for Codecov
- `.agents/skills/define-user-story/SKILL.md` — agent skill for interactive story definition and optional WDIO test scaffolding
- `test/ui/noAiFallback.spec.ts` — new WDIO test covering `XC-002` (graceful degradation without AI), demonstrating the `@covers` workflow
- `.sdlc/adrs/ADR-023-wdio-feature-coverage.md` — architecture decision record documenting the rationale and mechanics

### Modified files
- `test/ui/smoke.spec.ts`, `test/ui/languageServer.spec.ts`, `test/ui/languageServerFullStack.spec.ts`, `packages/lightspeed/test/wdio/lightspeed.spec.ts` — added `@covers` tags mapping existing tests to user stories
- `.github/workflows/ci.yml` — removed WDIO V8 coverage uploads, added story coverage report step with `--lcov` output, added Codecov upload for the `stories` flag
- `codecov.yml` — removed `wdio` flag, added `stories` flag with `carryforward: true`, scoped `coverage/project/default` to unit test flags only, added separate `coverage/project/stories` status check with 20% target
- `sonar-project.properties` — removed `coverage/wdio/lcov.info` path
- `eslint.config.mjs` — added `covers` to allowed JSDoc tags
- `package.json` — added `test:story-coverage` script
- `scripts/help.mjs` — added `test:story-coverage` to catalog
- `.agents/skills/submit-pr/SKILL.md` — added self-review question 10 (detect new user-facing functionality without a user story)
- `CONTRIBUTING.md` — added "User story coverage" section with `@covers` syntax and workflow
- `CLAUDE.md` — added story coverage commands and explanation
- `AGENTS.md` — added `user-stories.yaml` to project structure, `define-user-story` to key skills table
- `.cspell.json` — added "monocart" to SDLC word list

## Test plan

- [x] `pnpm run ci` passes (compile + lint + test:coverage + build)
- [x] `node scripts/story-coverage.mjs --threshold 20 --lcov coverage/stories.lcov` reports 26% and generates valid lcov
- [x] Synthetic lcov has 54 lines (one per story), 14 hits, matching the markdown report
- [x] New WDIO test `noAiFallback.spec.ts` compiles and is detected by the coverage script
- [ ] CI runs story coverage step and uploads to Codecov
- [ ] Codecov shows separate `coverage/project/stories` status check