### PR TITLE
feat(core): port tox-ansible integration from main with full rewrite

### DIFF
--- a/.sdlc/user-stories.yaml
+++ b/.sdlc/user-stories.yaml
@@ -795,3 +795,35 @@ stories:
       - Walkthroughs are available from the extension
       - Opening a walkthrough shows the guided steps
       - The opened walkthrough is identified for usage tracking
+
+  # ---------------------------------------------------------------------------
+  # TOX — Tox-Ansible Integration
+  # ---------------------------------------------------------------------------
+  - id: TOX-001
+    title: Discover tox-ansible test environments
+    story: >
+      As an Ansible collection developer, I want the extension to
+      automatically discover tox-ansible test environments in my
+      workspace so that I can see integration, sanity, and unit test
+      targets in the Test Explorer without running tox manually.
+    prd_refs: []
+    requires_ai: false
+    criteria:
+      - Test Explorer shows tox-ansible environments grouped by category
+      - Environments refresh when tox config files change
+      - Empty state is shown when tox or tox-ansible is not installed
+
+  - id: TOX-002
+    title: Run tox-ansible tests from Test Explorer
+    story: >
+      As an Ansible collection developer, I want to run individual or
+      grouped tox-ansible test environments from the Test Explorer and
+      see pass/fail results with output, so that I can validate my
+      collection without switching to a terminal.
+    prd_refs: []
+    requires_ai: false
+    criteria:
+      - Clicking Run on a test item executes the tox environment
+      - Pass/fail is determined by tox exit code
+      - Failed tests show stderr/stdout output
+      - Duration is reported for each test run

--- a/package.json
+++ b/package.json
@@ -34,6 +34,20 @@
     "redhat.abbenay-provider"
   ],
   "contributes": {
+    "taskDefinitions": [
+      {
+        "type": "ansible-tox",
+        "required": [
+          "environment"
+        ],
+        "properties": {
+          "environment": {
+            "type": "string",
+            "description": "Tox-ansible environment name (e.g., 'integration-py3.12-devel')"
+          }
+        }
+      }
+    ],
     "icons": {
       "ansible-logo": {
         "description": "Ansible logo icon for status bar",

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -46,6 +46,11 @@ export type {
     TelemetryEventName,
     TelemetryResult,
     TelemetryOutcomeOptions,
+    ToxTestCategory,
+    ToxEnvironment,
+    ToxRunResult,
+    ToxAvailability,
+    ToxGhMatrixEntry,
 } from './types';
 export { TelemetryEvents, buildOutcomeProperties } from './types';
 

--- a/packages/common/src/types/index.ts
+++ b/packages/common/src/types/index.ts
@@ -37,3 +37,10 @@ export type {
 } from './playbook';
 export { TelemetryEvents, buildOutcomeProperties } from './telemetry';
 export type { TelemetryEventName, TelemetryResult, TelemetryOutcomeOptions } from './telemetry';
+export type {
+    ToxTestCategory,
+    ToxEnvironment,
+    ToxRunResult,
+    ToxAvailability,
+    ToxGhMatrixEntry,
+} from './toxAnsible';

--- a/packages/common/src/types/telemetry.ts
+++ b/packages/common/src/types/telemetry.ts
@@ -52,6 +52,10 @@ export const TelemetryEvents = {
 
     // Walkthroughs
     WALKTHROUGH_OPEN: 'walkthrough.open',
+
+    // Tox-Ansible
+    TOX_DISCOVER: 'tox.discover',
+    TOX_RUN: 'tox.run',
 } as const;
 
 export type TelemetryEventName = (typeof TelemetryEvents)[keyof typeof TelemetryEvents];

--- a/packages/common/src/types/toxAnsible.ts
+++ b/packages/common/src/types/toxAnsible.ts
@@ -35,6 +35,8 @@ export interface ToxRunResult {
     stderr: string;
     /** Duration in milliseconds */
     durationMs: number;
+    /** True when the run was killed by the execution timeout */
+    timedOut?: boolean;
 }
 
 /** Availability check result for tox and tox-ansible. */

--- a/packages/common/src/types/toxAnsible.ts
+++ b/packages/common/src/types/toxAnsible.ts
@@ -1,0 +1,60 @@
+/**
+ * Types for tox-ansible integration.
+ *
+ * Browser-safe — no Node.js dependencies.
+ */
+
+/** Test category derived from tox-ansible environment name factors. */
+export type ToxTestCategory = 'integration' | 'sanity' | 'unit' | 'unknown';
+
+/** A single tox-ansible test environment. */
+export interface ToxEnvironment {
+    /** Full environment name, e.g. "integration-py3.12-devel" */
+    name: string;
+    /** Test category extracted from name factors */
+    category: ToxTestCategory;
+    /** Python version factor, e.g. "3.12" */
+    pythonVersion: string;
+    /** Ansible version factor, e.g. "2.17", "devel" */
+    ansibleVersion: string;
+    /** Human-readable description from tox list output */
+    description?: string;
+}
+
+/** Result of running a single tox environment. */
+export interface ToxRunResult {
+    /** Environment that was run */
+    environment: string;
+    /** Whether the run succeeded (exit code 0) */
+    success: boolean;
+    /** Exit code from the tox process */
+    exitCode: number;
+    /** Captured stdout */
+    stdout: string;
+    /** Captured stderr */
+    stderr: string;
+    /** Duration in milliseconds */
+    durationMs: number;
+}
+
+/** Availability check result for tox and tox-ansible. */
+export interface ToxAvailability {
+    /** Whether tox is installed in the environment */
+    toxInstalled: boolean;
+    /** Whether the tox-ansible plugin is loaded */
+    toxAnsibleInstalled: boolean;
+    /** tox version string when available */
+    toxVersion?: string;
+}
+
+/** --gh-matrix JSON entry from tox-ansible. */
+export interface ToxGhMatrixEntry {
+    /** Environment name, e.g. "integration-py3.12-devel" */
+    name: string;
+    /** Human-readable description */
+    description: string;
+    /** Factor list, e.g. ["integration", "py3.12", "devel"] */
+    factors: string[];
+    /** Python version, e.g. "3.12" */
+    python: string;
+}

--- a/packages/mcp-server/src/handlers.ts
+++ b/packages/mcp-server/src/handlers.ts
@@ -22,6 +22,7 @@ import {
     GalaxyDocsCache,
     GitHubCollectionCache,
     SCMDocsCache,
+    ToxAnsibleService,
     getCommandService,
     isExecutionEnvironmentDefinition,
     planAnsibleBuilderBuild,
@@ -186,6 +187,12 @@ export class McpToolHandler {
 
                 case 'get_extension_walkthrough':
                     return this._handleGetExtensionWalkthrough();
+
+                // Tox-Ansible
+                case 'tox_list_environments':
+                    return await this._handleToxListEnvironments(args);
+                case 'tox_run_environment':
+                    return await this._handleToxRunEnvironment(args);
 
                 default:
                     return mcpError({
@@ -2107,5 +2114,111 @@ their reactions. Keep explanations concise and practical.
         }
 
         return undefined;
+    }
+
+    // === Tox-Ansible Handlers ===
+
+    /**
+     * Get a ToxAnsibleService instance (lazily created).
+     * @returns ToxAnsibleService for tox discovery/execution
+     */
+    private _getToxService(): InstanceType<typeof ToxAnsibleService> {
+        return new ToxAnsibleService();
+    }
+
+    /**
+     * List tox-ansible test environments in a workspace directory.
+     * @param args - Tool args: `workspace_dir` (required)
+     * @returns JSON list of discovered environments grouped by category
+     */
+    private async _handleToxListEnvironments(
+        args: Record<string, unknown>,
+    ): Promise<McpToolResult> {
+        const workspaceDir = args.workspace_dir as string | undefined;
+        if (!workspaceDir) {
+            return mcpError({
+                code: 'MISSING_PARAM',
+                recoverability: 'fail',
+                message: 'workspace_dir is required',
+            });
+        }
+
+        const service = this._getToxService();
+        const availability = await service.checkAvailability();
+
+        if (!availability.toxInstalled) {
+            return mcpError({
+                code: 'SERVICE_UNAVAILABLE',
+                recoverability: 'escalate',
+                message: 'tox is not installed in the active Python environment',
+                suggestion: 'Install ansible-dev-tools: pip install ansible-dev-tools',
+            });
+        }
+
+        if (!availability.toxAnsibleInstalled) {
+            return mcpError({
+                code: 'SERVICE_UNAVAILABLE',
+                recoverability: 'escalate',
+                message: 'tox-ansible plugin is not installed',
+                suggestion: 'Install tox-ansible: pip install tox-ansible',
+            });
+        }
+
+        const envs = await service.listEnvironments(workspaceDir);
+
+        const grouped: Record<string, typeof envs> = {};
+        for (const env of envs) {
+            const cat = env.category;
+            grouped[cat] = [...(grouped[cat] ?? []), env];
+        }
+
+        const text =
+            envs.length === 0
+                ? 'No tox-ansible environments found. Ensure tox-ansible.ini or tox.ini exists in the workspace.'
+                : JSON.stringify(
+                      {
+                          total: envs.length,
+                          tox_version: availability.toxVersion,
+                          categories: grouped,
+                      },
+                      null,
+                      2,
+                  );
+
+        return { content: [{ type: 'text', text }] };
+    }
+
+    /**
+     * Run a specific tox-ansible environment and return results.
+     * @param args - Tool args: `environment` + `workspace_dir` (required), `timeout_ms` (optional)
+     * @returns JSON result with exit code, stdout, stderr, and duration
+     */
+    private async _handleToxRunEnvironment(args: Record<string, unknown>): Promise<McpToolResult> {
+        const environment = args.environment as string | undefined;
+        const workspaceDir = args.workspace_dir as string | undefined;
+
+        if (!environment) {
+            return mcpError({
+                code: 'MISSING_PARAM',
+                recoverability: 'fail',
+                message: 'environment is required',
+            });
+        }
+
+        if (!workspaceDir) {
+            return mcpError({
+                code: 'MISSING_PARAM',
+                recoverability: 'fail',
+                message: 'workspace_dir is required',
+            });
+        }
+
+        const timeoutMs = typeof args.timeout_ms === 'number' ? args.timeout_ms : undefined;
+        const service = this._getToxService();
+        const result = await service.runEnvironment(environment, workspaceDir, timeoutMs);
+
+        return {
+            content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+        };
     }
 }

--- a/packages/mcp-server/src/handlers.ts
+++ b/packages/mcp-server/src/handlers.ts
@@ -2119,6 +2119,23 @@ their reactions. Keep explanations concise and practical.
     // === Tox-Ansible Handlers ===
 
     /**
+     * Validate that a workspace_dir is an absolute path without traversal.
+     * MCP inputs originate from AI assistants and may include untrusted values.
+     * @param dir - Raw workspace_dir from tool args
+     * @returns Error result if invalid, undefined if valid
+     */
+    private _validateWorkspaceDir(dir: string): McpToolResult | undefined {
+        if (!path.isAbsolute(dir) || dir.includes('..')) {
+            return mcpError({
+                code: 'INVALID_INPUT',
+                recoverability: 'fail',
+                message: 'workspace_dir must be an absolute path without traversal sequences',
+            });
+        }
+        return undefined;
+    }
+
+    /**
      * Get a ToxAnsibleService instance (lazily created).
      * @returns ToxAnsibleService for tox discovery/execution
      */
@@ -2142,6 +2159,9 @@ their reactions. Keep explanations concise and practical.
                 message: 'workspace_dir is required',
             });
         }
+
+        const pathErr = this._validateWorkspaceDir(workspaceDir);
+        if (pathErr) return pathErr;
 
         const service = this._getToxService();
         const availability = await service.checkAvailability();
@@ -2212,6 +2232,9 @@ their reactions. Keep explanations concise and practical.
                 message: 'workspace_dir is required',
             });
         }
+
+        const pathErr = this._validateWorkspaceDir(workspaceDir);
+        if (pathErr) return pathErr;
 
         const service = this._getToxService();
         const availability = await service.checkAvailability();

--- a/packages/mcp-server/src/handlers.ts
+++ b/packages/mcp-server/src/handlers.ts
@@ -2213,8 +2213,31 @@ their reactions. Keep explanations concise and practical.
             });
         }
 
-        const timeoutMs = typeof args.timeout_ms === 'number' ? args.timeout_ms : undefined;
         const service = this._getToxService();
+        const availability = await service.checkAvailability();
+
+        if (!availability.toxInstalled) {
+            return mcpError({
+                code: 'SERVICE_UNAVAILABLE',
+                recoverability: 'escalate',
+                message: 'tox is not installed in the active Python environment',
+                suggestion: 'Install ansible-dev-tools: pip install ansible-dev-tools',
+            });
+        }
+
+        if (!availability.toxAnsibleInstalled) {
+            return mcpError({
+                code: 'SERVICE_UNAVAILABLE',
+                recoverability: 'escalate',
+                message: 'tox-ansible plugin is not installed',
+                suggestion: 'Install tox-ansible: pip install tox-ansible',
+            });
+        }
+
+        const timeoutMs =
+            typeof args.timeout_ms === 'number' && args.timeout_ms > 0
+                ? args.timeout_ms
+                : undefined;
         const result = await service.runEnvironment(environment, workspaceDir, timeoutMs);
 
         return {

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -932,6 +932,58 @@ become, connection, vault, etc.) passed through via the \`--\` separator.`,
     },
 };
 
+// === Tox-Ansible Tools ===
+
+export const TOX_LIST_ENVIRONMENTS_TOOL: McpToolDefinition = {
+    name: 'tox_list_environments',
+    description: `List tox-ansible test environments discovered in the workspace.
+
+Returns environments grouped by category (integration, sanity, unit) with
+Python version and Ansible version factors.
+
+Requires tox and the tox-ansible plugin installed in the active Python environment.`,
+    annotations: READ_ONLY,
+    inputSchema: {
+        type: 'object',
+        properties: {
+            workspace_dir: {
+                type: 'string',
+                description: 'Absolute path to the workspace directory containing tox config',
+            },
+        },
+        required: ['workspace_dir'],
+    },
+};
+
+export const TOX_RUN_ENVIRONMENT_TOOL: McpToolDefinition = {
+    name: 'tox_run_environment',
+    description: `Run a specific tox-ansible test environment and return the result.
+
+Executes the environment via \`tox -e <name> --ansible\` and captures exit code,
+stdout, and stderr. Returns pass/fail status with duration.
+
+Use tox_list_environments first to discover available environment names.`,
+    annotations: DESTRUCTIVE,
+    inputSchema: {
+        type: 'object',
+        properties: {
+            environment: {
+                type: 'string',
+                description: 'Tox environment name (e.g., "integration-py3.12-devel")',
+            },
+            workspace_dir: {
+                type: 'string',
+                description: 'Absolute path to the workspace directory containing tox config',
+            },
+            timeout_ms: {
+                type: 'number',
+                description: 'Maximum execution time in milliseconds (default: 600000 = 10 min)',
+            },
+        },
+        required: ['environment', 'workspace_dir'],
+    },
+};
+
 // === Collection of all static tools ===
 
 export const STATIC_TOOLS: McpToolDefinition[] = [
@@ -973,4 +1025,8 @@ export const STATIC_TOOLS: McpToolDefinition[] = [
     // Getting started
     GET_AGENT_ONBOARDING_TOOL,
     GET_EXTENSION_WALKTHROUGH_TOOL,
+
+    // Tox-Ansible
+    TOX_LIST_ENVIRONMENTS_TOOL,
+    TOX_RUN_ENVIRONMENT_TOOL,
 ];

--- a/packages/mcp-server/test/handlers.test.ts
+++ b/packages/mcp-server/test/handlers.test.ts
@@ -1808,8 +1808,7 @@ describe('McpToolHandler', () => {
                 environment: 'unit-py3.12-devel',
                 workspace_dir: '/workspace',
             });
-            expect(result.isError).toBe(true);
-            const err = JSON.parse(result.content[0].text) as Record<string, unknown>;
+            const err = parseError(result);
             expect(err.code).toBe('SERVICE_UNAVAILABLE');
         });
     });

--- a/packages/mcp-server/test/handlers.test.ts
+++ b/packages/mcp-server/test/handlers.test.ts
@@ -1676,6 +1676,24 @@ describe('McpToolHandler', () => {
             expect(err.message).toContain('workspace_dir');
         });
 
+        it('rejects relative workspace_dir', async () => {
+            const result = await handler.handleTool('tox_list_environments', {
+                workspace_dir: 'relative/path',
+            });
+            const err = parseError(result);
+            expect(err.code).toBe('INVALID_INPUT');
+            expect(err.message).toContain('absolute path');
+        });
+
+        it('rejects workspace_dir with traversal sequences', async () => {
+            const result = await handler.handleTool('tox_list_environments', {
+                workspace_dir: '/workspace/../etc/passwd',
+            });
+            const err = parseError(result);
+            expect(err.code).toBe('INVALID_INPUT');
+            expect(err.message).toContain('traversal');
+        });
+
         it('returns SERVICE_UNAVAILABLE when tox is not installed', async () => {
             hoisted.toxInstance.checkAvailability.mockResolvedValueOnce({
                 toxInstalled: false,
@@ -1739,6 +1757,26 @@ describe('McpToolHandler', () => {
             const err = parseError(result);
             expect(err.code).toBe('MISSING_PARAM');
             expect(err.message).toContain('workspace_dir');
+        });
+
+        it('rejects relative workspace_dir', async () => {
+            const result = await handler.handleTool('tox_run_environment', {
+                environment: 'unit-py3.12-devel',
+                workspace_dir: 'relative/path',
+            });
+            const err = parseError(result);
+            expect(err.code).toBe('INVALID_INPUT');
+            expect(err.message).toContain('absolute path');
+        });
+
+        it('rejects workspace_dir with traversal sequences', async () => {
+            const result = await handler.handleTool('tox_run_environment', {
+                environment: 'unit-py3.12-devel',
+                workspace_dir: '/workspace/../etc/passwd',
+            });
+            const err = parseError(result);
+            expect(err.code).toBe('INVALID_INPUT');
+            expect(err.message).toContain('traversal');
         });
 
         it('returns run result on success', async () => {

--- a/packages/mcp-server/test/handlers.test.ts
+++ b/packages/mcp-server/test/handlers.test.ts
@@ -160,6 +160,36 @@ const hoisted = vi.hoisted(() => {
         getPluginDoc: vi.fn().mockResolvedValue(null),
     };
 
+    const toxInstance = {
+        checkAvailability: vi.fn().mockResolvedValue({
+            toxInstalled: true,
+            toxAnsibleInstalled: true,
+            toxVersion: '4.21.0',
+        }),
+        listEnvironments: vi.fn().mockResolvedValue([
+            {
+                name: 'unit-py3.12-devel',
+                category: 'unit',
+                pythonVersion: '3.12',
+                ansibleVersion: 'devel',
+            },
+            {
+                name: 'sanity-py3.12-devel',
+                category: 'sanity',
+                pythonVersion: '3.12',
+                ansibleVersion: 'devel',
+            },
+        ]),
+        runEnvironment: vi.fn().mockResolvedValue({
+            environment: 'unit-py3.12-devel',
+            success: true,
+            exitCode: 0,
+            stdout: 'OK',
+            stderr: '',
+            durationMs: 5000,
+        }),
+    };
+
     return {
         getPluginDocumentation,
         collectionsInstance,
@@ -171,6 +201,7 @@ const hoisted = vi.hoisted(() => {
         commandServiceInstance,
         devToolsInstance,
         creatorInstance,
+        toxInstance,
         forceRefresh,
         listCollectionNames,
         getCollection,
@@ -214,6 +245,7 @@ vi.mock('@ansible/developer-services', async (importOriginal) => {
             getInstance: vi.fn(() => hoisted.scmDocsInstance),
         },
         getCommandService: vi.fn(() => hoisted.commandServiceInstance),
+        ToxAnsibleService: vi.fn().mockImplementation(() => hoisted.toxInstance),
         SkillRegistry: {
             getInstance: vi.fn(() => ({
                 setSources: vi.fn(),
@@ -231,6 +263,7 @@ vi.mock('@ansible/developer-services', async (importOriginal) => {
 
 import { McpToolHandler } from '../src/handlers';
 import type { McpToolResult, McpErrorDetail } from '../src/tools';
+import { ToxAnsibleService } from '@ansible/developer-services';
 
 /**
  * Extract and parse a structured error from an MCP tool result.
@@ -251,6 +284,39 @@ describe('McpToolHandler', () => {
         fsMock.readFileSync.mockReturnValue('');
 
         hoisted.isLoaded.mockReturnValue(true);
+
+        // Re-set ToxAnsibleService mock after clearAllMocks
+        (ToxAnsibleService as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+            () => hoisted.toxInstance,
+        );
+        hoisted.toxInstance.checkAvailability.mockResolvedValue({
+            toxInstalled: true,
+            toxAnsibleInstalled: true,
+            toxVersion: '4.21.0',
+        });
+        hoisted.toxInstance.listEnvironments.mockResolvedValue([
+            {
+                name: 'unit-py3.12-devel',
+                category: 'unit',
+                pythonVersion: '3.12',
+                ansibleVersion: 'devel',
+            },
+            {
+                name: 'sanity-py3.12-devel',
+                category: 'sanity',
+                pythonVersion: '3.12',
+                ansibleVersion: 'devel',
+            },
+        ]);
+        hoisted.toxInstance.runEnvironment.mockResolvedValue({
+            environment: 'unit-py3.12-devel',
+            success: true,
+            exitCode: 0,
+            stdout: 'OK',
+            stderr: '',
+            durationMs: 5000,
+        });
+
         hoisted.listCollectionNames.mockReturnValue(['ansible.builtin']);
         hoisted.getCollection.mockImplementation((name: string) => ({
             info: {
@@ -1589,6 +1655,105 @@ describe('McpToolHandler', () => {
 
             expect(text).toContain('interactive walkthrough');
             expect(text).toContain('Do NOT dump all steps at once');
+        });
+    });
+
+    describe('tox_list_environments', () => {
+        it('returns error when workspace_dir is missing', async () => {
+            const result = await handler.handleTool('tox_list_environments', {});
+            const err = parseError(result);
+            expect(err.code).toBe('MISSING_PARAM');
+            expect(err.message).toContain('workspace_dir');
+        });
+
+        it('returns SERVICE_UNAVAILABLE when tox is not installed', async () => {
+            hoisted.toxInstance.checkAvailability.mockResolvedValueOnce({
+                toxInstalled: false,
+                toxAnsibleInstalled: false,
+            });
+            const result = await handler.handleTool('tox_list_environments', {
+                workspace_dir: '/workspace',
+            });
+            const err = parseError(result);
+            expect(err.code).toBe('SERVICE_UNAVAILABLE');
+            expect(err.message).toContain('tox');
+        });
+
+        it('returns SERVICE_UNAVAILABLE when tox-ansible plugin is missing', async () => {
+            hoisted.toxInstance.checkAvailability.mockResolvedValueOnce({
+                toxInstalled: true,
+                toxAnsibleInstalled: false,
+            });
+            const result = await handler.handleTool('tox_list_environments', {
+                workspace_dir: '/workspace',
+            });
+            const err = parseError(result);
+            expect(err.code).toBe('SERVICE_UNAVAILABLE');
+            expect(err.message).toContain('tox-ansible');
+        });
+
+        it('returns grouped environments on success', async () => {
+            const result = await handler.handleTool('tox_list_environments', {
+                workspace_dir: '/workspace',
+            });
+            expect(result.isError).toBeUndefined();
+            const data = JSON.parse(result.content[0].text) as Record<string, unknown>;
+            expect(data.total).toBe(2);
+            expect(data.tox_version).toBe('4.21.0');
+        });
+
+        it('returns guidance when no environments found', async () => {
+            hoisted.toxInstance.listEnvironments.mockResolvedValueOnce([]);
+            const result = await handler.handleTool('tox_list_environments', {
+                workspace_dir: '/workspace',
+            });
+            expect(result.isError).toBeUndefined();
+            expect(result.content[0].text).toContain('No tox-ansible environments found');
+        });
+    });
+
+    describe('tox_run_environment', () => {
+        it('returns error when environment is missing', async () => {
+            const result = await handler.handleTool('tox_run_environment', {
+                workspace_dir: '/workspace',
+            });
+            const err = parseError(result);
+            expect(err.code).toBe('MISSING_PARAM');
+            expect(err.message).toContain('environment');
+        });
+
+        it('returns error when workspace_dir is missing', async () => {
+            const result = await handler.handleTool('tox_run_environment', {
+                environment: 'unit-py3.12-devel',
+            });
+            const err = parseError(result);
+            expect(err.code).toBe('MISSING_PARAM');
+            expect(err.message).toContain('workspace_dir');
+        });
+
+        it('returns run result on success', async () => {
+            const result = await handler.handleTool('tox_run_environment', {
+                environment: 'unit-py3.12-devel',
+                workspace_dir: '/workspace',
+            });
+            expect(result.isError).toBeUndefined();
+            const data = JSON.parse(result.content[0].text) as Record<string, unknown>;
+            expect(data.success).toBe(true);
+            expect(data.exitCode).toBe(0);
+            expect(data.environment).toBe('unit-py3.12-devel');
+        });
+
+        it('passes timeout_ms to service', async () => {
+            await handler.handleTool('tox_run_environment', {
+                environment: 'unit-py3.12-devel',
+                workspace_dir: '/workspace',
+                timeout_ms: 120000,
+            });
+            expect(hoisted.toxInstance.runEnvironment).toHaveBeenCalledWith(
+                'unit-py3.12-devel',
+                '/workspace',
+                120000,
+            );
         });
     });
 });

--- a/packages/mcp-server/test/handlers.test.ts
+++ b/packages/mcp-server/test/handlers.test.ts
@@ -20,7 +20,16 @@ const hoisted = vi.hoisted(() => {
     const forceRefresh = vi.fn().mockResolvedValue(undefined);
     const refresh = vi.fn().mockResolvedValue(undefined);
     const listCollectionNames = vi.fn(() => ['ansible.builtin']);
-    const getCollection = vi.fn((name: string) => ({
+    interface CollectionInfo {
+        info: {
+            name: string;
+            version: string;
+            description: string;
+            authors: string[];
+        };
+        pluginTypes: Map<string, { name: string; fullName: string; shortDescription: string }[]>;
+    }
+    const getCollection = vi.fn((name: string): CollectionInfo | undefined => ({
         info: {
             name,
             version: '1.0.0',
@@ -109,6 +118,7 @@ const hoisted = vi.hoisted(() => {
                     name: string;
                     version: string;
                     description: string;
+                    repository?: string;
                 }[],
         ),
     };
@@ -146,7 +156,7 @@ const hoisted = vi.hoisted(() => {
     const creatorInstance = {
         isLoaded: vi.fn(() => true),
         refresh: vi.fn().mockResolvedValue(undefined),
-        getSchema: vi.fn(() => null),
+        getSchema: vi.fn(() => null as Record<string, unknown> | null),
         loadSchema: vi.fn().mockResolvedValue(null),
     };
 
@@ -1754,6 +1764,53 @@ describe('McpToolHandler', () => {
                 '/workspace',
                 120000,
             );
+        });
+
+        it('returns failure data without isError when test fails', async () => {
+            hoisted.toxInstance.runEnvironment.mockResolvedValueOnce({
+                environment: 'unit-py3.12-devel',
+                success: false,
+                exitCode: 2,
+                stdout: 'FAILED test_foo.py',
+                stderr: '',
+                durationMs: 5000,
+            });
+            const result = await handler.handleTool('tox_run_environment', {
+                environment: 'unit-py3.12-devel',
+                workspace_dir: '/workspace',
+            });
+            expect(result.isError).toBeUndefined();
+            const data = JSON.parse(result.content[0].text) as Record<string, unknown>;
+            expect(data.success).toBe(false);
+            expect(data.exitCode).toBe(2);
+            expect(data.environment).toBe('unit-py3.12-devel');
+        });
+
+        it('rejects zero or negative timeout_ms', async () => {
+            await handler.handleTool('tox_run_environment', {
+                environment: 'unit-py3.12-devel',
+                workspace_dir: '/workspace',
+                timeout_ms: 0,
+            });
+            expect(hoisted.toxInstance.runEnvironment).toHaveBeenCalledWith(
+                'unit-py3.12-devel',
+                '/workspace',
+                undefined,
+            );
+        });
+
+        it('returns SERVICE_UNAVAILABLE when tox not installed', async () => {
+            hoisted.toxInstance.checkAvailability.mockResolvedValueOnce({
+                toxInstalled: false,
+                toxAnsibleInstalled: false,
+            });
+            const result = await handler.handleTool('tox_run_environment', {
+                environment: 'unit-py3.12-devel',
+                workspace_dir: '/workspace',
+            });
+            expect(result.isError).toBe(true);
+            const err = JSON.parse(result.content[0].text) as Record<string, unknown>;
+            expect(err.code).toBe('SERVICE_UNAVAILABLE');
         });
     });
 });

--- a/packages/services/src/CommandService.ts
+++ b/packages/services/src/CommandService.ts
@@ -216,12 +216,14 @@ export class CommandService {
      * @param file - Executable path or name.
      * @param args - Arguments passed directly to the process (no shell interpolation).
      * @param options - Execution options such as cwd, env, and timeout.
+     * @param signal - Optional AbortSignal to kill the child process on cancellation.
      * @returns Captured stdout, stderr, and exit code from the subprocess.
      */
     public async runCommandArgs(
         file: string,
         args: string[],
         options: CommandOptions = {},
+        signal?: AbortSignal,
     ): Promise<ExecResult> {
         const cwd = options.cwd ?? this.getWorkspaceRoot() ?? process.cwd();
         const maxBuffer = options.maxBuffer ?? 10 * 1024 * 1024;
@@ -242,6 +244,7 @@ export class CommandService {
                 maxBuffer,
                 timeout: options.timeout,
                 env,
+                signal,
             });
             return {
                 stdout: stdout.trim(),
@@ -249,6 +252,9 @@ export class CommandService {
                 exitCode: 0,
             };
         } catch (error) {
+            if (signal?.aborted) {
+                return { stdout: '', stderr: 'Cancelled', exitCode: 1 };
+            }
             const execError = error as cp.ExecException & { stdout?: string; stderr?: string };
             return {
                 stdout: execError.stdout?.trim() ?? '',

--- a/packages/services/src/ToxAnsibleService.ts
+++ b/packages/services/src/ToxAnsibleService.ts
@@ -125,7 +125,7 @@ export function parseNoDescOutput(stdout: string): ToxEnvironment[] {
 }
 
 /**
- *
+ * Discovers and runs tox-ansible test environments via the tox CLI.
  */
 export class ToxAnsibleService {
     private readonly _cmd: CommandService;

--- a/packages/services/src/ToxAnsibleService.ts
+++ b/packages/services/src/ToxAnsibleService.ts
@@ -1,0 +1,323 @@
+/**
+ * ToxAnsibleService
+ *
+ * Discovers and runs tox-ansible test environments via the tox CLI.
+ * Uses CommandService for venv-aware execution (ADR-005 invariant 7).
+ *
+ * Discovery uses `tox list --ansible --gh-matrix` for structured JSON
+ * output with pre-split factors, falling back to `--no-desc` text
+ * parsing when --gh-matrix is unavailable.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { log } from '@ansible/common';
+import type {
+    ToxEnvironment,
+    ToxTestCategory,
+    ToxRunResult,
+    ToxAvailability,
+    ToxGhMatrixEntry,
+} from '@ansible/common';
+import { CommandService } from './CommandService';
+
+const KNOWN_CATEGORIES = new Set<string>(['integration', 'sanity', 'unit']);
+const TOX_LIST_TIMEOUT_MS = 30_000;
+const TOX_RUN_DEFAULT_TIMEOUT_MS = 10 * 60 * 1000; // 10 min
+
+const CONFIG_FILE_CANDIDATES = ['tox-ansible.ini', 'tox.ini'] as const;
+
+/**
+ * Match tox-ansible environment names in category-first format.
+ * Example: "integration-py3.12-devel"
+ */
+const CATEGORY_FIRST_PATTERN = /^(integration|sanity|unit)-py(\d+\.\d+)-(.+)$/;
+
+/**
+ * Match tox-ansible environment names in python-first format.
+ * Example: "py312-2.17-integration-default"
+ */
+const PYTHON_FIRST_PATTERN = /^py(\d)(\d+)-(\d+\.\d+|devel)-(integration|sanity|unit)(?:-(.+))?$/;
+
+/**
+ * Parse an environment name into category, python version, and ansible version.
+ * Tries multiple patterns and falls back to 'unknown' category.
+ * @param name - Full tox environment name to parse
+ * @returns Parsed components: category, pythonVersion, ansibleVersion
+ */
+export function parseToxEnvironmentName(name: string): {
+    category: ToxTestCategory;
+    pythonVersion: string;
+    ansibleVersion: string;
+} {
+    const catFirst = CATEGORY_FIRST_PATTERN.exec(name);
+    if (catFirst) {
+        return {
+            category: catFirst[1] as ToxTestCategory,
+            pythonVersion: catFirst[2],
+            ansibleVersion: catFirst[3],
+        };
+    }
+
+    const pyFirst = PYTHON_FIRST_PATTERN.exec(name);
+    if (pyFirst) {
+        return {
+            category: pyFirst[4] as ToxTestCategory,
+            pythonVersion: `${pyFirst[1]}.${pyFirst[2]}`,
+            ansibleVersion: pyFirst[3],
+        };
+    }
+
+    return { category: 'unknown', pythonVersion: '', ansibleVersion: '' };
+}
+
+/**
+ * Parse --gh-matrix JSON into ToxEnvironment[].
+ * Extracts category from the factors array.
+ * @param json - Raw JSON string from tox --gh-matrix output
+ * @returns Parsed tox environments, empty array on invalid input
+ */
+export function parseGhMatrixJson(json: string): ToxEnvironment[] {
+    let entries: ToxGhMatrixEntry[];
+    try {
+        entries = JSON.parse(json) as ToxGhMatrixEntry[];
+    } catch {
+        log('ToxAnsibleService: failed to parse --gh-matrix JSON');
+        return [];
+    }
+
+    if (!Array.isArray(entries)) {
+        log('ToxAnsibleService: --gh-matrix output is not an array');
+        return [];
+    }
+
+    return entries.map((entry) => {
+        const categoryFactor = entry.factors.find((f) => KNOWN_CATEGORIES.has(f));
+        const ansibleFactor = entry.factors.find(
+            (f) => !KNOWN_CATEGORIES.has(f) && !f.startsWith('py'),
+        );
+
+        return {
+            name: entry.name,
+            category: (categoryFactor as ToxTestCategory | undefined) ?? 'unknown',
+            pythonVersion: entry.python,
+            ansibleVersion: ansibleFactor ?? '',
+            description: entry.description,
+        };
+    });
+}
+
+/**
+ * Parse `tox list --ansible --no-desc` plain-text output into ToxEnvironment[].
+ * One environment name per line, blank lines and header lines skipped.
+ * @param stdout - Raw stdout from tox list command
+ * @returns Parsed tox environments
+ */
+export function parseNoDescOutput(stdout: string): ToxEnvironment[] {
+    return stdout
+        .split('\n')
+        .map((line) => line.trim())
+        .filter((line) => line.length > 0 && !line.startsWith('default') && !line.includes(':'))
+        .map((name) => {
+            const parsed = parseToxEnvironmentName(name);
+            return { name, ...parsed };
+        });
+}
+
+/**
+ *
+ */
+export class ToxAnsibleService {
+    private readonly _cmd: CommandService;
+
+    /**
+     * @param cmd - CommandService instance for venv-aware execution
+     */
+    constructor(cmd?: CommandService) {
+        this._cmd = cmd ?? CommandService.getInstance();
+    }
+
+    /**
+     * Check whether tox and the tox-ansible plugin are available.
+     * @returns Availability status with tox and plugin detection
+     */
+    async checkAvailability(): Promise<ToxAvailability> {
+        const toxPath = await this._cmd.getToolPath('tox');
+        if (!toxPath) {
+            return { toxInstalled: false, toxAnsibleInstalled: false };
+        }
+
+        const result = await this._cmd.runCommandArgs(toxPath, ['--version'], {
+            timeout: TOX_LIST_TIMEOUT_MS,
+        });
+
+        if (result.exitCode !== 0) {
+            return { toxInstalled: false, toxAnsibleInstalled: false };
+        }
+
+        const versionOutput = result.stdout;
+        const toxAnsibleInstalled = versionOutput.includes('tox-ansible');
+        const versionMatch = /^(\S+)/.exec(versionOutput);
+
+        return {
+            toxInstalled: true,
+            toxAnsibleInstalled,
+            toxVersion: versionMatch?.[1],
+        };
+    }
+
+    /**
+     * Auto-detect the tox config file in the workspace directory.
+     * Priority: tox-ansible.ini > tox.ini (pyproject.toml handled by tox natively).
+     * @param workspaceDir - Absolute path to the workspace root
+     * @returns Absolute path to the detected config file, or undefined
+     */
+    detectConfigFile(workspaceDir: string): string | undefined {
+        for (const candidate of CONFIG_FILE_CANDIDATES) {
+            const filePath = path.join(workspaceDir, candidate);
+            if (fs.existsSync(filePath)) {
+                log(`ToxAnsibleService: detected config ${candidate}`);
+                return filePath;
+            }
+        }
+
+        const pyproject = path.join(workspaceDir, 'pyproject.toml');
+        if (fs.existsSync(pyproject)) {
+            log('ToxAnsibleService: pyproject.toml found (tox handles natively)');
+            return undefined;
+        }
+
+        log('ToxAnsibleService: no tox config file found');
+        return undefined;
+    }
+
+    /**
+     * Discover all tox-ansible environments in the workspace.
+     *
+     * Strategy (per D1 review decision):
+     * 1. Try `--gh-matrix` for structured JSON with pre-split factors
+     * 2. Fall back to `--no-desc` text parsing
+     * @param workspaceDir - Absolute path to the workspace root
+     * @returns Discovered tox environments, empty array on failure
+     */
+    async listEnvironments(workspaceDir: string): Promise<ToxEnvironment[]> {
+        const toxPath = await this._cmd.getToolPath('tox');
+        if (!toxPath) {
+            log('ToxAnsibleService: tox not found');
+            return [];
+        }
+
+        const baseArgs = ['list', '--ansible'];
+        const configFile = this.detectConfigFile(workspaceDir);
+        if (configFile && !configFile.endsWith('pyproject.toml')) {
+            baseArgs.push('--conf', configFile);
+        }
+
+        // Try --gh-matrix first (structured JSON)
+        const ghMatrixResult = await this._cmd.runCommandArgs(
+            toxPath,
+            [...baseArgs, '--gh-matrix'],
+            { cwd: workspaceDir, timeout: TOX_LIST_TIMEOUT_MS },
+        );
+
+        if (ghMatrixResult.exitCode === 0 && ghMatrixResult.stdout.trim().startsWith('[')) {
+            const envs = parseGhMatrixJson(ghMatrixResult.stdout);
+            if (envs.length > 0) {
+                log(`ToxAnsibleService: discovered ${String(envs.length)} envs via --gh-matrix`);
+                return envs;
+            }
+        }
+
+        // Fall back to --no-desc text parsing
+        const noDescResult = await this._cmd.runCommandArgs(toxPath, [...baseArgs, '--no-desc'], {
+            cwd: workspaceDir,
+            timeout: TOX_LIST_TIMEOUT_MS,
+        });
+
+        if (noDescResult.exitCode !== 0) {
+            log(
+                `ToxAnsibleService: tox list failed (exit ${String(noDescResult.exitCode)}): ${noDescResult.stderr}`,
+            );
+            return [];
+        }
+
+        const envs = parseNoDescOutput(noDescResult.stdout);
+        log(`ToxAnsibleService: discovered ${String(envs.length)} envs via --no-desc`);
+        return envs;
+    }
+
+    /**
+     * Run a single tox-ansible environment and capture the result.
+     * @param envName - Tox environment name to run
+     * @param workspaceDir - Absolute path to the workspace root
+     * @param timeoutMs - Maximum execution time in milliseconds
+     * @returns Run result with exit code, output, and duration
+     */
+    async runEnvironment(
+        envName: string,
+        workspaceDir: string,
+        timeoutMs: number = TOX_RUN_DEFAULT_TIMEOUT_MS,
+    ): Promise<ToxRunResult> {
+        const toxPath = await this._cmd.getToolPath('tox');
+        if (!toxPath) {
+            return {
+                environment: envName,
+                success: false,
+                exitCode: 1,
+                stdout: '',
+                stderr: 'tox not found. Install ansible-dev-tools first.',
+                durationMs: 0,
+            };
+        }
+
+        const args = ['-e', envName, '--ansible'];
+        const configFile = this.detectConfigFile(workspaceDir);
+        if (configFile && !configFile.endsWith('pyproject.toml')) {
+            args.push('--conf', configFile);
+        }
+
+        const start = Date.now();
+
+        const result = await this._cmd.runCommandArgs(toxPath, args, {
+            cwd: workspaceDir,
+            timeout: timeoutMs,
+        });
+
+        const durationMs = Date.now() - start;
+
+        return {
+            environment: envName,
+            success: result.exitCode === 0,
+            exitCode: result.exitCode,
+            stdout: result.stdout,
+            stderr: result.stderr,
+            durationMs,
+        };
+    }
+
+    /**
+     * Run multiple tox-ansible environments sequentially, reporting progress.
+     * @param envNames - List of environment names to run
+     * @param workspaceDir - Absolute path to the workspace root
+     * @param onProgress - Optional callback for progress updates
+     * @param timeoutMs - Maximum execution time per environment in milliseconds
+     * @returns Array of run results in execution order
+     */
+    async runEnvironments(
+        envNames: string[],
+        workspaceDir: string,
+        onProgress?: (env: string, state: 'started' | 'passed' | 'failed') => void,
+        timeoutMs?: number,
+    ): Promise<ToxRunResult[]> {
+        const results: ToxRunResult[] = [];
+
+        for (const envName of envNames) {
+            onProgress?.(envName, 'started');
+            const result = await this.runEnvironment(envName, workspaceDir, timeoutMs);
+            onProgress?.(envName, result.success ? 'passed' : 'failed');
+            results.push(result);
+        }
+
+        return results;
+    }
+}

--- a/packages/services/src/ToxAnsibleService.ts
+++ b/packages/services/src/ToxAnsibleService.ts
@@ -305,16 +305,16 @@ export class ToxAnsibleService {
         );
 
         const durationMs = Date.now() - start;
-        const abortedDuringExec = signal?.aborted && r.exitCode !== 0;
+        const cancelled = signal?.aborted && r.stderr === 'Cancelled';
 
         return {
             environment: envName,
-            success: !abortedDuringExec && r.exitCode === 0,
+            success: !cancelled && r.exitCode === 0,
             exitCode: r.exitCode,
-            stdout: abortedDuringExec ? '' : r.stdout,
-            stderr: abortedDuringExec ? 'Cancelled by user' : r.stderr,
+            stdout: cancelled ? '' : r.stdout,
+            stderr: cancelled ? 'Cancelled by user' : r.stderr,
             durationMs,
-            timedOut: !abortedDuringExec && r.exitCode !== 0 && durationMs >= timeoutMs,
+            timedOut: !cancelled && r.exitCode !== 0 && durationMs >= timeoutMs,
         };
     }
 

--- a/packages/services/src/ToxAnsibleService.ts
+++ b/packages/services/src/ToxAnsibleService.ts
@@ -251,12 +251,14 @@ export class ToxAnsibleService {
      * @param envName - Tox environment name to run
      * @param workspaceDir - Absolute path to the workspace root
      * @param timeoutMs - Maximum execution time in milliseconds
+     * @param signal - AbortSignal to cancel the running process
      * @returns Run result with exit code, output, and duration
      */
     async runEnvironment(
         envName: string,
         workspaceDir: string,
         timeoutMs: number = TOX_RUN_DEFAULT_TIMEOUT_MS,
+        signal?: AbortSignal,
     ): Promise<ToxRunResult> {
         const toxPath = await this._cmd.getToolPath('tox');
         if (!toxPath) {
@@ -278,19 +280,41 @@ export class ToxAnsibleService {
 
         const start = Date.now();
 
-        const result = await this._cmd.runCommandArgs(toxPath, args, {
+        if (signal?.aborted) {
+            return {
+                environment: envName,
+                success: false,
+                exitCode: 1,
+                stdout: '',
+                stderr: 'Cancelled',
+                durationMs: 0,
+            };
+        }
+
+        const r = await this._cmd.runCommandArgs(toxPath, args, {
             cwd: workspaceDir,
             timeout: timeoutMs,
         });
 
         const durationMs = Date.now() - start;
 
+        if (signal?.aborted) {
+            return {
+                environment: envName,
+                success: false,
+                exitCode: 1,
+                stdout: '',
+                stderr: 'Cancelled by user',
+                durationMs,
+            };
+        }
+
         return {
             environment: envName,
-            success: result.exitCode === 0,
-            exitCode: result.exitCode,
-            stdout: result.stdout,
-            stderr: result.stderr,
+            success: r.exitCode === 0,
+            exitCode: r.exitCode,
+            stdout: r.stdout,
+            stderr: r.stderr,
             durationMs,
         };
     }

--- a/packages/services/src/ToxAnsibleService.ts
+++ b/packages/services/src/ToxAnsibleService.ts
@@ -91,20 +91,22 @@ export function parseGhMatrixJson(json: string): ToxEnvironment[] {
         return [];
     }
 
-    return entries.map((entry) => {
-        const categoryFactor = entry.factors.find((f) => KNOWN_CATEGORIES.has(f));
-        const ansibleFactor = entry.factors.find(
-            (f) => !KNOWN_CATEGORIES.has(f) && !f.startsWith('py'),
-        );
+    return entries
+        .filter((entry) => entry.name && Array.isArray(entry.factors))
+        .map((entry) => {
+            const categoryFactor = entry.factors.find((f) => KNOWN_CATEGORIES.has(f));
+            const ansibleFactor = entry.factors.find(
+                (f) => !KNOWN_CATEGORIES.has(f) && !f.startsWith('py'),
+            );
 
-        return {
-            name: entry.name,
-            category: (categoryFactor as ToxTestCategory | undefined) ?? 'unknown',
-            pythonVersion: entry.python,
-            ansibleVersion: ansibleFactor ?? '',
-            description: entry.description,
-        };
-    });
+            return {
+                name: entry.name,
+                category: (categoryFactor as ToxTestCategory | undefined) ?? 'unknown',
+                pythonVersion: entry.python,
+                ansibleVersion: ansibleFactor ?? '',
+                description: entry.description,
+            };
+        });
 }
 
 /**
@@ -325,10 +327,12 @@ export class ToxAnsibleService {
 
     /**
      * Run multiple tox-ansible environments sequentially, reporting progress.
+     * Stops early if the signal is aborted between environments.
      * @param envNames - List of environment names to run
      * @param workspaceDir - Absolute path to the workspace root
      * @param onProgress - Optional callback for progress updates
      * @param timeoutMs - Maximum execution time per environment in milliseconds
+     * @param signal - AbortSignal to cancel remaining runs
      * @returns Array of run results in execution order
      */
     async runEnvironments(
@@ -336,12 +340,14 @@ export class ToxAnsibleService {
         workspaceDir: string,
         onProgress?: (env: string, state: 'started' | 'passed' | 'failed') => void,
         timeoutMs?: number,
+        signal?: AbortSignal,
     ): Promise<ToxRunResult[]> {
         const results: ToxRunResult[] = [];
 
         for (const envName of envNames) {
+            if (signal?.aborted) break;
             onProgress?.(envName, 'started');
-            const result = await this.runEnvironment(envName, workspaceDir, timeoutMs);
+            const result = await this.runEnvironment(envName, workspaceDir, timeoutMs, signal);
             onProgress?.(envName, result.success ? 'passed' : 'failed');
             results.push(result);
         }

--- a/packages/services/src/ToxAnsibleService.ts
+++ b/packages/services/src/ToxAnsibleService.ts
@@ -29,9 +29,11 @@ const CONFIG_FILE_CANDIDATES = ['tox-ansible.ini', 'tox.ini'] as const;
 
 /**
  * Match tox-ansible environment names in category-first format.
- * Example: "integration-py3.12-devel"
+ * Example: "integration-py3.12-devel" or "integration-py3.12-2.17"
+ * Captures only the ansible version factor (first segment after python),
+ * not scenario suffixes like "-default".
  */
-const CATEGORY_FIRST_PATTERN = /^(integration|sanity|unit)-py(\d+\.\d+)-(.+)$/;
+const CATEGORY_FIRST_PATTERN = /^(integration|sanity|unit)-py(\d+\.\d+)-(\d+\.\d+|devel)(?:-.+)?$/;
 
 /**
  * Match tox-ansible environment names in python-first format.
@@ -303,25 +305,16 @@ export class ToxAnsibleService {
         );
 
         const durationMs = Date.now() - start;
-
-        if (signal?.aborted) {
-            return {
-                environment: envName,
-                success: false,
-                exitCode: 1,
-                stdout: '',
-                stderr: 'Cancelled by user',
-                durationMs,
-            };
-        }
+        const abortedDuringExec = signal?.aborted && r.exitCode !== 0;
 
         return {
             environment: envName,
-            success: r.exitCode === 0,
+            success: !abortedDuringExec && r.exitCode === 0,
             exitCode: r.exitCode,
-            stdout: r.stdout,
-            stderr: r.stderr,
+            stdout: abortedDuringExec ? '' : r.stdout,
+            stderr: abortedDuringExec ? 'Cancelled by user' : r.stderr,
             durationMs,
+            timedOut: !abortedDuringExec && r.exitCode !== 0 && durationMs >= timeoutMs,
         };
     }
 

--- a/packages/services/src/ToxAnsibleService.ts
+++ b/packages/services/src/ToxAnsibleService.ts
@@ -248,10 +248,12 @@ export class ToxAnsibleService {
 
     /**
      * Run a single tox-ansible environment and capture the result.
+     * The signal is forwarded to the child process so the tox run is
+     * actually killed when the user clicks "Stop" in Test Explorer.
      * @param envName - Tox environment name to run
      * @param workspaceDir - Absolute path to the workspace root
      * @param timeoutMs - Maximum execution time in milliseconds
-     * @param signal - AbortSignal to cancel the running process
+     * @param signal - AbortSignal to kill the tox child process on cancellation
      * @returns Run result with exit code, output, and duration
      */
     async runEnvironment(
@@ -291,10 +293,12 @@ export class ToxAnsibleService {
             };
         }
 
-        const r = await this._cmd.runCommandArgs(toxPath, args, {
-            cwd: workspaceDir,
-            timeout: timeoutMs,
-        });
+        const r = await this._cmd.runCommandArgs(
+            toxPath,
+            args,
+            { cwd: workspaceDir, timeout: timeoutMs },
+            signal,
+        );
 
         const durationMs = Date.now() - start;
 

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -92,6 +92,11 @@ export type {
     ParsedCollection,
     MetadataDumpResult,
     NavigatorEEOptions,
+    ToxTestCategory,
+    ToxEnvironment,
+    ToxRunResult,
+    ToxAvailability,
+    ToxGhMatrixEntry,
 } from '@ansible/common';
 
 // --- Services ---
@@ -132,6 +137,7 @@ export { GitHubCollectionCache } from './GitHubCollectionCache';
 export { SCMDocsCache } from './SCMDocsCache';
 export { SkillRegistry, _resetGitHubToken } from './SkillRegistry';
 export { discoverPlaybooks } from './PlaybookDiscovery';
+export { ToxAnsibleService } from './ToxAnsibleService';
 export type { DiscoveredPlaybook } from './PlaybookDiscovery';
 
 // VS Code-specific type re-export

--- a/packages/services/test/services/ToxAnsibleService.test.ts
+++ b/packages/services/test/services/ToxAnsibleService.test.ts
@@ -386,6 +386,28 @@ describe('ToxAnsibleService', () => {
             expect(callArgs[1]).toContain('-e');
             expect(callArgs[1]).toContain('unit-py3.12-devel');
         });
+
+        it('forwards AbortSignal to CommandService', async () => {
+            const controller = new AbortController();
+            await service.runEnvironment('unit-py3.12-devel', tmpDir, undefined, controller.signal);
+
+            expect(runCommandArgsMock.mock.calls[0][3]).toBe(controller.signal);
+        });
+
+        it('returns cancelled result for pre-aborted signal', async () => {
+            const controller = new AbortController();
+            controller.abort();
+
+            const result = await service.runEnvironment(
+                'unit-py3.12-devel',
+                tmpDir,
+                undefined,
+                controller.signal,
+            );
+            expect(result.success).toBe(false);
+            expect(result.stderr).toBe('Cancelled');
+            expect(runCommandArgsMock).not.toHaveBeenCalled();
+        });
     });
 
     describe('runEnvironments', () => {

--- a/packages/services/test/services/ToxAnsibleService.test.ts
+++ b/packages/services/test/services/ToxAnsibleService.test.ts
@@ -186,10 +186,6 @@ describe('parseNoDescOutput', () => {
 // ---------------------------------------------------------------------------
 
 /**
- *
- * @param overrides
- */
-/**
  * Create a mock ExecResult with optional overrides.
  * @param overrides - Fields to override on the default result
  * @returns ExecResult with defaults merged

--- a/packages/services/test/services/ToxAnsibleService.test.ts
+++ b/packages/services/test/services/ToxAnsibleService.test.ts
@@ -86,6 +86,22 @@ describe('parseToxEnvironmentName', () => {
             ansibleVersion: '',
         });
     });
+
+    it('parses category-first with scenario suffix, capturing only ansible version', () => {
+        expect(parseToxEnvironmentName('integration-py3.12-devel-default')).toEqual({
+            category: 'integration',
+            pythonVersion: '3.12',
+            ansibleVersion: 'devel',
+        });
+    });
+
+    it('parses category-first with numeric version and suffix', () => {
+        expect(parseToxEnvironmentName('sanity-py3.11-2.17-extra')).toEqual({
+            category: 'sanity',
+            pythonVersion: '3.11',
+            ansibleVersion: '2.17',
+        });
+    });
 });
 
 describe('parseGhMatrixJson', () => {
@@ -129,6 +145,19 @@ describe('parseGhMatrixJson', () => {
 
     it('returns empty array for non-array JSON', () => {
         expect(parseGhMatrixJson('{"key": "value"}')).toEqual([]);
+    });
+
+    it('skips entries with missing or non-array factors', () => {
+        const json = JSON.stringify([
+            { name: 'good-env', factors: ['unit'], python: '3.12', description: 'ok' },
+            { name: 'no-factors', python: '3.12', description: 'bad' },
+            { name: 'string-factors', factors: 'not-array', python: '3.12', description: 'bad' },
+            { python: '3.12', factors: ['unit'], description: 'no name' },
+        ]);
+
+        const result = parseGhMatrixJson(json);
+        expect(result).toHaveLength(1);
+        expect(result[0].name).toBe('good-env');
     });
 
     it('handles entries with no known category factor', () => {
@@ -408,6 +437,32 @@ describe('ToxAnsibleService', () => {
             expect(result.stderr).toBe('Cancelled');
             expect(runCommandArgsMock).not.toHaveBeenCalled();
         });
+
+        it('sets timedOut when duration exceeds timeout and exit is non-zero', async () => {
+            const shortTimeout = 50;
+            runCommandArgsMock.mockImplementation(
+                () =>
+                    new Promise((resolve) => {
+                        setTimeout(() => {
+                            resolve(makeResult({ exitCode: 1, stderr: 'killed' }));
+                        }, shortTimeout + 10);
+                    }),
+            );
+
+            const result = await service.runEnvironment('unit-py3.12-devel', tmpDir, shortTimeout);
+            expect(result.timedOut).toBe(true);
+            expect(result.success).toBe(false);
+        });
+
+        it('does not set timedOut on normal failure within timeout', async () => {
+            runCommandArgsMock.mockResolvedValue(
+                makeResult({ exitCode: 1, stderr: 'test failed' }),
+            );
+
+            const result = await service.runEnvironment('unit-py3.12-devel', tmpDir, 600_000);
+            expect(result.timedOut).toBe(false);
+            expect(result.success).toBe(false);
+        });
     });
 
     describe('runEnvironments', () => {
@@ -434,6 +489,25 @@ describe('ToxAnsibleService', () => {
 
             expect(progress).toHaveBeenCalledWith('unit-py3.12-devel', 'started');
             expect(progress).toHaveBeenCalledWith('unit-py3.12-devel', 'passed');
+        });
+
+        it('stops early when signal is aborted between environments', async () => {
+            const controller = new AbortController();
+            runCommandArgsMock.mockImplementation(() => {
+                controller.abort();
+                return Promise.resolve(makeResult());
+            });
+
+            const results = await service.runEnvironments(
+                ['env1', 'env2', 'env3'],
+                tmpDir,
+                undefined,
+                undefined,
+                controller.signal,
+            );
+
+            expect(results).toHaveLength(1);
+            expect(results[0].success).toBe(true);
         });
     });
 });

--- a/packages/services/test/services/ToxAnsibleService.test.ts
+++ b/packages/services/test/services/ToxAnsibleService.test.ts
@@ -1,0 +1,421 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+    parseToxEnvironmentName,
+    parseGhMatrixJson,
+    parseNoDescOutput,
+    ToxAnsibleService,
+} from '../../src/ToxAnsibleService';
+import type { ExecResult } from '@ansible/common';
+
+// ---------------------------------------------------------------------------
+// Mock CommandService at module level (ESM-safe pattern used throughout repo)
+// ---------------------------------------------------------------------------
+
+const getToolPathMock = vi.hoisted(() => vi.fn());
+const runCommandArgsMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../../src/CommandService', () => ({
+    CommandService: {
+        getInstance: () => ({
+            getToolPath: getToolPathMock,
+            runCommandArgs: runCommandArgsMock,
+        }),
+    },
+}));
+
+// ---------------------------------------------------------------------------
+// Pure parser tests — no mocking needed
+// ---------------------------------------------------------------------------
+
+describe('parseToxEnvironmentName', () => {
+    it('parses category-first format', () => {
+        expect(parseToxEnvironmentName('integration-py3.12-devel')).toEqual({
+            category: 'integration',
+            pythonVersion: '3.12',
+            ansibleVersion: 'devel',
+        });
+    });
+
+    it('parses sanity env', () => {
+        expect(parseToxEnvironmentName('sanity-py3.11-2.17')).toEqual({
+            category: 'sanity',
+            pythonVersion: '3.11',
+            ansibleVersion: '2.17',
+        });
+    });
+
+    it('parses unit env', () => {
+        expect(parseToxEnvironmentName('unit-py3.13-2.19')).toEqual({
+            category: 'unit',
+            pythonVersion: '3.13',
+            ansibleVersion: '2.19',
+        });
+    });
+
+    it('parses python-first format', () => {
+        expect(parseToxEnvironmentName('py312-2.17-integration-default')).toEqual({
+            category: 'integration',
+            pythonVersion: '3.12',
+            ansibleVersion: '2.17',
+        });
+    });
+
+    it('parses python-first format without scenario', () => {
+        expect(parseToxEnvironmentName('py311-devel-unit')).toEqual({
+            category: 'unit',
+            pythonVersion: '3.11',
+            ansibleVersion: 'devel',
+        });
+    });
+
+    it('returns unknown for unrecognized format', () => {
+        expect(parseToxEnvironmentName('custom-env-name')).toEqual({
+            category: 'unknown',
+            pythonVersion: '',
+            ansibleVersion: '',
+        });
+    });
+
+    it('returns unknown for empty string', () => {
+        expect(parseToxEnvironmentName('')).toEqual({
+            category: 'unknown',
+            pythonVersion: '',
+            ansibleVersion: '',
+        });
+    });
+});
+
+describe('parseGhMatrixJson', () => {
+    it('parses valid --gh-matrix output', () => {
+        const json = JSON.stringify([
+            {
+                name: 'integration-py3.12-devel',
+                description: 'Integration tests using devel',
+                factors: ['integration', 'py3.12', 'devel'],
+                python: '3.12',
+            },
+            {
+                name: 'unit-py3.11-2.17',
+                description: 'Unit tests using 2.17',
+                factors: ['unit', 'py3.11', '2.17'],
+                python: '3.11',
+            },
+        ]);
+
+        const result = parseGhMatrixJson(json);
+        expect(result).toHaveLength(2);
+        expect(result[0]).toEqual({
+            name: 'integration-py3.12-devel',
+            category: 'integration',
+            pythonVersion: '3.12',
+            ansibleVersion: 'devel',
+            description: 'Integration tests using devel',
+        });
+        expect(result[1]).toEqual({
+            name: 'unit-py3.11-2.17',
+            category: 'unit',
+            pythonVersion: '3.11',
+            ansibleVersion: '2.17',
+            description: 'Unit tests using 2.17',
+        });
+    });
+
+    it('returns empty array for invalid JSON', () => {
+        expect(parseGhMatrixJson('not json')).toEqual([]);
+    });
+
+    it('returns empty array for non-array JSON', () => {
+        expect(parseGhMatrixJson('{"key": "value"}')).toEqual([]);
+    });
+
+    it('handles entries with no known category factor', () => {
+        const json = JSON.stringify([
+            {
+                name: 'custom-env',
+                description: 'Custom',
+                factors: ['custom', 'py3.12'],
+                python: '3.12',
+            },
+        ]);
+
+        const result = parseGhMatrixJson(json);
+        expect(result[0].category).toBe('unknown');
+    });
+});
+
+describe('parseNoDescOutput', () => {
+    it('parses multi-line output', () => {
+        const stdout = [
+            'integration-py3.11-2.17',
+            'integration-py3.12-devel',
+            'sanity-py3.12-devel',
+            'unit-py3.11-2.17',
+        ].join('\n');
+
+        const result = parseNoDescOutput(stdout);
+        expect(result).toHaveLength(4);
+        expect(result[0].name).toBe('integration-py3.11-2.17');
+        expect(result[0].category).toBe('integration');
+        expect(result[3].name).toBe('unit-py3.11-2.17');
+        expect(result[3].category).toBe('unit');
+    });
+
+    it('skips blank lines', () => {
+        const stdout = '\nintegration-py3.12-devel\n\nunit-py3.11-2.17\n';
+        const result = parseNoDescOutput(stdout);
+        expect(result).toHaveLength(2);
+    });
+
+    it('skips header lines', () => {
+        const stdout = 'default environments:\nintegration-py3.12-devel\n';
+        const result = parseNoDescOutput(stdout);
+        expect(result).toHaveLength(1);
+        expect(result[0].name).toBe('integration-py3.12-devel');
+    });
+
+    it('returns empty array for empty output', () => {
+        expect(parseNoDescOutput('')).toEqual([]);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// ToxAnsibleService tests — use module-level CommandService mock + real tmpdir
+// ---------------------------------------------------------------------------
+
+/**
+ *
+ * @param overrides
+ */
+/**
+ * Create a mock ExecResult with optional overrides.
+ * @param overrides - Fields to override on the default result
+ * @returns ExecResult with defaults merged
+ */
+function makeResult(overrides: Partial<ExecResult> = {}): ExecResult {
+    return { stdout: '', stderr: '', exitCode: 0, ...overrides };
+}
+
+describe('ToxAnsibleService', () => {
+    let service: ToxAnsibleService;
+    let tmpDir: string;
+
+    beforeEach(() => {
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tox-test-'));
+        getToolPathMock.mockReset();
+        runCommandArgsMock.mockReset();
+        getToolPathMock.mockResolvedValue('/usr/bin/tox');
+        runCommandArgsMock.mockResolvedValue(makeResult());
+        service = new ToxAnsibleService();
+    });
+
+    afterEach(() => {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    describe('checkAvailability', () => {
+        it('returns toxInstalled=false when tox not in PATH', async () => {
+            getToolPathMock.mockResolvedValue(null);
+
+            const result = await service.checkAvailability();
+            expect(result.toxInstalled).toBe(false);
+            expect(result.toxAnsibleInstalled).toBe(false);
+        });
+
+        it('detects tox without tox-ansible plugin', async () => {
+            runCommandArgsMock.mockResolvedValue(
+                makeResult({ stdout: '4.21.0 from /usr/lib/python' }),
+            );
+
+            const result = await service.checkAvailability();
+            expect(result.toxInstalled).toBe(true);
+            expect(result.toxAnsibleInstalled).toBe(false);
+            expect(result.toxVersion).toBe('4.21.0');
+        });
+
+        it('detects tox with tox-ansible plugin', async () => {
+            runCommandArgsMock.mockResolvedValue(
+                makeResult({
+                    stdout: '4.21.0 from /usr/lib/python\ntox-ansible-26.3.0',
+                }),
+            );
+
+            const result = await service.checkAvailability();
+            expect(result.toxInstalled).toBe(true);
+            expect(result.toxAnsibleInstalled).toBe(true);
+        });
+
+        it('returns toxInstalled=false when --version fails', async () => {
+            runCommandArgsMock.mockResolvedValue(makeResult({ exitCode: 1, stderr: 'error' }));
+
+            const result = await service.checkAvailability();
+            expect(result.toxInstalled).toBe(false);
+        });
+    });
+
+    describe('detectConfigFile', () => {
+        it('returns tox-ansible.ini when it exists', () => {
+            fs.writeFileSync(path.join(tmpDir, 'tox-ansible.ini'), '');
+
+            const result = service.detectConfigFile(tmpDir);
+            expect(result).toBe(path.join(tmpDir, 'tox-ansible.ini'));
+        });
+
+        it('prefers tox-ansible.ini over tox.ini', () => {
+            fs.writeFileSync(path.join(tmpDir, 'tox-ansible.ini'), '');
+            fs.writeFileSync(path.join(tmpDir, 'tox.ini'), '');
+
+            const result = service.detectConfigFile(tmpDir);
+            expect(result).toBe(path.join(tmpDir, 'tox-ansible.ini'));
+        });
+
+        it('returns tox.ini when tox-ansible.ini absent', () => {
+            fs.writeFileSync(path.join(tmpDir, 'tox.ini'), '');
+
+            const result = service.detectConfigFile(tmpDir);
+            expect(result).toBe(path.join(tmpDir, 'tox.ini'));
+        });
+
+        it('returns undefined when no config files exist', () => {
+            const result = service.detectConfigFile(tmpDir);
+            expect(result).toBeUndefined();
+        });
+
+        it('returns undefined for pyproject.toml (tox handles natively)', () => {
+            fs.writeFileSync(path.join(tmpDir, 'pyproject.toml'), '');
+
+            const result = service.detectConfigFile(tmpDir);
+            expect(result).toBeUndefined();
+        });
+    });
+
+    describe('listEnvironments', () => {
+        it('uses --gh-matrix when available', async () => {
+            const ghMatrixOutput = JSON.stringify([
+                {
+                    name: 'unit-py3.12-devel',
+                    description: 'Unit tests',
+                    factors: ['unit', 'py3.12', 'devel'],
+                    python: '3.12',
+                },
+            ]);
+
+            runCommandArgsMock.mockResolvedValue(makeResult({ stdout: ghMatrixOutput }));
+
+            const envs = await service.listEnvironments(tmpDir);
+            expect(envs).toHaveLength(1);
+            expect(envs[0].name).toBe('unit-py3.12-devel');
+            expect(envs[0].category).toBe('unit');
+            expect(envs[0].description).toBe('Unit tests');
+        });
+
+        it('falls back to --no-desc when --gh-matrix fails', async () => {
+            runCommandArgsMock
+                .mockResolvedValueOnce(makeResult({ exitCode: 1, stderr: 'unknown flag' }))
+                .mockResolvedValueOnce(
+                    makeResult({ stdout: 'integration-py3.11-2.17\nunit-py3.12-devel' }),
+                );
+
+            const envs = await service.listEnvironments(tmpDir);
+            expect(envs).toHaveLength(2);
+            expect(envs[0].name).toBe('integration-py3.11-2.17');
+        });
+
+        it('returns empty when tox not found', async () => {
+            getToolPathMock.mockResolvedValue(null);
+
+            const envs = await service.listEnvironments(tmpDir);
+            expect(envs).toEqual([]);
+        });
+
+        it('passes --conf when tox-ansible.ini exists', async () => {
+            fs.writeFileSync(path.join(tmpDir, 'tox-ansible.ini'), '');
+            runCommandArgsMock.mockResolvedValue(makeResult({ stdout: '[]' }));
+
+            await service.listEnvironments(tmpDir);
+
+            const firstCallArgs = runCommandArgsMock.mock.calls[0] as [string, string[]];
+            expect(firstCallArgs[1]).toContain('--conf');
+        });
+
+        it('does not pass --conf for pyproject.toml', async () => {
+            fs.writeFileSync(path.join(tmpDir, 'pyproject.toml'), '');
+            runCommandArgsMock.mockResolvedValue(makeResult({ stdout: '[]' }));
+
+            await service.listEnvironments(tmpDir);
+
+            const firstCallArgs = runCommandArgsMock.mock.calls[0] as [string, string[]];
+            expect(firstCallArgs[1]).not.toContain('--conf');
+        });
+    });
+
+    describe('runEnvironment', () => {
+        it('returns success result on exit code 0', async () => {
+            runCommandArgsMock.mockResolvedValue(makeResult({ stdout: 'PASSED', stderr: '' }));
+
+            const result = await service.runEnvironment('unit-py3.12-devel', tmpDir);
+            expect(result.success).toBe(true);
+            expect(result.exitCode).toBe(0);
+            expect(result.environment).toBe('unit-py3.12-devel');
+            expect(result.stdout).toBe('PASSED');
+            expect(result.durationMs).toBeGreaterThanOrEqual(0);
+        });
+
+        it('returns failure result on non-zero exit code', async () => {
+            runCommandArgsMock.mockResolvedValue(
+                makeResult({ exitCode: 1, stdout: '', stderr: 'FAILED' }),
+            );
+
+            const result = await service.runEnvironment('unit-py3.12-devel', tmpDir);
+            expect(result.success).toBe(false);
+            expect(result.exitCode).toBe(1);
+            expect(result.stderr).toBe('FAILED');
+        });
+
+        it('returns failure when tox not found', async () => {
+            getToolPathMock.mockResolvedValue(null);
+
+            const result = await service.runEnvironment('unit-py3.12-devel', tmpDir);
+            expect(result.success).toBe(false);
+            expect(result.stderr).toContain('tox not found');
+        });
+
+        it('passes --ansible and -e flags', async () => {
+            await service.runEnvironment('unit-py3.12-devel', tmpDir);
+
+            const callArgs = runCommandArgsMock.mock.calls[0] as [string, string[]];
+            expect(callArgs[1]).toContain('--ansible');
+            expect(callArgs[1]).toContain('-e');
+            expect(callArgs[1]).toContain('unit-py3.12-devel');
+        });
+    });
+
+    describe('runEnvironments', () => {
+        it('runs multiple environments sequentially', async () => {
+            runCommandArgsMock
+                .mockResolvedValueOnce(makeResult({ stdout: 'PASS1' }))
+                .mockResolvedValueOnce(makeResult({ exitCode: 1, stderr: 'FAIL2' }));
+
+            const results = await service.runEnvironments(
+                ['unit-py3.12-devel', 'sanity-py3.12-devel'],
+                tmpDir,
+            );
+
+            expect(results).toHaveLength(2);
+            expect(results[0].success).toBe(true);
+            expect(results[1].success).toBe(false);
+        });
+
+        it('calls progress callback', async () => {
+            runCommandArgsMock.mockResolvedValue(makeResult());
+
+            const progress = vi.fn();
+            await service.runEnvironments(['unit-py3.12-devel'], tmpDir, progress);
+
+            expect(progress).toHaveBeenCalledWith('unit-py3.12-devel', 'started');
+            expect(progress).toHaveBeenCalledWith('unit-py3.12-devel', 'passed');
+        });
+    });
+});

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -170,7 +170,7 @@ export async function activate(context: vscode.ExtensionContext) {
     registerFileAssociation(context);
     registerExtensionConflictDetection(context);
     registerVaultCommand(context);
-    registerToxAnsible(context);
+    registerToxAnsible(context, telemetry);
     registerWalkthroughTelemetry(context, telemetry);
     registerGettingStarted(context, telemetry);
     registerLightspeed(context, telemetry)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -78,6 +78,7 @@ import { getLlmService } from '@src/services/LlmService';
 import { registerFileAssociation } from '@src/features/fileAssociation';
 import { registerExtensionConflictDetection } from '@src/features/extensionConflicts';
 import { registerVaultCommand } from '@src/features/vault';
+import { registerToxAnsible } from '@src/features/toxAnsible/register';
 import { registerLightspeed } from '@src/features/lightspeed/register';
 import { registerWalkthroughTelemetry } from '@src/telemetry';
 import { registerGettingStarted } from '@src/features/gettingStarted';
@@ -169,6 +170,7 @@ export async function activate(context: vscode.ExtensionContext) {
     registerFileAssociation(context);
     registerExtensionConflictDetection(context);
     registerVaultCommand(context);
+    registerToxAnsible(context);
     registerWalkthroughTelemetry(context, telemetry);
     registerGettingStarted(context, telemetry);
     registerLightspeed(context, telemetry)

--- a/src/features/toxAnsible/ToxTaskProvider.ts
+++ b/src/features/toxAnsible/ToxTaskProvider.ts
@@ -89,15 +89,15 @@ export class ToxTaskProvider implements vscode.TaskProvider {
             environment: envName,
         };
 
-        let command = `tox -e ${envName} --ansible`;
+        const args = ['-e', envName, '--ansible'];
         if (folder?.uri.fsPath) {
             const configFile = this._service.detectConfigFile(folder.uri.fsPath);
             if (configFile && !configFile.endsWith('pyproject.toml')) {
-                command += ` --conf "${configFile}"`;
+                args.push('--conf', configFile);
             }
         }
 
-        const execution = new vscode.ShellExecution(command, {
+        const execution = new vscode.ShellExecution('tox', args, {
             cwd: folder?.uri.fsPath,
         });
 

--- a/src/features/toxAnsible/ToxTaskProvider.ts
+++ b/src/features/toxAnsible/ToxTaskProvider.ts
@@ -1,0 +1,113 @@
+/**
+ * ToxTaskProvider — VS Code Task Provider for tox-ansible environments.
+ *
+ * Surfaces tox-ansible environments as VS Code tasks accessible via
+ * Command Palette → "Run Task". Uses ToxAnsibleService for discovery.
+ */
+
+import * as vscode from 'vscode';
+import { ToxAnsibleService } from '@ansible/developer-services';
+import { log } from '@src/extension';
+
+const TASK_TYPE = 'ansible-tox';
+const TASK_SOURCE = 'ansible-tox';
+
+/**
+ *
+ */
+export class ToxTaskProvider implements vscode.TaskProvider {
+    private readonly _service: ToxAnsibleService;
+
+    /**
+     * @param service - ToxAnsibleService instance for discovery
+     */
+    constructor(service?: ToxAnsibleService) {
+        this._service = service ?? new ToxAnsibleService();
+    }
+
+    /**
+     * Provide all tox-ansible environments as VS Code tasks.
+     * Called by VS Code when the user opens "Run Task" or the Tasks view.
+     * @returns Array of VS Code tasks for each tox-ansible environment
+     */
+    async provideTasks(): Promise<vscode.Task[]> {
+        const folders = vscode.workspace.workspaceFolders;
+        if (!folders?.length) return [];
+
+        const tasks: vscode.Task[] = [];
+
+        for (const folder of folders) {
+            const availability = await this._service.checkAvailability();
+            if (!availability.toxInstalled || !availability.toxAnsibleInstalled) continue;
+
+            const envs = await this._service.listEnvironments(folder.uri.fsPath);
+
+            for (const env of envs) {
+                const task = this._createTask(env.name, env.description, folder);
+                tasks.push(task);
+            }
+
+            if (envs.length > 0) {
+                log(`ToxTaskProvider: provided ${String(envs.length)} tasks from ${folder.name}`);
+            }
+        }
+
+        return tasks;
+    }
+
+    /**
+     * Resolve a task definition from tasks.json. Fills in the execution
+     * details for user-defined ansible-tox tasks.
+     * @param task - Task to resolve with execution details
+     * @returns Resolved task with ShellExecution, or undefined
+     */
+    resolveTask(task: vscode.Task): vscode.Task | undefined {
+        const definition = task.definition as { type: string; environment?: string };
+        if (definition.type !== TASK_TYPE || !definition.environment) {
+            return undefined;
+        }
+
+        const folder = task.scope as vscode.WorkspaceFolder | undefined;
+        return this._createTask(
+            definition.environment,
+            undefined,
+            folder ?? vscode.workspace.workspaceFolders?.[0],
+        );
+    }
+
+    /**
+     * Create a VS Code Task for a tox-ansible environment.
+     * @param envName - Tox environment name
+     * @param description - Optional human-readable description
+     * @param folder - Workspace folder for cwd
+     * @returns Configured VS Code task
+     */
+    private _createTask(
+        envName: string,
+        description: string | undefined,
+        folder: vscode.WorkspaceFolder | undefined,
+    ): vscode.Task {
+        const definition: vscode.TaskDefinition = {
+            type: TASK_TYPE,
+            environment: envName,
+        };
+
+        const execution = new vscode.ShellExecution(`tox -e ${envName} --ansible`, {
+            cwd: folder?.uri.fsPath,
+        });
+
+        const task = new vscode.Task(
+            definition,
+            folder ?? vscode.TaskScope.Workspace,
+            envName,
+            TASK_SOURCE,
+            execution,
+        );
+
+        task.detail = description ?? `Run tox-ansible environment: ${envName}`;
+        task.group = vscode.TaskGroup.Test;
+        task.presentationOptions = { reveal: vscode.TaskRevealKind.Always };
+
+        return task;
+    }
+}

--- a/src/features/toxAnsible/ToxTaskProvider.ts
+++ b/src/features/toxAnsible/ToxTaskProvider.ts
@@ -12,9 +12,7 @@ import { log } from '@src/extension';
 const TASK_TYPE = 'ansible-tox';
 const TASK_SOURCE = 'ansible-tox';
 
-/**
- *
- */
+/** VS Code Task Provider for tox-ansible environments. */
 export class ToxTaskProvider implements vscode.TaskProvider {
     private readonly _service: ToxAnsibleService;
 
@@ -67,12 +65,11 @@ export class ToxTaskProvider implements vscode.TaskProvider {
             return undefined;
         }
 
-        const folder = task.scope as vscode.WorkspaceFolder | undefined;
-        return this._createTask(
-            definition.environment,
-            undefined,
-            folder ?? vscode.workspace.workspaceFolders?.[0],
-        );
+        const folder =
+            task.scope && typeof task.scope === 'object' && 'uri' in task.scope
+                ? task.scope
+                : vscode.workspace.workspaceFolders?.[0];
+        return this._createTask(definition.environment, undefined, folder);
     }
 
     /**
@@ -92,7 +89,15 @@ export class ToxTaskProvider implements vscode.TaskProvider {
             environment: envName,
         };
 
-        const execution = new vscode.ShellExecution(`tox -e ${envName} --ansible`, {
+        let command = `tox -e ${envName} --ansible`;
+        if (folder?.uri.fsPath) {
+            const configFile = this._service.detectConfigFile(folder.uri.fsPath);
+            if (configFile && !configFile.endsWith('pyproject.toml')) {
+                command += ` --conf "${configFile}"`;
+            }
+        }
+
+        const execution = new vscode.ShellExecution(command, {
             cwd: folder?.uri.fsPath,
         });
 

--- a/src/features/toxAnsible/ToxTaskProvider.ts
+++ b/src/features/toxAnsible/ToxTaskProvider.ts
@@ -6,7 +6,7 @@
  */
 
 import * as vscode from 'vscode';
-import { ToxAnsibleService } from '@ansible/developer-services';
+import { ToxAnsibleService, CommandService } from '@ansible/developer-services';
 import { log } from '@src/extension';
 
 const TASK_TYPE = 'ansible-tox';
@@ -15,12 +15,15 @@ const TASK_SOURCE = 'ansible-tox';
 /** VS Code Task Provider for tox-ansible environments. */
 export class ToxTaskProvider implements vscode.TaskProvider {
     private readonly _service: ToxAnsibleService;
+    private readonly _cmd: CommandService;
 
     /**
      * @param service - ToxAnsibleService instance for discovery
+     * @param cmd - CommandService instance for venv-aware path resolution
      */
-    constructor(service?: ToxAnsibleService) {
+    constructor(service?: ToxAnsibleService, cmd?: CommandService) {
         this._service = service ?? new ToxAnsibleService();
+        this._cmd = cmd ?? CommandService.getInstance();
     }
 
     /**
@@ -32,16 +35,16 @@ export class ToxTaskProvider implements vscode.TaskProvider {
         const folders = vscode.workspace.workspaceFolders;
         if (!folders?.length) return [];
 
+        const availability = await this._service.checkAvailability();
+        if (!availability.toxInstalled || !availability.toxAnsibleInstalled) return [];
+
         const tasks: vscode.Task[] = [];
 
         for (const folder of folders) {
-            const availability = await this._service.checkAvailability();
-            if (!availability.toxInstalled || !availability.toxAnsibleInstalled) continue;
-
             const envs = await this._service.listEnvironments(folder.uri.fsPath);
 
             for (const env of envs) {
-                const task = this._createTask(env.name, env.description, folder);
+                const task = await this._createTask(env.name, env.description, folder);
                 tasks.push(task);
             }
 
@@ -59,7 +62,7 @@ export class ToxTaskProvider implements vscode.TaskProvider {
      * @param task - Task to resolve with execution details
      * @returns Resolved task with ShellExecution, or undefined
      */
-    resolveTask(task: vscode.Task): vscode.Task | undefined {
+    async resolveTask(task: vscode.Task): Promise<vscode.Task | undefined> {
         const definition = task.definition as { type: string; environment?: string };
         if (definition.type !== TASK_TYPE || !definition.environment) {
             return undefined;
@@ -74,21 +77,23 @@ export class ToxTaskProvider implements vscode.TaskProvider {
 
     /**
      * Create a VS Code Task for a tox-ansible environment.
+     * Uses CommandService.getToolPath for venv-aware tox resolution.
      * @param envName - Tox environment name
      * @param description - Optional human-readable description
      * @param folder - Workspace folder for cwd
      * @returns Configured VS Code task
      */
-    private _createTask(
+    private async _createTask(
         envName: string,
         description: string | undefined,
         folder: vscode.WorkspaceFolder | undefined,
-    ): vscode.Task {
+    ): Promise<vscode.Task> {
         const definition: vscode.TaskDefinition = {
             type: TASK_TYPE,
             environment: envName,
         };
 
+        const toxPath = (await this._cmd.getToolPath('tox')) ?? 'tox';
         const args = ['-e', envName, '--ansible'];
         if (folder?.uri.fsPath) {
             const configFile = this._service.detectConfigFile(folder.uri.fsPath);
@@ -97,7 +102,7 @@ export class ToxTaskProvider implements vscode.TaskProvider {
             }
         }
 
-        const execution = new vscode.ShellExecution('tox', args, {
+        const execution = new vscode.ShellExecution(toxPath, args, {
             cwd: folder?.uri.fsPath,
         });
 

--- a/src/features/toxAnsible/ToxTestController.ts
+++ b/src/features/toxAnsible/ToxTestController.ts
@@ -8,7 +8,12 @@
 
 import * as vscode from 'vscode';
 import { ToxAnsibleService } from '@ansible/developer-services';
-import type { ToxEnvironment, ToxTestCategory, ToxRunResult } from '@ansible/developer-services';
+import type {
+    ToxEnvironment,
+    ToxTestCategory,
+    ToxRunResult,
+    ToxAvailability,
+} from '@ansible/developer-services';
 import { log } from '@src/extension';
 
 const CONTROLLER_ID = 'ansibleToxTests';
@@ -30,12 +35,18 @@ export class ToxTestController implements vscode.Disposable {
     private readonly _disposables: vscode.Disposable[] = [];
     private readonly _watchers: vscode.FileSystemWatcher[] = [];
     private _discovering = false;
+    private _pendingRediscover = false;
     private _discoverDebounce?: ReturnType<typeof setTimeout>;
+    private _discoverResolve?: () => void;
 
     /**
      * @param service - ToxAnsibleService instance for discovery and execution
+     * @param _telemetry - Optional telemetry callback for discovery/run events
      */
-    constructor(service?: ToxAnsibleService) {
+    constructor(
+        service?: ToxAnsibleService,
+        private readonly _telemetry?: (name: string, props?: Record<string, string>) => void,
+    ) {
         this._service = service ?? new ToxAnsibleService();
         this._controller = vscode.tests.createTestController(CONTROLLER_ID, CONTROLLER_LABEL);
 
@@ -56,54 +67,95 @@ export class ToxTestController implements vscode.Disposable {
 
     /**
      * Discover tox-ansible environments and populate the test tree.
-     * Debounces rapid calls (e.g., from file watchers) to ensure the
-     * latest state is always picked up.
+     * Debounces rapid calls (e.g., from file watchers). If discovery is
+     * already in progress, schedules a re-run after it completes so the
+     * final file-system state is always picked up.
      */
     async discoverTests(): Promise<void> {
         if (this._discoverDebounce) {
             clearTimeout(this._discoverDebounce);
+            this._discoverResolve?.();
         }
 
         return new Promise<void>((resolve) => {
+            this._discoverResolve = resolve;
             this._discoverDebounce = setTimeout(() => {
-                void this._doDiscoverTests().then(resolve);
+                this._discoverResolve = undefined;
+                void this._guardedDiscover().then(resolve);
             }, DISCOVER_DEBOUNCE_MS);
         });
     }
 
     /**
-     * Perform the actual discovery, guarded by _discovering lock.
+     * Guard discovery so trailing requests during an active run are
+     * re-executed once the current discovery finishes.
      */
-    private async _doDiscoverTests(): Promise<void> {
-        if (this._discovering) return;
+    private async _guardedDiscover(): Promise<void> {
+        if (this._discovering) {
+            this._pendingRediscover = true;
+            return;
+        }
         this._discovering = true;
-
         try {
-            const folders = vscode.workspace.workspaceFolders;
-            if (!folders?.length) return;
-
-            this._controller.items.replace([]);
-
-            for (const folder of folders) {
-                const workspaceDir = folder.uri.fsPath;
-                const availability = await this._service.checkAvailability();
-
-                if (!availability.toxInstalled || !availability.toxAnsibleInstalled) {
-                    log(`ToxTestController: tox-ansible not available in ${workspaceDir}`);
-                    continue;
-                }
-
-                const envs = await this._service.listEnvironments(workspaceDir);
-                if (envs.length === 0) continue;
-
-                this._buildTestTree(envs, folder);
-                log(
-                    `ToxTestController: loaded ${String(envs.length)} environments from ${folder.name}`,
-                );
+            this._pendingRediscover = false;
+            await this._doDiscoverTests();
+            // File-watcher callbacks may set _pendingRediscover during the await above
+            while (this._pendingRediscover as boolean) {
+                this._pendingRediscover = false;
+                await this._doDiscoverTests();
             }
         } finally {
             this._discovering = false;
         }
+    }
+
+    /**
+     * Perform the actual test discovery across workspace folders.
+     */
+    private async _doDiscoverTests(): Promise<void> {
+        const startedAt = Date.now();
+        const folders = vscode.workspace.workspaceFolders;
+        if (!folders?.length) return;
+
+        const availability = await this._service.checkAvailability();
+        if (!availability.toxInstalled || !availability.toxAnsibleInstalled) {
+            log('ToxTestController: tox-ansible not available');
+            this._controller.items.replace([]);
+            this._showEmptyState(availability);
+            return;
+        }
+
+        this._controller.items.replace([]);
+        let totalEnvs = 0;
+
+        for (const folder of folders) {
+            const envs = await this._service.listEnvironments(folder.uri.fsPath);
+            if (envs.length === 0) continue;
+
+            this._buildTestTree(envs, folder);
+            totalEnvs += envs.length;
+            log(
+                `ToxTestController: loaded ${String(envs.length)} environments from ${folder.name}`,
+            );
+        }
+
+        this._telemetry?.('tox.discover', {
+            result: 'success',
+            envCount: String(totalEnvs),
+            durationMs: String(Date.now() - startedAt),
+        });
+    }
+
+    /**
+     * Show an informational message when tox-ansible is not available.
+     * Satisfies TOX-001 empty state acceptance criterion.
+     * @param availability - Tox/tox-ansible availability check result
+     */
+    private _showEmptyState(availability: ToxAvailability): void {
+        const msg = !availability.toxInstalled
+            ? 'tox is not installed. Install ansible-dev-tools to enable tox-ansible testing.'
+            : 'tox-ansible plugin is not installed. Run: pip install tox-ansible';
+        void vscode.window.showInformationMessage(msg);
     }
 
     /**
@@ -213,6 +265,7 @@ export class ToxTestController implements vscode.Disposable {
         abortController: AbortController,
     ): Promise<void> {
         run.started(item);
+        const startedAt = Date.now();
 
         try {
             const result = await this._service.runEnvironment(
@@ -222,17 +275,29 @@ export class ToxTestController implements vscode.Disposable {
                 abortController.signal,
             );
 
-            if (abortController.signal.aborted) {
+            if (abortController.signal.aborted && !result.success) {
                 run.skipped(item);
+                this._telemetry?.('tox.run', { result: 'cancel', environment: envName });
                 return;
             }
 
             this._reportResult(run, item, result);
+            this._telemetry?.('tox.run', {
+                result: result.success ? 'success' : 'error',
+                environment: envName,
+                durationMs: String(Date.now() - startedAt),
+                ...(result.timedOut ? { timedOut: 'true' } : {}),
+            });
         } catch (err) {
             run.errored(
                 item,
                 new vscode.TestMessage(err instanceof Error ? err.message : 'Unknown error'),
             );
+            this._telemetry?.('tox.run', {
+                result: 'error',
+                environment: envName,
+                errorCode: 'unexpected_exception',
+            });
         }
     }
 
@@ -250,6 +315,12 @@ export class ToxTestController implements vscode.Disposable {
 
         if (result.success) {
             run.passed(item, result.durationMs);
+        } else if (result.timedOut) {
+            run.errored(
+                item,
+                new vscode.TestMessage(`Timed out after ${String(result.durationMs)}ms`),
+                result.durationMs,
+            );
         } else {
             run.failed(
                 item,
@@ -308,6 +379,8 @@ export class ToxTestController implements vscode.Disposable {
 
     /**
      * Resolve the workspace directory for a test item.
+     * Appends "/" to folder URIs to prevent prefix collisions
+     * (e.g., "file:///workspace" matching "file:///workspace2").
      * @param item - Test item whose workspace to find
      * @returns Workspace directory path, or undefined
      */
@@ -316,17 +389,19 @@ export class ToxTestController implements vscode.Disposable {
         if (!folders?.length) return undefined;
 
         for (const folder of folders) {
-            if (item.id.startsWith(folder.uri.toString())) {
+            const folderPrefix = folder.uri.toString() + '/';
+            if (item.id.startsWith(folderPrefix)) {
                 return folder.uri.fsPath;
             }
         }
 
-        return folders[0].uri.fsPath;
+        return undefined;
     }
 
     /** Release all watchers, timers, and the test controller. */
     dispose(): void {
         if (this._discoverDebounce) clearTimeout(this._discoverDebounce);
+        this._discoverResolve?.();
         for (const d of this._disposables) d.dispose();
         this._controller.dispose();
     }

--- a/src/features/toxAnsible/ToxTestController.ts
+++ b/src/features/toxAnsible/ToxTestController.ts
@@ -13,6 +13,8 @@ import { log } from '@src/extension';
 
 const CONTROLLER_ID = 'ansibleToxTests';
 const CONTROLLER_LABEL = 'Ansible Tox';
+const DISCOVER_DEBOUNCE_MS = 500;
+const CATEGORY_ID_PREFIX = 'category:';
 
 const CATEGORY_LABELS: Record<ToxTestCategory, string> = {
     integration: 'Integration',
@@ -21,15 +23,14 @@ const CATEGORY_LABELS: Record<ToxTestCategory, string> = {
     unknown: 'Other',
 };
 
-/**
- *
- */
+/** VS Code Test Controller for tox-ansible environments. */
 export class ToxTestController implements vscode.Disposable {
     private readonly _controller: vscode.TestController;
     private readonly _service: ToxAnsibleService;
     private readonly _disposables: vscode.Disposable[] = [];
     private readonly _watchers: vscode.FileSystemWatcher[] = [];
     private _discovering = false;
+    private _discoverDebounce?: ReturnType<typeof setTimeout>;
 
     /**
      * @param service - ToxAnsibleService instance for discovery and execution
@@ -55,9 +56,25 @@ export class ToxTestController implements vscode.Disposable {
 
     /**
      * Discover tox-ansible environments and populate the test tree.
-     * Clears all existing items before rebuilding to avoid stale/duplicate entries.
+     * Debounces rapid calls (e.g., from file watchers) to ensure the
+     * latest state is always picked up.
      */
     async discoverTests(): Promise<void> {
+        if (this._discoverDebounce) {
+            clearTimeout(this._discoverDebounce);
+        }
+
+        return new Promise<void>((resolve) => {
+            this._discoverDebounce = setTimeout(() => {
+                void this._doDiscoverTests().then(resolve);
+            }, DISCOVER_DEBOUNCE_MS);
+        });
+    }
+
+    /**
+     * Perform the actual discovery, guarded by _discovering lock.
+     */
+    private async _doDiscoverTests(): Promise<void> {
         if (this._discovering) return;
         this._discovering = true;
 
@@ -91,6 +108,7 @@ export class ToxTestController implements vscode.Disposable {
 
     /**
      * Build the TestItem hierarchy grouped by category.
+     * Category IDs use a "category:" prefix to avoid collision with env names.
      * @param envs - Discovered environments to organize
      * @param folder - Workspace folder these belong to
      */
@@ -103,7 +121,7 @@ export class ToxTestController implements vscode.Disposable {
         for (const env of envs) {
             let categoryItem = categories.get(env.category);
             if (!categoryItem) {
-                const catId = `${folder.uri.toString()}/${env.category}`;
+                const catId = `${folder.uri.toString()}/${CATEGORY_ID_PREFIX}${env.category}`;
                 categoryItem = this._controller.createTestItem(
                     catId,
                     `${prefix}${CATEGORY_LABELS[env.category]}`,
@@ -122,9 +140,7 @@ export class ToxTestController implements vscode.Disposable {
         }
     }
 
-    /**
-     *
-     */
+    /** Watch tox config files and trigger re-discovery on changes. */
     private _setupFileWatchers(): void {
         const patterns = ['**/tox-ansible.ini', '**/tox.ini', '**/pyproject.toml'];
         for (const pattern of patterns) {
@@ -171,11 +187,16 @@ export class ToxTestController implements vscode.Disposable {
 
             const result = await this._service.runEnvironment(envName, workspaceDir);
 
+            const output = [result.stdout, result.stderr].filter(Boolean).join('\n');
+            if (output) {
+                run.appendOutput(output.replace(/\r?\n/g, '\r\n') + '\r\n', undefined, item);
+            }
+
             if (result.success) {
                 run.passed(item, result.durationMs);
             } else {
                 const message = new vscode.TestMessage(
-                    result.stderr || result.stdout || `Exit code: ${String(result.exitCode)}`,
+                    output || `Exit code: ${String(result.exitCode)}`,
                 );
                 run.failed(item, message, result.durationMs);
             }
@@ -185,25 +206,32 @@ export class ToxTestController implements vscode.Disposable {
     }
 
     /**
-     * Collect leaf test items from a run request.
+     * Collect leaf test items from a run request, respecting exclude list.
      * If specific tests are selected, expand category nodes to individual envs.
      * @param request - VS Code test run request
      * @returns Flat list of leaf test items to execute
      */
     private _collectTestItems(request: vscode.TestRunRequest): vscode.TestItem[] {
         const items: vscode.TestItem[] = [];
+        const excludeSet = new Set(request.exclude ?? []);
 
         if (request.include) {
             for (const item of request.include) {
+                if (excludeSet.has(item)) continue;
                 if (item.children.size > 0) {
-                    item.children.forEach((child) => items.push(child));
+                    item.children.forEach((child) => {
+                        if (!excludeSet.has(child)) items.push(child);
+                    });
                 } else {
                     items.push(item);
                 }
             }
         } else {
             this._controller.items.forEach((category) => {
-                category.children.forEach((child) => items.push(child));
+                if (excludeSet.has(category)) return;
+                category.children.forEach((child) => {
+                    if (!excludeSet.has(child)) items.push(child);
+                });
             });
         }
 
@@ -212,13 +240,14 @@ export class ToxTestController implements vscode.Disposable {
 
     /**
      * Extract the tox environment name from a test item ID.
+     * Category nodes use the "category:" prefix and are skipped.
      * @param item - Test item to extract from
      * @returns Environment name or undefined for category nodes
      */
     private _extractEnvName(item: vscode.TestItem): string | undefined {
         const parts = item.id.split('/');
         const lastPart = parts[parts.length - 1];
-        if (Object.keys(CATEGORY_LABELS).includes(lastPart)) {
+        if (lastPart.startsWith(CATEGORY_ID_PREFIX)) {
             return undefined;
         }
         return lastPart;
@@ -242,10 +271,9 @@ export class ToxTestController implements vscode.Disposable {
         return folders[0].uri.fsPath;
     }
 
-    /**
-     *
-     */
+    /** Release all watchers, timers, and the test controller. */
     dispose(): void {
+        if (this._discoverDebounce) clearTimeout(this._discoverDebounce);
         for (const d of this._disposables) d.dispose();
         this._controller.dispose();
     }

--- a/src/features/toxAnsible/ToxTestController.ts
+++ b/src/features/toxAnsible/ToxTestController.ts
@@ -8,7 +8,7 @@
 
 import * as vscode from 'vscode';
 import { ToxAnsibleService } from '@ansible/developer-services';
-import type { ToxEnvironment, ToxTestCategory } from '@ansible/developer-services';
+import type { ToxEnvironment, ToxTestCategory, ToxRunResult } from '@ansible/developer-services';
 import { log } from '@src/extension';
 
 const CONTROLLER_ID = 'ansibleToxTests';
@@ -189,39 +189,74 @@ export class ToxTestController implements vscode.Disposable {
                     continue;
                 }
 
-                run.started(item);
-
-                const result = await this._service.runEnvironment(
-                    envName,
-                    workspaceDir,
-                    undefined,
-                    abortController.signal,
-                );
-
-                if (abortController.signal.aborted) {
-                    run.skipped(item);
-                    continue;
-                }
-
-                const output = [result.stdout, result.stderr].filter(Boolean).join('\n');
-                if (output) {
-                    run.appendOutput(output.replace(/\r?\n/g, '\r\n') + '\r\n', undefined, item);
-                }
-
-                if (result.success) {
-                    run.passed(item, result.durationMs);
-                } else {
-                    const message = new vscode.TestMessage(
-                        output || `Exit code: ${String(result.exitCode)}`,
-                    );
-                    run.failed(item, message, result.durationMs);
-                }
+                await this._executeItem(run, item, envName, workspaceDir, abortController);
             }
         } finally {
             cancelSub.dispose();
+            run.end();
+        }
+    }
+
+    /**
+     * Execute a single test item and report the result.
+     * @param run - Active test run to report into
+     * @param item - Test item being executed
+     * @param envName - Tox environment name to run
+     * @param workspaceDir - Workspace root path
+     * @param abortController - Controller whose signal cancels the tox process
+     */
+    private async _executeItem(
+        run: vscode.TestRun,
+        item: vscode.TestItem,
+        envName: string,
+        workspaceDir: string,
+        abortController: AbortController,
+    ): Promise<void> {
+        run.started(item);
+
+        try {
+            const result = await this._service.runEnvironment(
+                envName,
+                workspaceDir,
+                undefined,
+                abortController.signal,
+            );
+
+            if (abortController.signal.aborted) {
+                run.skipped(item);
+                return;
+            }
+
+            this._reportResult(run, item, result);
+        } catch (err) {
+            run.errored(
+                item,
+                new vscode.TestMessage(err instanceof Error ? err.message : 'Unknown error'),
+            );
+        }
+    }
+
+    /**
+     * Report a ToxRunResult to the test run, appending output and setting verdict.
+     * @param run - Active test run to report into
+     * @param item - Test item the result belongs to
+     * @param result - Run result from ToxAnsibleService
+     */
+    private _reportResult(run: vscode.TestRun, item: vscode.TestItem, result: ToxRunResult): void {
+        const output = [result.stdout, result.stderr].filter(Boolean).join('\n');
+        if (output) {
+            run.appendOutput(output.replace(/\r?\n/g, '\r\n') + '\r\n', undefined, item);
         }
 
-        run.end();
+        if (result.success) {
+            run.passed(item, result.durationMs);
+        } else {
+            run.failed(
+                item,
+                new vscode.TestMessage(output || `Exit code: ${String(result.exitCode)}`),
+                result.durationMs,
+            );
+        }
     }
 
     /**
@@ -264,9 +299,8 @@ export class ToxTestController implements vscode.Disposable {
      * @returns Environment name or undefined for category nodes
      */
     private _extractEnvName(item: vscode.TestItem): string | undefined {
-        const parts = item.id.split('/');
-        const lastPart = parts[parts.length - 1];
-        if (lastPart.startsWith(CATEGORY_ID_PREFIX)) {
+        const lastPart = item.id.split('/').at(-1);
+        if (!lastPart || lastPart.startsWith(CATEGORY_ID_PREFIX)) {
             return undefined;
         }
         return lastPart;

--- a/src/features/toxAnsible/ToxTestController.ts
+++ b/src/features/toxAnsible/ToxTestController.ts
@@ -1,0 +1,252 @@
+/**
+ * ToxTestController — VS Code Test Controller for tox-ansible environments.
+ *
+ * Provides test discovery and execution through the Test Explorer sidebar.
+ * Groups environments by category (integration, sanity, unit) and maps
+ * tox exit codes to pass/fail verdicts via ToxAnsibleService.
+ */
+
+import * as vscode from 'vscode';
+import { ToxAnsibleService } from '@ansible/developer-services';
+import type { ToxEnvironment, ToxTestCategory } from '@ansible/developer-services';
+import { log } from '@src/extension';
+
+const CONTROLLER_ID = 'ansibleToxTests';
+const CONTROLLER_LABEL = 'Ansible Tox';
+
+const CATEGORY_LABELS: Record<ToxTestCategory, string> = {
+    integration: 'Integration',
+    sanity: 'Sanity',
+    unit: 'Unit',
+    unknown: 'Other',
+};
+
+/**
+ *
+ */
+export class ToxTestController implements vscode.Disposable {
+    private readonly _controller: vscode.TestController;
+    private readonly _service: ToxAnsibleService;
+    private readonly _disposables: vscode.Disposable[] = [];
+    private readonly _watchers: vscode.FileSystemWatcher[] = [];
+    private _discovering = false;
+
+    /**
+     * @param service - ToxAnsibleService instance for discovery and execution
+     */
+    constructor(service?: ToxAnsibleService) {
+        this._service = service ?? new ToxAnsibleService();
+        this._controller = vscode.tests.createTestController(CONTROLLER_ID, CONTROLLER_LABEL);
+
+        this._controller.refreshHandler = () => {
+            void this.discoverTests();
+        };
+
+        this._controller.createRunProfile(
+            'Run',
+            vscode.TestRunProfileKind.Run,
+            (request, token) => this._runTests(request, token),
+            true,
+        );
+
+        this._setupFileWatchers();
+        void this.discoverTests();
+    }
+
+    /**
+     * Discover tox-ansible environments and populate the test tree.
+     * Clears all existing items before rebuilding to avoid stale/duplicate entries.
+     */
+    async discoverTests(): Promise<void> {
+        if (this._discovering) return;
+        this._discovering = true;
+
+        try {
+            const folders = vscode.workspace.workspaceFolders;
+            if (!folders?.length) return;
+
+            this._controller.items.replace([]);
+
+            for (const folder of folders) {
+                const workspaceDir = folder.uri.fsPath;
+                const availability = await this._service.checkAvailability();
+
+                if (!availability.toxInstalled || !availability.toxAnsibleInstalled) {
+                    log(`ToxTestController: tox-ansible not available in ${workspaceDir}`);
+                    continue;
+                }
+
+                const envs = await this._service.listEnvironments(workspaceDir);
+                if (envs.length === 0) continue;
+
+                this._buildTestTree(envs, folder);
+                log(
+                    `ToxTestController: loaded ${String(envs.length)} environments from ${folder.name}`,
+                );
+            }
+        } finally {
+            this._discovering = false;
+        }
+    }
+
+    /**
+     * Build the TestItem hierarchy grouped by category.
+     * @param envs - Discovered environments to organize
+     * @param folder - Workspace folder these belong to
+     */
+    private _buildTestTree(envs: ToxEnvironment[], folder: vscode.WorkspaceFolder): void {
+        const categories = new Map<ToxTestCategory, vscode.TestItem>();
+
+        const multiRoot = (vscode.workspace.workspaceFolders?.length ?? 0) > 1;
+        const prefix = multiRoot ? `${folder.name}: ` : '';
+
+        for (const env of envs) {
+            let categoryItem = categories.get(env.category);
+            if (!categoryItem) {
+                const catId = `${folder.uri.toString()}/${env.category}`;
+                categoryItem = this._controller.createTestItem(
+                    catId,
+                    `${prefix}${CATEGORY_LABELS[env.category]}`,
+                );
+                categoryItem.canResolveChildren = false;
+                categories.set(env.category, categoryItem);
+                this._controller.items.add(categoryItem);
+            }
+
+            const envItem = this._controller.createTestItem(
+                `${folder.uri.toString()}/${env.name}`,
+                env.name,
+            );
+            envItem.description = env.description;
+            categoryItem.children.add(envItem);
+        }
+    }
+
+    /**
+     *
+     */
+    private _setupFileWatchers(): void {
+        const patterns = ['**/tox-ansible.ini', '**/tox.ini', '**/pyproject.toml'];
+        for (const pattern of patterns) {
+            const watcher = vscode.workspace.createFileSystemWatcher(pattern);
+            watcher.onDidChange(() => void this.discoverTests());
+            watcher.onDidCreate(() => void this.discoverTests());
+            watcher.onDidDelete(() => void this.discoverTests());
+            this._watchers.push(watcher);
+            this._disposables.push(watcher);
+        }
+    }
+
+    /**
+     * Execute selected tests or all tests if no specific selection.
+     * @param request - VS Code test run request with included items
+     * @param token - Cancellation token for aborting the run
+     */
+    private async _runTests(
+        request: vscode.TestRunRequest,
+        token: vscode.CancellationToken,
+    ): Promise<void> {
+        const run = this._controller.createTestRun(request);
+        const items = this._collectTestItems(request);
+
+        for (const item of items) {
+            if (token.isCancellationRequested) {
+                run.skipped(item);
+                continue;
+            }
+
+            const envName = this._extractEnvName(item);
+            if (!envName) {
+                run.skipped(item);
+                continue;
+            }
+
+            const workspaceDir = this._resolveWorkspaceDir(item);
+            if (!workspaceDir) {
+                run.errored(item, new vscode.TestMessage('No workspace folder found'));
+                continue;
+            }
+
+            run.started(item);
+
+            const result = await this._service.runEnvironment(envName, workspaceDir);
+
+            if (result.success) {
+                run.passed(item, result.durationMs);
+            } else {
+                const message = new vscode.TestMessage(
+                    result.stderr || result.stdout || `Exit code: ${String(result.exitCode)}`,
+                );
+                run.failed(item, message, result.durationMs);
+            }
+        }
+
+        run.end();
+    }
+
+    /**
+     * Collect leaf test items from a run request.
+     * If specific tests are selected, expand category nodes to individual envs.
+     * @param request - VS Code test run request
+     * @returns Flat list of leaf test items to execute
+     */
+    private _collectTestItems(request: vscode.TestRunRequest): vscode.TestItem[] {
+        const items: vscode.TestItem[] = [];
+
+        if (request.include) {
+            for (const item of request.include) {
+                if (item.children.size > 0) {
+                    item.children.forEach((child) => items.push(child));
+                } else {
+                    items.push(item);
+                }
+            }
+        } else {
+            this._controller.items.forEach((category) => {
+                category.children.forEach((child) => items.push(child));
+            });
+        }
+
+        return items;
+    }
+
+    /**
+     * Extract the tox environment name from a test item ID.
+     * @param item - Test item to extract from
+     * @returns Environment name or undefined for category nodes
+     */
+    private _extractEnvName(item: vscode.TestItem): string | undefined {
+        const parts = item.id.split('/');
+        const lastPart = parts[parts.length - 1];
+        if (Object.keys(CATEGORY_LABELS).includes(lastPart)) {
+            return undefined;
+        }
+        return lastPart;
+    }
+
+    /**
+     * Resolve the workspace directory for a test item.
+     * @param item - Test item whose workspace to find
+     * @returns Workspace directory path, or undefined
+     */
+    private _resolveWorkspaceDir(item: vscode.TestItem): string | undefined {
+        const folders = vscode.workspace.workspaceFolders;
+        if (!folders?.length) return undefined;
+
+        for (const folder of folders) {
+            if (item.id.startsWith(folder.uri.toString())) {
+                return folder.uri.fsPath;
+            }
+        }
+
+        return folders[0].uri.fsPath;
+    }
+
+    /**
+     *
+     */
+    dispose(): void {
+        for (const d of this._disposables) d.dispose();
+        this._controller.dispose();
+    }
+}

--- a/src/features/toxAnsible/ToxTestController.ts
+++ b/src/features/toxAnsible/ToxTestController.ts
@@ -165,41 +165,60 @@ export class ToxTestController implements vscode.Disposable {
         const run = this._controller.createTestRun(request);
         const items = this._collectTestItems(request);
 
-        for (const item of items) {
-            if (token.isCancellationRequested) {
-                run.skipped(item);
-                continue;
-            }
+        const abortController = new AbortController();
+        const cancelSub = token.onCancellationRequested(() => {
+            abortController.abort();
+        });
 
-            const envName = this._extractEnvName(item);
-            if (!envName) {
-                run.skipped(item);
-                continue;
-            }
+        try {
+            for (const item of items) {
+                if (token.isCancellationRequested) {
+                    run.skipped(item);
+                    continue;
+                }
 
-            const workspaceDir = this._resolveWorkspaceDir(item);
-            if (!workspaceDir) {
-                run.errored(item, new vscode.TestMessage('No workspace folder found'));
-                continue;
-            }
+                const envName = this._extractEnvName(item);
+                if (!envName) {
+                    run.skipped(item);
+                    continue;
+                }
 
-            run.started(item);
+                const workspaceDir = this._resolveWorkspaceDir(item);
+                if (!workspaceDir) {
+                    run.errored(item, new vscode.TestMessage('No workspace folder found'));
+                    continue;
+                }
 
-            const result = await this._service.runEnvironment(envName, workspaceDir);
+                run.started(item);
 
-            const output = [result.stdout, result.stderr].filter(Boolean).join('\n');
-            if (output) {
-                run.appendOutput(output.replace(/\r?\n/g, '\r\n') + '\r\n', undefined, item);
-            }
-
-            if (result.success) {
-                run.passed(item, result.durationMs);
-            } else {
-                const message = new vscode.TestMessage(
-                    output || `Exit code: ${String(result.exitCode)}`,
+                const result = await this._service.runEnvironment(
+                    envName,
+                    workspaceDir,
+                    undefined,
+                    abortController.signal,
                 );
-                run.failed(item, message, result.durationMs);
+
+                if (abortController.signal.aborted) {
+                    run.skipped(item);
+                    continue;
+                }
+
+                const output = [result.stdout, result.stderr].filter(Boolean).join('\n');
+                if (output) {
+                    run.appendOutput(output.replace(/\r?\n/g, '\r\n') + '\r\n', undefined, item);
+                }
+
+                if (result.success) {
+                    run.passed(item, result.durationMs);
+                } else {
+                    const message = new vscode.TestMessage(
+                        output || `Exit code: ${String(result.exitCode)}`,
+                    );
+                    run.failed(item, message, result.durationMs);
+                }
             }
+        } finally {
+            cancelSub.dispose();
         }
 
         run.end();

--- a/src/features/toxAnsible/register.ts
+++ b/src/features/toxAnsible/register.ts
@@ -8,15 +8,24 @@
 import * as vscode from 'vscode';
 import { ToxTestController } from '@src/features/toxAnsible/ToxTestController';
 import { ToxTaskProvider } from '@src/features/toxAnsible/ToxTaskProvider';
+import type { TelemetryService } from '@src/services/TelemetryService';
 
 const TASK_TYPE = 'ansible-tox';
 
 /**
  * Register the tox-ansible Test Controller and Task Provider.
  * @param context - Extension context for managing disposable subscriptions
+ * @param telemetry - TelemetryService for emitting TOX_DISCOVER/TOX_RUN events
  */
-export function registerToxAnsible(context: vscode.ExtensionContext): void {
-    const controller = new ToxTestController();
+export function registerToxAnsible(
+    context: vscode.ExtensionContext,
+    telemetry: TelemetryService,
+): void {
+    const emitter = (name: string, props?: Record<string, string>) => {
+        telemetry.sendEvent(name as Parameters<typeof telemetry.sendEvent>[0], props);
+    };
+
+    const controller = new ToxTestController(undefined, emitter);
     context.subscriptions.push(controller);
 
     const taskProvider = vscode.tasks.registerTaskProvider(TASK_TYPE, new ToxTaskProvider());

--- a/src/features/toxAnsible/register.ts
+++ b/src/features/toxAnsible/register.ts
@@ -1,0 +1,24 @@
+/**
+ * Register tox-ansible features — Test Controller and Task Provider.
+ *
+ * Follows the feature registration pattern used by other features
+ * (extensionConflicts, vault, fileAssociation).
+ */
+
+import * as vscode from 'vscode';
+import { ToxTestController } from '@src/features/toxAnsible/ToxTestController';
+import { ToxTaskProvider } from '@src/features/toxAnsible/ToxTaskProvider';
+
+const TASK_TYPE = 'ansible-tox';
+
+/**
+ * Register the tox-ansible Test Controller and Task Provider.
+ * @param context - Extension context for managing disposable subscriptions
+ */
+export function registerToxAnsible(context: vscode.ExtensionContext): void {
+    const controller = new ToxTestController();
+    context.subscriptions.push(controller);
+
+    const taskProvider = vscode.tasks.registerTaskProvider(TASK_TYPE, new ToxTaskProvider());
+    context.subscriptions.push(taskProvider);
+}

--- a/test/ui/toxAnsible.spec.ts
+++ b/test/ui/toxAnsible.spec.ts
@@ -1,0 +1,33 @@
+import { browser } from '@wdio/globals';
+
+/**
+ * @covers TOX-001
+ */
+describe('Tox-Ansible test discovery', () => {
+    it('should register the ansible-tox task type', async () => {
+        const hasTaskType: boolean = await browser.executeWorkbench((vscode) => {
+            const ext = vscode.extensions.getExtension('redhat.ansible');
+            if (!ext) return false;
+            const pkg = ext.packageJSON as {
+                contributes?: {
+                    taskDefinitions?: { type: string }[];
+                };
+            };
+            return (pkg.contributes?.taskDefinitions ?? []).some((td) => td.type === 'ansible-tox');
+        });
+        expect(hasTaskType).toBe(true);
+    });
+});
+
+/**
+ * @covers TOX-002
+ */
+describe('Tox-Ansible test execution', () => {
+    it('should have a test controller registered', async () => {
+        const hasController: boolean = await browser.executeWorkbench((vscode) => {
+            const ext = vscode.extensions.getExtension('redhat.ansible');
+            return ext?.isActive === true;
+        });
+        expect(hasController).toBe(true);
+    });
+});

--- a/test/unit/features/toxAnsible.test.ts
+++ b/test/unit/features/toxAnsible.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type * as vscode from 'vscode';
 
 const mocks = vi.hoisted(() => {
     const createTestController = vi.fn();
@@ -112,6 +113,7 @@ vi.mock('@ansible/developer-services', () => ({
             stderr: '',
             durationMs: 5000,
         }),
+        detectConfigFile: vi.fn().mockReturnValue(undefined),
     })),
 }));
 
@@ -119,9 +121,9 @@ vi.mock('@src/extension', () => ({
     log: vi.fn(),
 }));
 
-import { ToxTestController } from '@src/features/toxAnsible/ToxTestController';
-import { ToxTaskProvider } from '@src/features/toxAnsible/ToxTaskProvider';
-import { registerToxAnsible } from '@src/features/toxAnsible/register';
+import { ToxTestController } from '../../../src/features/toxAnsible/ToxTestController';
+import { ToxTaskProvider } from '../../../src/features/toxAnsible/ToxTaskProvider';
+import { registerToxAnsible } from '../../../src/features/toxAnsible/register';
 
 beforeEach(() => {
     vi.clearAllMocks();
@@ -191,8 +193,34 @@ describe('ToxTaskProvider', () => {
         const provider = new ToxTaskProvider();
         const result = provider.resolveTask({
             definition: { type: 'not-tox', environment: 'foo' },
-        });
+            scope: 1,
+        } as unknown as vscode.Task);
         expect(result).toBeUndefined();
+    });
+
+    it('resolves a task when scope is an enum value', () => {
+        const provider = new ToxTaskProvider();
+        const result = provider.resolveTask({
+            definition: { type: 'ansible-tox', environment: 'unit-py3.12-devel' },
+            scope: 1,
+        } as unknown as vscode.Task);
+        expect(result).toBeDefined();
+        expect((result as unknown as { name: string }).name).toBe('unit-py3.12-devel');
+    });
+
+    it('resolves a task when scope is a WorkspaceFolder', () => {
+        const provider = new ToxTaskProvider();
+        const folder = {
+            uri: { fsPath: '/workspace', toString: () => 'file:///workspace' },
+            name: 'workspace',
+            index: 0,
+        };
+        const result = provider.resolveTask({
+            definition: { type: 'ansible-tox', environment: 'unit-py3.12-devel' },
+            scope: folder,
+        } as unknown as vscode.Task);
+        expect(result).toBeDefined();
+        expect((result as unknown as { name: string }).name).toBe('unit-py3.12-devel');
     });
 });
 
@@ -201,7 +229,7 @@ describe('registerToxAnsible', () => {
         const context = {
             subscriptions: { push: vi.fn() },
         };
-        registerToxAnsible(context);
+        registerToxAnsible(context as unknown as vscode.ExtensionContext);
         expect(context.subscriptions.push).toHaveBeenCalledTimes(2);
     });
 });

--- a/test/unit/features/toxAnsible.test.ts
+++ b/test/unit/features/toxAnsible.test.ts
@@ -119,6 +119,16 @@ vi.mock('@ansible/developer-services', () => ({
         }),
         detectConfigFile: vi.fn().mockReturnValue(undefined),
     })),
+    CommandService: Object.assign(
+        vi.fn().mockImplementation(() => ({
+            getToolPath: vi.fn().mockResolvedValue('/usr/bin/tox'),
+        })),
+        {
+            getInstance: vi.fn().mockReturnValue({
+                getToolPath: vi.fn().mockResolvedValue('/usr/bin/tox'),
+            }),
+        },
+    ),
 }));
 
 vi.mock('@src/extension', () => ({
@@ -193,18 +203,18 @@ describe('ToxTaskProvider', () => {
         expect(tasks[0].group).toEqual({ id: 'test' });
     });
 
-    it('returns undefined for non-matching task type on resolve', () => {
+    it('returns undefined for non-matching task type on resolve', async () => {
         const provider = new ToxTaskProvider();
-        const result = provider.resolveTask({
+        const result = await provider.resolveTask({
             definition: { type: 'not-tox', environment: 'foo' },
             scope: 1,
         } as unknown as vscode.Task);
         expect(result).toBeUndefined();
     });
 
-    it('resolves a task when scope is an enum value', () => {
+    it('resolves a task when scope is an enum value', async () => {
         const provider = new ToxTaskProvider();
-        const result = provider.resolveTask({
+        const result = await provider.resolveTask({
             definition: { type: 'ansible-tox', environment: 'unit-py3.12-devel' },
             scope: 1,
         } as unknown as vscode.Task);
@@ -212,14 +222,14 @@ describe('ToxTaskProvider', () => {
         expect((result as unknown as { name: string }).name).toBe('unit-py3.12-devel');
     });
 
-    it('resolves a task when scope is a WorkspaceFolder', () => {
+    it('resolves a task when scope is a WorkspaceFolder', async () => {
         const provider = new ToxTaskProvider();
         const folder = {
             uri: { fsPath: '/workspace', toString: () => 'file:///workspace' },
             name: 'workspace',
             index: 0,
         };
-        const result = provider.resolveTask({
+        const result = await provider.resolveTask({
             definition: { type: 'ansible-tox', environment: 'unit-py3.12-devel' },
             scope: folder,
         } as unknown as vscode.Task);
@@ -228,12 +238,17 @@ describe('ToxTaskProvider', () => {
     });
 });
 
+vi.mock('@src/services/TelemetryService', () => ({
+    TelemetryService: vi.fn(),
+}));
+
 describe('registerToxAnsible', () => {
     it('registers controller and task provider', () => {
         const context = {
             subscriptions: { push: vi.fn() },
         };
-        registerToxAnsible(context as unknown as vscode.ExtensionContext);
+        const telemetry = { sendEvent: vi.fn() };
+        registerToxAnsible(context as unknown as vscode.ExtensionContext, telemetry as never);
         expect(context.subscriptions.push).toHaveBeenCalledTimes(2);
     });
 });

--- a/test/unit/features/toxAnsible.test.ts
+++ b/test/unit/features/toxAnsible.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+    const createTestController = vi.fn();
+    const createRunProfile = vi.fn();
+    const createTestRun = vi.fn();
+    const createTestItem = vi.fn();
+    const createFileSystemWatcher = vi.fn();
+    const registerTaskProvider = vi.fn();
+
+    const testItems = {
+        replace: vi.fn(),
+        add: vi.fn(),
+        forEach: vi.fn(),
+    };
+
+    const controller = {
+        createTestItem,
+        createRunProfile,
+        createTestRun,
+        items: testItems,
+        refreshHandler: null as (() => void) | null,
+        dispose: vi.fn(),
+    };
+
+    const watcher = {
+        onDidChange: vi.fn(() => ({ dispose: vi.fn() })),
+        onDidCreate: vi.fn(() => ({ dispose: vi.fn() })),
+        onDidDelete: vi.fn(() => ({ dispose: vi.fn() })),
+        dispose: vi.fn(),
+    };
+
+    return {
+        createTestController,
+        createRunProfile,
+        createTestRun,
+        createTestItem,
+        createFileSystemWatcher,
+        registerTaskProvider,
+        testItems,
+        controller,
+        watcher,
+    };
+});
+
+vi.mock('vscode', () => ({
+    tests: {
+        createTestController: (...args: unknown[]) => {
+            mocks.createTestController(...args);
+            return mocks.controller;
+        },
+    },
+    workspace: {
+        workspaceFolders: [
+            {
+                uri: { fsPath: '/workspace', toString: () => 'file:///workspace' },
+                name: 'workspace',
+            },
+        ],
+        createFileSystemWatcher: (...args: unknown[]) => {
+            mocks.createFileSystemWatcher(...args);
+            return mocks.watcher;
+        },
+    },
+    tasks: {
+        registerTaskProvider: mocks.registerTaskProvider,
+    },
+    TestRunProfileKind: { Run: 1 },
+    TestMessage: vi.fn((msg: string) => ({ message: msg })),
+    TaskGroup: { Test: { id: 'test' } },
+    TaskRevealKind: { Always: 1 },
+    TaskScope: { Workspace: 1 },
+    ShellExecution: vi.fn((cmd: string, opts?: unknown) => ({ commandLine: cmd, options: opts })),
+    Task: vi.fn((def: unknown, scope: unknown, name: string, source: string, exec: unknown) => ({
+        definition: def,
+        scope,
+        name,
+        source,
+        execution: exec,
+        detail: undefined as string | undefined,
+        group: undefined,
+        presentationOptions: undefined,
+    })),
+}));
+
+vi.mock('@ansible/developer-services', () => ({
+    ToxAnsibleService: vi.fn().mockImplementation(() => ({
+        checkAvailability: vi.fn().mockResolvedValue({
+            toxInstalled: true,
+            toxAnsibleInstalled: true,
+            toxVersion: '4.0.0',
+        }),
+        listEnvironments: vi.fn().mockResolvedValue([
+            {
+                name: 'unit-py3.12-devel',
+                category: 'unit',
+                pythonVersion: '3.12',
+                ansibleVersion: 'devel',
+            },
+            {
+                name: 'sanity-py3.12-devel',
+                category: 'sanity',
+                pythonVersion: '3.12',
+                ansibleVersion: 'devel',
+            },
+        ]),
+        runEnvironment: vi.fn().mockResolvedValue({
+            environment: 'unit-py3.12-devel',
+            success: true,
+            exitCode: 0,
+            stdout: 'OK',
+            stderr: '',
+            durationMs: 5000,
+        }),
+    })),
+}));
+
+vi.mock('@src/extension', () => ({
+    log: vi.fn(),
+}));
+
+import { ToxTestController } from '@src/features/toxAnsible/ToxTestController';
+import { ToxTaskProvider } from '@src/features/toxAnsible/ToxTaskProvider';
+import { registerToxAnsible } from '@src/features/toxAnsible/register';
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.createTestItem.mockImplementation((id: string, label: string) => ({
+        id,
+        label,
+        children: {
+            add: vi.fn(),
+            forEach: vi.fn(),
+            size: 0,
+        },
+        canResolveChildren: false,
+        description: undefined,
+    }));
+});
+
+describe('ToxTestController', () => {
+    it('creates a test controller with correct ID and label', () => {
+        const controller = new ToxTestController();
+        expect(mocks.createTestController).toHaveBeenCalledWith('ansibleToxTests', 'Ansible Tox');
+        controller.dispose();
+    });
+
+    it('creates a run profile for execution', () => {
+        const controller = new ToxTestController();
+        expect(mocks.createRunProfile).toHaveBeenCalledWith('Run', 1, expect.any(Function), true);
+        controller.dispose();
+    });
+
+    it('sets up file watchers for tox config files', () => {
+        const controller = new ToxTestController();
+        expect(mocks.createFileSystemWatcher).toHaveBeenCalledWith('**/tox-ansible.ini');
+        expect(mocks.createFileSystemWatcher).toHaveBeenCalledWith('**/tox.ini');
+        expect(mocks.createFileSystemWatcher).toHaveBeenCalledWith('**/pyproject.toml');
+        controller.dispose();
+    });
+
+    it('sets a refreshHandler on the controller', () => {
+        const controller = new ToxTestController();
+        expect(mocks.controller.refreshHandler).not.toBeNull();
+        controller.dispose();
+    });
+
+    it('disposes all resources', () => {
+        const controller = new ToxTestController();
+        controller.dispose();
+        expect(mocks.controller.dispose).toHaveBeenCalled();
+    });
+});
+
+describe('ToxTaskProvider', () => {
+    it('provides tasks for discovered environments', async () => {
+        const provider = new ToxTaskProvider();
+        const tasks = await provider.provideTasks();
+        expect(tasks).toHaveLength(2);
+        expect(tasks[0].name).toBe('unit-py3.12-devel');
+        expect(tasks[1].name).toBe('sanity-py3.12-devel');
+    });
+
+    it('sets task group to Test', async () => {
+        const provider = new ToxTaskProvider();
+        const tasks = await provider.provideTasks();
+        expect(tasks[0].group).toEqual({ id: 'test' });
+    });
+
+    it('returns undefined for non-matching task type on resolve', () => {
+        const provider = new ToxTaskProvider();
+        const result = provider.resolveTask({
+            definition: { type: 'not-tox', environment: 'foo' },
+        });
+        expect(result).toBeUndefined();
+    });
+});
+
+describe('registerToxAnsible', () => {
+    it('registers controller and task provider', () => {
+        const context = {
+            subscriptions: { push: vi.fn() },
+        };
+        registerToxAnsible(context);
+        expect(context.subscriptions.push).toHaveBeenCalledTimes(2);
+    });
+});

--- a/test/unit/features/toxAnsible.test.ts
+++ b/test/unit/features/toxAnsible.test.ts
@@ -71,7 +71,11 @@ vi.mock('vscode', () => ({
     TaskGroup: { Test: { id: 'test' } },
     TaskRevealKind: { Always: 1 },
     TaskScope: { Workspace: 1 },
-    ShellExecution: vi.fn((cmd: string, opts?: unknown) => ({ commandLine: cmd, options: opts })),
+    ShellExecution: vi.fn((cmd: string, argsOrOpts?: unknown, opts?: unknown) =>
+        Array.isArray(argsOrOpts)
+            ? { command: cmd, args: argsOrOpts, options: opts }
+            : { commandLine: cmd, options: argsOrOpts },
+    ),
     Task: vi.fn((def: unknown, scope: unknown, name: string, source: string, exec: unknown) => ({
         definition: def,
         scope,


### PR DESCRIPTION
## Summary

- Rewrites the tox-ansible integration for the `next` architecture, addressing all 10 reliability bugs from the `main` branch implementation (AAP-81423)
- Adds `ToxAnsibleService` in `@ansible/developer-services` with JSON-first discovery (`tox list --ansible --gh-matrix`) and proper exit-code-based test verdicts via `CommandService`
- Registers `ToxTestController` (Test Explorer) + `ToxTaskProvider` (Run Task) + MCP tools (`tox_list_environments`, `tox_run_environment`)

## What changed

| Layer | Files |
|-------|-------|
| Types | `packages/common/src/types/toxAnsible.ts` |
| Service | `packages/services/src/ToxAnsibleService.ts` |
| Extension | `src/features/toxAnsible/{ToxTestController,ToxTaskProvider,register}.ts` |
| MCP | `packages/mcp-server/src/{tools,handlers}.ts` |
| Telemetry | `packages/common/src/types/telemetry.ts` (TOX_DISCOVER, TOX_RUN) |
| User stories | `.sdlc/user-stories.yaml` (TOX-001, TOX-002) |
| Tests | Unit tests for service, controller, task provider, MCP handlers; WDIO skeleton |
| Config | `package.json` (taskDefinitions: `ansible-tox`) |

## Key improvements over main

1. **No false passes** — exit code determines pass/fail (main used terminal fire-and-forget)
2. **No stale items** — items cleared before re-discovery
3. **No duplicates** — single CLI discovery path (main had INI parse + env loop)
4. **CommandService** — venv-aware execution (main bypassed it)
5. **Cross-platform** — uses `path.join` (main hardcoded `/bin/`)
6. **Timeout support** — 10 min default per env (main hung forever)
7. **MCP parity** — agents can discover/run tox tests (invariant 9)
8. **JSON discovery** — `--gh-matrix` with `--no-desc` fallback (main parsed INI)

## Test plan

- [x] `pnpm run compile` — clean
- [x] `pnpm run lint:eslint` — passed
- [x] `pnpm exec vitest run` — 77 files, 1287 tests, all green
- [x] `pnpm run build` — all 4 bundles produced
- [ ] Manual: open a collection workspace with tox-ansible → verify Test Explorer populates
- [ ] Manual: run a tox env from Test Explorer → verify pass/fail reporting
- [ ] Manual: "Run Task" → verify tox-ansible environments appear

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Reworked tox-ansible integration to discover environments via JSON-first parsing and run tests using exit-code verdicts, with AbortSignal cancellation and a 10-minute timeout to prevent stale items, false passes, and hangs. refactor(tox-ansible): streamline entry parsing and enhance runEnvironments with AbortSignal support.

- Added `ToxAnsibleService` with JSON-first discovery (`--gh-matrix`), `--no-desc` fallback, and signal-aware `runEnvironment(s)` execution
- Implemented tox-ansible Test Explorer controller (categorized discovery, cancellable runs) and Run Task integration (`ansible-tox` task type)
- Added MCP tools to list and run tox-ansible environments with structured results and timeout handling
- Introduced shared tox types and telemetry events, plus user stories and configuration/test coverage
- Registered the new feature in extension activation and added/updated unit, MCP, and UI tests
<!-- end of auto-generated comment: release notes by coderabbit.ai -->