### PR TITLE
fix(ci): restore gates and artifacts dropped in #2979

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -6,7 +6,7 @@
 # Tracking: https://github.com/rhysd/actionlint/issues/693
 
 paths:
-  .github/workflows/ci.yml:
+  .github/workflows/next.yml:
     ignore:
       - 'unexpected key "parallel"'
       - 'step must run script with "run" section'

--- a/.github/workflows/next.yml
+++ b/.github/workflows/next.yml
@@ -12,27 +12,28 @@ concurrency:
 
 jobs:
   test:
-    name: test-${{ matrix.id }}
+    name: test-${{ matrix.id }}-node${{ matrix.node-version }}
     runs-on: ${{ matrix.runs-on }}
     permissions:
       contents: read
       id-token: write
     strategy:
+      fail-fast: false
       matrix:
-        id: [linux, macos]
-        node-version: [24]
+        id: [linux]
+        node-version: [22, 24, 26]
         runs-on:
           - ubuntu-latest
           # - windows-2022
     timeout-minutes: 20
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: pnpm
@@ -94,7 +95,7 @@ jobs:
 
       - name: Upload story coverage to Codecov
         if: ${{ !cancelled() && runner.os != 'Windows' && hashFiles('coverage/stories.lcov') != '' }}
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@a99c28d3f0da835de33ff2feb2e15691c7b9641f # v7
         with:
           files: ./coverage/stories.lcov
           flags: stories
@@ -114,7 +115,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: ${{ always() && hashFiles('coverage/cobertura-coverage.xml') != '' }}
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@a99c28d3f0da835de33ff2feb2e15691c7b9641f # v7
         with:
           files: ./coverage/cobertura-coverage.xml
           flags: unit-node${{ matrix.node-version }}
@@ -134,11 +135,11 @@ jobs:
 
       - name: Upload logs and coverage reports
         if: ${{ !cancelled() && runner.os != 'Windows' }}
-        uses: ansible/actions/upload-artifact@main
+        uses: ansible/actions/upload-artifact@b2b0657c2e1d083cf979eba2fd04ae79e5ab3900 # v1.1.2
         env:
           GITLEAKS_CONFIG: .gitleaks.toml
         with:
-          name: logs-${{ matrix.runs-on }}-${{ github.run_attempt }}.zip
+          name: logs-${{ matrix.runs-on }}-node${{ matrix.node-version }}-${{ github.run_attempt }}.zip
           path: |
             coverage/**/lcov.info
             dist
@@ -147,35 +148,49 @@ jobs:
           if-no-files-found: ignore
           retention-days: 90
 
-      - name: Upload VSIX
-        if: ${{ !cancelled() && matrix.id == 'linux' }}
-        uses: actions/upload-artifact@v7
-        with:
-          path: "*.vsix"
-          archive: false
-          retention-days: 14
+      - name: Pack npm tarballs
+        if: ${{ !cancelled() && matrix.id == 'linux' && matrix.node-version == 24 }}
+        run: |
+          pnpm --filter @ansible/common pack --pack-destination "$GITHUB_WORKSPACE"
+          pnpm --filter @ansible/developer-services pack --pack-destination "$GITHUB_WORKSPACE"
+          pnpm --filter @ansible/mcp-server pack --pack-destination "$GITHUB_WORKSPACE"
+          pnpm --filter @ansible/language-server pack --pack-destination "$GITHUB_WORKSPACE"
 
-      - name: Upload plugin
-        if: ${{ !cancelled() && matrix.id == 'linux' }}
-        uses: actions/upload-artifact@v7
-        with:
-          name: plugin
-          path: dist/ansible-devtools-plugin.zip
-          archive: false
-          retention-days: 14
-
-      - name: Upload MCP server
-        if: ${{ !cancelled() && matrix.id == 'linux' }}
-        uses: actions/upload-artifact@v7
-        with:
-          name: mcp-server
-          path: dist/mcp-server.js
-          retention-days: 14
-
-      - name: Upload language server
-        if: ${{ !cancelled() && matrix.id == 'linux' }}
-        uses: actions/upload-artifact@v7
-        with:
-          name: language-server
-          path: dist/language-server.js
-          retention-days: 14
+      - parallel:
+          - name: Upload VSIX
+            if: ${{ !cancelled() && matrix.id == 'linux' && matrix.node-version == 24 }}
+            uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+            with:
+              name: vsix
+              path: "*.vsix"
+              archive: false
+              retention-days: 14
+          - name: Upload plugin
+            if: ${{ !cancelled() && matrix.id == 'linux' && matrix.node-version == 24 }}
+            uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+            with:
+              name: plugin
+              path: dist/ansible-devtools-plugin.zip
+              archive: false
+              retention-days: 14
+          - name: Upload MCP server
+            if: ${{ !cancelled() && matrix.id == 'linux' && matrix.node-version == 24 }}
+            uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+            with:
+              name: mcp-server
+              path: dist/mcp-server.js
+              retention-days: 14
+          - name: Upload language server
+            if: ${{ !cancelled() && matrix.id == 'linux' && matrix.node-version == 24 }}
+            uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+            with:
+              name: language-server
+              path: dist/language-server.js
+              retention-days: 14
+          - name: Upload npm tarballs
+            if: ${{ !cancelled() && matrix.id == 'linux' && matrix.node-version == 24 }}
+            uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+            with:
+              name: npm-tarballs
+              path: "*.tgz"
+              retention-days: 14

--- a/.github/workflows/next.yml
+++ b/.github/workflows/next.yml
@@ -66,35 +66,37 @@ jobs:
             if: runner.os != 'Windows'
             run: xvfb-run --auto-servernum pnpm run test:integration
 
+      # WDIO UI: Node 26 currently fails Chromedriver session create with
+      # UND_ERR_INVALID_ARG (undici/webdriver). Keep 26 for lint/unit/integration.
       - parallel:
           - name: Pre-install Chromedriver
-            if: runner.os != 'Windows'
+            if: runner.os != 'Windows' && matrix.node-version != 26
             run: pnpm exec tsx tools/ensure-chromedriver.mts
           - name: Install test dependency extensions
-            if: runner.os != 'Windows'
+            if: runner.os != 'Windows' && matrix.node-version != 26
             run: pnpm run pretest:ui
           - name: Build Lightspeed webviews
-            if: runner.os != 'Windows'
+            if: runner.os != 'Windows' && matrix.node-version != 26
             run: pnpm run build:lightspeed:webviews
 
       - name: Run UI tests
-        if: runner.os != 'Windows'
+        if: runner.os != 'Windows' && matrix.node-version != 26
         run: xvfb-run --auto-servernum pnpm run test:ui
         env:
           WDIO_COVERAGE: "1"
 
       - name: Run Lightspeed UI tests
-        if: runner.os != 'Windows'
+        if: runner.os != 'Windows' && matrix.node-version != 26
         run: xvfb-run --auto-servernum pnpm run test:lightspeed:ui
         env:
           WDIO_COVERAGE: "1"
 
       - name: Story coverage report
-        if: ${{ !cancelled() && runner.os != 'Windows' }}
+        if: ${{ !cancelled() && runner.os != 'Windows' && matrix.node-version != 26 }}
         run: node scripts/story-coverage.mjs --threshold 20 --lcov coverage/stories.lcov
 
       - name: Upload story coverage to Codecov
-        if: ${{ !cancelled() && runner.os != 'Windows' && hashFiles('coverage/stories.lcov') != '' }}
+        if: ${{ !cancelled() && runner.os != 'Windows' && matrix.node-version != 26 && hashFiles('coverage/stories.lcov') != '' }}
         uses: codecov/codecov-action@a99c28d3f0da835de33ff2feb2e15691c7b9641f # v7
         with:
           files: ./coverage/stories.lcov
@@ -104,7 +106,7 @@ jobs:
           use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
 
       - name: Upload WDIO coverage to Codecov
-        if: ${{ always() && runner.os != 'Windows' && hashFiles('coverage/wdio/lcov.info') != '' }}
+        if: ${{ always() && runner.os != 'Windows' && matrix.node-version != 26 && hashFiles('coverage/wdio/lcov.info') != '' }}
         uses: codecov/codecov-action@a99c28d3f0da835de33ff2feb2e15691c7b9641f # v7
         with:
           files: ./coverage/wdio/lcov.info

--- a/.github/workflows/next.yml
+++ b/.github/workflows/next.yml
@@ -196,3 +196,14 @@ jobs:
               name: npm-tarballs
               path: "*.tgz"
               retention-days: 14
+
+  # Branch ruleset `next` requires a check named exactly `test-linux`
+  # (see ruleset 18317703). Matrix jobs report as test-linux-nodeNN.
+  test-linux:
+    name: test-linux
+    needs: test
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require all Node matrix cells to succeed
+        run: test "${{ needs.test.result }}" = "success"

--- a/.skillmark.toml
+++ b/.skillmark.toml
@@ -22,4 +22,6 @@ script-quality = 0.10
 discoverability = 0.05
 
 [paths]
-exclude = ["node_modules/", "dist/", "out/", ".wdio-vscode/"]
+# Also pass --exclude .wdio-vscode/** in prek.toml (skillmark v0.1.0 does not
+# reliably apply this table to nested WDIO VS Code downloads).
+exclude = ["node_modules/", "dist/", "out/", ".wdio-vscode/", "**/.wdio-vscode/**"]

--- a/.skillmark.toml
+++ b/.skillmark.toml
@@ -22,6 +22,7 @@ script-quality = 0.10
 discoverability = 0.05
 
 [paths]
-# Also pass --exclude .wdio-vscode/** in prek.toml (skillmark v0.1.0 does not
-# reliably apply this table to nested WDIO VS Code downloads).
+# Defense in depth: prek.toml also scopes skillmark to `.agents/skills` +
+# `skills` and passes `--exclude .wdio-vscode/**` so WDIO VS Code downloads
+# are not validated even if auto-discovery expands later.
 exclude = ["node_modules/", "dist/", "out/", ".wdio-vscode/", "**/.wdio-vscode/**"]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,14 +94,13 @@ See the `branching-strategy` skill for full details.
 
 ### Prerequisites
 
-`pnpm run ci` requires tools beyond the workspace `node_modules` install:
+`pnpm run ci` requires one tool that is **not** a workspace dependency:
 
 - **uv** — Python package runner, provides `uvx` (`pipx install uv`)
-- **prek** — available via the `@j178/prek` dependency (`pnpm exec prek`)
-  or a global install (`pipx install prek`)
 
-`uv` is installed automatically in CI. Contributors must install `uv`
-locally before running `pnpm run ci` or `pnpm run lint`.
+`prek` comes from the `@j178/prek` workspace dependency (`pnpm exec prek` /
+`pnpm run lint`). `uv` is installed automatically in CI; contributors must
+install it locally before running `pnpm run ci` or `pnpm run lint`.
 
 ### Before committing
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,11 +94,13 @@ See the `branching-strategy` skill for full details.
 
 ### Prerequisites
 
-`pnpm run ci` requires two tools that are **not** pnpm dependencies:
+`pnpm run ci` requires tools beyond the workspace `node_modules` install:
 
 - **uv** — Python package runner, provides `uvx` (`pipx install uv`)
+- **prek** — available via the `@j178/prek` dependency (`pnpm exec prek`)
+  or a global install (`pipx install prek`)
 
-Both are installed automatically in CI. Contributors must install them
+`uv` is installed automatically in CI. Contributors must install `uv`
 locally before running `pnpm run ci` or `pnpm run lint`.
 
 ### Before committing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,9 +142,9 @@ Dynamic versioning from git tags via `tools/version.mts`:
 
 ## CI/CD
 
-GitHub Actions (`.github/workflows/ci.yml`):
+GitHub Actions (`.github/workflows/next.yml`):
 
-- **next** workflow — matrix Node 22/24/26 (lint, test, UI, package artifacts)
+- **next** workflow — matrix Node 22/24/26 (lint, test, UI on 22/24, package artifacts)
 - **Windows + WSL2** tests (`.github/workflows/wsl2-ui.yml`)
 - **docs** deployment (`.github/workflows/docs-deploy.yml`)
 - **release** — VS Code Marketplace + Open VSX (`.github/workflows/release-vsix.yml`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,7 +144,7 @@ Dynamic versioning from git tags via `tools/version.mts`:
 
 GitHub Actions (`.github/workflows/ci.yml`):
 
-- **lint** → **build-and-test** (Node 20, 22) → **integration** → **ui** → **package**
+- **next** workflow — matrix Node 22/24/26 (lint, test, UI, package artifacts)
 - **Windows + WSL2** tests (`.github/workflows/wsl2-ui.yml`)
 - **docs** deployment (`.github/workflows/docs-deploy.yml`)
 - **release** — VS Code Marketplace + Open VSX (`.github/workflows/release-vsix.yml`)

--- a/package.json
+++ b/package.json
@@ -1293,7 +1293,7 @@
     "check": "pnpm run compile && pnpm run lint && pnpm run test",
     "ci": "pnpm run compile && pnpm run lint && pnpm run test:coverage && pnpm run build",
     "test:watch": "vitest",
-    "package": "npm run build && vsce package --no-dependencies && ./scripts/build-plugin.sh",
+    "package": "pnpm run build && vsce package --no-dependencies && ./scripts/build-plugin.sh",
     "package:install": "vsce package --no-dependencies && code --install-extension *.vsix --force && rm -f *.vsix",
     "test:integration": "tsc -p test/integration/tsconfig.json && vscode-test",
     "test:integration:no-envs": "tsc -p test/integration/tsconfig.json && vscode-test --label no-python-envs",

--- a/prek.toml
+++ b/prek.toml
@@ -23,10 +23,15 @@ hooks = [
     id = "skillmark",
     language = "rust",
     priority = 0,
-    # Scope to repo agent skills only. skillmark v0.1.0 auto-discovers
-    # third-party SKILL.md trees under .wdio-vscode/ and its --exclude /
-    # [paths].exclude handling does not filter those paths reliably.
-    args = ["--config", ".skillmark.toml", ".agents/skills", "skills"]
+    # Scope to repo skills; also exclude .wdio-vscode (WDIO VS Code downloads).
+    args = [
+      "--config",
+      ".skillmark.toml",
+      "--exclude",
+      ".wdio-vscode/**",
+      ".agents/skills",
+      "skills",
+    ]
   },
 ]
 

--- a/prek.toml
+++ b/prek.toml
@@ -15,18 +15,20 @@ hooks = [
 ]
 
 # ── Skillmark — agentskills.io spec validation ─────────────────────────
-# Not mature enough, this repo has one github star.
-# [[repos]]
-# repo = "https://github.com/michellepellon/skillmark"
-# rev = "v0.1.0"
-# hooks = [
-#   {
-#     id = "skillmark",
-#     language = "rust",
-#     priority = 0,
-#     args = ["--config", ".skillmark.toml"]
-#   },
-# ]
+[[repos]]
+repo = "https://github.com/michellepellon/skillmark"
+rev = "v0.1.0"
+hooks = [
+  {
+    id = "skillmark",
+    language = "rust",
+    priority = 0,
+    # Scope to repo agent skills only. skillmark v0.1.0 auto-discovers
+    # third-party SKILL.md trees under .wdio-vscode/ and its --exclude /
+    # [paths].exclude handling does not filter those paths reliably.
+    args = ["--config", ".skillmark.toml", ".agents/skills", "skills"]
+  },
+]
 
 # ── Markdownlint ───────────────────────────────────────────────────────
 [[repos]]
@@ -42,13 +44,13 @@ hooks = [
 ]
 
 # ── Actionlint — GitHub Actions workflow validation ────────────────────
-# See: https://github.com/rhysd/actionlint/issues/693
-# [[repos]]
-# repo = "https://github.com/rhysd/actionlint"
-# rev = "v1.7.7"
-# hooks = [
-#   { id = "actionlint" },
-# ]
+# parallel-step ignores live in .github/actionlint.yaml (see actionlint#693).
+[[repos]]
+repo = "https://github.com/rhysd/actionlint"
+rev = "v1.7.7"
+hooks = [
+  { id = "actionlint" },
+]
 
 # ── pre-commit-hooks (additional checks) ───────────────────────────────
 [[repos]]


### PR DESCRIPTION
## Summary

- Restore CI Node matrix to **22 / 24 / 26** (`engines` still allows `>=22.18.0`; #2979 collapsed to 24-only without a compatibility reason)
- Re-enable **actionlint** and **skillmark** in `prek.toml` (actionlint path updated to `next.yml`; skillmark scoped to `.agents/skills` + `skills` with `--exclude .wdio-vscode/**`)
- Pin artifact actions to commit SHAs; stop using `ansible/actions/upload-artifact@main`
- Restore stable **`vsix`** artifact name + **npm tarball** uploads (once on linux/node 24)
- Fix `package` script to use `pnpm run build` instead of `npm run build`
- Drop the bogus `macos`×`ubuntu-latest` duplicate matrix cells — tracked in #3034
- Skip WDIO UI on Node 26 only (`UND_ERR_INVALID_ARG`) — tracked in #3035; lint/unit/integration/package still run on 26

Keeps the monolithic `test` job from #2979 (job count intentionally unchanged).

Addresses post-merge review on #2979 / AAP-81317 fallout.

## Test plan

- [x] `pnpm run ci` locally (pre-push)
- [x] `pnpm exec prek run skillmark actionlint -a`
- [x] CI shows `test-linux-node22`, `test-linux-node24`, `test-linux-node26`
- [ ] `test-linux-node26` green with UI skipped
- [ ] PR artifacts include `vsix`, `plugin`, `mcp-server`, `language-server`, `npm-tarballs`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Adds an aggregator job to emit the required `test-linux` check while retaining version-specific matrix job names.
- Restores Node 22/24/26 Linux CI gates/artifacts: re-enables actionlint + skillmark, pins actions, restores VSIX and npm tarball uploads.
- Pins artifacts, updates the `package` script to `pnpm run build`, and skips WDIO UI tests on Node 26.

Related: `#2979`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->