### PR TITLE
Make Abbenay a hard dependency for vscode-ansible

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,11 +27,11 @@
   },
   "extensionDependencies": [
     "ms-python.python",
-    "redhat.vscode-yaml"
+    "redhat.vscode-yaml",
+    "redhat.abbenay-provider"
   ],
   "extensionRecommendations": [
-    "ms-python.vscode-python-envs",
-    "redhat.abbenay-provider"
+    "ms-python.vscode-python-envs"
   ],
   "contributes": {
     "taskDefinitions": [

--- a/scripts/install-test-extensions.mjs
+++ b/scripts/install-test-extensions.mjs
@@ -24,8 +24,6 @@ const DEPENDENCY_EXTENSIONS = [
   "ms-python.vscode-python-envs",
   "ms-vscode-remote.remote-wsl",
   "redhat.vscode-yaml",
-  // Hard dependency (package.json extensionDependencies); required for
-  // redhat.ansible to activate under WDIO.
   "redhat.abbenay-provider",
 ];
 

--- a/scripts/install-test-extensions.mjs
+++ b/scripts/install-test-extensions.mjs
@@ -24,6 +24,9 @@ const DEPENDENCY_EXTENSIONS = [
   "ms-python.vscode-python-envs",
   "ms-vscode-remote.remote-wsl",
   "redhat.vscode-yaml",
+  // Hard dependency (package.json extensionDependencies); required for
+  // redhat.ansible to activate under WDIO.
+  "redhat.abbenay-provider",
 ];
 
 fs.mkdirSync(extensionsDir, { recursive: true });


### PR DESCRIPTION
## Summary
- Move `redhat.abbenay-provider` from `extensionRecommendations` to `extensionDependencies`
- Aligns Abbenay with `ms-python.python` and `redhat.vscode-yaml` so it auto-installs with Ansible
- Added `redhat.abbenay-provider` to the extensions installed by WDIO UI tests.
- JIRA - https://redhat.atlassian.net/browse/AAP-82840