### PR TITLE
chore: rename test pipeline to next and enable macos testing

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,7 +1,10 @@
 reviews:
   auto_review:
     enabled: true
-    drafts: false  # will exceed rate limits if enabled
+    drafts: false # will exceed rate limits if enabled
+    base_branches:
+      - "main"
+      - "next"
   auto_title_instructions: Use conventional commits structure
   fail_commit_status: true
   high_level_summary_instructions: |
@@ -19,8 +22,8 @@ reviews:
   review_status: false
   pre_merge_checks:
     docstrings:
-      mode: "off"  # not particularly useful, we will enable an eslint plugin for this
+      mode: "off" # not particularly useful, we will enable an eslint plugin for this
   tools:
     github-checks:
       enabled: true
-      timeout_ms: 900000  # waits 15 minutes for github checks to complete, cannot be bigger than this
+      timeout_ms: 900000 # waits 15 minutes for github checks to complete, cannot be bigger than this

--- a/.github/workflows/next.yml
+++ b/.github/workflows/next.yml
@@ -1,4 +1,4 @@
-name: CI
+name: next
 
 on:
   push:
@@ -19,7 +19,7 @@ jobs:
       id-token: write
     strategy:
       matrix:
-        id: [linux]
+        id: [linux, macos]
         node-version: [24]
         runs-on:
           - ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ docs/.astro/
 docs/dist/
 packages/common/src/skills/*.content.ts
 **/*.tgz
+.cursor/hooks/state/continual-learning.json


### PR DESCRIPTION
Related: https://redhat.atlassian.net/browse/AAP-81317


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Renames the test workflow to `next`, broadens the job matrix to include macOS, and updates CodeRabbit settings for `main`/`next` branch reviews while ignoring Cursor hook state files. This aligns CI with the new pipeline and adds cross-platform coverage.

chore: rename test pipeline to next and enable macos testing
Related: AAP-81317

<!-- end of auto-generated comment: release notes by coderabbit.ai -->