### PR TITLE
feat: Add configurable `ansible-navigator` support for playbook execution

### DIFF
--- a/.sdlc/todos/complete/add-ansible-navigator-run.md
+++ b/.sdlc/todos/complete/add-ansible-navigator-run.md
@@ -1,7 +1,8 @@
 ---
 title: Add ansible-navigator run support
 created: 2026-05-26
-status: pending
+status: done
+completed: 2026-07-16
 priority: medium
 scope: extension
 ---
@@ -18,9 +19,9 @@ execution, execution environment integration, and artifact collection.
 
 ## Acceptance criteria
 
-- [ ] "Run via ansible-navigator" option in Playbooks tree context menu
-- [ ] ansible-navigator discovered via CommandService from active venv
-- [ ] Runs in integrated terminal with venv activation
+- [x] "Run via ansible-navigator" option in Playbooks tree context menu
+- [x] ansible-navigator discovered via CommandService from active venv
+- [x] Runs in integrated terminal with venv activation
 
 ## Notes
 

--- a/.sdlc/user-stories.yaml
+++ b/.sdlc/user-stories.yaml
@@ -449,6 +449,34 @@ stories:
       - AI summary action is available on playbook tree items
       - Summary describes the playbook's purpose and structure
 
+  - id: PLB-007
+    title: Run playbook via ansible-navigator
+    story: >
+      As an Ansible developer, I want to run a playbook via
+      ansible-navigator from the sidebar, so that I can leverage
+      execution environments and artifact collection.
+    prd_refs: [US-6, AC-4]
+    requires_ai: false
+    criteria:
+      - Run via ansible-navigator action appears when navigator is installed
+      - Runs ansible-navigator run in an integrated terminal with venv activation
+      - Uses playbook configuration for flags via -- passthrough
+
+  - id: PLB-008
+    title: Configurable executor for playbook progress viewer
+    story: >
+      As an Ansible developer, I want to choose between ansible-playbook
+      and ansible-navigator as my playbook executor in the configuration
+      panel and progress viewer, so that I can use execution environments
+      with real-time progress visualization.
+    prd_refs: [US-6, AC-4]
+    requires_ai: false
+    criteria:
+      - Executor dropdown in playbook configuration form
+      - VS Code setting for default executor
+      - Progress viewer works with both ansible-playbook and ansible-navigator
+      - Callback plugin volume-mounted into EE containers for navigator runs
+
   # ---------------------------------------------------------------------------
   # EE — Execution Environment Inspection
   # PRD: Section 5 (Execution Environment Inspection), US-7, AC-5

--- a/.sdlc/user-stories.yaml
+++ b/.sdlc/user-stories.yaml
@@ -462,7 +462,7 @@ stories:
       - Executor dropdown in playbook configuration form
       - VS Code setting (ansibleEnvironments.playbookExecutor) for default executor
       - Run Playbook action uses configured executor
-      - Progress viewer uses configured executor with --execution-environment false
+      - Progress viewer uses the configured executor; ansible-navigator runs include --execution-environment false
       - Command preview in config form reflects selected executor
 
   # ---------------------------------------------------------------------------

--- a/package.json
+++ b/package.json
@@ -536,6 +536,11 @@
         "icon": "$(graph)"
       },
       {
+        "command": "ansiblePlaybooks.runWithNavigator",
+        "title": "Run via ansible-navigator",
+        "icon": "$(rocket)"
+      },
+      {
         "command": "ansiblePlaybooks.openPlaybook",
         "title": "Edit Playbook",
         "icon": "$(edit)"
@@ -913,19 +918,24 @@
           "group": "inline@2"
         },
         {
-          "command": "ansiblePlaybooks.openPlaybook",
-          "when": "view == ansiblePlaybooks && viewItem == playbook",
+          "command": "ansiblePlaybooks.runWithNavigator",
+          "when": "view == ansiblePlaybooks && viewItem == playbook && ansible.navigatorAvailable",
           "group": "inline@3"
         },
         {
-          "command": "ansiblePlaybooks.editConfig",
+          "command": "ansiblePlaybooks.openPlaybook",
           "when": "view == ansiblePlaybooks && viewItem == playbook",
           "group": "inline@4"
         },
         {
+          "command": "ansiblePlaybooks.editConfig",
+          "when": "view == ansiblePlaybooks && viewItem == playbook",
+          "group": "inline@5"
+        },
+        {
           "command": "ansiblePlaybooks.aiSummary",
           "when": "view == ansiblePlaybooks && viewItem == playbook && config.ansibleEnvironments.enableAiFeatures",
-          "group": "inline@5"
+          "group": "inline@6"
         },
         {
           "command": "ansibleMcpTools.copyPrompt",
@@ -1070,6 +1080,19 @@
             }
           },
           "description": "AI skill sources. Each source points to a GitHub repo or local directory containing SKILL.md files."
+        },
+        "ansibleEnvironments.playbookExecutor": {
+          "type": "string",
+          "enum": [
+            "ansible-playbook",
+            "ansible-navigator"
+          ],
+          "default": "ansible-playbook",
+          "enumDescriptions": [
+            "Run playbooks directly with ansible-playbook",
+            "Run playbooks via ansible-navigator (supports execution environments and artifact collection)"
+          ],
+          "markdownDescription": "Default executor for running playbooks from the progress viewer and configuration panel."
         },
         "ansibleEnvironments.pluginDocZoom": {
           "type": "number",

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -36,6 +36,7 @@ export type {
     SkillCategory,
     TrustLevel,
     RepoFormat,
+    PlaybookExecutor,
     PlaybookConfig,
     PlaybookPlay,
     ProgressEvent,
@@ -62,11 +63,15 @@ export { BUILTIN_SKILLS } from './skills';
 
 // --- Parsers ---
 export {
+    buildPlaybookFlags,
     buildPlaybookCommand,
+    buildNavigatorCommand,
+    buildNavigatorEECommand,
     parsePlaybook,
     mergePlaybookConfig,
     DEFAULT_PLAYBOOK_CONFIG,
 } from './parsers/playbookParser';
+export type { NavigatorEEOptions } from './parsers/playbookParser';
 export { extractMetadataJson, parseMetadataDump } from './parsers/metadataDumpParser';
 export type {
     MetadataDump,

--- a/packages/common/src/parsers/playbookParser.ts
+++ b/packages/common/src/parsers/playbookParser.ts
@@ -3,6 +3,7 @@
  * No VS Code dependency — suitable for MCP server and UI consumers.
  */
 import type { PlaybookConfig, PlaybookPlay } from '../types/playbook';
+import { quoteIfNeeded } from '../utils/creatorArgs';
 
 /** Default playbook run configuration. */
 export const DEFAULT_PLAYBOOK_CONFIG: PlaybookConfig = {
@@ -154,7 +155,8 @@ export function buildPlaybookFlags(config: PlaybookConfig): string[] {
  * @returns Space-joined ansible-playbook command.
  */
 export function buildPlaybookCommand(playbookPath: string, config: PlaybookConfig): string {
-    return ['ansible-playbook', ...buildPlaybookFlags(config), playbookPath].join(' ');
+    const args = ['ansible-playbook', ...buildPlaybookFlags(config), playbookPath];
+    return args.map(quoteIfNeeded).join(' ');
 }
 
 /**
@@ -176,7 +178,7 @@ export function buildNavigatorCommand(playbookPath: string, config: PlaybookConf
         args.push('--', ...passthroughFlags);
     }
 
-    return args.join(' ');
+    return args.map(quoteIfNeeded).join(' ');
 }
 
 /** Options for ansible-navigator execution environment integration. */
@@ -229,7 +231,7 @@ export function buildNavigatorEECommand(
         args.push('--', ...passthroughFlags);
     }
 
-    return args.join(' ');
+    return args.map(quoteIfNeeded).join(' ');
 }
 
 /**

--- a/packages/common/src/parsers/playbookParser.ts
+++ b/packages/common/src/parsers/playbookParser.ts
@@ -4,8 +4,9 @@
  */
 import type { PlaybookConfig, PlaybookPlay } from '../types/playbook';
 
-/** Default ansible-playbook run configuration. */
+/** Default playbook run configuration. */
 export const DEFAULT_PLAYBOOK_CONFIG: PlaybookConfig = {
+    executor: 'ansible-playbook',
     inventory: [],
     limit: '',
     tags: [],
@@ -31,31 +32,33 @@ export const DEFAULT_PLAYBOOK_CONFIG: PlaybookConfig = {
 };
 
 /**
- * Build an ansible-playbook CLI command string from configuration.
+ * Build ansible-playbook CLI flags from configuration (no executable or playbook path).
  *
- * @param playbookPath - Path to the playbook file (appended last).
+ * Shared by both `buildPlaybookCommand` and `buildNavigatorCommand` to avoid
+ * duplicating flag translation logic.
+ *
  * @param config - Effective run settings.
- * @returns Space-joined ansible-playbook command.
+ * @returns Array of CLI flag strings.
  */
-export function buildPlaybookCommand(playbookPath: string, config: PlaybookConfig): string {
-    const args: string[] = ['ansible-playbook'];
+export function buildPlaybookFlags(config: PlaybookConfig): string[] {
+    const flags: string[] = [];
 
     if (config.inventory && config.inventory.length > 0) {
         for (const inv of config.inventory) {
             if (inv) {
-                args.push('-i', inv);
+                flags.push('-i', inv);
             }
         }
     }
 
     if (config.limit) {
-        args.push('-l', config.limit);
+        flags.push('-l', config.limit);
     }
 
     if (config.tags && config.tags.length > 0) {
         for (const tag of config.tags) {
             if (tag) {
-                args.push('-t', tag);
+                flags.push('-t', tag);
             }
         }
     }
@@ -63,84 +66,168 @@ export function buildPlaybookCommand(playbookPath: string, config: PlaybookConfi
     if (config.skipTags && config.skipTags.length > 0) {
         for (const tag of config.skipTags) {
             if (tag) {
-                args.push('--skip-tags', tag);
+                flags.push('--skip-tags', tag);
             }
         }
     }
 
     if (config.extraVars) {
-        args.push('-e', config.extraVars);
+        flags.push('-e', config.extraVars);
     }
 
     if (config.check) {
-        args.push('--check');
+        flags.push('--check');
     }
 
     if (config.diff) {
-        args.push('--diff');
+        flags.push('--diff');
     }
 
     if (config.verbose && config.verbose > 0) {
-        args.push('-' + 'v'.repeat(Math.min(config.verbose, 6)));
+        flags.push('-' + 'v'.repeat(Math.min(config.verbose, 6)));
     }
 
     if (config.forks && config.forks !== 5) {
-        args.push('-f', String(config.forks));
+        flags.push('-f', String(config.forks));
     }
 
     if (config.connection && config.connection !== 'ssh') {
-        args.push('-c', config.connection);
+        flags.push('-c', config.connection);
     }
 
     if (config.user) {
-        args.push('-u', config.user);
+        flags.push('-u', config.user);
     }
 
     if (config.timeout) {
-        args.push('-T', String(config.timeout));
+        flags.push('-T', String(config.timeout));
     }
 
     if (config.privateKey) {
-        args.push('--private-key', config.privateKey);
+        flags.push('--private-key', config.privateKey);
     }
 
     if (config.become) {
-        args.push('--become');
+        flags.push('--become');
     }
 
     if (config.becomeMethod && config.becomeMethod !== 'sudo') {
-        args.push('--become-method', config.becomeMethod);
+        flags.push('--become-method', config.becomeMethod);
     }
 
     if (config.becomeUser && config.becomeUser !== 'root') {
-        args.push('--become-user', config.becomeUser);
+        flags.push('--become-user', config.becomeUser);
     }
 
     if (config.vaultPasswordFile) {
-        args.push('--vault-password-file', config.vaultPasswordFile);
+        flags.push('--vault-password-file', config.vaultPasswordFile);
     }
 
     if (config.startAtTask) {
-        args.push('--start-at-task', config.startAtTask);
+        flags.push('--start-at-task', config.startAtTask);
     }
 
     if (config.step) {
-        args.push('--step');
+        flags.push('--step');
     }
 
     if (config.askPass) {
-        args.push('--ask-pass');
+        flags.push('--ask-pass');
     }
 
     if (config.askBecomePass) {
-        args.push('--ask-become-pass');
+        flags.push('--ask-become-pass');
     }
 
     if (config.askVaultPass) {
-        args.push('--ask-vault-pass');
+        flags.push('--ask-vault-pass');
     }
 
-    args.push(playbookPath);
+    return flags;
+}
+
+/**
+ * Build an ansible-playbook CLI command string from configuration.
+ *
+ * @param playbookPath - Path to the playbook file (appended last).
+ * @param config - Effective run settings.
+ * @returns Space-joined ansible-playbook command.
+ */
+export function buildPlaybookCommand(playbookPath: string, config: PlaybookConfig): string {
+    return ['ansible-playbook', ...buildPlaybookFlags(config), playbookPath].join(' ');
+}
+
+/**
+ * Build an ansible-navigator run command string from playbook configuration.
+ *
+ * Uses `--mode stdout` for predictable output in VS Code's integrated terminal.
+ * Playbook flags are passed after `--` so ansible-navigator forwards them to
+ * the underlying ansible-playbook invocation.
+ *
+ * @param playbookPath - Path to the playbook file.
+ * @param config - Effective run settings.
+ * @returns Space-joined ansible-navigator run command.
+ */
+export function buildNavigatorCommand(playbookPath: string, config: PlaybookConfig): string {
+    const args: string[] = ['ansible-navigator', 'run', playbookPath, '--mode', 'stdout'];
+
+    const passthroughFlags = buildPlaybookFlags(config);
+    if (passthroughFlags.length > 0) {
+        args.push('--', ...passthroughFlags);
+    }
+
+    return args.join(' ');
+}
+
+/** Options for ansible-navigator execution environment integration. */
+export interface NavigatorEEVolumeMount {
+    src: string;
+    dest: string;
+    options?: string;
+}
+
+export interface NavigatorEEOptions {
+    volumeMounts?: NavigatorEEVolumeMount[];
+    setEnvVars?: Record<string, string>;
+    passEnvVars?: string[];
+}
+
+/**
+ * Build an ansible-navigator run command with EE volume mounts and env vars.
+ *
+ * Injects `--execution-environment-volume-mounts` and `--senv` flags before the
+ * `--` passthrough separator so the callback plugin and Unix socket are accessible
+ * inside the execution environment container.
+ *
+ * @param playbookPath - Path to the playbook file.
+ * @param config - Effective run settings.
+ * @param eeOptions - Volume mounts and env vars for the EE container.
+ * @returns Space-joined ansible-navigator run command with EE flags.
+ */
+export function buildNavigatorEECommand(
+    playbookPath: string,
+    config: PlaybookConfig,
+    eeOptions: NavigatorEEOptions,
+): string {
+    const args: string[] = ['ansible-navigator', 'run', playbookPath, '--mode', 'stdout'];
+
+    for (const mount of eeOptions.volumeMounts ?? []) {
+        const mountStr = mount.options
+            ? `${mount.src}:${mount.dest}:${mount.options}`
+            : `${mount.src}:${mount.dest}`;
+        args.push('--execution-environment-volume-mounts', mountStr);
+    }
+    for (const [key, value] of Object.entries(eeOptions.setEnvVars ?? {})) {
+        args.push('--senv', `${key}=${value}`);
+    }
+    for (const varName of eeOptions.passEnvVars ?? []) {
+        args.push('--penv', varName);
+    }
+
+    const passthroughFlags = buildPlaybookFlags(config);
+    if (passthroughFlags.length > 0) {
+        args.push('--', ...passthroughFlags);
+    }
 
     return args.join(' ');
 }

--- a/packages/common/src/types/index.ts
+++ b/packages/common/src/types/index.ts
@@ -27,6 +27,7 @@ export type { GalaxyCollection } from './galaxy';
 export type { GitHubCollection } from './github';
 export type { SkillEntry, SkillSource, SkillCategory, TrustLevel, RepoFormat } from './skills';
 export type {
+    PlaybookExecutor,
     PlaybookConfig,
     PlaybookPlay,
     ProgressEvent,

--- a/packages/common/src/types/playbook.ts
+++ b/packages/common/src/types/playbook.ts
@@ -2,8 +2,12 @@
  * Shared playbook types used across extension, MCP server, and UI.
  */
 
-/** Run settings for ansible-playbook. */
+/** Which tool is used to execute a playbook. */
+export type PlaybookExecutor = 'ansible-playbook' | 'ansible-navigator';
+
+/** Run settings for playbook execution. */
 export interface PlaybookConfig {
+    executor?: PlaybookExecutor;
     inventory?: string[];
     limit?: string;
     tags?: string[];
@@ -78,4 +82,5 @@ export interface PlaybookRunOptions {
     workspaceFolder: string;
     command: string;
     extensionPath: string;
+    executor?: PlaybookExecutor;
 }

--- a/packages/common/test/parsers/playbookParser.test.ts
+++ b/packages/common/test/parsers/playbookParser.test.ts
@@ -150,7 +150,19 @@ describe('buildPlaybookCommand', () => {
             startAtTask: 'Install httpd',
         };
         const cmd = buildPlaybookCommand('site.yml', config);
-        expect(cmd).toContain('--start-at-task Install httpd');
+        expect(cmd).toContain('--start-at-task "Install httpd"');
+    });
+
+    it('quotes arguments that contain spaces', () => {
+        const config: PlaybookConfig = {
+            ...DEFAULT_PLAYBOOK_CONFIG,
+            extraVars: '{"msg": "hello world"}',
+            limit: 'web servers',
+        };
+        const cmd = buildPlaybookCommand('my playbook.yml', config);
+        expect(cmd).toContain('-e "{\\"msg\\": \\"hello world\\"}"');
+        expect(cmd).toContain('-l "web servers"');
+        expect(cmd).toMatch(/"my playbook\.yml"$/);
     });
 
     it('adds step flag', () => {
@@ -224,7 +236,13 @@ describe('buildPlaybookFlags', () => {
         };
         const flags = buildPlaybookFlags(config);
         const cmd = buildPlaybookCommand('site.yml', config);
-        expect(cmd).toBe(['ansible-playbook', ...flags, 'site.yml'].join(' '));
+        // Command builders quote args for shell safety; flags remain raw.
+        expect(cmd).toContain('-i hosts');
+        expect(cmd).toContain('--check');
+        expect(cmd).toContain('-f 10');
+        expect(cmd).toMatch(/^ansible-playbook /);
+        expect(cmd).toMatch(/ site\.yml$/);
+        expect(flags).toEqual(['-i', 'hosts', '--check', '-f', '10']);
     });
 });
 

--- a/packages/common/test/parsers/playbookParser.test.ts
+++ b/packages/common/test/parsers/playbookParser.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect } from 'vitest';
 import {
+    buildPlaybookFlags,
     buildPlaybookCommand,
+    buildNavigatorCommand,
+    buildNavigatorEECommand,
     parsePlaybook,
     mergePlaybookConfig,
     DEFAULT_PLAYBOOK_CONFIG,
@@ -177,6 +180,186 @@ describe('buildPlaybookCommand', () => {
         };
         const cmd = buildPlaybookCommand('deploy.yml', config);
         expect(cmd).toMatch(/deploy\.yml$/);
+    });
+});
+
+describe('buildPlaybookFlags', () => {
+    it('returns empty array for default config', () => {
+        const flags = buildPlaybookFlags(DEFAULT_PLAYBOOK_CONFIG);
+        expect(flags).toEqual([]);
+    });
+
+    it('returns inventory flags', () => {
+        const config: PlaybookConfig = {
+            ...DEFAULT_PLAYBOOK_CONFIG,
+            inventory: ['hosts.ini', 'staging/'],
+        };
+        const flags = buildPlaybookFlags(config);
+        expect(flags).toEqual(['-i', 'hosts.ini', '-i', 'staging/']);
+    });
+
+    it('returns all non-default flags', () => {
+        const config: PlaybookConfig = {
+            ...DEFAULT_PLAYBOOK_CONFIG,
+            limit: 'web',
+            check: true,
+            diff: true,
+            verbose: 2,
+            become: true,
+        };
+        const flags = buildPlaybookFlags(config);
+        expect(flags).toContain('-l');
+        expect(flags).toContain('--check');
+        expect(flags).toContain('--diff');
+        expect(flags).toContain('-vv');
+        expect(flags).toContain('--become');
+    });
+
+    it('produces identical output to what buildPlaybookCommand embeds', () => {
+        const config: PlaybookConfig = {
+            ...DEFAULT_PLAYBOOK_CONFIG,
+            inventory: ['hosts'],
+            check: true,
+            forks: 10,
+        };
+        const flags = buildPlaybookFlags(config);
+        const cmd = buildPlaybookCommand('site.yml', config);
+        expect(cmd).toBe(['ansible-playbook', ...flags, 'site.yml'].join(' '));
+    });
+});
+
+describe('buildNavigatorCommand', () => {
+    it('returns basic command with just playbook path', () => {
+        const cmd = buildNavigatorCommand('site.yml', DEFAULT_PLAYBOOK_CONFIG);
+        expect(cmd).toBe('ansible-navigator run site.yml --mode stdout');
+    });
+
+    it('uses -- passthrough for config flags', () => {
+        const config: PlaybookConfig = {
+            ...DEFAULT_PLAYBOOK_CONFIG,
+            inventory: ['hosts.ini'],
+            check: true,
+        };
+        const cmd = buildNavigatorCommand('site.yml', config);
+        expect(cmd).toBe('ansible-navigator run site.yml --mode stdout -- -i hosts.ini --check');
+    });
+
+    it('includes all playbook flags after --', () => {
+        const config: PlaybookConfig = {
+            ...DEFAULT_PLAYBOOK_CONFIG,
+            limit: 'web:&prod',
+            tags: ['deploy'],
+            become: true,
+            becomeMethod: 'doas',
+            verbose: 3,
+        };
+        const cmd = buildNavigatorCommand('deploy.yml', config);
+        expect(cmd).toContain('ansible-navigator run deploy.yml --mode stdout --');
+        expect(cmd).toContain('-l web:&prod');
+        expect(cmd).toContain('-t deploy');
+        expect(cmd).toContain('--become');
+        expect(cmd).toContain('--become-method doas');
+        expect(cmd).toContain('-vvv');
+    });
+
+    it('omits -- separator when config has no flags', () => {
+        const cmd = buildNavigatorCommand('site.yml', DEFAULT_PLAYBOOK_CONFIG);
+        expect(cmd).not.toMatch(/ -- /);
+        expect(cmd).toBe('ansible-navigator run site.yml --mode stdout');
+    });
+
+    it('playbook path follows run subcommand', () => {
+        const cmd = buildNavigatorCommand('deploy/app.yml', DEFAULT_PLAYBOOK_CONFIG);
+        expect(cmd).toMatch(/^ansible-navigator run deploy\/app\.yml/);
+    });
+});
+
+describe('buildNavigatorEECommand', () => {
+    it('returns basic command without EE options', () => {
+        const cmd = buildNavigatorEECommand('site.yml', DEFAULT_PLAYBOOK_CONFIG, {});
+        expect(cmd).toBe('ansible-navigator run site.yml --mode stdout');
+    });
+
+    it('adds volume mount flags before -- separator', () => {
+        const cmd = buildNavigatorEECommand('site.yml', DEFAULT_PLAYBOOK_CONFIG, {
+            volumeMounts: [
+                { src: '/host/plugins', dest: '/container/plugins', options: 'ro' },
+                { src: '/tmp/sockets', dest: '/tmp/sockets', options: 'Z' },
+            ],
+        });
+        expect(cmd).toContain(
+            '--execution-environment-volume-mounts /host/plugins:/container/plugins:ro',
+        );
+        expect(cmd).toContain('--execution-environment-volume-mounts /tmp/sockets:/tmp/sockets:Z');
+    });
+
+    it('adds --senv flags for container env vars', () => {
+        const cmd = buildNavigatorEECommand('site.yml', DEFAULT_PLAYBOOK_CONFIG, {
+            setEnvVars: {
+                ANSIBLE_CALLBACK_PLUGINS: '/container/callback',
+                ANSIBLE_CALLBACKS_ENABLED: 'vscode_progress',
+            },
+        });
+        expect(cmd).toContain('--senv ANSIBLE_CALLBACK_PLUGINS=/container/callback');
+        expect(cmd).toContain('--senv ANSIBLE_CALLBACKS_ENABLED=vscode_progress');
+    });
+
+    it('adds --penv flags for passthrough env vars', () => {
+        const cmd = buildNavigatorEECommand('site.yml', DEFAULT_PLAYBOOK_CONFIG, {
+            passEnvVars: ['SSH_AUTH_SOCK', 'AWS_PROFILE'],
+        });
+        expect(cmd).toContain('--penv SSH_AUTH_SOCK');
+        expect(cmd).toContain('--penv AWS_PROFILE');
+    });
+
+    it('puts EE flags before -- and playbook flags after', () => {
+        const config: PlaybookConfig = {
+            ...DEFAULT_PLAYBOOK_CONFIG,
+            inventory: ['hosts.ini'],
+            check: true,
+        };
+        const cmd = buildNavigatorEECommand('site.yml', config, {
+            volumeMounts: [{ src: '/a', dest: '/b' }],
+            setEnvVars: { FOO: 'bar' },
+        });
+        const parts = cmd.split(' -- ');
+        expect(parts).toHaveLength(2);
+        expect(parts[0]).toContain('--execution-environment-volume-mounts /a:/b');
+        expect(parts[0]).toContain('--senv FOO=bar');
+        expect(parts[1]).toContain('-i hosts.ini');
+        expect(parts[1]).toContain('--check');
+    });
+
+    it('handles volume mount without options', () => {
+        const cmd = buildNavigatorEECommand('site.yml', DEFAULT_PLAYBOOK_CONFIG, {
+            volumeMounts: [{ src: '/src', dest: '/dest' }],
+        });
+        expect(cmd).toContain('--execution-environment-volume-mounts /src:/dest');
+        expect(cmd).not.toContain('/src:/dest:');
+    });
+});
+
+describe('PlaybookConfig.executor', () => {
+    it('DEFAULT_PLAYBOOK_CONFIG has ansible-playbook executor', () => {
+        expect(DEFAULT_PLAYBOOK_CONFIG.executor).toBe('ansible-playbook');
+    });
+
+    it('mergePlaybookConfig preserves executor override', () => {
+        const result = mergePlaybookConfig({ executor: 'ansible-navigator' });
+        expect(result.executor).toBe('ansible-navigator');
+    });
+
+    it('mergePlaybookConfig defaults to ansible-playbook', () => {
+        const result = mergePlaybookConfig();
+        expect(result.executor).toBe('ansible-playbook');
+    });
+
+    it('later executor override wins', () => {
+        const result = mergePlaybookConfig(
+            { executor: 'ansible-navigator' },
+            { executor: 'ansible-playbook' },
+        );
+        expect(result.executor).toBe('ansible-playbook');
     });
 });
 

--- a/packages/mcp-server/src/handlers.ts
+++ b/packages/mcp-server/src/handlers.ts
@@ -25,8 +25,16 @@ import {
     getCommandService,
     isExecutionEnvironmentDefinition,
     planAnsibleBuilderBuild,
+    buildNavigatorCommand,
+    DEFAULT_PLAYBOOK_CONFIG,
 } from '@ansible/developer-services';
-import type { PluginOption, PluginInfo, PluginData, SchemaNode } from '@ansible/developer-services';
+import type {
+    PluginOption,
+    PluginInfo,
+    PluginData,
+    SchemaNode,
+    PlaybookConfig,
+} from '@ansible/developer-services';
 
 /**
  * Normalizes ansible-doc fields that may be a single string or string array.
@@ -153,6 +161,10 @@ export class McpToolHandler {
                     return await this._handleGetEEDetails(args);
                 case 'build_execution_environment':
                     return await this._handleBuildEE(args);
+
+                // Playbook execution
+                case 'run_playbook_navigator':
+                    return await this._handleRunPlaybookNavigator(args);
 
                 // Dev tools
                 case 'list_ansible_dev_tools':
@@ -1526,6 +1538,96 @@ export class McpToolHandler {
         }
     }
 
+    // === Playbook Execution Handlers ===
+
+    /**
+     * Handles `run_playbook_navigator` by running ansible-navigator in stdout mode.
+     *
+     * @param args - Tool args: `playbook_path` (required), optional inventory, limit, etc.
+     * @returns Navigator stdout/stderr output or a structured error
+     */
+    private async _handleRunPlaybookNavigator(
+        args: Record<string, unknown>,
+    ): Promise<McpToolResult> {
+        const playbookPath = args.playbook_path as string | undefined;
+        if (!playbookPath) {
+            return mcpError({
+                code: 'MISSING_PARAM',
+                recoverability: 'fail',
+                message: 'Missing required parameter: playbook_path',
+                suggestion: 'Provide the absolute path to a playbook YAML file.',
+            });
+        }
+
+        if (!fs.existsSync(playbookPath)) {
+            return mcpError({
+                code: 'NOT_FOUND',
+                recoverability: 'fail',
+                message: `Playbook not found: ${playbookPath}`,
+            });
+        }
+
+        const commandService = getCommandService();
+        const navigatorAvailable = await commandService.isToolAvailable('ansible-navigator');
+        if (!navigatorAvailable) {
+            return mcpError({
+                code: 'SERVICE_UNAVAILABLE',
+                recoverability: 'escalate',
+                message: 'ansible-navigator is not installed in the active Python environment',
+                suggestion:
+                    'Install ansible-dev-tools (which includes ansible-navigator) using the install_ansible_dev_tools tool.',
+            });
+        }
+
+        const config: PlaybookConfig = {
+            ...DEFAULT_PLAYBOOK_CONFIG,
+            inventory: (args.inventory as string[] | undefined) ?? [],
+            limit: (args.limit as string | undefined) ?? '',
+            tags: (args.tags as string[] | undefined) ?? [],
+            skipTags: (args.skip_tags as string[] | undefined) ?? [],
+            extraVars: (args.extra_vars as string | undefined) ?? '',
+            check: (args.check as boolean | undefined) ?? false,
+            diff: (args.diff as boolean | undefined) ?? false,
+            verbose: (args.verbose as number | undefined) ?? 0,
+            forks: (args.forks as number | undefined) ?? 5,
+            connection: (args.connection as string | undefined) ?? 'ssh',
+            user: (args.user as string | undefined) ?? '',
+            timeout: args.timeout as number | undefined,
+            privateKey: (args.private_key as string | undefined) ?? '',
+            become: (args.become as boolean | undefined) ?? false,
+            becomeMethod: (args.become_method as string | undefined) ?? 'sudo',
+            becomeUser: (args.become_user as string | undefined) ?? 'root',
+            vaultPasswordFile: (args.vault_password_file as string | undefined) ?? '',
+        };
+
+        const command = buildNavigatorCommand(path.basename(playbookPath), config);
+        const shellArgs = command.split(' ').slice(1);
+        const cwd = path.dirname(playbookPath);
+
+        try {
+            const result = await commandService.runAnsibleNavigator(shellArgs, {
+                cwd,
+                timeout: 30 * 60 * 1000,
+            });
+            const output = [result.stdout, result.stderr].filter(Boolean).join('\n');
+            return {
+                content: [
+                    {
+                        type: 'text',
+                        text: `## ansible-navigator run (exit code: ${String(result.exitCode)})\n\n\`\`\`\n${output}\n\`\`\``,
+                    },
+                ],
+                isError: result.exitCode !== 0,
+            };
+        } catch (error) {
+            return mcpError({
+                code: 'OPERATION_FAILED',
+                recoverability: 'retry',
+                message: `ansible-navigator failed: ${error instanceof Error ? error.message : String(error)}`,
+            });
+        }
+    }
+
     // === Dev Tools Handlers ===
 
     /**
@@ -1810,6 +1912,9 @@ export class McpToolHandler {
 ### Scaffolding (destructive, \`ac_*\` tools)
 - Dynamically generated from ansible-creator schema
 - Use \`get_ansible_creator_schema\` to see available commands
+
+### Playbook Execution
+- \`run_playbook_navigator\` -- run a playbook via ansible-navigator in stdout mode
 
 ### Execution Environments
 - \`list_execution_environments\` / \`get_ee_details\` -- inspect container-based EEs (read-only)

--- a/packages/mcp-server/src/handlers.ts
+++ b/packages/mcp-server/src/handlers.ts
@@ -25,7 +25,7 @@ import {
     getCommandService,
     isExecutionEnvironmentDefinition,
     planAnsibleBuilderBuild,
-    buildNavigatorCommand,
+    buildPlaybookFlags,
     DEFAULT_PLAYBOOK_CONFIG,
 } from '@ansible/developer-services';
 import type {
@@ -1600,8 +1600,11 @@ export class McpToolHandler {
             vaultPasswordFile: (args.vault_password_file as string | undefined) ?? '',
         };
 
-        const command = buildNavigatorCommand(path.basename(playbookPath), config);
-        const shellArgs = command.split(' ').slice(1);
+        const passthroughFlags = buildPlaybookFlags(config);
+        const shellArgs = ['run', path.basename(playbookPath), '--mode', 'stdout'];
+        if (passthroughFlags.length > 0) {
+            shellArgs.push('--', ...passthroughFlags);
+        }
         const cwd = path.dirname(playbookPath);
 
         try {

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -838,6 +838,100 @@ export const GET_EXTENSION_WALKTHROUGH_TOOL: McpToolDefinition = {
     },
 };
 
+// === Playbook Execution ===
+
+export const RUN_PLAYBOOK_NAVIGATOR_TOOL: McpToolDefinition = {
+    name: 'run_playbook_navigator',
+    description: `Run an Ansible playbook using ansible-navigator in stdout mode.
+
+Executes \`ansible-navigator run <playbook> --mode stdout\` in the active Python environment.
+Requires ansible-navigator (via ansible-dev-tools) to be installed.
+Supports the same playbook flags as ansible-playbook (inventory, limit, tags, check, diff,
+become, connection, vault, etc.) passed through via the \`--\` separator.`,
+    annotations: DESTRUCTIVE,
+    inputSchema: {
+        type: 'object',
+        properties: {
+            playbook_path: {
+                type: 'string',
+                description: 'Absolute path to the playbook YAML file',
+            },
+            inventory: {
+                type: 'array',
+                items: { type: 'string' },
+                description: 'Inventory file paths (repeatable)',
+            },
+            limit: {
+                type: 'string',
+                description: 'Host pattern to limit execution',
+            },
+            tags: {
+                type: 'array',
+                items: { type: 'string' },
+                description: 'Tags to select tasks',
+            },
+            skip_tags: {
+                type: 'array',
+                items: { type: 'string' },
+                description: 'Tags to skip',
+            },
+            check: {
+                type: 'boolean',
+                description: 'Run in check mode (dry run)',
+            },
+            diff: {
+                type: 'boolean',
+                description: 'Show change diffs',
+            },
+            extra_vars: {
+                type: 'string',
+                description: 'Extra variables (key=value or @file)',
+            },
+            verbose: {
+                type: 'number',
+                description: 'Verbosity level (0-6)',
+            },
+            forks: {
+                type: 'number',
+                description: 'Number of parallel processes (default: 5)',
+            },
+            connection: {
+                type: 'string',
+                description: 'Connection type (default: ssh)',
+            },
+            user: {
+                type: 'string',
+                description: 'Remote user for connection',
+            },
+            timeout: {
+                type: 'number',
+                description: 'Connection timeout in seconds',
+            },
+            private_key: {
+                type: 'string',
+                description: 'Path to SSH private key file',
+            },
+            become: {
+                type: 'boolean',
+                description: 'Enable privilege escalation',
+            },
+            become_method: {
+                type: 'string',
+                description: 'Privilege escalation method (default: sudo)',
+            },
+            become_user: {
+                type: 'string',
+                description: 'Privilege escalation target user (default: root)',
+            },
+            vault_password_file: {
+                type: 'string',
+                description: 'Path to vault password file',
+            },
+        },
+        required: ['playbook_path'],
+    },
+};
+
 // === Collection of all static tools ===
 
 export const STATIC_TOOLS: McpToolDefinition[] = [
@@ -861,6 +955,9 @@ export const STATIC_TOOLS: McpToolDefinition[] = [
     LIST_EE_TOOL,
     GET_EE_DETAILS_TOOL,
     BUILD_EE_TOOL,
+
+    // Playbook execution
+    RUN_PLAYBOOK_NAVIGATOR_TOOL,
 
     // Dev tools
     LIST_DEV_TOOLS_TOOL,

--- a/packages/services/src/CommandService.ts
+++ b/packages/services/src/CommandService.ts
@@ -292,10 +292,14 @@ export class CommandService {
      * Run ansible-navigator command.
      *
      * @param args - Arguments passed to ansible-navigator.
+     * @param options - Execution options such as cwd, env, and timeout.
      * @returns Captured stdout, stderr, and exit code from ansible-navigator.
      */
-    public async runAnsibleNavigator(args: string[]): Promise<ExecResult> {
-        return this.runTool('ansible-navigator', args);
+    public async runAnsibleNavigator(
+        args: string[],
+        options: CommandOptions = {},
+    ): Promise<ExecResult> {
+        return this.runTool('ansible-navigator', args, options);
     }
 
     /**

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -16,7 +16,10 @@ export {
     valueToString,
     formatLabel,
     CREATOR_FILTERED_KEYS,
+    buildPlaybookFlags,
     buildPlaybookCommand,
+    buildNavigatorCommand,
+    buildNavigatorEECommand,
     parsePlaybook,
     mergePlaybookConfig,
     DEFAULT_PLAYBOOK_CONFIG,
@@ -75,6 +78,7 @@ export type {
     SkillCategory,
     TrustLevel,
     RepoFormat,
+    PlaybookExecutor,
     PlaybookConfig,
     PlaybookPlay,
     ProgressEvent,
@@ -87,6 +91,7 @@ export type {
     MetadataDump,
     ParsedCollection,
     MetadataDumpResult,
+    NavigatorEEOptions,
 } from '@ansible/common';
 
 // --- Services ---

--- a/packages/ui/src/views/PlaybookConfigView.tsx
+++ b/packages/ui/src/views/PlaybookConfigView.tsx
@@ -241,6 +241,19 @@ export function PlaybookConfigView() {
                         <div style={styles.previewBox}>{preview}</div>
                     </div>
 
+                    <FormSection title="Executor">
+                        <FormSelect
+                            label="Run With"
+                            value={config.executor ?? 'ansible-playbook'}
+                            onChange={(v) => {
+                                updateField('executor', v);
+                            }}
+                            options={['ansible-playbook', 'ansible-navigator']}
+                            description="ansible-navigator provides execution environment integration and artifact collection"
+                            defaultValue="ansible-playbook"
+                        />
+                    </FormSection>
+
                     <FormSection title="Inventory & Targeting">
                         <FormListBuilder
                             label="Inventory"

--- a/packages/ui/src/views/PlaybookConfigView.tsx
+++ b/packages/ui/src/views/PlaybookConfigView.tsx
@@ -2,7 +2,7 @@ import { useState, useCallback, useEffect, useMemo } from 'react';
 import type { CSSProperties } from 'react';
 import { useBridge } from '../bridge/context';
 import type { PlaybookConfigBridge } from '../bridge/playbook';
-import type { PlaybookConfig } from '@ansible/common';
+import type { PlaybookConfig, PlaybookExecutor } from '@ansible/common';
 import { FormTextField } from '../components/form/FormTextField';
 import { FormSelect } from '../components/form/FormSelect';
 import { FormCheckbox } from '../components/form/FormCheckbox';
@@ -246,7 +246,10 @@ export function PlaybookConfigView() {
                             label="Run With"
                             value={config.executor ?? 'ansible-playbook'}
                             onChange={(v) => {
-                                updateField('executor', v);
+                                if (v === 'ansible-playbook' || v === 'ansible-navigator') {
+                                    const executor: PlaybookExecutor = v;
+                                    updateField('executor', executor);
+                                }
                             }}
                             options={['ansible-playbook', 'ansible-navigator']}
                             description="ansible-navigator provides execution environment integration and artifact collection"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -445,6 +445,19 @@ export function activate(context: vscode.ExtensionContext) {
     });
     context.subscriptions.push(packagesView);
 
+    // Track ansible-navigator availability for conditional menu items
+    const updateNavigatorAvailability = async () => {
+        const available = await commandService.isToolAvailable('ansible-navigator');
+        await vscode.commands.executeCommand('setContext', 'ansible.navigatorAvailable', available);
+    };
+    const navToolsService = DevToolsService.getInstance();
+    context.subscriptions.push(
+        (navToolsService.onDidChange as vscode.Event<void>)(() => {
+            void updateNavigatorAvailability();
+        }),
+    );
+    void updateNavigatorAvailability();
+
     // Register the Collections view
     const collectionsProvider = new CollectionsProvider(pythonEnvService);
     const collectionsView = vscode.window.createTreeView('ansibleDevToolsCollections', {
@@ -1048,29 +1061,55 @@ export function activate(context: vscode.ExtensionContext) {
         },
     );
 
-    // Run playbook with progress viewer
+    // Run playbook with progress viewer (respects configured executor)
     const playbooksRunWithProgressCommand = vscode.commands.registerCommand(
         'ansiblePlaybooks.runWithProgress',
         async (node: { playbook: PlaybookInfo }) => {
             const playbooksService = PlaybooksService.getInstance();
             const config = playbooksService.getPlaybookConfig(node.playbook.relativePath);
 
-            // Calculate path relative to the playbook's workspace folder
             const workspaceFolderPath = node.playbook.workspaceFolder.fsPath;
             const playbookRelativePath = path.relative(workspaceFolderPath, node.playbook.path);
 
-            const command = playbooksService.buildCommand(playbookRelativePath, config);
+            const useNavigator = config.executor === 'ansible-navigator';
+            const command = useNavigator
+                ? playbooksService.buildNavigatorCommand(playbookRelativePath, config)
+                : playbooksService.buildCommand(playbookRelativePath, config);
 
             log(`Running playbook with progress: ${command} in ${workspaceFolderPath}`);
 
-            // Show progress panel
             await PlaybookProgressPanel.show(context.extensionUri, {
                 playbookPath: node.playbook.path,
                 playbookName: node.playbook.name,
                 workspaceFolder: node.playbook.workspaceFolder,
                 command: command,
                 extensionPath: context.extensionPath,
+                executor: config.executor,
             });
+        },
+    );
+
+    const playbooksRunNavigatorCommand = vscode.commands.registerCommand(
+        'ansiblePlaybooks.runWithNavigator',
+        async (node: { playbook: PlaybookInfo }) => {
+            const playbooksService = PlaybooksService.getInstance();
+            const config = playbooksService.getPlaybookConfig(node.playbook.relativePath);
+
+            const workspaceFolderPath = node.playbook.workspaceFolder.fsPath;
+            const playbookRelativePath = path.relative(workspaceFolderPath, node.playbook.path);
+
+            const command = playbooksService.buildNavigatorCommand(playbookRelativePath, config);
+
+            log(`Running playbook via ansible-navigator: ${command} in ${workspaceFolderPath}`);
+
+            const terminalService = TerminalService.getInstance();
+            const managed = await terminalService.createActivatedTerminal({
+                name: `ansible-navigator: ${node.playbook.name}`,
+                cwd: node.playbook.workspaceFolder,
+                show: true,
+            });
+
+            void managed.sendCommand(command, { waitForCompletion: false });
         },
     );
 
@@ -1565,6 +1604,7 @@ export function activate(context: vscode.ExtensionContext) {
         playbooksEditDefaultsCommand,
         playbooksRunCommand,
         playbooksRunWithProgressCommand,
+        playbooksRunNavigatorCommand,
         playbooksOpenCommand,
         playbooksGoToPlayCommand,
         playbooksAiSummaryCommand,

--- a/src/panels/PlaybookConfigPanel.ts
+++ b/src/panels/PlaybookConfigPanel.ts
@@ -5,7 +5,7 @@ import {
     type PlaybookConfig,
 } from '@src/services/PlaybooksService';
 import { PlaybookProgressPanel, type PlaybookRunOptions } from '@src/panels/PlaybookProgressPanel';
-import { buildPlaybookCommand } from '@ansible/developer-services';
+import { buildPlaybookCommand, buildNavigatorCommand } from '@ansible/developer-services';
 import { log } from '@src/extension';
 
 /** Thin webview host for the playbook configuration form. Delegates UI to @ansible/ui PlaybookConfigView. */
@@ -172,7 +172,12 @@ export class PlaybookConfigPanel {
      */
     private async _runPlaybook(config: PlaybookConfig): Promise<void> {
         if (!this._playbook) return;
-        const command = buildPlaybookCommand(this._playbook.relativePath, config);
+
+        const useNavigator = config.executor === 'ansible-navigator';
+        const command = useNavigator
+            ? buildNavigatorCommand(this._playbook.relativePath, config)
+            : buildPlaybookCommand(this._playbook.relativePath, config);
+
         log(`PlaybookConfigPanel: Running: ${command}`);
 
         const runOptions: PlaybookRunOptions = {
@@ -181,6 +186,7 @@ export class PlaybookConfigPanel {
             workspaceFolder: this._playbook.workspaceFolder,
             command,
             extensionPath: this._extensionUri.fsPath,
+            executor: config.executor ?? 'ansible-playbook',
         };
 
         await PlaybookProgressPanel.show(this._extensionUri, runOptions);

--- a/src/panels/PlaybookProgressPanel.ts
+++ b/src/panels/PlaybookProgressPanel.ts
@@ -11,7 +11,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import { log } from '@src/extension';
 import type { ProgressEvent } from '@ansible/developer-services';
-import { buildTaskAnalysisPrompt } from '@ansible/developer-services';
+import { buildTaskAnalysisPrompt, buildNavigatorEECommand } from '@ansible/developer-services';
 import { openChatWithPrompt } from '@src/features/chatProvider';
 
 /**
@@ -29,6 +29,7 @@ export interface PlaybookRunOptions {
     workspaceFolder: vscode.Uri;
     command: string;
     extensionPath: string;
+    executor?: 'ansible-playbook' | 'ansible-navigator';
 }
 
 /** Thin webview host that streams ansible-playbook events to PlaybookProgressView. */
@@ -189,25 +190,101 @@ export class PlaybookProgressPanel {
         await this._createSocketServer();
 
         const callbackPath = path.join(options.extensionPath, 'resources', 'callback_plugins');
-        log(`PlaybookProgress: Starting with socket ${this._socketPath ?? ''}`);
+        const executorLabel =
+            options.executor === 'ansible-navigator' ? 'ansible-navigator' : 'ansible-playbook';
+        log(
+            `PlaybookProgress: Starting with socket ${this._socketPath ?? ''} (executor: ${executorLabel})`,
+        );
 
         const { TerminalService } = await import('../services/TerminalService');
         const terminalService = TerminalService.getInstance();
 
         const managed = await terminalService.createActivatedTerminal({
-            name: `ansible-playbook: ${options.playbookName}`,
+            name: `${executorLabel}: ${options.playbookName}`,
             cwd: options.workspaceFolder,
             show: false,
         });
 
         this._terminal = managed.terminal;
 
+        // For the progress viewer, we force --execution-environment false on
+        // navigator commands. The env-var prefix (ANSIBLE_CALLBACK_PLUGINS,
+        // ANSIBLE_ENV_SOCKET) only works when ansible-playbook runs on the
+        // host — env vars don't cross the container boundary. The EE volume-
+        // mount path (_startNavigatorEERun) handles the containerized case
+        // but is reserved for future use.
+        let terminalCommand = options.command;
+        if (options.executor === 'ansible-navigator') {
+            terminalCommand = this._injectNavigatorNoEE(terminalCommand);
+        }
+
         managed.terminal.sendText(
             `ANSIBLE_CALLBACK_PLUGINS=${shellQuote(callbackPath)} ` +
                 `ANSIBLE_CALLBACKS_ENABLED=vscode_progress ` +
                 `ANSIBLE_ENV_SOCKET=${shellQuote(this._socketPath ?? '')} ` +
-                options.command,
+                terminalCommand,
         );
+    }
+
+    /**
+     * Insert `--execution-environment false` into an ansible-navigator command
+     * so the playbook runs on the host (not in a container). Placed before the
+     * `--` passthrough separator if one exists.
+     */
+    private _injectNavigatorNoEE(command: string): string {
+        const eeFlag = '--execution-environment false';
+        const separatorIdx = command.indexOf(' -- ');
+        if (separatorIdx !== -1) {
+            return (
+                command.slice(0, separatorIdx) +
+                ` ${eeFlag}` +
+                command.slice(separatorIdx)
+            );
+        }
+        return `${command} ${eeFlag}`;
+    }
+
+    /**
+     * Start a navigator run with EE volume mounts for the callback plugin and socket.
+     * Used when ansible-navigator runs with execution environments enabled, where
+     * shell env vars don't cross the container boundary.
+     *
+     * @param terminal - VS Code terminal to send the command to.
+     * @param options - Playbook run configuration.
+     * @param callbackPath - Host path to the callback plugin directory.
+     */
+    private async _startNavigatorEERun(
+        terminal: vscode.Terminal,
+        options: PlaybookRunOptions,
+        callbackPath: string,
+    ): Promise<void> {
+        const socketDir = path.dirname(this._socketPath ?? '');
+        const containerCallbackPath = '/tmp/vscode-callback-plugins';
+        const containerSocketDir = '/tmp/vscode-ansible-progress';
+        const containerSocketPath = path.join(
+            containerSocketDir,
+            path.basename(this._socketPath ?? ''),
+        );
+
+        const { PlaybooksService } = await import('../services/PlaybooksService');
+        const playbooksService = PlaybooksService.getInstance();
+        const workspaceFolderPath = options.workspaceFolder.fsPath;
+        const playbookRelativePath = path.relative(workspaceFolderPath, options.playbookPath);
+        const config = playbooksService.getPlaybookConfig(playbookRelativePath);
+
+        const command = buildNavigatorEECommand(playbookRelativePath, config, {
+            volumeMounts: [
+                { src: callbackPath, dest: containerCallbackPath, options: 'ro' },
+                { src: socketDir, dest: containerSocketDir, options: 'Z' },
+            ],
+            setEnvVars: {
+                ANSIBLE_CALLBACK_PLUGINS: containerCallbackPath,
+                ANSIBLE_CALLBACKS_ENABLED: 'vscode_progress',
+                ANSIBLE_ENV_SOCKET: containerSocketPath,
+            },
+        });
+
+        terminal.sendText(command);
     }
 
     /** Create a Unix socket server to receive callback plugin events. */
@@ -216,7 +293,11 @@ export class PlaybookProgressPanel {
             this._socketServer.close();
         }
 
-        this._socketPath = path.join(os.tmpdir(), `ansible-env-${String(Date.now())}.sock`);
+        const socketDir = path.join(os.tmpdir(), 'vscode-ansible-progress');
+        if (!fs.existsSync(socketDir)) {
+            fs.mkdirSync(socketDir, { recursive: true });
+        }
+        this._socketPath = path.join(socketDir, `run-${String(Date.now())}.sock`);
 
         try {
             if (fs.existsSync(this._socketPath)) {

--- a/src/panels/PlaybookProgressPanel.ts
+++ b/src/panels/PlaybookProgressPanel.ts
@@ -47,6 +47,8 @@ export class PlaybookProgressPanel {
     private _disposables: vscode.Disposable[] = [];
     private _socketServer: net.Server | undefined;
     private _socketPath: string | undefined;
+    /** Per-run temp directory (mode 0o700) that owns `_socketPath`. */
+    private _socketDir: string | undefined;
     private _isRunning = false;
     private _terminal: vscode.Terminal | undefined;
     private _lastOptions: PlaybookRunOptions | undefined;
@@ -196,13 +198,7 @@ export class PlaybookProgressPanel {
             this._socketServer.close();
             this._socketServer = undefined;
         }
-        if (this._socketPath) {
-            try {
-                fs.unlinkSync(this._socketPath);
-            } catch {
-                /* ignore */
-            }
-        }
+        this._cleanupSocketDir();
 
         await this._createSocketServer();
 
@@ -309,19 +305,9 @@ export class PlaybookProgressPanel {
             this._socketServer.close();
         }
 
-        const socketDir = path.join(os.tmpdir(), 'vscode-ansible-progress');
-        if (!fs.existsSync(socketDir)) {
-            fs.mkdirSync(socketDir, { recursive: true });
-        }
-        this._socketPath = path.join(socketDir, `run-${String(Date.now())}.sock`);
-
-        try {
-            if (fs.existsSync(this._socketPath)) {
-                fs.unlinkSync(this._socketPath);
-            }
-        } catch {
-            /* ignore */
-        }
+        // Unique per-run directory with owner-only permissions (Node mkdtemp → 0o700).
+        this._socketDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vscode-ansible-progress-'));
+        this._socketPath = path.join(this._socketDir, 'run.sock');
 
         return new Promise((resolve, reject) => {
             this._socketServer = net.createServer((socket) => {
@@ -475,6 +461,17 @@ export class PlaybookProgressPanel {
             this._socketServer.close();
             this._socketServer = undefined;
         }
+        this._cleanupSocketDir();
+
+        this._panel.dispose();
+        while (this._disposables.length) {
+            const x = this._disposables.pop();
+            x?.dispose();
+        }
+    }
+
+    /** Remove the per-run socket file and its owner-only temp directory. */
+    private _cleanupSocketDir(): void {
         if (this._socketPath) {
             try {
                 fs.unlinkSync(this._socketPath);
@@ -483,11 +480,13 @@ export class PlaybookProgressPanel {
             }
             this._socketPath = undefined;
         }
-
-        this._panel.dispose();
-        while (this._disposables.length) {
-            const x = this._disposables.pop();
-            x?.dispose();
+        if (this._socketDir) {
+            try {
+                fs.rmSync(this._socketDir, { recursive: true, force: true });
+            } catch {
+                /* ignore */
+            }
+            this._socketDir = undefined;
         }
     }
 }

--- a/src/panels/bridges/VsCodeBridge.ts
+++ b/src/panels/bridges/VsCodeBridge.ts
@@ -17,7 +17,7 @@ import type {
     DiagnosticsData,
 } from '@ansible/ui';
 import type { PlaybookConfig, ProgressEvent, AiAnalyzeData } from '@ansible/common';
-import { buildPlaybookCommand } from '@ansible/common';
+import { buildPlaybookCommand, buildNavigatorCommand } from '@ansible/common';
 
 type VsCodeApi = {
     postMessage(message: unknown): void;
@@ -209,7 +209,10 @@ export class VsCodeBridge implements EEBridge, PluginDocBridge, CreatorBridge, P
     }
 
     buildPreview(config: PlaybookConfig): string {
-        return buildPlaybookCommand(this.playbookPath || '<playbook>', config);
+        const pb = this.playbookPath || '<playbook>';
+        return config.executor === 'ansible-navigator'
+            ? buildNavigatorCommand(pb, config)
+            : buildPlaybookCommand(pb, config);
     }
 
     // PlaybookProgressBridge

--- a/src/services/PlaybooksService.ts
+++ b/src/services/PlaybooksService.ts
@@ -4,9 +4,11 @@ import * as path from 'path';
 import { log } from '@src/extension';
 import {
     buildPlaybookCommand,
+    buildNavigatorCommand,
     buildPlaybookSummaryPrompt,
     discoverPlaybooks,
     DEFAULT_PLAYBOOK_CONFIG,
+    type PlaybookExecutor,
     type PlaybookConfig,
     type PlaybookPlay,
 } from '@ansible/developer-services';
@@ -166,9 +168,18 @@ export class PlaybooksService {
      * @returns Global playbook configuration merged with defaults
      */
     public getGlobalConfig(): PlaybookConfig {
+        const settingsExecutor = vscode.workspace
+            .getConfiguration('ansibleEnvironments')
+            .get<PlaybookExecutor>('playbookExecutor', 'ansible-playbook');
+
+        const base: PlaybookConfig = {
+            ...DEFAULT_PLAYBOOK_CONFIG,
+            executor: settingsExecutor,
+        };
+
         const configDir = this._getConfigDir();
         if (!configDir) {
-            return { ...DEFAULT_PLAYBOOK_CONFIG };
+            return base;
         }
 
         const configPath = path.join(configDir, GLOBAL_CONFIG_FILE);
@@ -176,7 +187,7 @@ export class PlaybooksService {
             if (fs.existsSync(configPath)) {
                 const content = fs.readFileSync(configPath, 'utf-8');
                 return {
-                    ...DEFAULT_PLAYBOOK_CONFIG,
+                    ...base,
                     ...(JSON.parse(content) as Partial<PlaybookConfig>),
                 };
             }
@@ -185,7 +196,7 @@ export class PlaybooksService {
                 `PlaybooksService: Error reading global config: ${error instanceof Error ? error.message : String(error)}`,
             );
         }
-        return { ...DEFAULT_PLAYBOOK_CONFIG };
+        return base;
     }
 
     /**
@@ -291,6 +302,17 @@ export class PlaybooksService {
      */
     public buildCommand(playbookPath: string, config: PlaybookConfig): string {
         return buildPlaybookCommand(playbookPath, config);
+    }
+
+    /**
+     * Build an ansible-navigator run command from saved configuration.
+     * Uses --mode stdout for predictable terminal output in VS Code.
+     * @param playbookPath - Playbook file path passed to ansible-navigator run
+     * @param config - Effective playbook run settings
+     * @returns Shell-ready ansible-navigator run command string
+     */
+    public buildNavigatorCommand(playbookPath: string, config: PlaybookConfig): string {
+        return buildNavigatorCommand(playbookPath, config);
     }
 
     /**


### PR DESCRIPTION
## Summary

- Add configurable playbook executor: choose between `ansible-playbook` and `ansible-navigator` via a VS Code setting or per-playbook config dropdown
- Both "Run Playbook" and "Run with Progress Viewer" respect the configured executor — no separate navigator icon
- Progress viewer forces `--execution-environment false` for navigator runs so the callback plugin streams events locally
- Add `run_playbook_navigator` MCP tool per ADR-012
- Reserve `buildNavigatorEECommand()` with volume mount and `--senv` support for future EE-enabled progress viewer

## Changes

- **`packages/common/src/types/playbook.ts`**: Add `PlaybookExecutor` type, `executor` field on `PlaybookConfig` and `PlaybookRunOptions`
- **`packages/common/src/parsers/playbookParser.ts`**: Extract `buildPlaybookFlags()`, add `buildNavigatorCommand()`, `buildNavigatorEECommand()` with `NavigatorEEOptions`; quote shell-bound args via `quoteIfNeeded`
- **`package.json`**: Add `ansibleEnvironments.playbookExecutor` setting
- **`src/extension.ts`**: `run` and `runWithProgress` commands branch on `config.executor`
- **`src/panels/PlaybookConfigPanel.ts`**: `_runPlaybook()` branches on executor
- **`src/panels/PlaybookProgressPanel.ts`**: Injects `--execution-environment false` for navigator; unique per-run 0o700 socket directory; EE volume-mount method reserved
- **`packages/ui/src/views/PlaybookConfigView.tsx`**: Executor dropdown in config form (narrowed to `PlaybookExecutor`)
- **`src/panels/bridges/VsCodeBridge.ts`**: `buildPreview()` branches on executor
- **`src/services/PlaybooksService.ts`**: Reads `playbookExecutor` setting in `getGlobalConfig()`
- **`packages/mcp-server/`**: `RUN_PLAYBOOK_NAVIGATOR_TOOL` definition + handler with full flag parity; argv built via `buildPlaybookFlags` (no string split)
- **`packages/services/src/CommandService.ts`**: `runAnsibleNavigator()` accepts options for cwd/timeout
- **`.sdlc/`**: Consolidated PLB-007 user story; completed todo

## Review follow-ups

- [x] CodeRabbit: quote CLI args with `quoteIfNeeded` before shell join (`b32b8bd3`)
- [x] CodeRabbit: MCP navigator handler passes argv array directly instead of splitting a joined command (`b32b8bd3`)
- [x] CodeRabbit: clarify PLB-007 progress-viewer EE flag is navigator-only (`80b3b320`)
- [x] CodeRabbit: narrow executor FormSelect onChange to `PlaybookExecutor` (`80b3b320`)
- [x] CodeRabbit: unique per-run owner-only socket directory for progress viewer (`80b3b320`)

## Test plan

- [x] `pnpm run compile` passes
- [x] `pnpm exec vitest run` passes
- [x] `pnpm run build` passes (all 4 bundles)
- [x] `pnpm run ci` passes locally (including coverage)
- [x] Manual: Run Playbook uses configured executor
- [x] Manual: Progress viewer works with ansible-navigator (--ee false)
- [ ] `pnpm run test:ui` (manual verification for e2e)

https://redhat.atlassian.net/browse/AAP-81397

Assisted-by: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Configurable playbook execution now supports switching between ansible-playbook and ansible-navigator for both terminal runs and the progress viewer. This was needed to align execution, previews, and progress behavior under one executor setting, so the UI and backend generate consistent commands and flags. 

- Adds executor selection via VS Code setting (`ansibleEnvironments.playbookExecutor`) and a per-playbook “Run With” dropdown (`PlaybookExecutor`)
- Routes “Run Playbook” and “Run with Progress Viewer” to the chosen executor and updates terminal/preview command generation accordingly
- Implements shared command builders (`buildPlaybookFlags`, `buildNavigatorCommand`, `buildNavigatorEECommand`) and extends tests for quoting, passthrough flags, and EE options
- Adds navigator-specific progress behavior by injecting `--execution-environment false`, while reserving containerized EE construction with volume mounts and `--senv`
- Introduces the `run_playbook_navigator` MCP tool, expands `CommandService.runAnsibleNavigator` to accept exec options, and improves progress socket handling per-run

Original commit message: Adds configurable `ansible-navigator` support for playbook execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->