### PR TITLE
Use abbenay.chat.send for direct prompt injection

### DIFF
--- a/src/features/chatProvider.ts
+++ b/src/features/chatProvider.ts
@@ -86,6 +86,18 @@ async function openVscodeChat(prompt: string): Promise<void> {
  * @param prompt - Prompt text to copy to clipboard
  */
 async function openAbbenayChat(prompt: string): Promise<void> {
+    const allCommands = await vscode.commands.getCommands(true);
+
+    if (allCommands.includes('abbenay.chat.send')) {
+        try {
+            await vscode.commands.executeCommand('abbenay.chat.send', { message: prompt });
+            vscode.window.showInformationMessage('Prompt sent to Abbenay chat.');
+            return;
+        } catch {
+            /* fall through to focus+clipboard */
+        }
+    }
+
     try {
         await vscode.commands.executeCommand('abbenay.chatView.focus');
         await vscode.env.clipboard.writeText(prompt);


### PR DESCRIPTION
## Summary

- Updates `openAbbenayChat()` in `chatProvider.ts` to use the new `abbenay.chat.send` command for zero-click prompt delivery
- Falls back gracefully to the existing focus+clipboard path for older Abbenay versions that lack the command
- All 17 AI chat trigger paths (sparkle buttons, MCP tool inject, skill load, etc.) now deliver prompts directly into the Abbenay chat when the updated Abbenay extension is installed

## Depends on

- https://github.com/redhat-developer/abbenay/pull/61 (adds the `abbenay.chat.send` command to the Abbenay extension)

## Test plan

- [ ] With updated Abbenay: set `chatProvider` to `abbenay`, trigger any AI Summary action — prompt appears in chat and LLM starts streaming (no clipboard toast)
- [ ] Without updated Abbenay: same action falls back to focus+clipboard with the existing toast message
- [ ] Without Abbenay installed: warning message shown
- [ ] `pnpm run lint` passes

---

Assisted-by: Cursor

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Updated `openAbbenayChat()` to send prompts directly through `abbenay.chat.send` when available, enabling zero-click delivery across all AI chat triggers.
- Preserved the existing focus-and-clipboard fallback for older Abbenay versions or failed send attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->