### PR TITLE
fix(deps): exclude ansible-core 2.17.x (CVE-2026-11332)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ dynamic = ["version"]
 
 [dependency-groups]
 dev = [
-  "ansible-core>=2.13.0",
+  "ansible-core>=2.13.0,!=2.17.*",
   "ansible-creator>=25.11.0",
   "ansible-dev-tools>=25.11.0",
   "ansible-lint>=6.8.7",

--- a/uv.lock
+++ b/uv.lock
@@ -47,11 +47,11 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 dependencies = [
-    { name = "cryptography", marker = "python_full_version < '3.12'" },
-    { name = "jinja2", marker = "python_full_version < '3.12'" },
-    { name = "packaging", marker = "python_full_version < '3.12'" },
-    { name = "pyyaml", marker = "python_full_version < '3.12'" },
-    { name = "resolvelib", marker = "python_full_version < '3.12'" },
+    { name = "cryptography" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "resolvelib" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/59/db/7d3c7be76df6fc3707db05a151b530a298bb37080fc9ecc669dbd7e82b28/ansible_core-2.19.11.tar.gz", hash = "sha256:e8d541720050fc0a7ddb568cde779cce25a9cf470aa489e63ee10d1c94df4248", size = 3430025, upload-time = "2026-06-18T19:37:36.721Z" }
 wheels = [
@@ -67,11 +67,11 @@ resolution-markers = [
     "python_full_version >= '3.12' and python_full_version < '3.14'",
 ]
 dependencies = [
-    { name = "cryptography", marker = "python_full_version >= '3.12'" },
-    { name = "jinja2", marker = "python_full_version >= '3.12'" },
-    { name = "packaging", marker = "python_full_version >= '3.12'" },
-    { name = "pyyaml", marker = "python_full_version >= '3.12'" },
-    { name = "resolvelib", marker = "python_full_version >= '3.12'" },
+    { name = "cryptography" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "resolvelib" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/26/6d/38d7eaea1df4a95c3b137e780f6ad2208d7886334a291cadde5d645f08a1/ansible_core-2.21.1.tar.gz", hash = "sha256:a5536ece95be84de15212b3644cdbbe9cbd9efd62e4e8a544cd6b0b27a083039", size = 3384534, upload-time = "2026-06-18T19:35:02.887Z" }
 wheels = [
@@ -2129,7 +2129,7 @@ lint = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "ansible-core", specifier = ">=2.13.0" },
+    { name = "ansible-core", specifier = ">=2.13.0,!=2.17.*" },
     { name = "ansible-creator", specifier = ">=25.11.0" },
     { name = "ansible-dev-tools", specifier = ">=25.11.0" },
     { name = "ansible-lint", specifier = ">=6.8.7" },


### PR DESCRIPTION
Exclude the entire ansible-core 2.17.x range from the dependency spec. 2.17 is EOL and will never receive the fix for CVE-2026-11332 (argument injection in ansible-galaxy role install, CVSS 7.8).

With this change, Python 3.10 users get ansible-core 2.16.19 (patched) and Python 3.11+ users get 2.18+ (patched). Nobody resolves to the vulnerable 2.17.x anymore.

Reference: https://github.com/advisories/GHSA-w8p5-mx5w-cpqj
Fix PR: https://github.com/ansible/ansible/pull/87070