### PR TITLE
refactor: reduce cognitive complexity in lightspeed view handlers

### DIFF
--- a/src/features/lightspeed/vue/views/ansibleCreatorUtils.ts
+++ b/src/features/lightspeed/vue/views/ansibleCreatorUtils.ts
@@ -263,100 +263,37 @@ export class AnsibleCreatorOperations {
     const isCollection =
       "initPath" in payload && !("destinationPath" in payload);
 
-    let ansibleCreatorInitCommand: string;
-    let destinationUrl: string;
-
-    if (isCollection) {
-      // Collection-specific logic
-      const collectionPayload = payload;
-      const { namespaceName, collectionName, initPath } = collectionPayload;
-
-      const initPathUrl =
-        initPath || `${os.homedir()}/.ansible/collections/ansible_collections`;
-
-      ansibleCreatorInitCommand = await this.getCollectionCreatorCommand(
-        namespaceName,
-        collectionName,
-        initPathUrl,
-      );
-
-      destinationUrl = initPathUrl.endsWith("/collections/ansible_collections")
-        ? Uri.joinPath(Uri.parse(initPathUrl), namespaceName, collectionName)
-            .fsPath
-        : initPathUrl;
-    } else {
-      // Project-specific logic
-      const projectPayload = payload;
-      const { destinationPath, namespaceName, collectionName } = projectPayload;
-
-      destinationUrl = destinationPath ? destinationPath : os.homedir();
-
-      ansibleCreatorInitCommand = await this.getPlaybookCreatorCommand(
-        namespaceName,
-        collectionName,
-        destinationUrl,
-      );
-    }
+    const built = await this.buildCreatorInitCommand(payload, isCollection);
+    const destinationUrl = built.destinationUrl;
+    let ansibleCreatorInitCommand = built.command;
 
     const creatorVersion = await getCreatorVersion();
     if (!creatorVersion || creatorVersion === "failed") {
-      let commandOutput =
-        "ansible-creator is not installed or not found in PATH.\n";
-      commandOutput += "Please install ansible-creator and try again.\n";
-      await webView.postMessage({
-        command: "execution-log",
-        arguments: {
-          commandOutput: commandOutput,
-          collectionUrl: isCollection ? destinationUrl : undefined,
-          projectUrl: isCollection ? undefined : destinationUrl,
-          status: "failed",
-        },
-      });
+      await this.postCreatorMissing(webView, isCollection, destinationUrl);
       return;
     }
-    let commandOutput = "";
+
     const versionCheck = this.checkVersionWithError(
       creatorVersion,
       ANSIBLE_CREATOR_VERSION_MIN,
     );
     const exceedMinVersion = versionCheck.isGte;
-    if (versionCheck.userMessage) {
-      commandOutput += versionCheck.userMessage;
-    }
+    let commandOutput = versionCheck.userMessage ?? "";
 
-    if (exceedMinVersion && payload.isOverwritten) {
-      ansibleCreatorInitCommand += " --overwrite";
-    } else if (!exceedMinVersion && payload.isOverwritten) {
-      ansibleCreatorInitCommand += " --force";
-    } else if (exceedMinVersion && !payload.isOverwritten) {
-      ansibleCreatorInitCommand += " --no-overwrite";
-    }
+    ansibleCreatorInitCommand = this.applyOverwriteFlag(
+      ansibleCreatorInitCommand,
+      exceedMinVersion,
+      payload.isOverwritten,
+    );
+    ansibleCreatorInitCommand += this.getVerbosityFlag(payload.verbosity);
 
-    const verbosityMap: Record<string, string> = {
-      off: "",
-      low: " -v",
-      medium: " -vv",
-      high: " -vvv",
-    };
-
-    const normalizedVerbosity = payload.verbosity.toLowerCase();
-    const verbosityFlag = verbosityMap[normalizedVerbosity] || "";
-    ansibleCreatorInitCommand += verbosityFlag;
-
-    let logFilePathUrl = "";
-
-    if (payload.logToFile) {
-      logFilePathUrl =
-        payload.logFilePath || `${os.tmpdir()}/ansible-creator.log`;
-      ansibleCreatorInitCommand += ` --lf=${logFilePathUrl}`;
-      ansibleCreatorInitCommand += ` --ll=${payload.logLevel.toLowerCase()}`;
-
-      if (isCollection) {
-        ansibleCreatorInitCommand += ` --la=${payload.logFileAppend}`;
-      } else {
-        ansibleCreatorInitCommand += ` --la=${payload.logFileAppend ? "true" : "false"}`;
-      }
-    }
+    const logFlags = this.applyLogFileFlags(
+      ansibleCreatorInitCommand,
+      payload,
+      isCollection,
+    );
+    ansibleCreatorInitCommand = logFlags.command;
+    const logFilePathUrl = logFlags.logFilePathUrl;
 
     const extSettings = new SettingsManager();
     await extSettings.initialize();
@@ -375,60 +312,13 @@ export class AnsibleCreatorOperations {
 
     // Execute ADE command for collections if needed
     if (isCollection && payload.isEditableModeInstall) {
-      const collectionPayload = payload;
-      const venvPathUrl = Uri.joinPath(
-        Uri.parse(destinationUrl),
-        ".venv",
-      ).fsPath;
-      let adeCommand = `cd ${destinationUrl} && ade install --venv ${venvPathUrl} --editable . --no-ansi`;
-
-      const verbosityMap: Record<string, string> = {
-        off: "",
-        low: " -v",
-        medium: " -vv",
-        high: " -vvv",
-      };
-
-      const normalizedVerbosity = collectionPayload.verbosity.toLowerCase();
-      const verbosityFlag = verbosityMap[normalizedVerbosity] || "";
-      adeCommand += verbosityFlag;
-
-      commandOutput += `\n\n-----------------------------------------ansible-dev-environment logs -----------------------------------------\n`;
-
-      await webView.postMessage({
-        command: "execution-log",
-        arguments: {
-          commandOutput:
-            "Collection scaffolding and environment installation in progress, please wait a few moments....\n",
-          logFileUrl: logFilePathUrl,
-          collectionUrl: destinationUrl,
-          status: "in-progress",
-        },
-      });
-      const adeVersion = await getADEVersion();
-      const adeVersionCheck = this.checkVersionWithError(
-        adeVersion,
-        ADE_ISOLATION_MODE_MIN,
+      commandOutput += await this.runAdeEditableInstall(
+        payload,
+        destinationUrl,
+        logFilePathUrl,
+        extSettings,
+        webView,
       );
-      const exceedADEImVersion = adeVersionCheck.isGte;
-
-      if (exceedADEImVersion) {
-        adeCommand += " --im=cfg";
-        const { command, env } = await withInterpreter(
-          extSettings.settings,
-          adeCommand,
-          "",
-        );
-        const adeExecutionResult = await runCommand(command, env);
-        commandOutput += adeExecutionResult.output;
-      } else {
-        commandOutput += `Collection could not be installed in editable mode.\n`;
-        commandOutput += `The required version of ansible-dev-environment (ade) for editable mode (using --isolation-mode=cfg) is ${ADE_ISOLATION_MODE_MIN}.\n`;
-        commandOutput += `The installed ade version on this system is ${adeVersion}\n`;
-        commandOutput += `Please upgrade to the latest version of ade for this feature.`;
-      }
-
-      console.debug("[ade] command: ", adeCommand);
     }
 
     await webView.postMessage({
@@ -441,6 +331,176 @@ export class AnsibleCreatorOperations {
         status: ansibleCreatorCommandPassed,
       },
     });
+  }
+
+  // Builds the base ansible-creator init command and resolves the destination
+  // URL for either a collection or a project payload.
+  private async buildCreatorInitCommand(
+    payload: AnsibleCollectionFormInterface | AnsibleProjectFormInterface,
+    isCollection: boolean,
+  ): Promise<{ command: string; destinationUrl: string }> {
+    if (isCollection) {
+      const collectionPayload = payload as AnsibleCollectionFormInterface;
+      const { namespaceName, collectionName, initPath } = collectionPayload;
+
+      const initPathUrl =
+        initPath || `${os.homedir()}/.ansible/collections/ansible_collections`;
+
+      const command = await this.getCollectionCreatorCommand(
+        namespaceName,
+        collectionName,
+        initPathUrl,
+      );
+
+      const destinationUrl = initPathUrl.endsWith(
+        "/collections/ansible_collections",
+      )
+        ? Uri.joinPath(Uri.parse(initPathUrl), namespaceName, collectionName)
+            .fsPath
+        : initPathUrl;
+
+      return { command, destinationUrl };
+    }
+
+    const projectPayload = payload as AnsibleProjectFormInterface;
+    const { destinationPath, namespaceName, collectionName } = projectPayload;
+
+    const destinationUrl = destinationPath ? destinationPath : os.homedir();
+
+    const command = await this.getPlaybookCreatorCommand(
+      namespaceName,
+      collectionName,
+      destinationUrl,
+    );
+
+    return { command, destinationUrl };
+  }
+
+  // Posts the "ansible-creator not installed" execution log and stops.
+  private async postCreatorMissing(
+    webView: vscode.Webview,
+    isCollection: boolean,
+    destinationUrl: string,
+  ) {
+    let commandOutput =
+      "ansible-creator is not installed or not found in PATH.\n";
+    commandOutput += "Please install ansible-creator and try again.\n";
+    await webView.postMessage({
+      command: "execution-log",
+      arguments: {
+        commandOutput: commandOutput,
+        collectionUrl: isCollection ? destinationUrl : undefined,
+        projectUrl: isCollection ? undefined : destinationUrl,
+        status: "failed",
+      },
+    });
+  }
+
+  // Appends the overwrite/force/no-overwrite flag based on the creator version
+  // gate and the user's overwrite choice.
+  private applyOverwriteFlag(
+    command: string,
+    exceedMinVersion: boolean,
+    isOverwritten: boolean,
+  ): string {
+    if (exceedMinVersion && isOverwritten) {
+      return command + " --overwrite";
+    } else if (!exceedMinVersion && isOverwritten) {
+      return command + " --force";
+    } else if (exceedMinVersion && !isOverwritten) {
+      return command + " --no-overwrite";
+    }
+    return command;
+  }
+
+  // Maps a verbosity level to its ansible-creator flag.
+  private getVerbosityFlag(verbosity: string): string {
+    const verbosityMap: Record<string, string> = {
+      off: "",
+      low: " -v",
+      medium: " -vv",
+      high: " -vvv",
+    };
+    return verbosityMap[verbosity.toLowerCase()] || "";
+  }
+
+  // Appends the log-file flags when logging to file is enabled and returns the
+  // resolved log file path (empty when logging is disabled).
+  private applyLogFileFlags(
+    command: string,
+    payload: AnsibleCollectionFormInterface | AnsibleProjectFormInterface,
+    isCollection: boolean,
+  ): { command: string; logFilePathUrl: string } {
+    if (!payload.logToFile) {
+      return { command, logFilePathUrl: "" };
+    }
+
+    const logFilePathUrl =
+      payload.logFilePath || `${os.tmpdir()}/ansible-creator.log`;
+    let updated = command;
+    updated += ` --lf=${logFilePathUrl}`;
+    updated += ` --ll=${payload.logLevel.toLowerCase()}`;
+
+    if (isCollection) {
+      updated += ` --la=${payload.logFileAppend}`;
+    } else {
+      updated += ` --la=${payload.logFileAppend ? "true" : "false"}`;
+    }
+
+    return { command: updated, logFilePathUrl };
+  }
+
+  // Runs the ansible-dev-environment editable-mode install for a collection and
+  // returns the log output to append to the overall command output.
+  private async runAdeEditableInstall(
+    payload: AnsibleCollectionFormInterface | AnsibleProjectFormInterface,
+    destinationUrl: string,
+    logFilePathUrl: string,
+    extSettings: SettingsManager,
+    webView: vscode.Webview,
+  ): Promise<string> {
+    let commandOutput = "";
+    const venvPathUrl = Uri.joinPath(Uri.parse(destinationUrl), ".venv").fsPath;
+    let adeCommand = `cd ${destinationUrl} && ade install --venv ${venvPathUrl} --editable . --no-ansi`;
+    adeCommand += this.getVerbosityFlag(payload.verbosity);
+
+    commandOutput += `\n\n-----------------------------------------ansible-dev-environment logs -----------------------------------------\n`;
+
+    await webView.postMessage({
+      command: "execution-log",
+      arguments: {
+        commandOutput:
+          "Collection scaffolding and environment installation in progress, please wait a few moments....\n",
+        logFileUrl: logFilePathUrl,
+        collectionUrl: destinationUrl,
+        status: "in-progress",
+      },
+    });
+    const adeVersion = await getADEVersion();
+    const adeVersionCheck = this.checkVersionWithError(
+      adeVersion,
+      ADE_ISOLATION_MODE_MIN,
+    );
+    const exceedADEImVersion = adeVersionCheck.isGte;
+
+    if (exceedADEImVersion) {
+      adeCommand += " --im=cfg";
+      const { command, env } = await withInterpreter(
+        extSettings.settings,
+        adeCommand,
+        "",
+      );
+      const adeExecutionResult = await runCommand(command, env);
+      commandOutput += adeExecutionResult.output;
+    } else {
+      commandOutput += `Collection could not be installed in editable mode.\n`;
+      commandOutput += `The required version of ansible-dev-environment (ade) for editable mode (using --isolation-mode=cfg) is ${ADE_ISOLATION_MODE_MIN}.\n`;
+      commandOutput += `The installed ade version on this system is ${adeVersion}\n`;
+      commandOutput += `Please upgrade to the latest version of ade for this feature.`;
+    }
+
+    console.debug("[ade] command: ", adeCommand);
+    return commandOutput;
   }
 
   public async isADEPresent(webView: vscode.Webview) {

--- a/src/features/lightspeed/vue/views/ansibleCreatorUtils.ts
+++ b/src/features/lightspeed/vue/views/ansibleCreatorUtils.ts
@@ -365,7 +365,7 @@ export class AnsibleCreatorOperations {
     const projectPayload = payload as AnsibleProjectFormInterface;
     const { destinationPath, namespaceName, collectionName } = projectPayload;
 
-    const destinationUrl = destinationPath ? destinationPath : os.homedir();
+    const destinationUrl = destinationPath || os.homedir();
 
     const command = await this.getPlaybookCreatorCommand(
       namespaceName,

--- a/src/features/lightspeed/vue/views/webviewMessageHandlers.ts
+++ b/src/features/lightspeed/vue/views/webviewMessageHandlers.ts
@@ -1023,205 +1023,63 @@ export class WebviewMessageHandlers {
 
       const {
         destinationPath,
-        verbosity,
-        isOverwritten,
         isCreateContextEnabled,
         isBuildImageEnabled,
         isInitEEProjectEnabled,
-        baseImage,
-        customBaseImage,
-        collections,
-        systemPackages,
-        pythonPackages,
-        tag,
       } = payload;
 
-      let commandResult: string;
-      let message: string;
       let commandOutput = "";
-
       commandOutput += `---------------------------------------- Execution environment generation logs ---------------------------------------\n`;
 
       const destinationPathUrl = destinationPath || this.getWorkspaceFolder();
       const filePath = `${destinationPathUrl}/execution-environment.yml`;
       const fileExists = fs.existsSync(expandPath(filePath));
-      let executionFileCreated = false;
 
-      if (fileExists && !isOverwritten) {
-        message = `Error: Execution environment file already exists at ${destinationPathUrl} and was not overwritten. Use the 'Overwrite' option to overwrite the existing file.`;
-        commandOutput += `${message}\n`;
-        commandResult = "failed";
-      } else {
-        const jsonData: ExecutionEnvironmentDefinition = {
-          version: 3,
-          images: {
-            base_image: {
-              name: baseImage || customBaseImage,
-            },
-          },
-          dependencies: {
-            ansible_core: { package_pip: "ansible-core" },
-            ansible_runner: { package_pip: "ansible-runner" },
-          },
-          options: {
-            tags: [tag],
-          },
-        };
-
-        const collectionsArray = collections
-          .split(",")
-          .map((col) => col.trim())
-          .filter((col) => col !== "");
-
-        if (collectionsArray.length > 0) {
-          jsonData.dependencies.galaxy = {
-            collections: collectionsArray.map((col) => ({ name: col })),
-          };
-        }
-
-        const systemPackagesArray = systemPackages
-          .split(",")
-          .map((pkg) => pkg.trim())
-          .filter((pkg) => pkg !== "");
-        if (systemPackagesArray.length > 0) {
-          jsonData.dependencies.system = systemPackagesArray;
-        }
-
-        const pythonPackagesArray = pythonPackages
-          .split(",")
-          .map((pkg) => pkg.trim())
-          .filter((pkg) => pkg !== "");
-        if (pythonPackagesArray.length > 0) {
-          jsonData.dependencies.python = pythonPackagesArray;
-        }
-
-        if (baseImage?.toLowerCase().includes("fedora")) {
-          jsonData.additional_build_steps = {
-            prepend_base: ["RUN $PKGMGR -y -q install python3-devel"],
-          };
-          jsonData.options.package_manager_path = "/usr/bin/dnf5";
-        } else if (
-          baseImage?.toLowerCase().includes("rhel") ||
-          baseImage?.toLowerCase().includes("redhat")
-        ) {
-          jsonData.options.package_manager_path = "/usr/bin/microdnf";
-        }
-
-        const isSuccess = this.generateYAMLFromJSON(
-          jsonData,
-          destinationPathUrl,
-        );
-
-        if (isSuccess) {
-          commandOutput += `Execution environment file created at ${destinationPathUrl}/execution-environment.yml\n`;
-          commandResult = "passed";
-          executionFileCreated = true;
-        } else {
-          commandOutput += `ERROR: Could not create execution environment file. Please check that your destination path exists and write permissions are configured for it.\n`;
-          commandResult = "failed";
-        }
-      }
+      const fileResult = this.createExecutionEnvFile(
+        payload,
+        destinationPathUrl,
+        fileExists,
+      );
+      commandOutput += fileResult.commandOutput;
+      let commandResult = fileResult.commandResult;
+      const executionFileCreated = fileResult.executionFileCreated;
 
       if (
         isCreateContextEnabled &&
         (executionFileCreated || isInitEEProjectEnabled)
       ) {
-        const createContextCommand = `ansible-builder create --file ${filePath} --context ${destinationPathUrl}/context`;
-        const createContextResult =
-          await this.runAnsibleBuilderCommand(createContextCommand);
-        if (createContextResult.success) {
-          commandOutput += `${createContextResult.output}\n`;
-          commandResult = "passed";
-        } else {
-          commandOutput += `${createContextResult.output}\n`;
-          commandResult = "failed";
-        }
+        const contextResult = await this.runCreateContext(
+          filePath,
+          destinationPathUrl,
+        );
+        commandOutput += contextResult.output;
+        commandResult = contextResult.result;
       }
 
       if (
         isBuildImageEnabled &&
         (executionFileCreated || isInitEEProjectEnabled)
       ) {
-        await webView.postMessage({
-          command: "execution-log",
-          arguments: {
-            commandOutput:
-              commandOutput +
-              "Building execution environment, this may take a few minutes....\n",
-            projectUrl: destinationPathUrl,
-            status: "in-progress",
-          },
-        });
-        await webView.postMessage({ command: "disable-build-button" });
-        await webView.postMessage({ command: "enable-open-file-button" });
-
-        let buildImageCommand = `ansible-builder build --file ${filePath} --context ${destinationPathUrl}/context`;
-
-        switch (verbosity) {
-          case "Off":
-            break;
-          case "Low":
-            buildImageCommand += " -v";
-            break;
-          case "Medium":
-            buildImageCommand += " -vv";
-            break;
-          case "High":
-            buildImageCommand += " -vvv";
-            break;
-          default:
-            break;
-        }
-
-        const buildImageResult =
-          await this.runAnsibleBuilderCommand(buildImageCommand);
-        if (buildImageResult.success) {
-          commandOutput += `${buildImageResult.output}\n`;
-          commandResult = "passed";
-        } else {
-          commandOutput += `${buildImageResult.output}\n`;
-          commandResult = "failed";
-        }
+        const buildResult = await this.runBuildImage(
+          payload,
+          filePath,
+          destinationPathUrl,
+          commandOutput,
+          webView,
+        );
+        commandOutput += buildResult.output;
+        commandResult = buildResult.result;
       }
 
       if (isInitEEProjectEnabled) {
-        await webView.postMessage({
-          command: "execution-log",
-          arguments: {
-            commandOutput:
-              commandOutput + "Building execution environment project....\n",
-            projectUrl: destinationPathUrl,
-            status: "in-progress",
-          },
-        });
-        await webView.postMessage({ command: "disable-build-button" });
-        await webView.postMessage({ command: "enable-open-file-button" });
-
-        let initEEProjectCommand = `ansible-creator init execution_env ${destinationPathUrl}`;
-
-        if (isOverwritten) {
-          initEEProjectCommand += " --overwrite";
-        } else if (!isOverwritten) {
-          initEEProjectCommand += " --no-overwrite";
-        }
-
-        console.debug("[ansible-creator] command: ", initEEProjectCommand);
-
-        const extSettings = new SettingsManager();
-        await extSettings.initialize();
-
-        const { command, env } = await withInterpreter(
-          extSettings.settings,
-          initEEProjectCommand,
-          "",
+        const initResult = await this.runInitEEProject(
+          payload,
+          destinationPathUrl,
+          commandOutput,
+          webView,
         );
-
-        commandOutput = "";
-        commandOutput += `----------------------------------------- ansible-creator logs ------------------------------------------\n`;
-
-        const ansibleCreatorExecutionResult = await runCommand(command, env);
-        commandOutput += ansibleCreatorExecutionResult.output;
-        commandResult = ansibleCreatorExecutionResult.status;
+        commandOutput = initResult.output;
+        commandResult = initResult.result;
       }
 
       console.debug(commandOutput);
@@ -1266,6 +1124,222 @@ export class WebviewMessageHandlers {
         command: "enable-build-button",
       });
     }
+  }
+
+  // Builds the execution-environment.yml definition object from the form
+  // payload (base image, dependency groups, and package-manager tweaks).
+  private buildExecutionEnvDefinition(
+    payload: AnsibleExecutionEnvInterface,
+  ): ExecutionEnvironmentDefinition {
+    const {
+      baseImage,
+      customBaseImage,
+      collections,
+      systemPackages,
+      pythonPackages,
+      tag,
+    } = payload;
+
+    const jsonData: ExecutionEnvironmentDefinition = {
+      version: 3,
+      images: {
+        base_image: {
+          name: baseImage || customBaseImage,
+        },
+      },
+      dependencies: {
+        ansible_core: { package_pip: "ansible-core" },
+        ansible_runner: { package_pip: "ansible-runner" },
+      },
+      options: {
+        tags: [tag],
+      },
+    };
+
+    const collectionsArray = collections
+      .split(",")
+      .map((col) => col.trim())
+      .filter((col) => col !== "");
+    if (collectionsArray.length > 0) {
+      jsonData.dependencies.galaxy = {
+        collections: collectionsArray.map((col) => ({ name: col })),
+      };
+    }
+
+    const systemPackagesArray = systemPackages
+      .split(",")
+      .map((pkg) => pkg.trim())
+      .filter((pkg) => pkg !== "");
+    if (systemPackagesArray.length > 0) {
+      jsonData.dependencies.system = systemPackagesArray;
+    }
+
+    const pythonPackagesArray = pythonPackages
+      .split(",")
+      .map((pkg) => pkg.trim())
+      .filter((pkg) => pkg !== "");
+    if (pythonPackagesArray.length > 0) {
+      jsonData.dependencies.python = pythonPackagesArray;
+    }
+
+    if (baseImage?.toLowerCase().includes("fedora")) {
+      jsonData.additional_build_steps = {
+        prepend_base: ["RUN $PKGMGR -y -q install python3-devel"],
+      };
+      jsonData.options.package_manager_path = "/usr/bin/dnf5";
+    } else if (
+      baseImage?.toLowerCase().includes("rhel") ||
+      baseImage?.toLowerCase().includes("redhat")
+    ) {
+      jsonData.options.package_manager_path = "/usr/bin/microdnf";
+    }
+
+    return jsonData;
+  }
+
+  // Creates the execution-environment.yml file (unless it already exists and
+  // overwrite is off) and reports the resulting log output and status.
+  private createExecutionEnvFile(
+    payload: AnsibleExecutionEnvInterface,
+    destinationPathUrl: string,
+    fileExists: boolean,
+  ): {
+    commandOutput: string;
+    commandResult: string;
+    executionFileCreated: boolean;
+  } {
+    if (fileExists && !payload.isOverwritten) {
+      const message = `Error: Execution environment file already exists at ${destinationPathUrl} and was not overwritten. Use the 'Overwrite' option to overwrite the existing file.`;
+      return {
+        commandOutput: `${message}\n`,
+        commandResult: "failed",
+        executionFileCreated: false,
+      };
+    }
+
+    const jsonData = this.buildExecutionEnvDefinition(payload);
+    const isSuccess = this.generateYAMLFromJSON(jsonData, destinationPathUrl);
+
+    if (isSuccess) {
+      return {
+        commandOutput: `Execution environment file created at ${destinationPathUrl}/execution-environment.yml\n`,
+        commandResult: "passed",
+        executionFileCreated: true,
+      };
+    }
+    return {
+      commandOutput: `ERROR: Could not create execution environment file. Please check that your destination path exists and write permissions are configured for it.\n`,
+      commandResult: "failed",
+      executionFileCreated: false,
+    };
+  }
+
+  // Runs the ansible-builder "create context" step and reports its outcome.
+  private async runCreateContext(
+    filePath: string,
+    destinationPathUrl: string,
+  ): Promise<{ output: string; result: string }> {
+    const createContextCommand = `ansible-builder create --file ${filePath} --context ${destinationPathUrl}/context`;
+    const createContextResult =
+      await this.runAnsibleBuilderCommand(createContextCommand);
+    return {
+      output: `${createContextResult.output}\n`,
+      result: createContextResult.success ? "passed" : "failed",
+    };
+  }
+
+  // Maps a verbosity level to its ansible-builder flag.
+  private getBuildVerbosityFlag(verbosity: string): string {
+    switch (verbosity) {
+      case "Low":
+        return " -v";
+      case "Medium":
+        return " -vv";
+      case "High":
+        return " -vvv";
+      default:
+        return "";
+    }
+  }
+
+  // Runs the ansible-builder "build image" step, emitting the in-progress UI
+  // updates before the (potentially long-running) build.
+  private async runBuildImage(
+    payload: AnsibleExecutionEnvInterface,
+    filePath: string,
+    destinationPathUrl: string,
+    commandOutput: string,
+    webView: vscode.Webview,
+  ): Promise<{ output: string; result: string }> {
+    await webView.postMessage({
+      command: "execution-log",
+      arguments: {
+        commandOutput:
+          commandOutput +
+          "Building execution environment, this may take a few minutes....\n",
+        projectUrl: destinationPathUrl,
+        status: "in-progress",
+      },
+    });
+    await webView.postMessage({ command: "disable-build-button" });
+    await webView.postMessage({ command: "enable-open-file-button" });
+
+    let buildImageCommand = `ansible-builder build --file ${filePath} --context ${destinationPathUrl}/context`;
+    buildImageCommand += this.getBuildVerbosityFlag(payload.verbosity);
+
+    const buildImageResult =
+      await this.runAnsibleBuilderCommand(buildImageCommand);
+    return {
+      output: `${buildImageResult.output}\n`,
+      result: buildImageResult.success ? "passed" : "failed",
+    };
+  }
+
+  // Runs the ansible-creator "init execution_env" step. Replaces the running
+  // command output with the creator logs (matching the original behavior).
+  private async runInitEEProject(
+    payload: AnsibleExecutionEnvInterface,
+    destinationPathUrl: string,
+    commandOutput: string,
+    webView: vscode.Webview,
+  ): Promise<{ output: string; result: string }> {
+    await webView.postMessage({
+      command: "execution-log",
+      arguments: {
+        commandOutput:
+          commandOutput + "Building execution environment project....\n",
+        projectUrl: destinationPathUrl,
+        status: "in-progress",
+      },
+    });
+    await webView.postMessage({ command: "disable-build-button" });
+    await webView.postMessage({ command: "enable-open-file-button" });
+
+    let initEEProjectCommand = `ansible-creator init execution_env ${destinationPathUrl}`;
+
+    if (payload.isOverwritten) {
+      initEEProjectCommand += " --overwrite";
+    } else if (!payload.isOverwritten) {
+      initEEProjectCommand += " --no-overwrite";
+    }
+
+    console.debug("[ansible-creator] command: ", initEEProjectCommand);
+
+    const extSettings = new SettingsManager();
+    await extSettings.initialize();
+
+    const { command, env } = await withInterpreter(
+      extSettings.settings,
+      initEEProjectCommand,
+      "",
+    );
+
+    let output = "";
+    output += `----------------------------------------- ansible-creator logs ------------------------------------------\n`;
+
+    const ansibleCreatorExecutionResult = await runCommand(command, env);
+    output += ansibleCreatorExecutionResult.output;
+    return { output, result: ansibleCreatorExecutionResult.status };
   }
 
   private generateYAMLFromJSON(

--- a/test/unit/lightspeed/views/runExecutionEnvCreateProcess.test.ts
+++ b/test/unit/lightspeed/views/runExecutionEnvCreateProcess.test.ts
@@ -1,0 +1,345 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { MockInstance } from "vitest";
+import * as vscode from "vscode";
+
+// --- Module-level dependencies of the SUT module (mirrors the sibling
+// webviewMessageHandlers.test.ts preamble so the import resolves cleanly). ---
+vi.mock("@src/extension", () => ({
+  lightSpeedManager: {
+    apiInstance: {
+      playbookGenerationRequest: vi.fn(),
+      feedbackRequest: vi.fn(),
+    },
+    providerManager: { generatePlaybook: vi.fn() },
+    settingsManager: {
+      settings: {
+        lightSpeedService: { provider: "google", modelName: "gpt-4" },
+      },
+    },
+    statusBarProvider: {
+      statusBar: { text: "" },
+      getLightSpeedStatusBarText: vi.fn().mockResolvedValue("Lightspeed"),
+    },
+    telemetry: {
+      telemetryService: {},
+      isTelemetryInit: vi.fn().mockResolvedValue(true),
+    },
+    lightspeedExplorerProvider: { refreshWebView: vi.fn() },
+  },
+}));
+
+vi.mock("@src/features/lightspeed/vue/views/lightspeedUtils", async () => {
+  const actual = await vi.importActual(
+    "@src/features/lightspeed/vue/views/lightspeedUtils",
+  );
+  return { ...actual };
+});
+
+vi.mock("@src/features/lightspeed/vue/views/fileOperations", () => ({
+  FileOperations: class {
+    openLogFile = vi.fn();
+    openFolderInWorkspaceProjects = vi.fn();
+    openFolderInWorkspacePlugin = vi.fn();
+    openFolderInWorkspaceRole = vi.fn();
+    openFolderInWorkspaceDevcontainer = vi.fn();
+    openDevfile = vi.fn();
+    openFileInEditor = vi.fn();
+  },
+  openNewPlaybookEditor: vi.fn(),
+  getCollectionsFromWorkspace: vi.fn().mockResolvedValue([]),
+  getRoleBaseDir: vi.fn(),
+  fileExists: vi.fn(),
+}));
+
+vi.mock("@src/features/lightspeed/vue/views/ansibleCreatorUtils", () => ({
+  AnsibleCreatorOperations: class {
+    runInitCommand = vi.fn();
+    runPluginAddCommand = vi.fn();
+    runRoleAddCommand = vi.fn();
+    isADEPresent = vi.fn();
+  },
+}));
+
+vi.mock("@src/utils/telemetryUtils", () => ({ sendTelemetry: vi.fn() }));
+
+// --- Dependencies exercised by runExecutionEnvCreateProcess itself. ---
+vi.mock("fs", async (importActual) => {
+  const actual = await importActual<typeof import("fs")>();
+  return { ...actual, existsSync: vi.fn(), writeFileSync: vi.fn() };
+});
+
+vi.mock("@src/features/contentCreator/utils", async (importActual) => {
+  const actual =
+    await importActual<typeof import("@src/features/contentCreator/utils")>();
+  return {
+    ...actual,
+    expandPath: (p: string) => p,
+    runCommand: vi
+      .fn()
+      .mockResolvedValue({ output: "creator-logs", status: "passed" }),
+  };
+});
+
+vi.mock("@src/features/utils/commandRunner", async (importActual) => {
+  const actual =
+    await importActual<typeof import("@src/features/utils/commandRunner")>();
+  return {
+    ...actual,
+    withInterpreter: vi
+      .fn()
+      .mockResolvedValue({ command: "resolved-cmd", env: {} }),
+  };
+});
+
+vi.mock("@src/settings", () => ({
+  SettingsManager: class {
+    settings = {};
+    async initialize() {
+      /* no-op */
+    }
+  },
+}));
+
+// Import after mocks.
+import { WebviewMessageHandlers } from "@src/features/lightspeed/vue/views/webviewMessageHandlers";
+import * as fs from "fs";
+import { runCommand } from "@src/features/contentCreator/utils";
+import type { AnsibleExecutionEnvInterface } from "@src/features/contentCreator/types";
+
+// The SUT method is public; the collaborators we spy on are private. Expose
+// them through a structural view so vi.spyOn can target them by name.
+interface Handlers {
+  runExecutionEnvCreateProcess: (
+    payload: AnsibleExecutionEnvInterface,
+    webView: vscode.Webview,
+  ) => Promise<void>;
+  getWorkspaceFolder: () => string;
+  generateYAMLFromJSON: (json: unknown, dest: string) => boolean;
+  runAnsibleBuilderCommand: (
+    cmd: string,
+  ) => Promise<{ success: boolean; output: string }>;
+}
+
+function basePayload(
+  overrides: Partial<AnsibleExecutionEnvInterface> = {},
+): AnsibleExecutionEnvInterface {
+  return {
+    destinationPath: "/dest",
+    verbosity: "Off",
+    isOverwritten: true,
+    isCreateContextEnabled: false,
+    isBuildImageEnabled: false,
+    isInitEEProjectEnabled: false,
+    baseImage: "quay.io/ansible/base:latest",
+    customBaseImage: "",
+    collections: "",
+    systemPackages: "",
+    pythonPackages: "",
+    tag: "latest",
+    ...overrides,
+  };
+}
+
+describe("runExecutionEnvCreateProcess", () => {
+  let handlers: Handlers;
+  let webView: vscode.Webview;
+  let yamlSpy: MockInstance;
+  let builderSpy: MockInstance;
+
+  function lastLog() {
+    const calls = vi.mocked(webView.postMessage).mock.calls.map((c) => c[0]);
+    return [...calls]
+      .reverse()
+      .find(
+        (m: unknown) => (m as { command?: string }).command === "execution-log",
+      ) as { arguments: { commandOutput: string; status: string } };
+  }
+
+  function postedCommands() {
+    return vi
+      .mocked(webView.postMessage)
+      .mock.calls.map((c) => (c[0] as { command: string }).command);
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    webView = { postMessage: vi.fn() } as unknown as vscode.Webview;
+    handlers = new WebviewMessageHandlers() as unknown as Handlers;
+
+    vi.spyOn(handlers, "getWorkspaceFolder").mockReturnValue("/ws");
+    yamlSpy = vi.spyOn(handlers, "generateYAMLFromJSON").mockReturnValue(true);
+    builderSpy = vi
+      .spyOn(handlers, "runAnsibleBuilderCommand")
+      .mockResolvedValue({ success: true, output: "builder-out" });
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+  });
+
+  it("posts a failed log and skips generation when the file exists and overwrite is off", async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    await handlers.runExecutionEnvCreateProcess(
+      basePayload({ isOverwritten: false }),
+      webView,
+    );
+
+    expect(yamlSpy).not.toHaveBeenCalled();
+    const log = lastLog();
+    expect(log.arguments.status).toBe("failed");
+    expect(log.arguments.commandOutput).toContain("already exists");
+  });
+
+  it("creates the file and enables the open-file button on success", async () => {
+    await handlers.runExecutionEnvCreateProcess(basePayload(), webView);
+
+    expect(yamlSpy).toHaveBeenCalledTimes(1);
+    const log = lastLog();
+    expect(log.arguments.status).toBe("passed");
+    expect(log.arguments.commandOutput).toContain(
+      "Execution environment file created",
+    );
+    expect(postedCommands()).toContain("enable-open-file-button");
+  });
+
+  it("reports failure and disables the open-file button when YAML generation fails", async () => {
+    yamlSpy.mockReturnValue(false);
+    await handlers.runExecutionEnvCreateProcess(basePayload(), webView);
+
+    const log = lastLog();
+    expect(log.arguments.status).toBe("failed");
+    expect(log.arguments.commandOutput).toContain(
+      "Could not create execution environment file",
+    );
+    expect(postedCommands()).toContain("disable-open-file-button");
+  });
+
+  it("includes collections, system/python packages and tag in the definition", async () => {
+    await handlers.runExecutionEnvCreateProcess(
+      basePayload({
+        collections: "ns.one, ns.two",
+        systemPackages: "gcc,make",
+        pythonPackages: "requests",
+        tag: "v1",
+      }),
+      webView,
+    );
+
+    const json = yamlSpy.mock.calls[0][0] as {
+      dependencies: {
+        galaxy?: { collections: { name: string }[] };
+        system?: string[];
+        python?: string[];
+      };
+      options: { tags: string[] };
+    };
+    expect(json.dependencies.galaxy?.collections).toEqual([
+      { name: "ns.one" },
+      { name: "ns.two" },
+    ]);
+    expect(json.dependencies.system).toEqual(["gcc", "make"]);
+    expect(json.dependencies.python).toEqual(["requests"]);
+    expect(json.options.tags).toEqual(["v1"]);
+  });
+
+  it("omits empty dependency groups", async () => {
+    await handlers.runExecutionEnvCreateProcess(basePayload(), webView);
+    const json = yamlSpy.mock.calls[0][0] as {
+      dependencies: Record<string, unknown>;
+    };
+    expect(json.dependencies.galaxy).toBeUndefined();
+    expect(json.dependencies.system).toBeUndefined();
+    expect(json.dependencies.python).toBeUndefined();
+  });
+
+  it("adds fedora build steps and the dnf5 package manager", async () => {
+    await handlers.runExecutionEnvCreateProcess(
+      basePayload({ baseImage: "quay.io/fedora/fedora:latest" }),
+      webView,
+    );
+    const json = yamlSpy.mock.calls[0][0] as {
+      additional_build_steps?: { prepend_base: string[] };
+      options: { package_manager_path?: string };
+    };
+    expect(json.additional_build_steps?.prepend_base).toEqual([
+      "RUN $PKGMGR -y -q install python3-devel",
+    ]);
+    expect(json.options.package_manager_path).toBe("/usr/bin/dnf5");
+  });
+
+  it("uses microdnf for rhel/redhat base images", async () => {
+    await handlers.runExecutionEnvCreateProcess(
+      basePayload({ baseImage: "registry.redhat.io/rhel9:latest" }),
+      webView,
+    );
+    const json = yamlSpy.mock.calls[0][0] as {
+      options: { package_manager_path?: string };
+    };
+    expect(json.options.package_manager_path).toBe("/usr/bin/microdnf");
+  });
+
+  it("falls back to customBaseImage when baseImage is empty", async () => {
+    await handlers.runExecutionEnvCreateProcess(
+      basePayload({ baseImage: "", customBaseImage: "my/custom:1" }),
+      webView,
+    );
+    const json = yamlSpy.mock.calls[0][0] as {
+      images: { base_image: { name: string } };
+    };
+    expect(json.images.base_image.name).toBe("my/custom:1");
+  });
+
+  it("runs create-context and sets the result from the builder outcome", async () => {
+    builderSpy.mockResolvedValue({ success: true, output: "ctx-out" });
+    await handlers.runExecutionEnvCreateProcess(
+      basePayload({ isCreateContextEnabled: true }),
+      webView,
+    );
+    expect(builderSpy).toHaveBeenCalledWith(
+      expect.stringContaining("ansible-builder create"),
+    );
+    expect(lastLog().arguments.status).toBe("passed");
+  });
+
+  it("marks the result failed when create-context fails", async () => {
+    builderSpy.mockResolvedValue({ success: false, output: "ctx-err" });
+    await handlers.runExecutionEnvCreateProcess(
+      basePayload({ isCreateContextEnabled: true }),
+      webView,
+    );
+    expect(lastLog().arguments.status).toBe("failed");
+  });
+
+  it("builds the image with the verbosity flag when enabled", async () => {
+    await handlers.runExecutionEnvCreateProcess(
+      basePayload({ isBuildImageEnabled: true, verbosity: "Medium" }),
+      webView,
+    );
+    expect(builderSpy).toHaveBeenCalledWith(
+      expect.stringContaining("ansible-builder build"),
+    );
+    expect(builderSpy).toHaveBeenCalledWith(expect.stringContaining(" -vv"));
+  });
+
+  it("runs the init-EE-project command and replaces output with creator logs", async () => {
+    vi.mocked(runCommand).mockResolvedValue({
+      output: "init-ee-logs",
+      status: "passed",
+    });
+    await handlers.runExecutionEnvCreateProcess(
+      basePayload({ isInitEEProjectEnabled: true, isOverwritten: true }),
+      webView,
+    );
+    const log = lastLog();
+    expect(log.arguments.commandOutput).toContain("init-ee-logs");
+    expect(log.arguments.status).toBe("passed");
+  });
+
+  it("posts a failed log from the catch block when an error is thrown", async () => {
+    yamlSpy.mockImplementation(() => {
+      throw new Error("boom");
+    });
+    await handlers.runExecutionEnvCreateProcess(basePayload(), webView);
+    const log = lastLog();
+    expect(log.arguments.status).toBe("failed");
+    expect(log.arguments.commandOutput).toContain("boom");
+    expect(postedCommands()).toContain("enable-build-button");
+  });
+});


### PR DESCRIPTION
## Summary

Resolves the two remaining **High**-severity SonarCloud findings (`typescript:S3776`, Cognitive Complexity > 15) in `src/features/lightspeed/vue/views/`:

| Function | File | Before | Rule limit |
|----------|------|--------|-----------|
| `runInitCommand` | `ansibleCreatorUtils.ts` | 33 | 15 |
| `runExecutionEnvCreateProcess` | `webviewMessageHandlers.ts` | 36 | 15 |

Both are **behavior-preserving** extract-method refactors — public APIs and all observable behavior (command strings, `webView.postMessage` sequences, status results) are unchanged.

## `runInitCommand` (complexity 33 → ≤15)
Extracted private helpers: `buildCreatorInitCommand`, `postCreatorMissing`, `applyOverwriteFlag`, `getVerbosityFlag`, `applyLogFileFlags`, `runAdeEditableInstall`. Verified against the existing 43-case characterization suite (added earlier in #2962).

## `runExecutionEnvCreateProcess` (complexity 36 → ≤15)
This function had **no unit coverage**, so this PR **adds a characterization test suite first** (`runExecutionEnvCreateProcess.test.ts`, 13 cases: file creation/overwrite guard, collection/system/python dependency groups, fedora→dnf5 / rhel→microdnf base-image handling, create-context, build-image verbosity, init-EE-project, and the catch/error path), then extracts: `buildExecutionEnvDefinition`, `createExecutionEnvFile`, `runCreateContext`, `getBuildVerbosityFlag`, `runBuildImage`, `runInitEEProject`.

## Verification
- `typescript:S3776` no longer reported by SonarQube's analyzer on either function (checked via `analyze_code_snippet`).
- `tsc --noEmit`, `eslint`, and `prek` (full `task lint`) all clean.
- Tests: 13 new + 43 (creator) + 39 (existing handlers) green; full `test/unit/lightspeed/views/` suite = 169 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Refactored `runInitCommand` and `runExecutionEnvCreateProcess` into private helper methods to reduce SonarCloud TS complexity while preserving command strings, postMessage order, and status outputs.
- Added a characterization test suite for execution-environment creation (overwrite/verbosity, base-image package-manager variants, and error paths) (Original commit message: Refactor high-complexity LightSpeed Vue view handlers).

_AI-assisted._
<!-- end of auto-generated comment: release notes by coderabbit.ai -->