### PR TITLE
feat(extension): add journey outcome props to telemetry events

### DIFF
--- a/USAGE_DATA.md
+++ b/USAGE_DATA.md
@@ -7,15 +7,16 @@
 
 The extension has two independent telemetry pipelines:
 
-| Pipeline | Route | Segment source | Amplitude destination |
-|---|---|---|---|
-| **Extension (client-side)** | VS Code extension -> Segment -> Amplitude | Extension-specific source | Extension-specific destination |
+| Pipeline                     | Route                                      | Segment source            | Amplitude destination          |
+| ---------------------------- | ------------------------------------------ | ------------------------- | ------------------------------ |
+| **Extension (client-side)**  | VS Code extension -> Segment -> Amplitude  | Extension-specific source | Extension-specific destination |
 | **Lightspeed (server-side)** | Lightspeed service -> Segment -> Amplitude | Lightspeed service source | Lightspeed service destination |
 
 These are separate Segment sources and Amplitude destinations. There is no
-data overlap. Schema coordination with the metrics team will be revisited
-if/when execution outcome events (success/failure, host count, collections
-used) are introduced on the client side.
+data overlap. Journey events may include a coarse `result` property
+(`success` | `cancel` | `error`) plus optional `durationMs` / `errorCode`.
+Host counts and collection identity remain deferred pending metrics/schema
+coordination.
 
 ## What's included in the vscode-ansible telemetry data
 
@@ -26,94 +27,95 @@ event properties are automatically sanitized by the Red Hat telemetry library.
 
 ### Lifecycle
 
-| Event | Description | Properties |
-| ----- | ----------- | ---------- |
-| `startup` | Extension startup (sent by Red Hat telemetry library) | Standard Red Hat startup metadata |
-| `shutdown` | Extension shutdown with session duration (sent automatically) | Standard Red Hat shutdown metadata |
-| `extension.activated` | Ansible extension finished activation | — |
+| Event                 | Description                                                   | Properties                         |
+| --------------------- | ------------------------------------------------------------- | ---------------------------------- |
+| `startup`             | Extension startup (sent by Red Hat telemetry library)         | Standard Red Hat startup metadata  |
+| `shutdown`            | Extension shutdown with session duration (sent automatically) | Standard Red Hat shutdown metadata |
+| `extension.activated` | Ansible extension finished activation                         | —                                  |
 
 ### Commands
 
-| Event | Description | Properties |
-| ----- | ----------- | ---------- |
+| Event              | Description                             | Properties                               |
+| ------------------ | --------------------------------------- | ---------------------------------------- |
 | `command.executed` | A tracked extension command was invoked | `commandId` — VS Code command identifier |
 
 ### Environments
 
-| Event | Description | Properties |
-| ----- | ----------- | ---------- |
-| `env.create` | User initiated Python environment creation | — |
-| `env.select` | User selected a Python environment | — |
+| Event        | Description                                | Properties                                                                      |
+| ------------ | ------------------------------------------ | ------------------------------------------------------------------------------- |
+| `env.create` | Environment creation finished (completion) | `result` — `success` \| `cancel` \| `error`; optional `durationMs`, `errorCode` |
+| `env.select` | User selected a Python environment         | —                                                                               |
 
 ### Collections
 
-| Event | Description | Properties |
-| ----- | ----------- | ---------- |
-| `collection.install` | User installed an Ansible collection | — |
-| `collection.search` | User searched for collections | — |
+| Event                | Description                              | Properties                                                                                |
+| -------------------- | ---------------------------------------- | ----------------------------------------------------------------------------------------- |
+| `collection.install` | Collection install finished or cancelled | `result` — `success` \| `cancel` \| `error`; optional `durationMs`, `errorCode` (no FQCN) |
+| `collection.search`  | User searched for collections            | —                                                                                         |
 
 ### Playbooks
 
-| Event | Description | Properties |
-| ----- | ----------- | ---------- |
-| `playbook.run` | User ran a playbook in the terminal | — |
-| `playbook.runWithProgress` | User ran a playbook with the progress viewer | — |
+| Event                      | Description                             | Properties                                                                                        |
+| -------------------------- | --------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| `playbook.run`             | Playbook terminal launch finished       | `result` — launch outcome (`success` \| `error`); optional `durationMs`, `errorCode`              |
+| `playbook.runWithProgress` | Progress-viewer run finished or stopped | `result` — ansible outcome (`success` \| `cancel` \| `error`); optional `durationMs`, `errorCode` |
 
 ### Creator
 
-| Event | Description | Properties |
-| ----- | ----------- | ---------- |
-| `creator.formOpen` | User opened an ansible-creator form | `command` — creator command name |
+| Event              | Description                            | Properties                                                                                                        |
+| ------------------ | -------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `creator.formOpen` | User opened an ansible-creator form    | `command` — creator command name                                                                                  |
+| `creator.complete` | Scaffold execute finished or cancelled | `result` — `success` \| `cancel` \| `error`; `command` — creator command name; optional `durationMs`, `errorCode` |
 
 ### Vault
 
-| Event | Description | Properties |
-| ----- | ----------- | ---------- |
-| `vault.use` | User invoked vault encryption/decryption | — |
+| Event       | Description                              | Properties |
+| ----------- | ---------------------------------------- | ---------- |
+| `vault.use` | User invoked vault encryption/decryption | —          |
 
 ### Plugin documentation
 
-| Event | Description | Properties |
-| ----- | ----------- | ---------- |
-| `pluginDoc.view` | User opened plugin documentation | — |
+| Event            | Description                      | Properties |
+| ---------------- | -------------------------------- | ---------- |
+| `pluginDoc.view` | User opened plugin documentation | —          |
 
 ### AI features
 
-| Event | Description | Properties |
-| ----- | ----------- | ---------- |
+| Event               | Description                  | Properties                                    |
+| ------------------- | ---------------------------- | --------------------------------------------- |
 | `ai.summaryRequest` | User requested an AI summary | `domain` — feature area (e.g., `collections`) |
 
 ### MCP
 
-| Event | Description | Properties |
-| ----- | ----------- | ---------- |
-| `mcp.toolUseInChat` | User injected an MCP tool prompt into chat | `toolName` — MCP tool identifier |
-| `mcp.configure` | User configured MCP integration | — |
+| Event               | Description                     | Properties                                                                      |
+| ------------------- | ------------------------------- | ------------------------------------------------------------------------------- |
+| `mcp.toolUseInChat` | MCP tool prompt inject finished | `toolName`; `result` — `success` \| `error`; optional `durationMs`, `errorCode` |
+| `mcp.configure`     | User configured MCP integration | —                                                                               |
 
 ### Skills
 
-| Event | Description | Properties |
-| ----- | ----------- | ---------- |
-| `skill.useInChat` | User injected a skill prompt into chat | — |
-| `skill.promptCopy` | User copied a skill prompt | — |
+| Event              | Description                  | Properties                                                          |
+| ------------------ | ---------------------------- | ------------------------------------------------------------------- |
+| `skill.useInChat`  | Skill prompt inject finished | `result` — `success` \| `error`; optional `durationMs`, `errorCode` |
+| `skill.promptCopy` | Skill prompt copy finished   | `result` — `success` \| `error`; optional `durationMs`, `errorCode` |
 
 ### LLM
 
-| Event | Description | Properties |
-| ----- | ----------- | ---------- |
-| `llm.modelSelect` | User selected an LLM model | — |
-| `llm.providerConfigure` | User configured an LLM provider | — |
+| Event                   | Description                     | Properties |
+| ----------------------- | ------------------------------- | ---------- |
+| `llm.modelSelect`       | User selected an LLM model      | —          |
+| `llm.providerConfigure` | User configured an LLM provider | —          |
 
 ### Execution environments
 
-| Event | Description | Properties |
-| ----- | ----------- | ---------- |
-| `ee.detailView` | User viewed execution environment details | — |
+| Event           | Description                               | Properties |
+| --------------- | ----------------------------------------- | ---------- |
+| `ee.detailView` | User viewed execution environment details | —          |
 
 ### Walkthroughs
 
-| Event | Description | Properties |
-| ----- | ----------- | ---------- |
+| Event              | Description               | Properties                               |
+| ------------------ | ------------------------- | ---------------------------------------- |
 | `walkthrough.open` | User opened a walkthrough | `walkthroughId` — walkthrough identifier |
 
 ### Ansible Lightspeed (when enabled)
@@ -121,19 +123,19 @@ event properties are automatically sanitized by the Red Hat telemetry library.
 When `ansible.lightspeed.enabled` is `true`, Lightspeed events are also
 reported through the same telemetry pipeline:
 
-| Event | Description |
-| ----- | ----------- |
-| `lightspeed.suggestion.accepted` | Inline suggestion accepted |
-| `lightspeed.suggestion.rejected` | Inline suggestion rejected |
-| `lightspeed.suggestion.ignored` | Inline suggestion ignored |
-| `lightspeed.generation.open` | Generation panel opened |
-| `lightspeed.generation.close` | Generation panel closed |
-| `lightspeed.generation.transition` | Generation panel state transition |
-| `lightspeed.generation.accept` | Generated content accepted |
-| `lightspeed.explanation.requested` | Code explanation requested |
-| `lightspeed.feedback.thumbsUp` | Positive feedback submitted |
-| `lightspeed.feedback.thumbsDown` | Negative feedback submitted |
-| `lightspeed.contentMatches.fetched` | Content matches retrieved |
+| Event                               | Description                       |
+| ----------------------------------- | --------------------------------- |
+| `lightspeed.suggestion.accepted`    | Inline suggestion accepted        |
+| `lightspeed.suggestion.rejected`    | Inline suggestion rejected        |
+| `lightspeed.suggestion.ignored`     | Inline suggestion ignored         |
+| `lightspeed.generation.open`        | Generation panel opened           |
+| `lightspeed.generation.close`       | Generation panel closed           |
+| `lightspeed.generation.transition`  | Generation panel state transition |
+| `lightspeed.generation.accept`      | Generated content accepted        |
+| `lightspeed.explanation.requested`  | Code explanation requested        |
+| `lightspeed.feedback.thumbsUp`      | Positive feedback submitted       |
+| `lightspeed.feedback.thumbsDown`    | Negative feedback submitted       |
+| `lightspeed.contentMatches.fetched` | Content matches retrieved         |
 
 ## Story-to-event mapping
 
@@ -151,51 +153,52 @@ UX story, marked as platform baseline, or removed.
 These events are infrastructure / library lifecycle and do **not** require
 a product story:
 
-| Event | Event key | Notes |
-| ----- | --------- | ----- |
-| Extension startup | `startup` | Sent by Red Hat telemetry library |
-| Extension shutdown | `shutdown` | Sent automatically with session duration |
+| Event                    | Event key          | Notes                                          |
+| ------------------------ | ------------------ | ---------------------------------------------- |
+| Extension startup        | `startup`          | Sent by Red Hat telemetry library              |
+| Extension shutdown       | `shutdown`         | Sent automatically with session duration       |
 | Tracked command executed | `command.executed` | Generic command wrapper (`commandId` property) |
 
 ### Extension `TelemetryEvents`
 
-| Event | Event key | User story | Status |
-| ----- | --------- | ---------- | ------ |
-| Extension activated | `extension.activated` | [XC-001] Extension activation and sidebar | Mapped |
-| Environment create | `env.create` | [ENV-002] Create virtual environment | Mapped |
-| Environment select | `env.select` | [ENV-003] Select Python environment | Mapped |
-| Collection install | `collection.install` | [COL-007] Install collection from sidebar | Mapped |
-| Collection search | `collection.search` | [COL-005] Search remote collections | Mapped |
-| Playbook run | `playbook.run` | [PLB-003] Run playbook in terminal | Mapped |
+| Event                      | Event key                  | User story                                          | Status |
+| -------------------------- | -------------------------- | --------------------------------------------------- | ------ |
+| Extension activated        | `extension.activated`      | [XC-001] Extension activation and sidebar           | Mapped |
+| Environment create         | `env.create`               | [ENV-002] Create virtual environment                | Mapped |
+| Environment select         | `env.select`               | [ENV-003] Select Python environment                 | Mapped |
+| Collection install         | `collection.install`       | [COL-007] Install collection from sidebar           | Mapped |
+| Collection search          | `collection.search`        | [COL-005] Search remote collections                 | Mapped |
+| Playbook run               | `playbook.run`             | [PLB-003] Run playbook in terminal                  | Mapped |
 | Playbook run with progress | `playbook.runWithProgress` | [PLB-004] Real-time playbook progress visualization | Mapped |
-| Creator form open | `creator.formOpen` | [SCF-001] Scaffold new Ansible content | Mapped |
-| Vault use | `vault.use` | [LSP-007] Vault encrypt and decrypt | Mapped |
-| Plugin doc view | `pluginDoc.view` | [COL-003] View plugin documentation | Mapped |
-| AI summary request | `ai.summaryRequest` | [AI-001] / [PLB-006] / [EE-003] (via `domain`) | Mapped |
-| MCP tool use in chat | `mcp.toolUseInChat` | [AI-008] Browse and use MCP tools | Mapped |
-| MCP configure | `mcp.configure` | [AI-009] Configure MCP for external AI clients | Mapped |
-| Skill use in chat | `skill.useInChat` | [AI-010] Browse AI skills | Mapped |
-| Skill prompt copy | `skill.promptCopy` | [AI-010] Browse AI skills | Mapped |
-| LLM model select | `llm.modelSelect` | [AI-007] Select LLM model and provider | Mapped |
-| LLM provider configure | `llm.providerConfigure` | [AI-007] Select LLM model and provider | Mapped |
-| EE detail view | `ee.detailView` | [EE-002] Inspect EE contents | Mapped |
-| Walkthrough open | `walkthrough.open` | [XC-004] Open guided walkthroughs | Mapped |
+| Creator form open          | `creator.formOpen`         | [SCF-001] Scaffold new Ansible content              | Mapped |
+| Creator complete           | `creator.complete`         | [SCF-001] Scaffold new Ansible content              | Mapped |
+| Vault use                  | `vault.use`                | [LSP-007] Vault encrypt and decrypt                 | Mapped |
+| Plugin doc view            | `pluginDoc.view`           | [COL-003] View plugin documentation                 | Mapped |
+| AI summary request         | `ai.summaryRequest`        | [AI-001] / [PLB-006] / [EE-003] (via `domain`)      | Mapped |
+| MCP tool use in chat       | `mcp.toolUseInChat`        | [AI-008] Browse and use MCP tools                   | Mapped |
+| MCP configure              | `mcp.configure`            | [AI-009] Configure MCP for external AI clients      | Mapped |
+| Skill use in chat          | `skill.useInChat`          | [AI-010] Browse AI skills                           | Mapped |
+| Skill prompt copy          | `skill.promptCopy`         | [AI-010] Browse AI skills                           | Mapped |
+| LLM model select           | `llm.modelSelect`          | [AI-007] Select LLM model and provider              | Mapped |
+| LLM provider configure     | `llm.providerConfigure`    | [AI-007] Select LLM model and provider              | Mapped |
+| EE detail view             | `ee.detailView`            | [EE-002] Inspect EE contents                        | Mapped |
+| Walkthrough open           | `walkthrough.open`         | [XC-004] Open guided walkthroughs                   | Mapped |
 
 ### Lightspeed events
 
-| Event | Event key | User story | Status |
-| ----- | --------- | ---------- | ------ |
-| Inline suggestion accepted | `lightspeed.suggestion.accepted` | [LS-005] Inline code suggestions | Mapped |
-| Inline suggestion rejected | `lightspeed.suggestion.rejected` | [LS-005] Inline code suggestions | Mapped |
-| Inline suggestion ignored | `lightspeed.suggestion.ignored` | [LS-005] Inline code suggestions | Mapped |
-| Generation panel opened | `lightspeed.generation.open` | [LS-002] Generate playbook via Lightspeed | Mapped |
-| Generation panel closed | `lightspeed.generation.close` | [LS-002] / [LS-003] Generation lifecycle | Mapped |
-| Generation step transition | `lightspeed.generation.transition` | [LS-002] / [LS-003] Generation lifecycle | Mapped |
-| Generation content accepted | `lightspeed.generation.accept` | [LS-002] / [LS-003] Generation lifecycle | Mapped |
-| Explanation requested | `lightspeed.explanation.requested` | [LS-004] Explain playbook via Lightspeed | Mapped |
-| Feedback thumbs up | `lightspeed.feedback.thumbsUp` | [LS-005] Inline code suggestions | Mapped |
-| Feedback thumbs down | `lightspeed.feedback.thumbsDown` | [LS-005] Inline code suggestions | Mapped |
-| Content matches fetched | `lightspeed.contentMatches.fetched` | [LS-005] Inline code suggestions | Mapped |
+| Event                       | Event key                           | User story                                | Status |
+| --------------------------- | ----------------------------------- | ----------------------------------------- | ------ |
+| Inline suggestion accepted  | `lightspeed.suggestion.accepted`    | [LS-005] Inline code suggestions          | Mapped |
+| Inline suggestion rejected  | `lightspeed.suggestion.rejected`    | [LS-005] Inline code suggestions          | Mapped |
+| Inline suggestion ignored   | `lightspeed.suggestion.ignored`     | [LS-005] Inline code suggestions          | Mapped |
+| Generation panel opened     | `lightspeed.generation.open`        | [LS-002] Generate playbook via Lightspeed | Mapped |
+| Generation panel closed     | `lightspeed.generation.close`       | [LS-002] / [LS-003] Generation lifecycle  | Mapped |
+| Generation step transition  | `lightspeed.generation.transition`  | [LS-002] / [LS-003] Generation lifecycle  | Mapped |
+| Generation content accepted | `lightspeed.generation.accept`      | [LS-002] / [LS-003] Generation lifecycle  | Mapped |
+| Explanation requested       | `lightspeed.explanation.requested`  | [LS-004] Explain playbook via Lightspeed  | Mapped |
+| Feedback thumbs up          | `lightspeed.feedback.thumbsUp`      | [LS-005] Inline code suggestions          | Mapped |
+| Feedback thumbs down        | `lightspeed.feedback.thumbsDown`    | [LS-005] Inline code suggestions          | Mapped |
+| Content matches fetched     | `lightspeed.contentMatches.fetched` | [LS-005] Inline code suggestions          | Mapped |
 
 ### Orphan events
 

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -43,8 +43,10 @@ export type {
     AiAnalyzeData,
     PlaybookRunOptions,
     TelemetryEventName,
+    TelemetryResult,
+    TelemetryOutcomeOptions,
 } from './types';
-export { TelemetryEvents } from './types';
+export { TelemetryEvents, buildOutcomeProperties } from './types';
 
 // --- Utils ---
 export {

--- a/packages/common/src/types/index.ts
+++ b/packages/common/src/types/index.ts
@@ -34,5 +34,5 @@ export type {
     AiAnalyzeData,
     PlaybookRunOptions,
 } from './playbook';
-export { TelemetryEvents } from './telemetry';
-export type { TelemetryEventName } from './telemetry';
+export { TelemetryEvents, buildOutcomeProperties } from './telemetry';
+export type { TelemetryEventName, TelemetryResult, TelemetryOutcomeOptions } from './telemetry';

--- a/packages/common/src/types/telemetry.ts
+++ b/packages/common/src/types/telemetry.ts
@@ -59,6 +59,9 @@ export type TelemetryEventName = (typeof TelemetryEvents)[keyof typeof Telemetry
 /** Journey outcome for completion-time telemetry events. */
 export type TelemetryResult = 'success' | 'cancel' | 'error';
 
+/** Keys owned by buildOutcomeProperties — never taken from `extra`. */
+const RESERVED_OUTCOME_KEYS = new Set(['result', 'durationMs', 'errorCode']);
+
 export interface TelemetryOutcomeOptions {
     /** Epoch ms when the action started; used to compute `durationMs`. */
     startedAt?: number;
@@ -72,7 +75,20 @@ export interface TelemetryOutcomeOptions {
 }
 
 /**
+ * Sanitize a coarse error category for telemetry.
+ *
+ * @param errorCode - Raw error code candidate
+ * @returns Sanitized non-empty string, or undefined if nothing remains
+ */
+function sanitizeErrorCode(errorCode: string): string | undefined {
+    const cleaned = errorCode.replace(/[^a-zA-Z0-9_.-]/g, '').slice(0, 64);
+    return cleaned.length > 0 ? cleaned : undefined;
+}
+
+/**
  * Build string properties for a journey outcome event.
+ *
+ * Reserved keys (`result`, `durationMs`, `errorCode`) always win over `extra`.
  *
  * @param result - success | cancel | error
  * @param options - Optional duration / errorCode / extra props
@@ -82,12 +98,21 @@ export function buildOutcomeProperties(
     result: TelemetryResult,
     options?: TelemetryOutcomeOptions,
 ): Record<string, string> {
-    const props: Record<string, string> = { result, ...(options?.extra ?? {}) };
+    const props: Record<string, string> = {};
+    for (const [key, value] of Object.entries(options?.extra ?? {})) {
+        if (!RESERVED_OUTCOME_KEYS.has(key)) {
+            props[key] = value;
+        }
+    }
+    props.result = result;
     if (options?.startedAt !== undefined) {
         props.durationMs = String(Math.max(0, Date.now() - options.startedAt));
     }
     if (result === 'error' && options?.errorCode) {
-        props.errorCode = options.errorCode.replace(/[^a-zA-Z0-9_.-]/g, '').slice(0, 64);
+        const sanitized = sanitizeErrorCode(options.errorCode);
+        if (sanitized) {
+            props.errorCode = sanitized;
+        }
     }
     return props;
 }

--- a/packages/common/src/types/telemetry.ts
+++ b/packages/common/src/types/telemetry.ts
@@ -1,5 +1,5 @@
 /**
- * Shared telemetry event name constants.
+ * Shared telemetry event name constants and outcome helpers.
  * Used by the extension and any subsystem that emits telemetry.
  */
 
@@ -24,6 +24,7 @@ export const TelemetryEvents = {
 
     // Creator
     CREATOR_FORM_OPEN: 'creator.formOpen',
+    CREATOR_COMPLETE: 'creator.complete',
 
     // Vault
     VAULT_USE: 'vault.use',
@@ -54,3 +55,39 @@ export const TelemetryEvents = {
 } as const;
 
 export type TelemetryEventName = (typeof TelemetryEvents)[keyof typeof TelemetryEvents];
+
+/** Journey outcome for completion-time telemetry events. */
+export type TelemetryResult = 'success' | 'cancel' | 'error';
+
+export interface TelemetryOutcomeOptions {
+    /** Epoch ms when the action started; used to compute `durationMs`. */
+    startedAt?: number;
+    /**
+     * Coarse, non-PII error category (e.g. `no_workspace`, `tool_missing`).
+     * Sanitized to `[a-zA-Z0-9_.-]` and truncated.
+     */
+    errorCode?: string;
+    /** Extra string properties to merge (must already be non-PII). */
+    extra?: Record<string, string>;
+}
+
+/**
+ * Build string properties for a journey outcome event.
+ *
+ * @param result - success | cancel | error
+ * @param options - Optional duration / errorCode / extra props
+ * @returns Properties suitable for TelemetryService.sendEvent
+ */
+export function buildOutcomeProperties(
+    result: TelemetryResult,
+    options?: TelemetryOutcomeOptions,
+): Record<string, string> {
+    const props: Record<string, string> = { result, ...(options?.extra ?? {}) };
+    if (options?.startedAt !== undefined) {
+        props.durationMs = String(Math.max(0, Date.now() - options.startedAt));
+    }
+    if (result === 'error' && options?.errorCode) {
+        props.errorCode = options.errorCode.replace(/[^a-zA-Z0-9_.-]/g, '').slice(0, 64);
+    }
+    return props;
+}

--- a/packages/common/test/types/telemetry.test.ts
+++ b/packages/common/test/types/telemetry.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { TelemetryEvents, buildOutcomeProperties } from '../../src/types/telemetry';
+
+describe('buildOutcomeProperties', () => {
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('includes result', () => {
+        expect(buildOutcomeProperties('success')).toEqual({ result: 'success' });
+        expect(buildOutcomeProperties('cancel')).toEqual({ result: 'cancel' });
+        expect(buildOutcomeProperties('error')).toEqual({ result: 'error' });
+    });
+
+    it('computes durationMs from startedAt', () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(1_000_000);
+        expect(buildOutcomeProperties('success', { startedAt: 999_000 })).toEqual({
+            result: 'success',
+            durationMs: '1000',
+        });
+    });
+
+    it('sanitizes errorCode and only includes it on error', () => {
+        expect(buildOutcomeProperties('error', { errorCode: 'no_workspace!!' })).toEqual({
+            result: 'error',
+            errorCode: 'no_workspace',
+        });
+        expect(buildOutcomeProperties('success', { errorCode: 'ignored' })).toEqual({
+            result: 'success',
+        });
+    });
+
+    it('merges extra non-PII props', () => {
+        expect(
+            buildOutcomeProperties('success', { extra: { command: 'init/collection' } }),
+        ).toEqual({
+            result: 'success',
+            command: 'init/collection',
+        });
+    });
+});
+
+describe('TelemetryEvents', () => {
+    it('includes creator.complete for scaffold outcomes', () => {
+        expect(TelemetryEvents.CREATOR_COMPLETE).toBe('creator.complete');
+    });
+});

--- a/packages/common/test/types/telemetry.test.ts
+++ b/packages/common/test/types/telemetry.test.ts
@@ -29,11 +29,21 @@ describe('buildOutcomeProperties', () => {
         expect(buildOutcomeProperties('success', { errorCode: 'ignored' })).toEqual({
             result: 'success',
         });
+        expect(buildOutcomeProperties('error', { errorCode: '!!!' })).toEqual({
+            result: 'error',
+        });
     });
 
-    it('merges extra non-PII props', () => {
+    it('merges extra non-PII props without overriding reserved keys', () => {
         expect(
-            buildOutcomeProperties('success', { extra: { command: 'init/collection' } }),
+            buildOutcomeProperties('success', {
+                extra: {
+                    command: 'init/collection',
+                    result: 'error',
+                    durationMs: '0',
+                    errorCode: 'evil',
+                },
+            }),
         ).toEqual({
             result: 'success',
             command: 'init/collection',

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -539,7 +539,7 @@ export async function activate(context: vscode.ExtensionContext) {
                         TelemetryEvents.SKILL_USE_IN_CHAT,
                         buildOutcomeProperties('success', { startedAt }),
                     );
-                } catch {
+                } catch (error) {
                     telemetry.sendEvent(
                         TelemetryEvents.SKILL_USE_IN_CHAT,
                         buildOutcomeProperties('error', {
@@ -547,6 +547,10 @@ export async function activate(context: vscode.ExtensionContext) {
                             errorCode: 'chat_inject_failed',
                         }),
                     );
+                    vscode.window.showErrorMessage(
+                        `Failed to use skill in chat: ${formatError(error)}`,
+                    );
+                    throw error;
                 }
             },
         ),
@@ -561,7 +565,7 @@ export async function activate(context: vscode.ExtensionContext) {
                         TelemetryEvents.SKILL_PROMPT_COPY,
                         buildOutcomeProperties('success', { startedAt }),
                     );
-                } catch {
+                } catch (error) {
                     telemetry.sendEvent(
                         TelemetryEvents.SKILL_PROMPT_COPY,
                         buildOutcomeProperties('error', {
@@ -569,6 +573,10 @@ export async function activate(context: vscode.ExtensionContext) {
                             errorCode: 'copy_failed',
                         }),
                     );
+                    vscode.window.showErrorMessage(
+                        `Failed to copy skill prompt: ${formatError(error)}`,
+                    );
+                    throw error;
                 }
             },
         ),
@@ -1112,14 +1120,14 @@ export async function activate(context: vscode.ExtensionContext) {
 
                 log('Terminal ready, sending command...');
 
-                // Fire and forget - user watches terminal output.
-                // result=success means launch succeeded (not ansible exit code).
-                void managed.sendCommand(command, { waitForCompletion: false });
+                // Await dispatch only (waitForCompletion: false) so launch failures
+                // hit the catch; playbook exit is not tracked here.
+                await managed.sendCommand(command, { waitForCompletion: false });
                 telemetry.sendEvent(
                     TelemetryEvents.PLAYBOOK_RUN,
                     buildOutcomeProperties('success', { startedAt }),
                 );
-            } catch {
+            } catch (error) {
                 telemetry.sendEvent(
                     TelemetryEvents.PLAYBOOK_RUN,
                     buildOutcomeProperties('error', {
@@ -1127,6 +1135,8 @@ export async function activate(context: vscode.ExtensionContext) {
                         errorCode: 'launch_failed',
                     }),
                 );
+                vscode.window.showErrorMessage(`Failed to run playbook: ${formatError(error)}`);
+                throw error;
             }
         },
     );
@@ -1157,7 +1167,7 @@ export async function activate(context: vscode.ExtensionContext) {
                     extensionPath: context.extensionPath,
                     telemetryStartedAt: startedAt,
                 });
-            } catch {
+            } catch (error) {
                 telemetry.sendEvent(
                     TelemetryEvents.PLAYBOOK_RUN_WITH_PROGRESS,
                     buildOutcomeProperties('error', {
@@ -1165,6 +1175,10 @@ export async function activate(context: vscode.ExtensionContext) {
                         errorCode: 'launch_failed',
                     }),
                 );
+                vscode.window.showErrorMessage(
+                    `Failed to run playbook with progress: ${formatError(error)}`,
+                );
+                throw error;
             }
         },
     );
@@ -1240,7 +1254,7 @@ export async function activate(context: vscode.ExtensionContext) {
                         extra: { toolName: toolInfo.tool.name },
                     }),
                 );
-            } catch {
+            } catch (error) {
                 telemetry.sendEvent(
                     TelemetryEvents.MCP_TOOL_USE_IN_CHAT,
                     buildOutcomeProperties('error', {
@@ -1249,6 +1263,10 @@ export async function activate(context: vscode.ExtensionContext) {
                         extra: { toolName: toolInfo.tool.name },
                     }),
                 );
+                vscode.window.showErrorMessage(
+                    `Failed to use MCP tool in chat: ${formatError(error)}`,
+                );
+                throw error;
             }
         },
     );

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -83,7 +83,7 @@ import { registerWalkthroughTelemetry } from '@src/telemetry';
 import { AnsibleStatusBar } from '@src/statusBar/ansibleStatusBar';
 import { DiagnosticsPanel } from '@src/panels/DiagnosticsPanel';
 import { TelemetryService } from '@src/services/TelemetryService';
-import { TelemetryEvents } from '@ansible/common';
+import { TelemetryEvents, buildOutcomeProperties } from '@ansible/common';
 
 // Create output channel for extension logs
 export const outputChannel = vscode.window.createOutputChannel('Ansible');
@@ -530,17 +530,46 @@ export async function activate(context: vscode.ExtensionContext) {
         }),
         vscode.commands.registerCommand(
             'ansibleSkills.useInChat',
-            (arg: SkillEntry | { skill: SkillEntry }) => {
-                telemetry.sendEvent(TelemetryEvents.SKILL_USE_IN_CHAT);
+            async (arg: SkillEntry | { skill: SkillEntry }) => {
+                const startedAt = Date.now();
                 const skill = 'skill' in arg ? arg.skill : arg;
-                void openChatWithSkill(skill);
+                try {
+                    await openChatWithSkill(skill);
+                    telemetry.sendEvent(
+                        TelemetryEvents.SKILL_USE_IN_CHAT,
+                        buildOutcomeProperties('success', { startedAt }),
+                    );
+                } catch {
+                    telemetry.sendEvent(
+                        TelemetryEvents.SKILL_USE_IN_CHAT,
+                        buildOutcomeProperties('error', {
+                            startedAt,
+                            errorCode: 'chat_inject_failed',
+                        }),
+                    );
+                }
             },
         ),
         vscode.commands.registerCommand(
             'ansibleSkills.copyPrompt',
-            (arg: SkillEntry | { skill: SkillEntry }) => {
+            async (arg: SkillEntry | { skill: SkillEntry }) => {
+                const startedAt = Date.now();
                 const skill = 'skill' in arg ? arg.skill : arg;
-                void copySkillPrompt(skill);
+                try {
+                    await copySkillPrompt(skill);
+                    telemetry.sendEvent(
+                        TelemetryEvents.SKILL_PROMPT_COPY,
+                        buildOutcomeProperties('success', { startedAt }),
+                    );
+                } catch {
+                    telemetry.sendEvent(
+                        TelemetryEvents.SKILL_PROMPT_COPY,
+                        buildOutcomeProperties('error', {
+                            startedAt,
+                            errorCode: 'copy_failed',
+                        }),
+                    );
+                }
             },
         ),
     );
@@ -608,11 +637,18 @@ export async function activate(context: vscode.ExtensionContext) {
     const envManagersCreateCommand = vscode.commands.registerCommand(
         'ansibleDevToolsEnvManagers.create',
         async () => {
-            telemetry.sendEvent(TelemetryEvents.ENV_CREATE);
+            const startedAt = Date.now();
             try {
                 const workspaceFolder = vscode.workspace.workspaceFolders?.[0]?.uri;
                 if (!workspaceFolder) {
                     vscode.window.showErrorMessage('No workspace folder open.');
+                    telemetry.sendEvent(
+                        TelemetryEvents.ENV_CREATE,
+                        buildOutcomeProperties('error', {
+                            startedAt,
+                            errorCode: 'no_workspace',
+                        }),
+                    );
                     return;
                 }
 
@@ -627,10 +663,26 @@ export async function activate(context: vscode.ExtensionContext) {
                     void envManagersProvider.refresh();
                     void devToolsProvider.refresh();
                     void collectionsProvider.refresh();
+                    telemetry.sendEvent(
+                        TelemetryEvents.ENV_CREATE,
+                        buildOutcomeProperties('success', { startedAt }),
+                    );
+                } else {
+                    telemetry.sendEvent(
+                        TelemetryEvents.ENV_CREATE,
+                        buildOutcomeProperties('cancel', { startedAt }),
+                    );
                 }
             } catch (error) {
                 vscode.window.showErrorMessage(
                     `Failed to create environment: ${formatError(error)}`,
+                );
+                telemetry.sendEvent(
+                    TelemetryEvents.ENV_CREATE,
+                    buildOutcomeProperties('error', {
+                        startedAt,
+                        errorCode: 'create_failed',
+                    }),
                 );
             }
         },
@@ -1036,57 +1088,84 @@ export async function activate(context: vscode.ExtensionContext) {
     const playbooksRunCommand = vscode.commands.registerCommand(
         'ansiblePlaybooks.run',
         async (node: { playbook: PlaybookInfo }) => {
-            telemetry.sendEvent(TelemetryEvents.PLAYBOOK_RUN);
-            const playbooksService = PlaybooksService.getInstance();
-            const config = playbooksService.getPlaybookConfig(node.playbook.relativePath);
+            const startedAt = Date.now();
+            try {
+                const playbooksService = PlaybooksService.getInstance();
+                const config = playbooksService.getPlaybookConfig(node.playbook.relativePath);
 
-            // Calculate path relative to the playbook's workspace folder
-            const workspaceFolderPath = node.playbook.workspaceFolder.fsPath;
-            const playbookRelativePath = path.relative(workspaceFolderPath, node.playbook.path);
+                // Calculate path relative to the playbook's workspace folder
+                const workspaceFolderPath = node.playbook.workspaceFolder.fsPath;
+                const playbookRelativePath = path.relative(workspaceFolderPath, node.playbook.path);
 
-            const command = playbooksService.buildCommand(playbookRelativePath, config);
+                const command = playbooksService.buildCommand(playbookRelativePath, config);
 
-            log(`Running playbook: ${command} in ${workspaceFolderPath}`);
+                log(`Running playbook: ${command} in ${workspaceFolderPath}`);
 
-            // Use TerminalService for proper venv activation handling
-            // Use the playbook's workspace folder as cwd
-            const terminalService = TerminalService.getInstance();
-            const managed = await terminalService.createActivatedTerminal({
-                name: `ansible-playbook: ${node.playbook.name}`,
-                cwd: node.playbook.workspaceFolder,
-                show: true,
-            });
+                // Use TerminalService for proper venv activation handling
+                // Use the playbook's workspace folder as cwd
+                const terminalService = TerminalService.getInstance();
+                const managed = await terminalService.createActivatedTerminal({
+                    name: `ansible-playbook: ${node.playbook.name}`,
+                    cwd: node.playbook.workspaceFolder,
+                    show: true,
+                });
 
-            log('Terminal ready, sending command...');
+                log('Terminal ready, sending command...');
 
-            // Fire and forget - user watches terminal output
-            void managed.sendCommand(command, { waitForCompletion: false });
+                // Fire and forget - user watches terminal output.
+                // result=success means launch succeeded (not ansible exit code).
+                void managed.sendCommand(command, { waitForCompletion: false });
+                telemetry.sendEvent(
+                    TelemetryEvents.PLAYBOOK_RUN,
+                    buildOutcomeProperties('success', { startedAt }),
+                );
+            } catch {
+                telemetry.sendEvent(
+                    TelemetryEvents.PLAYBOOK_RUN,
+                    buildOutcomeProperties('error', {
+                        startedAt,
+                        errorCode: 'launch_failed',
+                    }),
+                );
+            }
         },
     );
 
     const playbooksRunWithProgressCommand = vscode.commands.registerCommand(
         'ansiblePlaybooks.runWithProgress',
         async (node: { playbook: PlaybookInfo }) => {
-            telemetry.sendEvent(TelemetryEvents.PLAYBOOK_RUN_WITH_PROGRESS);
-            const playbooksService = PlaybooksService.getInstance();
-            const config = playbooksService.getPlaybookConfig(node.playbook.relativePath);
+            const startedAt = Date.now();
+            try {
+                const playbooksService = PlaybooksService.getInstance();
+                const config = playbooksService.getPlaybookConfig(node.playbook.relativePath);
 
-            // Calculate path relative to the playbook's workspace folder
-            const workspaceFolderPath = node.playbook.workspaceFolder.fsPath;
-            const playbookRelativePath = path.relative(workspaceFolderPath, node.playbook.path);
+                // Calculate path relative to the playbook's workspace folder
+                const workspaceFolderPath = node.playbook.workspaceFolder.fsPath;
+                const playbookRelativePath = path.relative(workspaceFolderPath, node.playbook.path);
 
-            const command = playbooksService.buildCommand(playbookRelativePath, config);
+                const command = playbooksService.buildCommand(playbookRelativePath, config);
 
-            log(`Running playbook with progress: ${command} in ${workspaceFolderPath}`);
+                log(`Running playbook with progress: ${command} in ${workspaceFolderPath}`);
 
-            // Show progress panel
-            await PlaybookProgressPanel.show(context.extensionUri, {
-                playbookPath: node.playbook.path,
-                playbookName: node.playbook.name,
-                workspaceFolder: node.playbook.workspaceFolder,
-                command: command,
-                extensionPath: context.extensionPath,
-            });
+                // Show progress panel — completion telemetry fires from the panel
+                // when playbook_complete arrives (ansible outcome).
+                await PlaybookProgressPanel.show(context.extensionUri, {
+                    playbookPath: node.playbook.path,
+                    playbookName: node.playbook.name,
+                    workspaceFolder: node.playbook.workspaceFolder,
+                    command: command,
+                    extensionPath: context.extensionPath,
+                    telemetryStartedAt: startedAt,
+                });
+            } catch {
+                telemetry.sendEvent(
+                    TelemetryEvents.PLAYBOOK_RUN_WITH_PROGRESS,
+                    buildOutcomeProperties('error', {
+                        startedAt,
+                        errorCode: 'launch_failed',
+                    }),
+                );
+            }
         },
     );
 
@@ -1151,10 +1230,26 @@ export async function activate(context: vscode.ExtensionContext) {
     const mcpToolsUseInChatCommand = vscode.commands.registerCommand(
         'ansibleMcpTools.useInChat',
         async (toolInfo: ToolInfo) => {
-            telemetry.sendEvent(TelemetryEvents.MCP_TOOL_USE_IN_CHAT, {
-                toolName: toolInfo.tool.name,
-            });
-            await injectToolPromptIntoChat(toolInfo);
+            const startedAt = Date.now();
+            try {
+                await injectToolPromptIntoChat(toolInfo);
+                telemetry.sendEvent(
+                    TelemetryEvents.MCP_TOOL_USE_IN_CHAT,
+                    buildOutcomeProperties('success', {
+                        startedAt,
+                        extra: { toolName: toolInfo.tool.name },
+                    }),
+                );
+            } catch {
+                telemetry.sendEvent(
+                    TelemetryEvents.MCP_TOOL_USE_IN_CHAT,
+                    buildOutcomeProperties('error', {
+                        startedAt,
+                        errorCode: 'chat_inject_failed',
+                        extra: { toolName: toolInfo.tool.name },
+                    }),
+                );
+            }
         },
     );
 
@@ -1387,7 +1482,8 @@ export async function activate(context: vscode.ExtensionContext) {
     const collectionsInstallCommand = vscode.commands.registerCommand(
         'ansibleDevToolsCollections.install',
         () => {
-            telemetry.sendEvent(TelemetryEvents.COLLECTION_INSTALL);
+            const startedAt = Date.now();
+            let accepted = false;
             try {
                 const collectionsService = CollectionsService.getInstance();
 
@@ -1453,38 +1549,49 @@ export async function activate(context: vscode.ExtensionContext) {
 
                 quickPick.onDidAccept(() => {
                     const selected = quickPick.selectedItems[0];
-                    // Skip if loading placeholder or no selection
+                    // Skip if loading placeholder
                     if (selected.label.startsWith('$(sync~spin)')) {
                         return;
                     }
 
+                    accepted = true;
                     quickPick.hide();
 
-                    const collectionName = selected.label;
-
-                    // Run installation with progress indicator
+                    // Run installation with progress indicator (no FQCN in telemetry)
                     void vscode.window.withProgress(
                         {
                             location: vscode.ProgressLocation.Notification,
-                            title: `Installing ${collectionName}`,
+                            title: `Installing ${selected.label}`,
                             cancellable: false,
                         },
                         async (progress) => {
                             progress.report({ message: 'Running ade install...' });
 
                             try {
-                                const output =
-                                    await collectionsService.installCollection(collectionName);
+                                const output = await collectionsService.installCollection(
+                                    selected.label,
+                                );
                                 vscode.window.showInformationMessage(
-                                    `Successfully installed ${collectionName}`,
+                                    `Successfully installed ${selected.label}`,
                                 );
                                 log(`Collection install output: ${output}`);
 
                                 // Refresh the collections view
                                 void collectionsProvider.refresh();
+                                telemetry.sendEvent(
+                                    TelemetryEvents.COLLECTION_INSTALL,
+                                    buildOutcomeProperties('success', { startedAt }),
+                                );
                             } catch (error) {
                                 vscode.window.showErrorMessage(
                                     `Failed to install collection: ${formatError(error)}`,
+                                );
+                                telemetry.sendEvent(
+                                    TelemetryEvents.COLLECTION_INSTALL,
+                                    buildOutcomeProperties('error', {
+                                        startedAt,
+                                        errorCode: 'install_failed',
+                                    }),
                                 );
                             }
                         },
@@ -1492,6 +1599,12 @@ export async function activate(context: vscode.ExtensionContext) {
                 });
 
                 quickPick.onDidHide(() => {
+                    if (!accepted) {
+                        telemetry.sendEvent(
+                            TelemetryEvents.COLLECTION_INSTALL,
+                            buildOutcomeProperties('cancel', { startedAt }),
+                        );
+                    }
                     loadListener.dispose();
                     progressListener.dispose();
                     quickPick.dispose();
@@ -1500,6 +1613,13 @@ export async function activate(context: vscode.ExtensionContext) {
             } catch (error) {
                 vscode.window.showErrorMessage(
                     `Failed to install collection: ${formatError(error)}`,
+                );
+                telemetry.sendEvent(
+                    TelemetryEvents.COLLECTION_INSTALL,
+                    buildOutcomeProperties('error', {
+                        startedAt,
+                        errorCode: 'picker_failed',
+                    }),
                 );
             }
         },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -83,7 +83,8 @@ import { registerWalkthroughTelemetry } from '@src/telemetry';
 import { AnsibleStatusBar } from '@src/statusBar/ansibleStatusBar';
 import { DiagnosticsPanel } from '@src/panels/DiagnosticsPanel';
 import { TelemetryService } from '@src/services/TelemetryService';
-import { TelemetryEvents, buildOutcomeProperties } from '@ansible/common';
+import { emitJourneyOutcome } from '@src/services/journeyTelemetry';
+import { TelemetryEvents } from '@ansible/common';
 
 // Create output channel for extension logs
 export const outputChannel = vscode.window.createOutputChannel('Ansible');
@@ -535,18 +536,14 @@ export async function activate(context: vscode.ExtensionContext) {
                 const skill = 'skill' in arg ? arg.skill : arg;
                 try {
                     await openChatWithSkill(skill);
-                    telemetry.sendEvent(
-                        TelemetryEvents.SKILL_USE_IN_CHAT,
-                        buildOutcomeProperties('success', { startedAt }),
-                    );
+                    emitJourneyOutcome(TelemetryEvents.SKILL_USE_IN_CHAT, 'success', {
+                        startedAt,
+                    });
                 } catch (error) {
-                    telemetry.sendEvent(
-                        TelemetryEvents.SKILL_USE_IN_CHAT,
-                        buildOutcomeProperties('error', {
-                            startedAt,
-                            errorCode: 'chat_inject_failed',
-                        }),
-                    );
+                    emitJourneyOutcome(TelemetryEvents.SKILL_USE_IN_CHAT, 'error', {
+                        startedAt,
+                        errorCode: 'chat_inject_failed',
+                    });
                     vscode.window.showErrorMessage(
                         `Failed to use skill in chat: ${formatError(error)}`,
                     );
@@ -561,18 +558,14 @@ export async function activate(context: vscode.ExtensionContext) {
                 const skill = 'skill' in arg ? arg.skill : arg;
                 try {
                     await copySkillPrompt(skill);
-                    telemetry.sendEvent(
-                        TelemetryEvents.SKILL_PROMPT_COPY,
-                        buildOutcomeProperties('success', { startedAt }),
-                    );
+                    emitJourneyOutcome(TelemetryEvents.SKILL_PROMPT_COPY, 'success', {
+                        startedAt,
+                    });
                 } catch (error) {
-                    telemetry.sendEvent(
-                        TelemetryEvents.SKILL_PROMPT_COPY,
-                        buildOutcomeProperties('error', {
-                            startedAt,
-                            errorCode: 'copy_failed',
-                        }),
-                    );
+                    emitJourneyOutcome(TelemetryEvents.SKILL_PROMPT_COPY, 'error', {
+                        startedAt,
+                        errorCode: 'copy_failed',
+                    });
                     vscode.window.showErrorMessage(
                         `Failed to copy skill prompt: ${formatError(error)}`,
                     );
@@ -650,13 +643,10 @@ export async function activate(context: vscode.ExtensionContext) {
                 const workspaceFolder = vscode.workspace.workspaceFolders?.[0]?.uri;
                 if (!workspaceFolder) {
                     vscode.window.showErrorMessage('No workspace folder open.');
-                    telemetry.sendEvent(
-                        TelemetryEvents.ENV_CREATE,
-                        buildOutcomeProperties('error', {
-                            startedAt,
-                            errorCode: 'no_workspace',
-                        }),
-                    );
+                    emitJourneyOutcome(TelemetryEvents.ENV_CREATE, 'error', {
+                        startedAt,
+                        errorCode: 'no_workspace',
+                    });
                     return;
                 }
 
@@ -671,27 +661,18 @@ export async function activate(context: vscode.ExtensionContext) {
                     void envManagersProvider.refresh();
                     void devToolsProvider.refresh();
                     void collectionsProvider.refresh();
-                    telemetry.sendEvent(
-                        TelemetryEvents.ENV_CREATE,
-                        buildOutcomeProperties('success', { startedAt }),
-                    );
+                    emitJourneyOutcome(TelemetryEvents.ENV_CREATE, 'success', { startedAt });
                 } else {
-                    telemetry.sendEvent(
-                        TelemetryEvents.ENV_CREATE,
-                        buildOutcomeProperties('cancel', { startedAt }),
-                    );
+                    emitJourneyOutcome(TelemetryEvents.ENV_CREATE, 'cancel', { startedAt });
                 }
             } catch (error) {
                 vscode.window.showErrorMessage(
                     `Failed to create environment: ${formatError(error)}`,
                 );
-                telemetry.sendEvent(
-                    TelemetryEvents.ENV_CREATE,
-                    buildOutcomeProperties('error', {
-                        startedAt,
-                        errorCode: 'create_failed',
-                    }),
-                );
+                emitJourneyOutcome(TelemetryEvents.ENV_CREATE, 'error', {
+                    startedAt,
+                    errorCode: 'create_failed',
+                });
             }
         },
     );
@@ -1123,18 +1104,12 @@ export async function activate(context: vscode.ExtensionContext) {
                 // Await dispatch only (waitForCompletion: false) so launch failures
                 // hit the catch; playbook exit is not tracked here.
                 await managed.sendCommand(command, { waitForCompletion: false });
-                telemetry.sendEvent(
-                    TelemetryEvents.PLAYBOOK_RUN,
-                    buildOutcomeProperties('success', { startedAt }),
-                );
+                emitJourneyOutcome(TelemetryEvents.PLAYBOOK_RUN, 'success', { startedAt });
             } catch (error) {
-                telemetry.sendEvent(
-                    TelemetryEvents.PLAYBOOK_RUN,
-                    buildOutcomeProperties('error', {
-                        startedAt,
-                        errorCode: 'launch_failed',
-                    }),
-                );
+                emitJourneyOutcome(TelemetryEvents.PLAYBOOK_RUN, 'error', {
+                    startedAt,
+                    errorCode: 'launch_failed',
+                });
                 vscode.window.showErrorMessage(`Failed to run playbook: ${formatError(error)}`);
                 throw error;
             }
@@ -1168,13 +1143,10 @@ export async function activate(context: vscode.ExtensionContext) {
                     telemetryStartedAt: startedAt,
                 });
             } catch (error) {
-                telemetry.sendEvent(
-                    TelemetryEvents.PLAYBOOK_RUN_WITH_PROGRESS,
-                    buildOutcomeProperties('error', {
-                        startedAt,
-                        errorCode: 'launch_failed',
-                    }),
-                );
+                emitJourneyOutcome(TelemetryEvents.PLAYBOOK_RUN_WITH_PROGRESS, 'error', {
+                    startedAt,
+                    errorCode: 'launch_failed',
+                });
                 vscode.window.showErrorMessage(
                     `Failed to run playbook with progress: ${formatError(error)}`,
                 );
@@ -1247,22 +1219,16 @@ export async function activate(context: vscode.ExtensionContext) {
             const startedAt = Date.now();
             try {
                 await injectToolPromptIntoChat(toolInfo);
-                telemetry.sendEvent(
-                    TelemetryEvents.MCP_TOOL_USE_IN_CHAT,
-                    buildOutcomeProperties('success', {
-                        startedAt,
-                        extra: { toolName: toolInfo.tool.name },
-                    }),
-                );
+                emitJourneyOutcome(TelemetryEvents.MCP_TOOL_USE_IN_CHAT, 'success', {
+                    startedAt,
+                    extra: { toolName: toolInfo.tool.name },
+                });
             } catch (error) {
-                telemetry.sendEvent(
-                    TelemetryEvents.MCP_TOOL_USE_IN_CHAT,
-                    buildOutcomeProperties('error', {
-                        startedAt,
-                        errorCode: 'chat_inject_failed',
-                        extra: { toolName: toolInfo.tool.name },
-                    }),
-                );
+                emitJourneyOutcome(TelemetryEvents.MCP_TOOL_USE_IN_CHAT, 'error', {
+                    startedAt,
+                    errorCode: 'chat_inject_failed',
+                    extra: { toolName: toolInfo.tool.name },
+                });
                 vscode.window.showErrorMessage(
                     `Failed to use MCP tool in chat: ${formatError(error)}`,
                 );
@@ -1596,21 +1562,17 @@ export async function activate(context: vscode.ExtensionContext) {
 
                                 // Refresh the collections view
                                 void collectionsProvider.refresh();
-                                telemetry.sendEvent(
-                                    TelemetryEvents.COLLECTION_INSTALL,
-                                    buildOutcomeProperties('success', { startedAt }),
-                                );
+                                emitJourneyOutcome(TelemetryEvents.COLLECTION_INSTALL, 'success', {
+                                    startedAt,
+                                });
                             } catch (error) {
                                 vscode.window.showErrorMessage(
                                     `Failed to install collection: ${formatError(error)}`,
                                 );
-                                telemetry.sendEvent(
-                                    TelemetryEvents.COLLECTION_INSTALL,
-                                    buildOutcomeProperties('error', {
-                                        startedAt,
-                                        errorCode: 'install_failed',
-                                    }),
-                                );
+                                emitJourneyOutcome(TelemetryEvents.COLLECTION_INSTALL, 'error', {
+                                    startedAt,
+                                    errorCode: 'install_failed',
+                                });
                             }
                         },
                     );
@@ -1618,10 +1580,9 @@ export async function activate(context: vscode.ExtensionContext) {
 
                 quickPick.onDidHide(() => {
                     if (!accepted) {
-                        telemetry.sendEvent(
-                            TelemetryEvents.COLLECTION_INSTALL,
-                            buildOutcomeProperties('cancel', { startedAt }),
-                        );
+                        emitJourneyOutcome(TelemetryEvents.COLLECTION_INSTALL, 'cancel', {
+                            startedAt,
+                        });
                     }
                     loadListener.dispose();
                     progressListener.dispose();
@@ -1632,13 +1593,10 @@ export async function activate(context: vscode.ExtensionContext) {
                 vscode.window.showErrorMessage(
                     `Failed to install collection: ${formatError(error)}`,
                 );
-                telemetry.sendEvent(
-                    TelemetryEvents.COLLECTION_INSTALL,
-                    buildOutcomeProperties('error', {
-                        startedAt,
-                        errorCode: 'picker_failed',
-                    }),
-                );
+                emitJourneyOutcome(TelemetryEvents.COLLECTION_INSTALL, 'error', {
+                    startedAt,
+                    errorCode: 'picker_failed',
+                });
             }
         },
     );

--- a/src/panels/CreatorFormPanel.ts
+++ b/src/panels/CreatorFormPanel.ts
@@ -1,16 +1,14 @@
 import * as vscode from 'vscode';
 import { log } from '@src/extension';
 import { buildCommandArgs, getCommandService, type SchemaNode } from '@ansible/developer-services';
-import { TelemetryEvents, buildOutcomeProperties } from '@ansible/common';
-import { TelemetryService } from '@src/services/TelemetryService';
+import { OnceJourneyEmitter, emitCreatorComplete } from '@src/services/journeyTelemetry';
 
 /** Thin webview host for the creator form. Delegates UI to @ansible/ui SchemaForm. */
 export class CreatorFormPanel {
     public static currentPanel: CreatorFormPanel | undefined;
     private readonly _panel: vscode.WebviewPanel;
     private _disposables: vscode.Disposable[] = [];
-    /** True after a terminal creator.complete outcome was emitted for this panel. */
-    private _outcomeSent = false;
+    private readonly _outcome = new OnceJourneyEmitter();
 
     /**
      * Show or replace the creator form panel for a schema command.
@@ -179,7 +177,7 @@ export class CreatorFormPanel {
                         output: 'ansible-creator not found. Install ansible-dev-tools first.',
                     },
                 });
-                this._sendCreatorOutcome('error', {
+                emitCreatorComplete(this._outcome, 'error', {
                     startedAt,
                     errorCode: 'tool_missing',
                     command: commandKey,
@@ -199,53 +197,27 @@ export class CreatorFormPanel {
                 void vscode.window.showInformationMessage(
                     `ansible-creator ${commandPath.join(' ')} completed successfully`,
                 );
-                this._sendCreatorOutcome('success', { startedAt, command: commandKey });
+                emitCreatorComplete(this._outcome, 'success', {
+                    startedAt,
+                    command: commandKey,
+                });
             } else {
                 void vscode.window.showErrorMessage(
                     `ansible-creator ${commandPath.join(' ')} failed (exit code ${String(result.exitCode)})`,
                 );
-                this._sendCreatorOutcome('error', {
+                emitCreatorComplete(this._outcome, 'error', {
                     startedAt,
                     errorCode: 'exit_nonzero',
                     command: commandKey,
                 });
             }
         } catch (error) {
-            this._sendCreatorOutcome('error', {
+            emitCreatorComplete(this._outcome, 'error', {
                 startedAt,
                 errorCode: 'execute_failed',
                 command: commandKey,
             });
             throw error;
-        }
-    }
-
-    /**
-     * Emit creator.complete once for this panel.
-     *
-     * @param result - success | cancel | error
-     * @param options - Timing / command / error metadata
-     * @param options.startedAt - Epoch ms when execute began
-     * @param options.errorCode - Coarse non-PII failure category
-     * @param options.command - Creator command path key
-     */
-    private _sendCreatorOutcome(
-        result: 'success' | 'cancel' | 'error',
-        options: { startedAt?: number; errorCode?: string; command: string },
-    ): void {
-        if (this._outcomeSent) return;
-        this._outcomeSent = true;
-        try {
-            TelemetryService.getInstance().sendEvent(
-                TelemetryEvents.CREATOR_COMPLETE,
-                buildOutcomeProperties(result, {
-                    startedAt: options.startedAt,
-                    errorCode: options.errorCode,
-                    extra: { command: options.command },
-                }),
-            );
-        } catch {
-            // Telemetry optional if service not initialized
         }
     }
 
@@ -303,8 +275,10 @@ export class CreatorFormPanel {
 
     /** Dispose the panel, listeners, and static current-panel reference. */
     public dispose(): void {
-        if (!this._outcomeSent) {
-            this._sendCreatorOutcome('cancel', { command: this._commandPath.join('/') });
+        if (!this._outcome.sent) {
+            emitCreatorComplete(this._outcome, 'cancel', {
+                command: this._commandPath.join('/'),
+            });
         }
         CreatorFormPanel.currentPanel = undefined;
         this._panel.dispose();

--- a/src/panels/CreatorFormPanel.ts
+++ b/src/panels/CreatorFormPanel.ts
@@ -1,6 +1,8 @@
 import * as vscode from 'vscode';
 import { log } from '@src/extension';
 import { buildCommandArgs, getCommandService, type SchemaNode } from '@ansible/developer-services';
+import { TelemetryEvents, buildOutcomeProperties } from '@ansible/common';
+import { TelemetryService } from '@src/services/TelemetryService';
 
 /** Thin webview host for the creator form. Delegates UI to @ansible/ui SchemaForm. */
 export class CreatorFormPanel {
@@ -95,6 +97,16 @@ export class CreatorFormPanel {
             return;
         }
         if (method === 'cancel') {
+            try {
+                TelemetryService.getInstance().sendEvent(
+                    TelemetryEvents.CREATOR_COMPLETE,
+                    buildOutcomeProperties('cancel', {
+                        extra: { command: this._commandPath.join('/') },
+                    }),
+                );
+            } catch {
+                // Telemetry optional if service not initialized
+            }
             this._panel.dispose();
             return;
         }
@@ -152,6 +164,8 @@ export class CreatorFormPanel {
         commandPath: string[],
         values: Record<string, unknown>,
     ): Promise<void> {
+        const startedAt = Date.now();
+        const commandKey = commandPath.join('/');
         const args = buildCommandArgs(commandPath, this._schema, values);
         log(`CreatorFormPanel: Executing: ansible-creator ${args.join(' ')}`);
 
@@ -159,6 +173,21 @@ export class CreatorFormPanel {
             method: 'executionStarted',
             params: { command: `ansible-creator ${args.join(' ')}` },
         });
+
+        const sendCreatorOutcome = (result: 'success' | 'error', errorCode?: string): void => {
+            try {
+                TelemetryService.getInstance().sendEvent(
+                    TelemetryEvents.CREATOR_COMPLETE,
+                    buildOutcomeProperties(result, {
+                        startedAt,
+                        errorCode,
+                        extra: { command: commandKey },
+                    }),
+                );
+            } catch {
+                // Telemetry optional if service not initialized
+            }
+        };
 
         const commandService = getCommandService();
         const toolPath = await commandService.getToolPath('ansible-creator');
@@ -170,6 +199,7 @@ export class CreatorFormPanel {
                     output: 'ansible-creator not found. Install ansible-dev-tools first.',
                 },
             });
+            sendCreatorOutcome('error', 'tool_missing');
             return;
         }
 
@@ -185,10 +215,12 @@ export class CreatorFormPanel {
             void vscode.window.showInformationMessage(
                 `ansible-creator ${commandPath.join(' ')} completed successfully`,
             );
+            sendCreatorOutcome('success');
         } else {
             void vscode.window.showErrorMessage(
                 `ansible-creator ${commandPath.join(' ')} failed (exit code ${String(result.exitCode)})`,
             );
+            sendCreatorOutcome('error', 'exit_nonzero');
         }
     }
 

--- a/src/panels/CreatorFormPanel.ts
+++ b/src/panels/CreatorFormPanel.ts
@@ -9,6 +9,8 @@ export class CreatorFormPanel {
     public static currentPanel: CreatorFormPanel | undefined;
     private readonly _panel: vscode.WebviewPanel;
     private _disposables: vscode.Disposable[] = [];
+    /** True after a terminal creator.complete outcome was emitted for this panel. */
+    private _outcomeSent = false;
 
     /**
      * Show or replace the creator form panel for a schema command.
@@ -97,16 +99,8 @@ export class CreatorFormPanel {
             return;
         }
         if (method === 'cancel') {
-            try {
-                TelemetryService.getInstance().sendEvent(
-                    TelemetryEvents.CREATOR_COMPLETE,
-                    buildOutcomeProperties('cancel', {
-                        extra: { command: this._commandPath.join('/') },
-                    }),
-                );
-            } catch {
-                // Telemetry optional if service not initialized
-            }
+            // Cancellation telemetry is emitted once from dispose() if no
+            // success/error outcome was already recorded.
             this._panel.dispose();
             return;
         }
@@ -174,53 +168,84 @@ export class CreatorFormPanel {
             params: { command: `ansible-creator ${args.join(' ')}` },
         });
 
-        const sendCreatorOutcome = (result: 'success' | 'error', errorCode?: string): void => {
-            try {
-                TelemetryService.getInstance().sendEvent(
-                    TelemetryEvents.CREATOR_COMPLETE,
-                    buildOutcomeProperties(result, {
-                        startedAt,
-                        errorCode,
-                        extra: { command: commandKey },
-                    }),
-                );
-            } catch {
-                // Telemetry optional if service not initialized
+        try {
+            const commandService = getCommandService();
+            const toolPath = await commandService.getToolPath('ansible-creator');
+            if (!toolPath) {
+                this._panel.webview.postMessage({
+                    method: 'executionFinished',
+                    params: {
+                        exitCode: 1,
+                        output: 'ansible-creator not found. Install ansible-dev-tools first.',
+                    },
+                });
+                this._sendCreatorOutcome('error', {
+                    startedAt,
+                    errorCode: 'tool_missing',
+                    command: commandKey,
+                });
+                return;
             }
-        };
 
-        const commandService = getCommandService();
-        const toolPath = await commandService.getToolPath('ansible-creator');
-        if (!toolPath) {
+            const result = await commandService.runCommandArgs(toolPath, args);
+            const output = [result.stdout, result.stderr].filter(Boolean).join('\n');
+
             this._panel.webview.postMessage({
                 method: 'executionFinished',
-                params: {
-                    exitCode: 1,
-                    output: 'ansible-creator not found. Install ansible-dev-tools first.',
-                },
+                params: { exitCode: result.exitCode, output },
             });
-            sendCreatorOutcome('error', 'tool_missing');
-            return;
+
+            if (result.exitCode === 0) {
+                void vscode.window.showInformationMessage(
+                    `ansible-creator ${commandPath.join(' ')} completed successfully`,
+                );
+                this._sendCreatorOutcome('success', { startedAt, command: commandKey });
+            } else {
+                void vscode.window.showErrorMessage(
+                    `ansible-creator ${commandPath.join(' ')} failed (exit code ${String(result.exitCode)})`,
+                );
+                this._sendCreatorOutcome('error', {
+                    startedAt,
+                    errorCode: 'exit_nonzero',
+                    command: commandKey,
+                });
+            }
+        } catch (error) {
+            this._sendCreatorOutcome('error', {
+                startedAt,
+                errorCode: 'execute_failed',
+                command: commandKey,
+            });
+            throw error;
         }
+    }
 
-        const result = await commandService.runCommandArgs(toolPath, args);
-        const output = [result.stdout, result.stderr].filter(Boolean).join('\n');
-
-        this._panel.webview.postMessage({
-            method: 'executionFinished',
-            params: { exitCode: result.exitCode, output },
-        });
-
-        if (result.exitCode === 0) {
-            void vscode.window.showInformationMessage(
-                `ansible-creator ${commandPath.join(' ')} completed successfully`,
+    /**
+     * Emit creator.complete once for this panel.
+     *
+     * @param result - success | cancel | error
+     * @param options - Timing / command / error metadata
+     * @param options.startedAt - Epoch ms when execute began
+     * @param options.errorCode - Coarse non-PII failure category
+     * @param options.command - Creator command path key
+     */
+    private _sendCreatorOutcome(
+        result: 'success' | 'cancel' | 'error',
+        options: { startedAt?: number; errorCode?: string; command: string },
+    ): void {
+        if (this._outcomeSent) return;
+        this._outcomeSent = true;
+        try {
+            TelemetryService.getInstance().sendEvent(
+                TelemetryEvents.CREATOR_COMPLETE,
+                buildOutcomeProperties(result, {
+                    startedAt: options.startedAt,
+                    errorCode: options.errorCode,
+                    extra: { command: options.command },
+                }),
             );
-            sendCreatorOutcome('success');
-        } else {
-            void vscode.window.showErrorMessage(
-                `ansible-creator ${commandPath.join(' ')} failed (exit code ${String(result.exitCode)})`,
-            );
-            sendCreatorOutcome('error', 'exit_nonzero');
+        } catch {
+            // Telemetry optional if service not initialized
         }
     }
 
@@ -278,6 +303,9 @@ export class CreatorFormPanel {
 
     /** Dispose the panel, listeners, and static current-panel reference. */
     public dispose(): void {
+        if (!this._outcomeSent) {
+            this._sendCreatorOutcome('cancel', { command: this._commandPath.join('/') });
+        }
         CreatorFormPanel.currentPanel = undefined;
         this._panel.dispose();
         while (this._disposables.length) {

--- a/src/panels/PlaybookProgressPanel.ts
+++ b/src/panels/PlaybookProgressPanel.ts
@@ -13,6 +13,8 @@ import { log } from '@src/extension';
 import type { ProgressEvent } from '@ansible/developer-services';
 import { buildTaskAnalysisPrompt } from '@ansible/developer-services';
 import { openChatWithPrompt } from '@src/features/chatProvider';
+import { TelemetryEvents, buildOutcomeProperties } from '@ansible/common';
+import { TelemetryService } from '@src/services/TelemetryService';
 
 /**
  * Single-quote a value for safe interpolation into a POSIX shell command.
@@ -29,6 +31,8 @@ export interface PlaybookRunOptions {
     workspaceFolder: vscode.Uri;
     command: string;
     extensionPath: string;
+    /** Epoch ms when the user invoked run-with-progress (for durationMs). */
+    telemetryStartedAt?: number;
 }
 
 /** Thin webview host that streams ansible-playbook events to PlaybookProgressView. */
@@ -42,6 +46,8 @@ export class PlaybookProgressPanel {
     private _isRunning = false;
     private _terminal: vscode.Terminal | undefined;
     private _lastOptions: PlaybookRunOptions | undefined;
+    private _telemetryStartedAt: number | undefined;
+    private _telemetrySent = false;
 
     /**
      * Show or reuse the playbook progress panel and start a new run.
@@ -137,6 +143,7 @@ export class PlaybookProgressPanel {
                 if (this._terminal && this._isRunning) {
                     this._terminal.sendText('\x03', false);
                     this._isRunning = false;
+                    this._sendPlaybookProgressOutcome('cancel');
                     void this._panel.webview.postMessage({ method: 'playbookStopped' });
                 }
                 break;
@@ -172,6 +179,8 @@ export class PlaybookProgressPanel {
     private async _startRun(options: PlaybookRunOptions): Promise<void> {
         this._lastOptions = options;
         this._isRunning = true;
+        this._telemetryStartedAt = options.telemetryStartedAt ?? Date.now();
+        this._telemetrySent = false;
         this._panel.title = `Playbook: ${options.playbookName}`;
 
         if (this._socketServer) {
@@ -277,12 +286,63 @@ export class PlaybookProgressPanel {
     private _handleEvent(event: ProgressEvent): void {
         if (event.type === 'playbook_complete') {
             this._isRunning = false;
+            const stats = event.data.stats;
+            let failed = false;
+            if (stats && typeof stats === 'object') {
+                for (const hostStats of Object.values(stats as Record<string, unknown>)) {
+                    if (!hostStats || typeof hostStats !== 'object') continue;
+                    const hs = hostStats as Record<string, unknown>;
+                    const failures = typeof hs.failures === 'number' ? hs.failures : 0;
+                    const unreachable = typeof hs.unreachable === 'number' ? hs.unreachable : 0;
+                    if (failures > 0 || unreachable > 0) {
+                        failed = true;
+                        break;
+                    }
+                }
+            }
+            const durationSec =
+                typeof event.data.duration === 'number' ? event.data.duration : undefined;
+            this._sendPlaybookProgressOutcome(failed ? 'error' : 'success', {
+                errorCode: failed ? 'playbook_failed' : undefined,
+                durationSec,
+            });
         }
 
         void this._panel.webview.postMessage({
             method: 'progressEvent',
             params: event,
         });
+    }
+
+    /**
+     * Emit playbook.runWithProgress once per run with journey outcome.
+     * @param result - success | cancel | error
+     * @param options - Optional error code / ansible-reported duration
+     * @param options.errorCode - Coarse non-PII failure category when result is error
+     * @param options.durationSec - Ansible-reported duration in seconds
+     */
+    private _sendPlaybookProgressOutcome(
+        result: 'success' | 'cancel' | 'error',
+        options?: { errorCode?: string; durationSec?: number },
+    ): void {
+        if (this._telemetrySent) return;
+        this._telemetrySent = true;
+        try {
+            const props = buildOutcomeProperties(result, {
+                startedAt: this._telemetryStartedAt,
+                errorCode: options?.errorCode,
+            });
+            // Prefer ansible-reported duration when available (seconds → ms)
+            if (options?.durationSec !== undefined) {
+                props.durationMs = String(Math.max(0, Math.round(options.durationSec * 1000)));
+            }
+            TelemetryService.getInstance().sendEvent(
+                TelemetryEvents.PLAYBOOK_RUN_WITH_PROGRESS,
+                props,
+            );
+        } catch {
+            // Telemetry optional if service not initialized
+        }
     }
 
     /**

--- a/src/panels/PlaybookProgressPanel.ts
+++ b/src/panels/PlaybookProgressPanel.ts
@@ -13,8 +13,11 @@ import { log } from '@src/extension';
 import type { ProgressEvent } from '@ansible/developer-services';
 import { buildTaskAnalysisPrompt } from '@ansible/developer-services';
 import { openChatWithPrompt } from '@src/features/chatProvider';
-import { TelemetryEvents, buildOutcomeProperties } from '@ansible/common';
-import { TelemetryService } from '@src/services/TelemetryService';
+import {
+    OnceJourneyEmitter,
+    emitPlaybookProgressOutcome,
+    isPlaybookStatsFailed,
+} from '@src/services/journeyTelemetry';
 
 /**
  * Single-quote a value for safe interpolation into a POSIX shell command.
@@ -47,7 +50,7 @@ export class PlaybookProgressPanel {
     private _terminal: vscode.Terminal | undefined;
     private _lastOptions: PlaybookRunOptions | undefined;
     private _telemetryStartedAt: number | undefined;
-    private _telemetrySent = false;
+    private _outcome = new OnceJourneyEmitter();
 
     /**
      * Show or reuse the playbook progress panel and start a new run.
@@ -143,7 +146,9 @@ export class PlaybookProgressPanel {
                 if (this._terminal && this._isRunning) {
                     this._terminal.sendText('\x03', false);
                     this._isRunning = false;
-                    this._sendPlaybookProgressOutcome('cancel');
+                    emitPlaybookProgressOutcome(this._outcome, 'cancel', {
+                        startedAt: this._telemetryStartedAt,
+                    });
                     void this._panel.webview.postMessage({ method: 'playbookStopped' });
                 }
                 break;
@@ -180,7 +185,7 @@ export class PlaybookProgressPanel {
         this._lastOptions = options;
         this._isRunning = true;
         this._telemetryStartedAt = options.telemetryStartedAt ?? Date.now();
-        this._telemetrySent = false;
+        this._outcome = new OnceJourneyEmitter();
         this._panel.title = `Playbook: ${options.playbookName}`;
 
         if (this._socketServer) {
@@ -286,25 +291,11 @@ export class PlaybookProgressPanel {
     private _handleEvent(event: ProgressEvent): void {
         if (event.type === 'playbook_complete') {
             this._isRunning = false;
-            const stats = event.data.stats;
-            let failed = false;
-            if (stats && typeof stats === 'object') {
-                for (const hostStats of Object.values(stats as Record<string, unknown>)) {
-                    if (!hostStats || typeof hostStats !== 'object') continue;
-                    const hs = hostStats as Record<string, unknown>;
-                    const failures = typeof hs.failures === 'number' ? hs.failures : 0;
-                    const unreachable = typeof hs.unreachable === 'number' ? hs.unreachable : 0;
-                    if (failures > 0 || unreachable > 0) {
-                        failed = true;
-                        break;
-                    }
-                }
-            }
-            const durationSec =
-                typeof event.data.duration === 'number' ? event.data.duration : undefined;
-            this._sendPlaybookProgressOutcome(failed ? 'error' : 'success', {
+            const failed = isPlaybookStatsFailed(event.data.stats);
+            emitPlaybookProgressOutcome(this._outcome, failed ? 'error' : 'success', {
+                startedAt: this._telemetryStartedAt,
                 errorCode: failed ? 'playbook_failed' : undefined,
-                durationSec,
+                durationSec: event.data.duration,
             });
         }
 
@@ -312,37 +303,6 @@ export class PlaybookProgressPanel {
             method: 'progressEvent',
             params: event,
         });
-    }
-
-    /**
-     * Emit playbook.runWithProgress once per run with journey outcome.
-     * @param result - success | cancel | error
-     * @param options - Optional error code / ansible-reported duration
-     * @param options.errorCode - Coarse non-PII failure category when result is error
-     * @param options.durationSec - Ansible-reported duration in seconds
-     */
-    private _sendPlaybookProgressOutcome(
-        result: 'success' | 'cancel' | 'error',
-        options?: { errorCode?: string; durationSec?: number },
-    ): void {
-        if (this._telemetrySent) return;
-        this._telemetrySent = true;
-        try {
-            const props = buildOutcomeProperties(result, {
-                startedAt: this._telemetryStartedAt,
-                errorCode: options?.errorCode,
-            });
-            // Prefer ansible-reported duration when available (seconds → ms)
-            if (options?.durationSec !== undefined) {
-                props.durationMs = String(Math.max(0, Math.round(options.durationSec * 1000)));
-            }
-            TelemetryService.getInstance().sendEvent(
-                TelemetryEvents.PLAYBOOK_RUN_WITH_PROGRESS,
-                props,
-            );
-        } catch {
-            // Telemetry optional if service not initialized
-        }
     }
 
     /**

--- a/src/panels/PlaybookProgressPanel.ts
+++ b/src/panels/PlaybookProgressPanel.ts
@@ -154,7 +154,10 @@ export class PlaybookProgressPanel {
                 break;
             case 'rerun':
                 if (this._lastOptions) {
-                    await this._startRun(this._lastOptions);
+                    await this._startRun({
+                        ...this._lastOptions,
+                        telemetryStartedAt: Date.now(),
+                    });
                 }
                 break;
             case 'editSource':
@@ -380,6 +383,12 @@ export class PlaybookProgressPanel {
 
     /** Dispose the panel, socket server, and static reference. */
     public dispose(): void {
+        if (this._isRunning) {
+            this._isRunning = false;
+            emitPlaybookProgressOutcome(this._outcome, 'cancel', {
+                startedAt: this._telemetryStartedAt,
+            });
+        }
         PlaybookProgressPanel._currentPanel = undefined;
 
         if (this._socketServer) {

--- a/src/services/journeyTelemetry.ts
+++ b/src/services/journeyTelemetry.ts
@@ -1,0 +1,161 @@
+/**
+ * Journey telemetry helpers shared by command handlers and panels.
+ * Keeps outcome emission testable without activating the full extension.
+ */
+
+import {
+    TelemetryEvents,
+    buildOutcomeProperties,
+    type TelemetryEventName,
+    type TelemetryOutcomeOptions,
+    type TelemetryResult,
+} from '@ansible/common';
+import { TelemetryService } from '@src/services/TelemetryService';
+
+/**
+ * Whether ansible playbook_complete host stats indicate failure.
+ *
+ * @param stats - `event.data.stats` from the progress callback plugin
+ * @returns True when any host has failures or unreachable counts
+ */
+export function isPlaybookStatsFailed(stats: unknown): boolean {
+    if (!stats || typeof stats !== 'object') return false;
+    for (const hostStats of Object.values(stats as Record<string, unknown>)) {
+        if (!hostStats || typeof hostStats !== 'object') continue;
+        const hs = hostStats as Record<string, unknown>;
+        const failures = typeof hs.failures === 'number' ? hs.failures : 0;
+        const unreachable = typeof hs.unreachable === 'number' ? hs.unreachable : 0;
+        if (failures > 0 || unreachable > 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/**
+ * Convert ansible-reported duration seconds to a durationMs property value.
+ *
+ * @param durationSec - Seconds from playbook_complete, if present
+ * @returns String milliseconds, or undefined when not a number
+ */
+export function durationSecToMs(durationSec: unknown): string | undefined {
+    if (typeof durationSec !== 'number' || Number.isNaN(durationSec)) {
+        return undefined;
+    }
+    return String(Math.max(0, Math.round(durationSec * 1000)));
+}
+
+/**
+ * Emit a journey outcome event (safe if TelemetryService is not initialized).
+ *
+ * @param name - Telemetry event name
+ * @param result - success | cancel | error
+ * @param options - Optional duration / errorCode / extra props
+ * @returns void
+ */
+export function emitJourneyOutcome(
+    name: TelemetryEventName,
+    result: TelemetryResult,
+    options?: TelemetryOutcomeOptions,
+): void {
+    try {
+        TelemetryService.getInstance().sendEvent(name, buildOutcomeProperties(result, options));
+    } catch {
+        // Telemetry optional if service not initialized
+    }
+}
+
+/**
+ * Emit a journey event once; subsequent calls no-op.
+ */
+export class OnceJourneyEmitter {
+    private _sent = false;
+
+    /**
+     * Whether an outcome has already been emitted.
+     *
+     * @returns True after the first successful send attempt
+     */
+    public get sent(): boolean {
+        return this._sent;
+    }
+
+    /**
+     * Send a journey outcome if this emitter has not already fired.
+     *
+     * @param name - Telemetry event name
+     * @param result - success | cancel | error
+     * @param options - Optional duration / errorCode / extra props
+     * @param overrides - Property overrides applied after buildOutcomeProperties
+     * @returns void
+     */
+    public send(
+        name: TelemetryEventName,
+        result: TelemetryResult,
+        options?: TelemetryOutcomeOptions,
+        overrides?: Record<string, string>,
+    ): void {
+        if (this._sent) return;
+        this._sent = true;
+        try {
+            const props = {
+                ...buildOutcomeProperties(result, options),
+                ...overrides,
+            };
+            TelemetryService.getInstance().sendEvent(name, props);
+        } catch {
+            // Telemetry optional if service not initialized
+        }
+    }
+}
+
+/**
+ * Emit creator.complete with outcome props.
+ *
+ * @param emitter - Once-guard for this panel instance
+ * @param result - success | cancel | error
+ * @param options - Timing / command / error metadata
+ * @param options.startedAt - Epoch ms when execute began
+ * @param options.errorCode - Coarse non-PII failure category
+ * @param options.command - Creator command path key
+ * @returns void
+ */
+export function emitCreatorComplete(
+    emitter: OnceJourneyEmitter,
+    result: TelemetryResult,
+    options: { startedAt?: number; errorCode?: string; command: string },
+): void {
+    emitter.send(TelemetryEvents.CREATOR_COMPLETE, result, {
+        startedAt: options.startedAt,
+        errorCode: options.errorCode,
+        extra: { command: options.command },
+    });
+}
+
+/**
+ * Emit playbook.runWithProgress with outcome props.
+ *
+ * @param emitter - Once-guard for this run
+ * @param result - success | cancel | error
+ * @param options - Timing / error / ansible duration
+ * @param options.startedAt - Epoch ms when the user invoked the command
+ * @param options.errorCode - Coarse non-PII failure category
+ * @param options.durationSec - Ansible-reported duration in seconds
+ * @returns void
+ */
+export function emitPlaybookProgressOutcome(
+    emitter: OnceJourneyEmitter,
+    result: TelemetryResult,
+    options?: { startedAt?: number; errorCode?: string; durationSec?: unknown },
+): void {
+    const durationMs = durationSecToMs(options?.durationSec);
+    emitter.send(
+        TelemetryEvents.PLAYBOOK_RUN_WITH_PROGRESS,
+        result,
+        {
+            startedAt: options?.startedAt,
+            errorCode: options?.errorCode,
+        },
+        durationMs !== undefined ? { durationMs } : undefined,
+    );
+}

--- a/src/services/journeyTelemetry.ts
+++ b/src/services/journeyTelemetry.ts
@@ -36,10 +36,10 @@ export function isPlaybookStatsFailed(stats: unknown): boolean {
  * Convert ansible-reported duration seconds to a durationMs property value.
  *
  * @param durationSec - Seconds from playbook_complete, if present
- * @returns String milliseconds, or undefined when not a number
+ * @returns String milliseconds, or undefined when not a finite number
  */
 export function durationSecToMs(durationSec: unknown): string | undefined {
-    if (typeof durationSec !== 'number' || Number.isNaN(durationSec)) {
+    if (typeof durationSec !== 'number' || !Number.isFinite(durationSec)) {
         return undefined;
     }
     return String(Math.max(0, Math.round(durationSec * 1000)));

--- a/test/unit/services/journeyTelemetry.test.ts
+++ b/test/unit/services/journeyTelemetry.test.ts
@@ -76,10 +76,12 @@ describe('journeyTelemetry', () => {
             expect(durationSecToMs(-2)).toBe('0');
         });
 
-        it('returns undefined for non-numeric values', () => {
+        it('returns undefined for non-numeric or non-finite values', () => {
             expect(durationSecToMs(undefined)).toBeUndefined();
             expect(durationSecToMs('3')).toBeUndefined();
             expect(durationSecToMs(Number.NaN)).toBeUndefined();
+            expect(durationSecToMs(Number.POSITIVE_INFINITY)).toBeUndefined();
+            expect(durationSecToMs(Number.NEGATIVE_INFINITY)).toBeUndefined();
         });
     });
 

--- a/test/unit/services/journeyTelemetry.test.ts
+++ b/test/unit/services/journeyTelemetry.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TelemetryEvents } from '@ansible/common';
+
+const mockSendEvent = vi.fn();
+
+vi.mock('../../../src/services/TelemetryService', () => ({
+    TelemetryService: {
+        getInstance: vi.fn(() => ({
+            sendEvent: mockSendEvent,
+        })),
+    },
+}));
+
+import { TelemetryService } from '../../../src/services/TelemetryService';
+import {
+    OnceJourneyEmitter,
+    durationSecToMs,
+    emitCreatorComplete,
+    emitJourneyOutcome,
+    emitPlaybookProgressOutcome,
+    isPlaybookStatsFailed,
+} from '../../../src/services/journeyTelemetry';
+
+describe('journeyTelemetry', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(TelemetryService.getInstance).mockReturnValue({
+            sendEvent: mockSendEvent,
+        } as unknown as TelemetryService);
+    });
+
+    describe('isPlaybookStatsFailed', () => {
+        it('returns false for missing or non-object stats', () => {
+            expect(isPlaybookStatsFailed(undefined)).toBe(false);
+            expect(isPlaybookStatsFailed(null)).toBe(false);
+            expect(isPlaybookStatsFailed('ok')).toBe(false);
+        });
+
+        it('returns false when all hosts have zero failures and unreachable', () => {
+            expect(
+                isPlaybookStatsFailed({
+                    host1: { failures: 0, unreachable: 0, ok: 2 },
+                    host2: { failures: 0, unreachable: 0 },
+                }),
+            ).toBe(false);
+        });
+
+        it('returns true when any host has failures or unreachable', () => {
+            expect(
+                isPlaybookStatsFailed({
+                    host1: { failures: 1, unreachable: 0 },
+                }),
+            ).toBe(true);
+            expect(
+                isPlaybookStatsFailed({
+                    host1: { failures: 0, unreachable: 2 },
+                }),
+            ).toBe(true);
+        });
+
+        it('skips non-object host entries', () => {
+            expect(
+                isPlaybookStatsFailed({
+                    host1: null,
+                    host2: 'bad',
+                    host3: { failures: 0, unreachable: 0 },
+                }),
+            ).toBe(false);
+        });
+    });
+
+    describe('durationSecToMs', () => {
+        it('converts seconds to rounded non-negative ms strings', () => {
+            expect(durationSecToMs(1.4)).toBe('1400');
+            expect(durationSecToMs(0)).toBe('0');
+            expect(durationSecToMs(-2)).toBe('0');
+        });
+
+        it('returns undefined for non-numeric values', () => {
+            expect(durationSecToMs(undefined)).toBeUndefined();
+            expect(durationSecToMs('3')).toBeUndefined();
+            expect(durationSecToMs(Number.NaN)).toBeUndefined();
+        });
+    });
+
+    describe('emitJourneyOutcome', () => {
+        it('sends buildOutcomeProperties via TelemetryService', () => {
+            const startedAt = Date.now() - 500;
+            emitJourneyOutcome(TelemetryEvents.ENV_CREATE, 'success', { startedAt });
+
+            expect(mockSendEvent).toHaveBeenCalledOnce();
+            expect(mockSendEvent).toHaveBeenCalledWith(
+                TelemetryEvents.ENV_CREATE,
+                expect.objectContaining({
+                    result: 'success',
+                    durationMs: expect.any(String),
+                }),
+            );
+        });
+
+        it('includes sanitized errorCode and extra props on error', () => {
+            emitJourneyOutcome(TelemetryEvents.COLLECTION_INSTALL, 'error', {
+                errorCode: 'install_failed',
+                extra: { toolName: 'foo' },
+            });
+
+            expect(mockSendEvent).toHaveBeenCalledWith(TelemetryEvents.COLLECTION_INSTALL, {
+                result: 'error',
+                errorCode: 'install_failed',
+                toolName: 'foo',
+            });
+        });
+
+        it('swallows errors when TelemetryService is not initialized', () => {
+            vi.mocked(TelemetryService.getInstance).mockImplementation(() => {
+                throw new Error('TelemetryService not initialized — call create() first');
+            });
+
+            expect(() => {
+                emitJourneyOutcome(TelemetryEvents.PLAYBOOK_RUN, 'cancel');
+            }).not.toThrow();
+            expect(mockSendEvent).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('OnceJourneyEmitter', () => {
+        it('emits once and no-ops on subsequent calls', () => {
+            const emitter = new OnceJourneyEmitter();
+            expect(emitter.sent).toBe(false);
+
+            emitter.send(TelemetryEvents.CREATOR_COMPLETE, 'success');
+            emitter.send(TelemetryEvents.CREATOR_COMPLETE, 'error', {
+                errorCode: 'should_not_emit',
+            });
+
+            expect(emitter.sent).toBe(true);
+            expect(mockSendEvent).toHaveBeenCalledOnce();
+            expect(mockSendEvent).toHaveBeenCalledWith(TelemetryEvents.CREATOR_COMPLETE, {
+                result: 'success',
+            });
+        });
+
+        it('applies property overrides after outcome props', () => {
+            const emitter = new OnceJourneyEmitter();
+            emitter.send(
+                TelemetryEvents.PLAYBOOK_RUN_WITH_PROGRESS,
+                'success',
+                { startedAt: Date.now() - 1000 },
+                { durationMs: '2500' },
+            );
+
+            expect(mockSendEvent.mock.calls[0]?.[1]).toMatchObject({
+                result: 'success',
+                durationMs: '2500',
+            });
+        });
+    });
+
+    describe('emitCreatorComplete', () => {
+        it('emits creator.complete with command extra and once-guard', () => {
+            const emitter = new OnceJourneyEmitter();
+            emitCreatorComplete(emitter, 'error', {
+                startedAt: Date.now() - 100,
+                errorCode: 'exit_nonzero',
+                command: 'init/collection',
+            });
+            emitCreatorComplete(emitter, 'cancel', { command: 'init/collection' });
+
+            expect(mockSendEvent).toHaveBeenCalledOnce();
+            expect(mockSendEvent).toHaveBeenCalledWith(
+                TelemetryEvents.CREATOR_COMPLETE,
+                expect.objectContaining({
+                    result: 'error',
+                    errorCode: 'exit_nonzero',
+                    command: 'init/collection',
+                }),
+            );
+        });
+    });
+
+    describe('emitPlaybookProgressOutcome', () => {
+        it('prefers ansible-reported durationSec over wall-clock startedAt', () => {
+            const emitter = new OnceJourneyEmitter();
+            emitPlaybookProgressOutcome(emitter, 'success', {
+                startedAt: Date.now() - 10_000,
+                durationSec: 1.25,
+            });
+
+            expect(mockSendEvent).toHaveBeenCalledWith(
+                TelemetryEvents.PLAYBOOK_RUN_WITH_PROGRESS,
+                expect.objectContaining({
+                    result: 'success',
+                    durationMs: '1250',
+                }),
+            );
+        });
+
+        it('emits playbook_failed error without duration when durationSec missing', () => {
+            const emitter = new OnceJourneyEmitter();
+            emitPlaybookProgressOutcome(emitter, 'error', {
+                startedAt: Date.now() - 200,
+                errorCode: 'playbook_failed',
+            });
+
+            const props = mockSendEvent.mock.calls[0]?.[1] as Record<string, string>;
+            expect(props.result).toBe('error');
+            expect(props.errorCode).toBe('playbook_failed');
+            expect(props.durationMs).toMatch(/^\d+$/);
+        });
+
+        it('emits cancel once', () => {
+            const emitter = new OnceJourneyEmitter();
+            emitPlaybookProgressOutcome(emitter, 'cancel', { startedAt: Date.now() });
+            emitPlaybookProgressOutcome(emitter, 'success', { startedAt: Date.now() });
+
+            expect(mockSendEvent).toHaveBeenCalledOnce();
+            expect(mockSendEvent.mock.calls[0]?.[1]).toMatchObject({ result: 'cancel' });
+        });
+    });
+});

--- a/test/unit/services/telemetryService.test.ts
+++ b/test/unit/services/telemetryService.test.ts
@@ -273,6 +273,7 @@ describe('TelemetryEvents', () => {
         expect(TelemetryEvents.COMMAND_EXECUTED).toBe('command.executed');
         expect(TelemetryEvents.PLAYBOOK_RUN).toBe('playbook.run');
         expect(TelemetryEvents.CREATOR_FORM_OPEN).toBe('creator.formOpen');
+        expect(TelemetryEvents.CREATOR_COMPLETE).toBe('creator.complete');
         expect(TelemetryEvents.COLLECTION_INSTALL).toBe('collection.install');
         expect(TelemetryEvents.AI_SUMMARY_REQUEST).toBe('ai.summaryRequest');
         expect(TelemetryEvents.MCP_TOOL_USE_IN_CHAT).toBe('mcp.toolUseInChat');


### PR DESCRIPTION
## Summary

- Emit completion-time journey outcomes (`result`: success|cancel|error, optional `durationMs` / `errorCode`) for env create, collection install, creator scaffold, playbook runs, and MCP/skill inject
- Add `creator.complete` (mapped to SCF-001) alongside existing `creator.formOpen`
- Shared helpers: `buildOutcomeProperties` in `@ansible/common`, `emitJourneyOutcome` / `OnceJourneyEmitter` in `src/services/journeyTelemetry.ts`
- Playbook progress edges: cancel on panel close while running, fresh `telemetryStartedAt` on rerun, reject non-finite ansible durations
- Document properties + mapping in `USAGE_DATA.md`
- Fixes #3028

## Changes

- `packages/common`: `TelemetryEvents.CREATOR_COMPLETE`, `buildOutcomeProperties`, unit tests
- `src/services/journeyTelemetry.ts`: testable outcome emitters + playbook stats/duration helpers
- `src/extension.ts`, `CreatorFormPanel`, `PlaybookProgressPanel`: completion-time ENV/COL/PLB/MCP/SKILL/SCF outcomes
- `USAGE_DATA.md`: property columns + story mapping for `creator.complete`
- Unit tests: `packages/common/test/types/telemetry.test.ts`, `test/unit/services/journeyTelemetry.test.ts`

## Test plan

- [x] `pnpm run ci` locally
- [ ] Enable `redhat.telemetry.enabled`, create env / install collection / run playbook / scaffold — confirm `result` in Segment debugger
- [ ] Cancel collection picker / creator form / close running progress panel — confirm `result=cancel`
- [ ] Run `telemetry-audit` skill — zero orphans, `creator.complete` mapped to SCF-001

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Adds completion-time journey outcome telemetry (`result`, optional `durationMs`/`errorCode`) for key flows (env creation, collection install, creator complete, playbooks, MCP/skill injection). Centralizes outcome-property construction in `@ansible/common` and emits at completion/cancellation edges, hardening playbook progress handling to cancel on panel close, reset duration on rerun, and ignore non-finite durations for reliable analytics. Original commit message: fix(extension): tighten playbook journey outcome edges.
- Introduces `buildOutcomeProperties`/outcome types in `@ansible/common`, adds typed `creator.complete` (`SCF-001`), and re-exports telemetry helpers/types
- Adds typed journey telemetry helpers (`emitJourneyOutcome`, `OnceJourneyEmitter`) and refactors telemetry emissions to completion/cancel points across creator, playbook progress, environment creation, collection install, and chat injection
- Updates playbook outcome handling (cancel on running progress-panel close, reset timing on rerun, reject non-finite Ansible durations) and adds unit tests for helpers/emitters
- Updates `USAGE_DATA.md` with the new outcome property schemas and story-to-event mappings

Author: Bradley A. Thornton <bthornto@redhat.com>
Committer: Bradley A. Thornton <bthornto@redhat.com>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->