### PR TITLE
fix(mcp): bump repeated tool listing perf threshold to 1000ms

### DIFF
--- a/packages/ansible-mcp-server/test/performance.test.ts
+++ b/packages/ansible-mcp-server/test/performance.test.ts
@@ -181,7 +181,7 @@ describe("Ansible Development Tools MCP Server Performance", () => {
 
       // CI environments (especially macOS and WSL) can be slower than local development
       // Allow more time for CI while still catching real performance regressions
-      expect(duration).toBeLessThan(500); // 1000 listings in less than this
+      expect(duration).toBeLessThan(1000); // 1000 listings in less than this
     });
   });
 });


### PR DESCRIPTION
## Summary

- Bump the performance test threshold for repeated tool listings from 500ms to 1000ms

## Context

The test at `packages/ansible-mcp-server/test/performance.test.ts:184` asserts that 1000 `listTools()` calls complete in under 500ms. CI macOS runners consistently exceed this (e.g. 515ms in [this run](https://github.com/ansible/vscode-ansible/actions/runs/29231499286/job/86773143374)), causing flaky failures. The rerun also failed with the same issue, confirming it's not a one-off.

1000ms still catches real performance regressions while accommodating CI runner variability.

## Test plan

- [ ] `test (macos)` CI job passes
- [x] All other performance tests continue to pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Increased the repeated `server.listTools()` performance test threshold from 500 ms to 1000 ms to accommodate macOS CI variability while still timing 1,000 calls for regression coverage.
- Updated the CI workflow to run `task lint` before the parallel build/package/docs steps, preventing a version-stamping race that could cause lint hooks to see modified files.

  
Original commit message: Update performance test threshold
<!-- end of auto-generated comment: release notes by coderabbit.ai -->