### PR TITLE
feat(extension): add settings shortcut commands

### DIFF
--- a/.sdlc/todos/complete/add-settings-shortcut-commands.md
+++ b/.sdlc/todos/complete/add-settings-shortcut-commands.md
@@ -1,7 +1,8 @@
 ---
 title: Add settings shortcut commands
 created: 2026-05-26
-status: pending
+completed: 2026-07-10
+status: done
 priority: low
 scope: extension
 ---
@@ -16,8 +17,8 @@ Python Settings". `next` has no such shortcuts.
 
 ## Acceptance criteria
 
-- [ ] Command palette entry to open settings filtered to extension config
-- [ ] Uses `vscode.commands.executeCommand('workbench.action.openSettings', '@ext:...')`
+- [x] Command palette entry to open settings filtered to extension config
+- [x] Uses `vscode.commands.executeCommand('workbench.action.openSettings', '@ext:...')`
 
 ## Notes
 

--- a/package.json
+++ b/package.json
@@ -454,6 +454,16 @@
         "icon": "$(refresh)"
       },
       {
+        "command": "ansible.extension-settings.open",
+        "title": "Open Ansible Extension Settings",
+        "category": "Ansible"
+      },
+      {
+        "command": "ansible.python-settings.open",
+        "title": "Open Python Settings",
+        "category": "Ansible"
+      },
+      {
         "command": "ansible-environments.configureCursorMcp",
         "title": "Ansible: Configure Cursor MCP"
       },

--- a/packages/services/src/CollectionsService.ts
+++ b/packages/services/src/CollectionsService.ts
@@ -656,7 +656,7 @@ export class CollectionsService {
         }
 
         this._log(`Cache miss for ${docKey}, falling back to ansible-doc subprocess`);
-        const typeFlag = this._getTypeFlag(pluginType);
+        const typeArgs = this._getTypeArgs(pluginType);
 
         const { getCommandService } = await import('./CommandService');
         const commandService = getCommandService();
@@ -664,7 +664,7 @@ export class CollectionsService {
         try {
             const result = await commandService.runTool(
                 'ansible-doc',
-                [typeFlag, `"${pluginFullName}"`, '--json'],
+                [...typeArgs, pluginFullName, '--json'],
                 {
                     env: { ANSIBLE_NOCOLOR: '1' },
                 },
@@ -830,27 +830,27 @@ export class CollectionsService {
      * @param pluginType - Plugin category such as module or lookup.
      * @returns ansible-doc type flag string, or empty when the type is unknown.
      */
-    private _getTypeFlag(pluginType: string): string {
-        const typeMap: Record<string, string> = {
-            module: '-t module',
-            become: '-t become',
-            cache: '-t cache',
-            callback: '-t callback',
-            cliconf: '-t cliconf',
-            connection: '-t connection',
-            filter: '-t filter',
-            httpapi: '-t httpapi',
-            inventory: '-t inventory',
-            lookup: '-t lookup',
-            netconf: '-t netconf',
-            shell: '-t shell',
-            strategy: '-t strategy',
-            test: '-t test',
-            vars: '-t vars',
-            role: '-t role',
-            keyword: '-t keyword',
-        };
-        return typeMap[pluginType] || '';
+    private _getTypeArgs(pluginType: string): string[] {
+        const validTypes = new Set([
+            'module',
+            'become',
+            'cache',
+            'callback',
+            'cliconf',
+            'connection',
+            'filter',
+            'httpapi',
+            'inventory',
+            'lookup',
+            'netconf',
+            'shell',
+            'strategy',
+            'test',
+            'vars',
+            'role',
+            'keyword',
+        ]);
+        return validTypes.has(pluginType) ? ['-t', pluginType] : [];
     }
 
     /**

--- a/packages/services/test/services/CommandService.test.ts
+++ b/packages/services/test/services/CommandService.test.ts
@@ -51,10 +51,11 @@ const execFileImpl = vi.hoisted(() =>
         (
             file: string,
             args: string[],
-            opts: Record<string, unknown>,
-            cb: (err: Error | null, stdout?: string, stderr?: string) => void,
+            optsOrCb: Record<string, unknown> | ((err: Error | null, stdout?: string, stderr?: string) => void),
+            maybeCb?: (err: Error | null, stdout?: string, stderr?: string) => void,
         ) => {
-            cb(null, 'out\n', '');
+            const cb = typeof optsOrCb === 'function' ? optsOrCb : maybeCb;
+            cb?.(null, 'out\n', '');
         },
     ),
 );
@@ -98,6 +99,20 @@ describe('CommandService', () => {
         execImpl.mockImplementation((cmd: string, arg2: unknown, arg3?: unknown) => {
             asExecCallback(arg2, arg3)(null, 'out\n', '');
         });
+        execFileImpl.mockReset();
+        execFileImpl.mockImplementation(
+            (
+                _file: string,
+                _args: string[],
+                optsOrCb:
+                    | Record<string, unknown>
+                    | ((err: Error | null, stdout?: string, stderr?: string) => void),
+                maybeCb?: (err: Error | null, stdout?: string, stderr?: string) => void,
+            ) => {
+                const cb = typeof optsOrCb === 'function' ? optsOrCb : maybeCb;
+                cb?.(null, 'out\n', '');
+            },
+        );
     });
 
     afterEach(() => {
@@ -167,11 +182,21 @@ describe('CommandService', () => {
         const { cacheSelectedEnvironment } = await import('../../src/EnvironmentCache');
         cacheSelectedEnvironment(path.join(binDir, 'python'));
 
-        execImpl.mockImplementation((cmd: string, arg2: unknown, arg3?: unknown) => {
-            expect(cmd).toContain('mycli');
-            expect(cmd).toContain('--flag');
-            asExecCallback(arg2, arg3)(null, 'cli-out\n', '');
-        });
+        execFileImpl.mockImplementation(
+            (
+                file: string,
+                args: string[],
+                optsOrCb:
+                    | Record<string, unknown>
+                    | ((err: Error | null, stdout?: string, stderr?: string) => void),
+                maybeCb?: (err: Error | null, stdout?: string, stderr?: string) => void,
+            ) => {
+                expect(file).toBe(tool);
+                expect(args).toEqual(['--flag', 'v']);
+                const cb = typeof optsOrCb === 'function' ? optsOrCb : maybeCb;
+                cb?.(null, 'cli-out\n', '');
+            },
+        );
 
         const { CommandService } = await import('../../src/CommandService');
         const svc = CommandService.getInstance();
@@ -181,13 +206,23 @@ describe('CommandService', () => {
     });
 
     it('runTool returns structured failure when the tool cannot be resolved', async () => {
-        execImpl.mockImplementation((cmd: string, arg2: unknown, arg3?: unknown) => {
-            if (/^(which|where)\s+/i.test(cmd.trim())) {
-                asExecCallback(arg2, arg3)(new Error('not in path'), '', '');
-                return;
-            }
-            asExecCallback(arg2, arg3)(null, 'out\n', '');
-        });
+        execFileImpl.mockImplementation(
+            (
+                file: string,
+                _args: string[],
+                optsOrCb:
+                    | Record<string, unknown>
+                    | ((err: Error | null, stdout?: string, stderr?: string) => void),
+                maybeCb?: (err: Error | null, stdout?: string, stderr?: string) => void,
+            ) => {
+                const cb = typeof optsOrCb === 'function' ? optsOrCb : maybeCb;
+                if (file === 'which' || file === 'where') {
+                    cb?.(new Error('not in path'), '', '');
+                    return;
+                }
+                cb?.(null, 'out\n', '');
+            },
+        );
 
         const { CommandService } = await import('../../src/CommandService');
         const svc = CommandService.getInstance();
@@ -199,15 +234,26 @@ describe('CommandService', () => {
     it('runAnsibleCreator delegates to runTool with ansible-creator name', async () => {
         const binDir = path.join(tmpDir, 'venv3', 'bin');
         fs.mkdirSync(binDir, { recursive: true });
-        fs.writeFileSync(path.join(binDir, 'ansible-creator'), '');
+        const tool = path.join(binDir, 'ansible-creator');
+        fs.writeFileSync(tool, '');
         const { cacheSelectedEnvironment } = await import('../../src/EnvironmentCache');
         cacheSelectedEnvironment(path.join(binDir, 'python'));
 
-        execImpl.mockImplementation((cmd: string, arg2: unknown, arg3?: unknown) => {
-            expect(cmd).toContain('ansible-creator');
-            expect(cmd).toContain('init');
-            asExecCallback(arg2, arg3)(null, 'creator-ok\n', '');
-        });
+        execFileImpl.mockImplementation(
+            (
+                file: string,
+                args: string[],
+                optsOrCb:
+                    | Record<string, unknown>
+                    | ((err: Error | null, stdout?: string, stderr?: string) => void),
+                maybeCb?: (err: Error | null, stdout?: string, stderr?: string) => void,
+            ) => {
+                expect(file).toBe(tool);
+                expect(args).toEqual(['init', 'playbook']);
+                const cb = typeof optsOrCb === 'function' ? optsOrCb : maybeCb;
+                cb?.(null, 'creator-ok\n', '');
+            },
+        );
 
         const { CommandService } = await import('../../src/CommandService');
         const svc = CommandService.getInstance();
@@ -219,14 +265,26 @@ describe('CommandService', () => {
     it('runAnsibleDoc delegates to runTool', async () => {
         const binDir = path.join(tmpDir, 'venv4', 'bin');
         fs.mkdirSync(binDir, { recursive: true });
-        fs.writeFileSync(path.join(binDir, 'ansible-doc'), '');
+        const tool = path.join(binDir, 'ansible-doc');
+        fs.writeFileSync(tool, '');
         const { cacheSelectedEnvironment } = await import('../../src/EnvironmentCache');
         cacheSelectedEnvironment(path.join(binDir, 'python'));
 
-        execImpl.mockImplementation((cmd: string, arg2: unknown, arg3?: unknown) => {
-            expect(cmd).toContain('ansible-doc');
-            asExecCallback(arg2, arg3)(null, 'doc-json\n', '');
-        });
+        execFileImpl.mockImplementation(
+            (
+                file: string,
+                args: string[],
+                optsOrCb:
+                    | Record<string, unknown>
+                    | ((err: Error | null, stdout?: string, stderr?: string) => void),
+                maybeCb?: (err: Error | null, stdout?: string, stderr?: string) => void,
+            ) => {
+                expect(file).toBe(tool);
+                expect(args).toEqual(['-l']);
+                const cb = typeof optsOrCb === 'function' ? optsOrCb : maybeCb;
+                cb?.(null, 'doc-json\n', '');
+            },
+        );
 
         const { CommandService } = await import('../../src/CommandService');
         const svc = CommandService.getInstance();
@@ -237,14 +295,26 @@ describe('CommandService', () => {
     it('installCollection runs ade install', async () => {
         const binDir = path.join(tmpDir, 'venv5', 'bin');
         fs.mkdirSync(binDir, { recursive: true });
-        fs.writeFileSync(path.join(binDir, 'ade'), '');
+        const tool = path.join(binDir, 'ade');
+        fs.writeFileSync(tool, '');
         const { cacheSelectedEnvironment } = await import('../../src/EnvironmentCache');
         cacheSelectedEnvironment(path.join(binDir, 'python'));
 
-        execImpl.mockImplementation((cmd: string, arg2: unknown, arg3?: unknown) => {
-            expect(cmd).toMatch(/ade.*install.*ns\.coll/);
-            asExecCallback(arg2, arg3)(null, 'installed\n', '');
-        });
+        execFileImpl.mockImplementation(
+            (
+                file: string,
+                args: string[],
+                optsOrCb:
+                    | Record<string, unknown>
+                    | ((err: Error | null, stdout?: string, stderr?: string) => void),
+                maybeCb?: (err: Error | null, stdout?: string, stderr?: string) => void,
+            ) => {
+                expect(file).toBe(tool);
+                expect(args).toEqual(['install', 'ns.coll']);
+                const cb = typeof optsOrCb === 'function' ? optsOrCb : maybeCb;
+                cb?.(null, 'installed\n', '');
+            },
+        );
 
         const { CommandService } = await import('../../src/CommandService');
         const svc = CommandService.getInstance();
@@ -260,13 +330,26 @@ describe('CommandService', () => {
         const { cacheSelectedEnvironment } = await import('../../src/EnvironmentCache');
         cacheSelectedEnvironment(path.join(binDir, 'python'));
 
-        execImpl.mockImplementation((cmd: string, arg2: unknown, arg3?: unknown) => {
-            if (/^(which|where)\s+/i.test(cmd.trim()) && cmd.includes('missing-binary-xyz')) {
-                asExecCallback(arg2, arg3)(new Error('not found'), '', '');
-                return;
-            }
-            asExecCallback(arg2, arg3)(null, 'out\n', '');
-        });
+        execFileImpl.mockImplementation(
+            (
+                file: string,
+                args: string[],
+                optsOrCb:
+                    | Record<string, unknown>
+                    | ((err: Error | null, stdout?: string, stderr?: string) => void),
+                maybeCb?: (err: Error | null, stdout?: string, stderr?: string) => void,
+            ) => {
+                const cb = typeof optsOrCb === 'function' ? optsOrCb : maybeCb;
+                if (
+                    (file === 'which' || file === 'where') &&
+                    args.includes('missing-binary-xyz')
+                ) {
+                    cb?.(new Error('not found'), '', '');
+                    return;
+                }
+                cb?.(null, 'out\n', '');
+            },
+        );
 
         const { CommandService } = await import('../../src/CommandService');
         const svc = CommandService.getInstance();
@@ -459,15 +542,26 @@ describe('CommandService', () => {
     it('runAnsibleNavigator delegates to runTool', async () => {
         const binDir = path.join(tmpDir, 'venv-nav', 'bin');
         fs.mkdirSync(binDir, { recursive: true });
-        fs.writeFileSync(path.join(binDir, 'ansible-navigator'), '');
+        const tool = path.join(binDir, 'ansible-navigator');
+        fs.writeFileSync(tool, '');
         const { cacheSelectedEnvironment } = await import('../../src/EnvironmentCache');
         cacheSelectedEnvironment(path.join(binDir, 'python'));
 
-        execImpl.mockImplementation((cmd: string, arg2: unknown, arg3?: unknown) => {
-            expect(cmd).toContain('ansible-navigator');
-            expect(cmd).toContain('run');
-            asExecCallback(arg2, arg3)(null, 'nav-ok\n', '');
-        });
+        execFileImpl.mockImplementation(
+            (
+                file: string,
+                args: string[],
+                optsOrCb:
+                    | Record<string, unknown>
+                    | ((err: Error | null, stdout?: string, stderr?: string) => void),
+                maybeCb?: (err: Error | null, stdout?: string, stderr?: string) => void,
+            ) => {
+                expect(file).toBe(tool);
+                expect(args).toEqual(['run', 'site.yml']);
+                const cb = typeof optsOrCb === 'function' ? optsOrCb : maybeCb;
+                cb?.(null, 'nav-ok\n', '');
+            },
+        );
 
         const { CommandService } = await import('../../src/CommandService');
         const svc = CommandService.getInstance();
@@ -483,13 +577,23 @@ describe('CommandService', () => {
         const { cacheSelectedEnvironment } = await import('../../src/EnvironmentCache');
         cacheSelectedEnvironment(path.join(binDir, 'python'));
 
-        execImpl.mockImplementation((cmd: string, arg2: unknown, arg3?: unknown) => {
-            if (cmd.includes('which') || cmd.includes('where')) {
-                asExecCallback(arg2, arg3)(null, '/usr/bin/some-tool\n', '');
-                return;
-            }
-            asExecCallback(arg2, arg3)(null, 'out\n', '');
-        });
+        execFileImpl.mockImplementation(
+            (
+                file: string,
+                args: string[],
+                optsOrCb:
+                    | Record<string, unknown>
+                    | ((err: Error | null, stdout?: string, stderr?: string) => void),
+                maybeCb?: (err: Error | null, stdout?: string, stderr?: string) => void,
+            ) => {
+                const cb = typeof optsOrCb === 'function' ? optsOrCb : maybeCb;
+                if ((file === 'which' || file === 'where') && args.includes('some-tool')) {
+                    cb?.(null, '/usr/bin/some-tool\n', '');
+                    return;
+                }
+                cb?.(null, 'out\n', '');
+            },
+        );
 
         const { CommandService } = await import('../../src/CommandService');
         const svc = CommandService.getInstance();

--- a/packages/services/test/services/CommandService.test.ts
+++ b/packages/services/test/services/CommandService.test.ts
@@ -51,7 +51,9 @@ const execFileImpl = vi.hoisted(() =>
         (
             file: string,
             args: string[],
-            optsOrCb: Record<string, unknown> | ((err: Error | null, stdout?: string, stderr?: string) => void),
+            optsOrCb:
+                | Record<string, unknown>
+                | ((err: Error | null, stdout?: string, stderr?: string) => void),
             maybeCb?: (err: Error | null, stdout?: string, stderr?: string) => void,
         ) => {
             const cb = typeof optsOrCb === 'function' ? optsOrCb : maybeCb;
@@ -340,10 +342,7 @@ describe('CommandService', () => {
                 maybeCb?: (err: Error | null, stdout?: string, stderr?: string) => void,
             ) => {
                 const cb = typeof optsOrCb === 'function' ? optsOrCb : maybeCb;
-                if (
-                    (file === 'which' || file === 'where') &&
-                    args.includes('missing-binary-xyz')
-                ) {
+                if ((file === 'which' || file === 'where') && args.includes('missing-binary-xyz')) {
                     cb?.(new Error('not found'), '', '');
                     return;
                 }

--- a/packages/services/test/services/ContainerRuntime.test.ts
+++ b/packages/services/test/services/ContainerRuntime.test.ts
@@ -89,18 +89,18 @@ describe('ContainerRuntime', () => {
 
     describe('detectEngine', () => {
         it('returns podman when available', async () => {
-            mocks.mockRunCommand.mockResolvedValue({
+            mocks.mockRunCommandArgs.mockResolvedValue({
                 exitCode: 0,
                 stdout: 'podman 5.0',
                 stderr: '',
             });
             const engine = await detectEngine();
             expect(engine).toBe('podman');
-            expect(mocks.mockRunCommand).toHaveBeenCalledWith('podman --version');
+            expect(mocks.mockRunCommandArgs).toHaveBeenCalledWith('podman', ['--version']);
         });
 
         it('falls back to docker when podman is not found', async () => {
-            mocks.mockRunCommand
+            mocks.mockRunCommandArgs
                 .mockResolvedValueOnce({ exitCode: 127, stdout: '', stderr: 'not found' })
                 .mockResolvedValueOnce({ exitCode: 0, stdout: 'Docker version 24.0', stderr: '' });
             const engine = await detectEngine();
@@ -108,7 +108,7 @@ describe('ContainerRuntime', () => {
         });
 
         it('returns null when neither is found', async () => {
-            mocks.mockRunCommand.mockResolvedValue({
+            mocks.mockRunCommandArgs.mockResolvedValue({
                 exitCode: 127,
                 stdout: '',
                 stderr: 'not found',
@@ -120,7 +120,7 @@ describe('ContainerRuntime', () => {
 
     describe('listImages (podman)', () => {
         it('parses podman JSON format', async () => {
-            mocks.mockRunCommand.mockResolvedValue({
+            mocks.mockRunCommandArgs.mockResolvedValue({
                 exitCode: 0,
                 stdout: PODMAN_IMAGES_JSON,
                 stderr: '',
@@ -148,7 +148,7 @@ describe('ContainerRuntime', () => {
         });
 
         it('returns empty array on failure', async () => {
-            mocks.mockRunCommand.mockResolvedValue({
+            mocks.mockRunCommandArgs.mockResolvedValue({
                 exitCode: 1,
                 stdout: '',
                 stderr: 'error',
@@ -160,7 +160,7 @@ describe('ContainerRuntime', () => {
 
     describe('listImages (docker)', () => {
         it('parses docker line-delimited JSON format', async () => {
-            mocks.mockRunCommand.mockResolvedValue({
+            mocks.mockRunCommandArgs.mockResolvedValue({
                 exitCode: 0,
                 stdout: DOCKER_IMAGES_LINES,
                 stderr: '',
@@ -179,7 +179,7 @@ describe('ContainerRuntime', () => {
 
     describe('inspectImage', () => {
         it('classifies EE image correctly', async () => {
-            mocks.mockRunCommand.mockResolvedValue({
+            mocks.mockRunCommandArgs.mockResolvedValue({
                 exitCode: 0,
                 stdout: INSPECT_EE_JSON,
                 stderr: '',
@@ -198,7 +198,7 @@ describe('ContainerRuntime', () => {
         });
 
         it('classifies non-EE image correctly', async () => {
-            mocks.mockRunCommand.mockResolvedValue({
+            mocks.mockRunCommandArgs.mockResolvedValue({
                 exitCode: 0,
                 stdout: INSPECT_NON_EE_JSON,
                 stderr: '',
@@ -236,7 +236,7 @@ describe('ContainerRuntime', () => {
 
     describe('inspectImage edge cases', () => {
         it('handles malformed JSON in inspect output', async () => {
-            mocks.mockRunCommand.mockResolvedValue({
+            mocks.mockRunCommandArgs.mockResolvedValue({
                 exitCode: 0,
                 stdout: 'not valid json {{{',
                 stderr: '',
@@ -255,7 +255,7 @@ describe('ContainerRuntime', () => {
         });
 
         it('handles inspect command failure', async () => {
-            mocks.mockRunCommand.mockResolvedValue({
+            mocks.mockRunCommandArgs.mockResolvedValue({
                 exitCode: 1,
                 stdout: '',
                 stderr: 'no such image',
@@ -281,7 +281,7 @@ describe('ContainerRuntime', () => {
                     WorkingDir: '/runner',
                 },
             });
-            mocks.mockRunCommand.mockResolvedValue({
+            mocks.mockRunCommandArgs.mockResolvedValue({
                 exitCode: 0,
                 stdout: singleObj,
                 stderr: '',
@@ -299,7 +299,7 @@ describe('ContainerRuntime', () => {
         });
 
         it('handles inspect JSON with missing Config', async () => {
-            mocks.mockRunCommand.mockResolvedValue({
+            mocks.mockRunCommandArgs.mockResolvedValue({
                 exitCode: 0,
                 stdout: JSON.stringify([{ Id: 'sha256:noconfig' }]),
                 stderr: '',
@@ -321,7 +321,7 @@ describe('ContainerRuntime', () => {
 
     describe('listImages edge cases', () => {
         it('returns empty on empty stdout', async () => {
-            mocks.mockRunCommand.mockResolvedValue({
+            mocks.mockRunCommandArgs.mockResolvedValue({
                 exitCode: 0,
                 stdout: '',
                 stderr: '',
@@ -331,7 +331,7 @@ describe('ContainerRuntime', () => {
         });
 
         it('handles malformed podman JSON gracefully', async () => {
-            mocks.mockRunCommand.mockResolvedValue({
+            mocks.mockRunCommandArgs.mockResolvedValue({
                 exitCode: 0,
                 stdout: 'not json at all',
                 stderr: '',
@@ -346,7 +346,7 @@ describe('ContainerRuntime', () => {
                 'not json line',
                 '{"ID":"sha256:good2","Repository":"img2","Tag":"v2","CreatedAt":"now","Size":"2MB"}',
             ].join('\n');
-            mocks.mockRunCommand.mockResolvedValue({
+            mocks.mockRunCommandArgs.mockResolvedValue({
                 exitCode: 0,
                 stdout: lines,
                 stderr: '',
@@ -364,7 +364,7 @@ describe('ContainerRuntime', () => {
                     Size: 0,
                 },
             ]);
-            mocks.mockRunCommand.mockResolvedValue({
+            mocks.mockRunCommandArgs.mockResolvedValue({
                 exitCode: 0,
                 stdout: data,
                 stderr: '',
@@ -382,7 +382,7 @@ describe('ContainerRuntime', () => {
                     Size: 1073741824,
                 },
             ]);
-            mocks.mockRunCommand.mockResolvedValue({
+            mocks.mockRunCommandArgs.mockResolvedValue({
                 exitCode: 0,
                 stdout: data,
                 stderr: '',
@@ -400,7 +400,7 @@ describe('ContainerRuntime', () => {
                     Size: 512,
                 },
             ]);
-            mocks.mockRunCommand.mockResolvedValue({
+            mocks.mockRunCommandArgs.mockResolvedValue({
                 exitCode: 0,
                 stdout: data,
                 stderr: '',
@@ -418,7 +418,7 @@ describe('ContainerRuntime', () => {
                     Size: 1024,
                 },
             ]);
-            mocks.mockRunCommand.mockResolvedValue({
+            mocks.mockRunCommandArgs.mockResolvedValue({
                 exitCode: 0,
                 stdout: data,
                 stderr: '',
@@ -432,7 +432,7 @@ describe('ContainerRuntime', () => {
             const data = JSON.stringify([
                 { Id: 'sha256:zero', Names: ['zero:v1'], CreatedAt: '2026-01-01', Size: 0 },
             ]);
-            mocks.mockRunCommand.mockResolvedValue({
+            mocks.mockRunCommandArgs.mockResolvedValue({
                 exitCode: 0,
                 stdout: data,
                 stderr: '',

--- a/packages/services/test/services/EnvironmentCache.test.ts
+++ b/packages/services/test/services/EnvironmentCache.test.ts
@@ -111,26 +111,25 @@ describe('EnvironmentCache', () => {
         expect(getCachedEnvironment()).toBeNull();
     });
 
-    it('findExecutableWithCache falls back to PATH via child_process.exec', async () => {
+    it('findExecutableWithCache falls back to PATH via child_process.execFile', async () => {
         vi.resetModules();
         process.env.ANSIBLE_ENV_WORKSPACE = tmpDir;
 
-        const execMock = vi.fn((cmd: string, arg2: unknown, arg3?: unknown) => {
-            expect(cmd).toMatch(/^(which|where)\s+/);
-            const cb =
-                typeof arg2 === 'function'
-                    ? (arg2 as (err: Error | null, stdout: string) => void)
-                    : (arg3 as (err: Error | null, stdout: string) => void);
-            cb(null, '/usr/bin/ansible-doc\n');
-        });
+        const execFileMock = vi.fn(
+            (file: string, args: string[], cb: (err: Error | null, stdout: string) => void) => {
+                expect(file).toMatch(/^(which|where)$/);
+                expect(args).toEqual(['ansible-doc']);
+                cb(null, '/usr/bin/ansible-doc\n');
+            },
+        );
 
         vi.doMock('child_process', () => ({
-            exec: execMock,
+            execFile: execFileMock,
         }));
 
         const { findExecutableWithCache } = await import('../../src/EnvironmentCache');
         const resolved = await findExecutableWithCache('ansible-doc');
         expect(resolved).toBe('/usr/bin/ansible-doc');
-        expect(execMock).toHaveBeenCalled();
+        expect(execFileMock).toHaveBeenCalled();
     });
 });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -201,6 +201,22 @@ export function activate(context: vscode.ExtensionContext) {
         log('VS Code MCP API not available (requires VS Code 1.99+)');
     }
 
+    // Settings shortcuts do not require a workspace folder
+    context.subscriptions.push(
+        vscode.commands.registerCommand('ansible.extension-settings.open', async () => {
+            await vscode.commands.executeCommand(
+                'workbench.action.openSettings',
+                '@ext:redhat.ansible',
+            );
+        }),
+        vscode.commands.registerCommand('ansible.python-settings.open', async () => {
+            await vscode.commands.executeCommand(
+                'workbench.action.openSettings',
+                '@ext:ms-python.python',
+            );
+        }),
+    );
+
     // Check if workspace is open
     if (!vscode.workspace.workspaceFolders || vscode.workspace.workspaceFolders.length === 0) {
         vscode.window.showWarningMessage('Ansible requires an open workspace folder.');

--- a/test/ui/languageServerFullStack.spec.ts
+++ b/test/ui/languageServerFullStack.spec.ts
@@ -172,9 +172,11 @@ describe('Language Server full stack e2e', function () {
                     await new Promise((r) => setTimeout(r, waitMs));
 
                     const pos = new vscode.Position(7, 8);
-                    const result: {
-                        items?: { label: string | { label: string } }[];
-                    } | undefined = await vscode.commands.executeCommand(
+                    const result:
+                        | {
+                              items?: { label: string | { label: string } }[];
+                          }
+                        | undefined = await vscode.commands.executeCommand(
                         'vscode.executeCompletionItemProvider',
                         doc.uri,
                         pos,

--- a/test/ui/languageServerFullStack.spec.ts
+++ b/test/ui/languageServerFullStack.spec.ts
@@ -155,46 +155,31 @@ describe('Language Server full stack e2e', function () {
         // column 8 should trigger the LS to call ansible-doc for module
         // options.  If ansible-doc is reachable, we'll get options like
         // "msg", "var", "verbosity".
-        //
-        // ansible-doc can take a while to respond in CI, so poll with retries
-        // instead of a single fixed wait.
-        const debugOptions = ['msg', 'var', 'verbosity'];
-        const maxAttempts = 10;
-        const pollInterval = 3000;
-        let foundOptions: string[] = [];
+        const labels: string[] = await browser.executeWorkbench(
+            async (vscode: typeof VsCode, uri: string) => {
+                const doc = await vscode.workspace.openTextDocument(vscode.Uri.file(uri));
+                await vscode.window.showTextDocument(doc);
 
-        for (let attempt = 0; attempt < maxAttempts; attempt++) {
-            const labels: string[] = await browser.executeWorkbench(
-                async (vscode: typeof VsCode, uri: string, waitMs: number) => {
-                    const doc = await vscode.workspace.openTextDocument(vscode.Uri.file(uri));
-                    await vscode.window.showTextDocument(doc);
+                await new Promise((r) => setTimeout(r, 5000));
 
-                    await new Promise((r) => setTimeout(r, waitMs));
-
-                    const pos = new vscode.Position(7, 8);
-                    const result:
-                        | {
-                              items?: { label: string | { label: string } }[];
-                          }
-                        | undefined = await vscode.commands.executeCommand(
+                const pos = new vscode.Position(7, 8);
+                const result: { items?: { label: string | { label: string } }[] } | undefined =
+                    await vscode.commands.executeCommand(
                         'vscode.executeCompletionItemProvider',
                         doc.uri,
                         pos,
                     );
 
-                    if (!result?.items) return [];
-                    return result.items.map((i) =>
-                        typeof i.label === 'string' ? i.label : i.label.label,
-                    );
-                },
-                fixtureUri,
-                attempt === 0 ? 5000 : pollInterval,
-            );
+                if (!result?.items) return [];
+                return result.items.map((i) =>
+                    typeof i.label === 'string' ? i.label : i.label.label,
+                );
+            },
+            fixtureUri,
+        );
 
-            foundOptions = debugOptions.filter((opt) => labels.includes(opt));
-            if (foundOptions.length > 0) break;
-        }
-
+        const debugOptions = ['msg', 'var', 'verbosity'];
+        const foundOptions = debugOptions.filter((opt) => labels.includes(opt));
         expect(foundOptions.length).toBeGreaterThan(0);
     });
 });

--- a/test/ui/languageServerFullStack.spec.ts
+++ b/test/ui/languageServerFullStack.spec.ts
@@ -155,31 +155,44 @@ describe('Language Server full stack e2e', function () {
         // column 8 should trigger the LS to call ansible-doc for module
         // options.  If ansible-doc is reachable, we'll get options like
         // "msg", "var", "verbosity".
-        const labels: string[] = await browser.executeWorkbench(
-            async (vscode: typeof VsCode, uri: string) => {
-                const doc = await vscode.workspace.openTextDocument(vscode.Uri.file(uri));
-                await vscode.window.showTextDocument(doc);
+        //
+        // ansible-doc can take a while to respond in CI, so poll with retries
+        // instead of a single fixed wait.
+        const debugOptions = ['msg', 'var', 'verbosity'];
+        const maxAttempts = 10;
+        const pollInterval = 3000;
+        let foundOptions: string[] = [];
 
-                await new Promise((r) => setTimeout(r, 5000));
+        for (let attempt = 0; attempt < maxAttempts; attempt++) {
+            const labels: string[] = await browser.executeWorkbench(
+                async (vscode: typeof VsCode, uri: string, waitMs: number) => {
+                    const doc = await vscode.workspace.openTextDocument(vscode.Uri.file(uri));
+                    await vscode.window.showTextDocument(doc);
 
-                const pos = new vscode.Position(7, 8);
-                const result: { items?: { label: string | { label: string } }[] } | undefined =
-                    await vscode.commands.executeCommand(
+                    await new Promise((r) => setTimeout(r, waitMs));
+
+                    const pos = new vscode.Position(7, 8);
+                    const result: {
+                        items?: { label: string | { label: string } }[];
+                    } | undefined = await vscode.commands.executeCommand(
                         'vscode.executeCompletionItemProvider',
                         doc.uri,
                         pos,
                     );
 
-                if (!result?.items) return [];
-                return result.items.map((i) =>
-                    typeof i.label === 'string' ? i.label : i.label.label,
-                );
-            },
-            fixtureUri,
-        );
+                    if (!result?.items) return [];
+                    return result.items.map((i) =>
+                        typeof i.label === 'string' ? i.label : i.label.label,
+                    );
+                },
+                fixtureUri,
+                attempt === 0 ? 5000 : pollInterval,
+            );
 
-        const debugOptions = ['msg', 'var', 'verbosity'];
-        const foundOptions = debugOptions.filter((opt) => labels.includes(opt));
+            foundOptions = debugOptions.filter((opt) => labels.includes(opt));
+            if (foundOptions.length > 0) break;
+        }
+
         expect(foundOptions.length).toBeGreaterThan(0);
     });
 });


### PR DESCRIPTION
## Summary
- Restore command-palette shortcuts to open VS Code settings filtered to the Ansible and Python extensions
- Register the handlers before the no-workspace early return so they work without an open folder
- Fix services unit-test mocks left behind by #3001 (`runCommandArgs` / `execFile`) so CI coverage jobs pass

## Changes
- Add `ansible.extension-settings.open` → `workbench.action.openSettings` with `@ext:redhat.ansible`
- Add `ansible.python-settings.open` → `workbench.action.openSettings` with `@ext:ms-python.python`
- Contribute both commands in `package.json`
- Mark the related SDLC todo complete
- Update `CommandService`, `ContainerRuntime`, and `EnvironmentCache` unit tests for the #3001 API migration

## Quality of life
- None beyond the completed SDLC todo file

## Test plan
- [ ] `pnpm run ci` passes (compile + lint + test:coverage + build)
- [ ] Command palette: **Ansible: Open Ansible Extension Settings** opens Settings filtered to this extension
- [ ] Command palette: **Ansible: Open Python Settings** opens Settings filtered to `ms-python.python`
- [ ] Both commands work with no workspace folder open
- [ ] Services unit tests for CommandService / ContainerRuntime / EnvironmentCache pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Adds command-palette shortcuts for Ansible and Python extension settings, registering handlers before the workspace check so they work without an open folder.
- Contributes both commands and updates related tests for `execFile` and `runCommandArgs` migrations.
- Updates `CollectionsService` to pass typed `ansible-doc` arguments and streamlines language-server test completion fetching.
- Marks the SDLC todo complete.

Commit message: Updates `CollectionsService` to use type arguments instead of type flags when retrieving `ansible-doc` arguments. Also streamlines language server end-to-end test completion-option fetching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->