### PR TITLE
test(als): raise provider unit coverage to 100%

### DIFF
--- a/packages/ansible-language-server/test/fixtures/common/collections/ansible_collections/org_1/coll_1/plugins/modules/module_1.py
+++ b/packages/ansible-language-server/test/fixtures/common/collections/ansible_collections/org_1/coll_1/plugins/modules/module_1.py
@@ -61,6 +61,26 @@ options:
   opt_2:
     description: Option 2
     type: str
+    aliases:
+      - option_two
+  opt_dict:
+    description: Dict option
+    type: dict
+    suboptions:
+      nested_a:
+        description: Nested A
+        type: int
+      nested_b:
+        description: Nested B
+        type: dict
+        suboptions:
+          deeper:
+            description: Deeper
+            type: int
+  opt_bool:
+    description: Bool option
+    type: bool
+    default: "yes"
   opt_3:
     description:
       - Option 3

--- a/packages/ansible-language-server/test/fixtures/semanticTokens/playbook.yml
+++ b/packages/ansible-language-server/test/fixtures/semanticTokens/playbook.yml
@@ -1,0 +1,55 @@
+---
+- name: Semantic tokens play
+  hosts: localhost
+  custom_play_key: play_value
+  environment:
+    FOO: bar
+    NESTED_ENV:
+      INNER: value
+  roles:
+    - name: role_1
+      when: true
+      custom_role_key: role_value
+  tasks:
+    - name: Known module with options
+      org_1.coll_1.module_1:
+        opt_1:
+          - sub_opt_1: choice_1
+            sub_opt_2:
+              - sub_sub_opt_1: value
+            unknown_list_item: scalar_value
+          - plain_scalar
+        opt_2: string_value
+        unknown_opt: ignored
+        opt_dict:
+          nested_a: 1
+          nested_b:
+            deeper: 2
+        ? [complex, key]
+        : complex_value
+      args:
+        opt_2: via_args
+      register: result
+
+    - name: Builtin style module without map value
+      ansible.builtin.debug: null
+
+    - name: Unknown module
+      not_a_real_module:
+        foo: bar
+        nested_map:
+          a: 1
+        nested_list:
+          - item_a
+          - key: item_b
+
+    - name: Block task
+      custom_block_key: block_value
+      block:
+        - name: Nested task
+          org_1.coll_1.module_1:
+            opt_2: nested
+      rescue:
+        - name: Rescue task
+          ansible.builtin.debug:
+            msg: rescued

--- a/packages/ansible-language-server/test/providers/completionProvider.test.ts
+++ b/packages/ansible-language-server/test/providers/completionProvider.test.ts
@@ -1,12 +1,15 @@
 import { TextDocument } from "vscode-languageserver-textdocument";
-import { expect, beforeAll, afterAll } from "vitest";
+import { expect, beforeAll, afterAll, afterEach } from "vitest";
+import sinon from "sinon";
 import { CompletionItemKind, CompletionItem } from "vscode-languageserver";
 import {
   doCompletion,
   doCompletionResolve,
+  hasCompletionDocumentUri,
 } from "@src/providers/completionProvider.js";
 import {} from "@src/providers/validationProvider.js";
 import { WorkspaceFolderContext } from "@src/services/workspaceManager.js";
+import { SchemaService } from "@src/services/schemaService.js";
 import {
   createTestWorkspaceManager,
   getDoc,
@@ -1281,4 +1284,201 @@ describe("doCompletion()", function () {
       });
     });
   }
+
+  describe("Schema, aliases, and edge-case completions", function () {
+    afterEach(function () {
+      sinon.restore();
+    });
+
+    it("returns schema completions when available", async function () {
+      const textDoc = TextDocument.create(
+        resolveDocUri("roles/demo/meta/main.yml"),
+        "ansible",
+        1,
+        `galaxy_info:\n  `,
+      );
+      const context = workspaceManager.getContext(
+        resolveDocUri("completion/simple_tasks.yml"),
+      );
+      expect(context).toBeDefined();
+      if (!context) return;
+
+      const schemaCompleterMod =
+        await import("@src/services/schemaCompleter.js");
+      const completeStub = sinon
+        .stub(schemaCompleterMod.SchemaCompleter.prototype, "complete")
+        .returns([
+          {
+            label: "author",
+            kind: CompletionItemKind.Property,
+          },
+        ]);
+
+      const schemaService = {
+        shouldValidateWithSchema: () => true,
+        getSchemaForDocument: async () => ({
+          type: "object",
+          properties: {
+            galaxy_info: {
+              type: "object",
+              properties: {
+                author: { type: "string", description: "Author" },
+              },
+            },
+          },
+        }),
+      } as unknown as SchemaService;
+
+      const items = await doCompletion(
+        textDoc,
+        { line: 1, character: 2 },
+        context,
+        schemaService,
+      );
+      expect(items).toHaveLength(1);
+      expect(items[0].label).toBe("author");
+      completeStub.restore();
+    });
+
+    it("falls through when schema completions are empty", async function () {
+      const textDoc = getDoc("completion/simple_tasks.yml");
+      const context = workspaceManager.getContext(textDoc.uri);
+      expect(context).toBeDefined();
+      if (!context) return;
+
+      const schemaService = {
+        shouldValidateWithSchema: () => true,
+        getSchemaForDocument: async () => undefined,
+      } as unknown as SchemaService;
+
+      // Cursor on a play-level key line so fall-through hits play keywords
+      const items = await doCompletion(
+        textDoc,
+        { line: 1, character: 2 },
+        context,
+        schemaService,
+      );
+      // Remaining play keywords (already-used keys like name/hosts are filtered)
+      expect(items.map((i) => i.label)).toEqual(
+        expect.arrayContaining(["roles", "handlers", "become"]),
+      );
+    });
+
+    it("offers alias options when aliases are enabled", async function () {
+      const textDoc = getDoc("completion/simple_tasks.yml");
+      const context = workspaceManager.getContext(textDoc.uri);
+      expect(context).toBeDefined();
+      if (!context) return;
+
+      const content = `- hosts: localhost
+  tasks:
+    - org_1.coll_1.module_1:
+        `;
+      const doc = TextDocument.create(textDoc.uri, "ansible", 1, content);
+      const items = await doCompletion(doc, { line: 3, character: 8 }, context);
+      const alias = items.find((i) => i.label === "option_two");
+      expect(alias).toBeTruthy();
+      expect(alias?.kind).toBe(CompletionItemKind.Reference);
+    });
+
+    it("offers bool choice values including string default", async function () {
+      const textDoc = getDoc("completion/simple_tasks.yml");
+      const context = workspaceManager.getContext(textDoc.uri);
+      expect(context).toBeDefined();
+      if (!context) return;
+
+      const content = `- hosts: localhost
+  tasks:
+    - org_1.coll_1.module_1:
+        opt_bool: `;
+      const doc = TextDocument.create(textDoc.uri, "ansible", 1, content);
+      const items = await doCompletion(
+        doc,
+        { line: 3, character: 18 },
+        context,
+      );
+      const labels = items.map((i) => i.label);
+      expect(labels).toEqual(expect.arrayContaining(["true", "false"]));
+    });
+
+    it("offers play keywords when play identity is still ambiguous", async function () {
+      const textDoc = getDoc("completion/simple_tasks.yml");
+      const context = workspaceManager.getContext(textDoc.uri);
+      expect(context).toBeDefined();
+      if (!context) return;
+
+      const content = `- `;
+      const doc = TextDocument.create(textDoc.uri, "ansible", 1, content);
+      const items = await doCompletion(doc, { line: 0, character: 2 }, context);
+      const labels = items.map((i) => i.label);
+      expect(labels.includes("block") || labels.includes("hosts")).toBe(true);
+    });
+
+    it("hasCompletionDocumentUri type guard", function () {
+      expect(hasCompletionDocumentUri({ documentUri: "x" })).toBe(true);
+      expect(hasCompletionDocumentUri(null)).toBe(false);
+      expect(hasCompletionDocumentUri({})).toBe(false);
+      expect(hasCompletionDocumentUri({ documentUri: 1 })).toBe(false);
+    });
+
+    it("completes hosts value after typing characters", async function () {
+      const textDoc = getDoc("completion/simple_tasks.yml");
+      const context = workspaceManager.getContext(textDoc.uri);
+      expect(context).toBeDefined();
+      if (!context) return;
+
+      const content = `- hosts: loc`;
+      const doc = TextDocument.create(textDoc.uri, "ansible", 1, content);
+      const items = await doCompletion(
+        doc,
+        { line: 0, character: 11 },
+        context,
+      );
+      expect(items.length).toBeGreaterThan(0);
+      expect(items.map((i) => i.label)).toEqual(
+        expect.arrayContaining(["localhost"]),
+      );
+    });
+
+    it("completes hosts and option values on null value positions", async function () {
+      const textDoc = getDoc("completion/simple_tasks.yml");
+      const context = workspaceManager.getContext(textDoc.uri);
+      expect(context).toBeDefined();
+      if (!context) return;
+
+      // Same-line null hosts value (triggers inventory completion)
+      const hostsDoc = TextDocument.create(
+        textDoc.uri,
+        "ansible",
+        1,
+        `- hosts: `,
+      );
+      const hostItems = await doCompletion(
+        hostsDoc,
+        { line: 0, character: 9 },
+        context,
+      );
+      expect(hostItems.map((i) => i.label)).toEqual(
+        expect.arrayContaining(["localhost", "all"]),
+      );
+
+      const optionDoc = TextDocument.create(
+        textDoc.uri,
+        "ansible",
+        1,
+        `- hosts: localhost
+  tasks:
+    - org_1.coll_1.module_1:
+        opt_3: `,
+      );
+      const optionItems = await doCompletion(
+        optionDoc,
+        { line: 3, character: 15 },
+        context,
+      );
+      expect(optionItems.map((i) => i.label)).toEqual(
+        expect.arrayContaining(["choice_1", "choice_2"]),
+      );
+    });
+  });
 });

--- a/packages/ansible-language-server/test/providers/completionProviderUtils.test.ts
+++ b/packages/ansible-language-server/test/providers/completionProviderUtils.test.ts
@@ -1,0 +1,58 @@
+import { expect } from "vitest";
+import * as path from "path";
+import { TextDocument } from "vscode-languageserver-textdocument";
+import { getVarsCompletion } from "@src/providers/completionProviderUtils.js";
+import { getPathAt, parseAllDocuments } from "@src/utils/yaml.js";
+import { resolveDocUri } from "@test/helper.js";
+
+describe("getVarsCompletion()", () => {
+  it("reads vars from an absolute vars_files path", () => {
+    const varsFileAbs = resolveDocUri("completion/default_vars.yml");
+    const playbookDir = path.dirname(
+      resolveDocUri("completion/playbook_with_vars.yml"),
+    );
+    const playbookPath = path.join(playbookDir, "absolute_vars_files.yml");
+
+    const content = `---
+- name: Absolute vars_files play
+  hosts: localhost
+  vars_files:
+    - ${varsFileAbs}
+  tasks:
+    - name: Use var
+      ansible.builtin.debug:
+        msg: "{{  }}"
+`;
+
+    const document = TextDocument.create(playbookPath, "ansible", 1, content);
+    const yamlDocs = parseAllDocuments(document.getText());
+    // Cursor inside the jinja brackets on the msg line
+    const lines = content.split("\n");
+    const msgLineIndex = lines.findIndex((l) => l.includes('msg: "{{'));
+    const msgLine = lines[msgLineIndex];
+    expect(msgLineIndex).toBeGreaterThanOrEqual(0);
+    expect(msgLine).toBeDefined();
+    if (!msgLine) {
+      return;
+    }
+    const position = {
+      line: msgLineIndex,
+      character: msgLine.indexOf("{{") + 3,
+    };
+    const pathNodes = getPathAt(document, position, yamlDocs);
+    expect(pathNodes).toBeTruthy();
+    if (!pathNodes) {
+      return;
+    }
+
+    const completions = getVarsCompletion(document.uri, pathNodes);
+    const labels = completions.map((c) => c.label);
+    expect(labels).toEqual(
+      expect.arrayContaining([
+        "default_var_1",
+        "default_var_2",
+        "default_var_3",
+      ]),
+    );
+  });
+});

--- a/packages/ansible-language-server/test/providers/completionResolver.test.ts
+++ b/packages/ansible-language-server/test/providers/completionResolver.test.ts
@@ -3,7 +3,8 @@
  * `doCompletionResolve()` is called to resolve the selected completion item.
  */
 
-import { expect, beforeAll, afterAll } from "vitest";
+import { expect, beforeAll, afterAll, afterEach } from "vitest";
+import sinon from "sinon";
 import { EOL } from "os";
 import { doCompletionResolve } from "@src/providers/completionProvider.js";
 import {} from "@src/providers/validationProvider.js";
@@ -308,6 +309,103 @@ describe("doCompletionResolve()", function () {
         });
 
         testResolveModuleOptionCompletion(context);
+      });
+    });
+
+    describe("Resolve edge cases", function () {
+      afterEach(function () {
+        sinon.restore();
+      });
+
+      it("ignores invalid completion resolve data shapes", async function () {
+        for (const data of [
+          null,
+          undefined,
+          { documentUri: "file:///tmp/x.yml" },
+        ]) {
+          const item = await doCompletionResolve(
+            {
+              label: "x",
+              data,
+            },
+            context,
+          );
+          expect(item.label).toBe("x");
+        }
+      });
+
+      it("resolves module completion using textEdit when present", async function () {
+        const item = await doCompletionResolve(
+          {
+            label: "module_3",
+            textEdit: {
+              range: {
+                start: { line: 0, character: 0 },
+                end: { line: 0, character: 1 },
+              },
+              newText: "",
+            },
+            data: {
+              documentUri: fixtureFileUri,
+              moduleFqcn: "org_1.coll_3.module_3",
+              inlineCollections: [],
+              atEndOfLine: true,
+              firstElementOfList: false,
+            },
+          },
+          context,
+        );
+        expect(item.textEdit?.newText).toContain("org_1.coll_3.module_3");
+      });
+
+      it("resolves option completion using textEdit when present", async function () {
+        const item = await doCompletionResolve(
+          {
+            label: "opt_1",
+            textEdit: {
+              range: {
+                start: { line: 0, character: 0 },
+                end: { line: 0, character: 1 },
+              },
+              newText: "",
+            },
+            data: {
+              documentUri: fixtureFileUri,
+              type: "string",
+              atEndOfLine: true,
+            },
+          },
+          context,
+        );
+        expect(item.textEdit?.newText).toBe("opt_1: ");
+      });
+
+      it("uses metadata collections when resolving short module names", async function () {
+        const settings = await context.documentSettings.get(fixtureFileUri);
+        settings.ansible.useFullyQualifiedCollectionNames = false;
+
+        sinon.stub(context.documentMetadata, "get").resolves({
+          collections: ["org_1.coll_3"],
+        } as never);
+
+        try {
+          const item = await doCompletionResolve(
+            {
+              label: "module_3",
+              data: {
+                documentUri: fixtureFileUri,
+                moduleFqcn: "org_1.coll_3.module_3",
+                inlineCollections: [],
+                atEndOfLine: false,
+                firstElementOfList: false,
+              },
+            },
+            context,
+          );
+          expect(item.insertText).toBe("module_3");
+        } finally {
+          settings.ansible.useFullyQualifiedCollectionNames = true;
+        }
       });
     });
   }

--- a/packages/ansible-language-server/test/providers/definitionProvider.test.ts
+++ b/packages/ansible-language-server/test/providers/definitionProvider.test.ts
@@ -1,5 +1,5 @@
 import { TextDocument } from "vscode-languageserver-textdocument";
-import { expect, beforeAll, afterAll } from "vitest";
+import { expect, beforeAll, afterAll, vi } from "vitest";
 import {
   createTestWorkspaceManager,
   getDoc,
@@ -10,6 +10,7 @@ import {
 } from "@test/helper.js";
 import { WorkspaceFolderContext } from "@src/services/workspaceManager.js";
 import { getDefinition } from "@src/providers/definitionProvider.js";
+import { DocsLibrary } from "@src/services/docsLibrary.js";
 import { fileExists } from "@src/utils/misc.js";
 import { URI } from "vscode-uri";
 
@@ -122,6 +123,49 @@ describe("getDefinition()", function () {
       if (context) {
         testModuleNamesForDefinition(context, textDoc);
       }
+    });
+  });
+
+  describe("Edge cases with mocked DocsLibrary", function () {
+    it("returns null when path cannot be resolved", async function () {
+      const doc = TextDocument.create(
+        "file:///tmp/def.yml",
+        "ansible",
+        1,
+        `# comment only
+`,
+      );
+      const docsLibrary = {
+        findModule: vi.fn().mockResolvedValue([undefined, undefined]),
+      } as unknown as DocsLibrary;
+
+      const result = await getDefinition(
+        doc,
+        { line: 0, character: 0 },
+        docsLibrary,
+      );
+      expect(result).toBeNull();
+    });
+
+    it("returns null when cursor is on a non-task key", async function () {
+      const doc = TextDocument.create(
+        "file:///tmp/def2.yml",
+        "ansible",
+        1,
+        `- hosts: localhost
+  tasks: []
+`,
+      );
+      const docsLibrary = {
+        findModule: vi.fn().mockResolvedValue([undefined, undefined]),
+      } as unknown as DocsLibrary;
+
+      const result = await getDefinition(
+        doc,
+        { line: 0, character: 4 },
+        docsLibrary,
+      );
+      expect(result).toBeNull();
     });
   });
 });

--- a/packages/ansible-language-server/test/providers/hoverProvider.test.ts
+++ b/packages/ansible-language-server/test/providers/hoverProvider.test.ts
@@ -1,6 +1,6 @@
 import { TextDocument } from "vscode-languageserver-textdocument";
 import { Hover, MarkupContent } from "vscode-languageserver";
-import { expect, beforeAll, afterAll } from "vitest";
+import { expect, beforeAll, afterAll, vi } from "vitest";
 import {
   createTestWorkspaceManager,
   getDoc,
@@ -10,6 +10,7 @@ import {
   setFixtureAnsibleCollectionPathEnv,
 } from "@test/helper.js";
 import { doHover } from "@src/providers/hoverProvider.js";
+import { DocsLibrary } from "@src/services/docsLibrary.js";
 import { WorkspaceFolderContext } from "@src/services/workspaceManager.js";
 
 function get_hover_value(hover: Hover | undefined | null): string {
@@ -648,6 +649,73 @@ describe("doHover()", function () {
           nonAdjacentTextDoc,
         );
       }
+    });
+  });
+
+  describe("Edge cases with mocked DocsLibrary", function () {
+    it("returns tombstone hover when module is removed", async function () {
+      const doc = TextDocument.create(
+        "file:///tmp/tombstone.yml",
+        "ansible",
+        1,
+        `- hosts: localhost
+  tasks:
+    - removed.module.name:
+        opt: 1
+`,
+      );
+      const docsLibrary = {
+        findModule: vi
+          .fn()
+          .mockResolvedValue([undefined, "removed.module.name"]),
+        getModuleRoute: vi.fn().mockReturnValue({
+          tombstone: {
+            removalDate: "2024-01-01",
+            removalVersion: "3.0.0",
+            warningText: "This module was removed.",
+          },
+        }),
+      } as unknown as DocsLibrary;
+
+      const hover = await doHover(doc, { line: 2, character: 10 }, docsLibrary);
+      expect(hover).toBeTruthy();
+      expect(get_hover_value(hover)).toContain("REMOVED");
+      expect(get_hover_value(hover)).toContain("This module was removed.");
+    });
+
+    it("returns null for unknown play keyword", async function () {
+      const doc = TextDocument.create(
+        "file:///tmp/unknown_kw.yml",
+        "ansible",
+        1,
+        `- hosts: localhost
+  not_a_real_play_keyword: true
+  tasks: []
+`,
+      );
+      const docsLibrary = {
+        findModule: vi.fn().mockResolvedValue([undefined, undefined]),
+        getModuleRoute: vi.fn(),
+      } as unknown as DocsLibrary;
+
+      const hover = await doHover(doc, { line: 1, character: 4 }, docsLibrary);
+      expect(hover).toBeNull();
+    });
+
+    it("returns null when cursor is not on a key", async function () {
+      const doc = TextDocument.create(
+        "file:///tmp/value.yml",
+        "ansible",
+        1,
+        `- hosts: localhost
+`,
+      );
+      const docsLibrary = {
+        findModule: vi.fn().mockResolvedValue([undefined, undefined]),
+      } as unknown as DocsLibrary;
+
+      const hover = await doHover(doc, { line: 0, character: 10 }, docsLibrary);
+      expect(hover).toBeNull();
     });
   });
 });

--- a/packages/ansible-language-server/test/providers/semanticTokenProvider.test.ts
+++ b/packages/ansible-language-server/test/providers/semanticTokenProvider.test.ts
@@ -1,0 +1,269 @@
+import { expect, beforeAll, afterAll } from "vitest";
+import { SemanticTokenTypes } from "vscode-languageserver";
+import { TextDocument } from "vscode-languageserver-textdocument";
+import {
+  doSemanticTokens,
+  tokenModifiers,
+  tokenTypes,
+} from "@src/providers/semanticTokenProvider.js";
+import {
+  createTestWorkspaceManager,
+  getDoc,
+  resolveDocUri,
+  setFixtureAnsibleCollectionPathEnv,
+} from "@test/helper.js";
+import { DocsLibrary } from "@src/services/docsLibrary.js";
+import { IModuleMetadata, IOption } from "@src/interfaces/module.js";
+
+type DecodedToken = {
+  line: number;
+  start: number;
+  length: number;
+  typeIndex: number;
+  modifiers: number;
+};
+
+function decodeSemanticTokens(data: number[] | Uint32Array): DecodedToken[] {
+  const tokens: DecodedToken[] = [];
+  let line = 0;
+  let character = 0;
+  for (let i = 0; i + 4 < data.length; i += 5) {
+    const deltaLine = data[i];
+    const deltaStart = data[i + 1];
+    line += deltaLine;
+    character = deltaLine === 0 ? character + deltaStart : deltaStart;
+    tokens.push({
+      line,
+      start: character,
+      length: data[i + 2],
+      typeIndex: data[i + 3],
+      modifiers: data[i + 4],
+    });
+  }
+  return tokens;
+}
+
+function tokenTypeIndexes(tokens: DecodedToken[]): Set<number> {
+  return new Set(tokens.map((t) => t.typeIndex));
+}
+
+describe("doSemanticTokens()", () => {
+  const workspaceManager = createTestWorkspaceManager();
+  const fixtureFilePath = "semanticTokens/playbook.yml";
+  const fixtureFileUri = resolveDocUri(fixtureFilePath);
+  const context = workspaceManager.getContext(fixtureFileUri);
+  const textDoc = getDoc(fixtureFilePath);
+
+  const methodType = tokenTypes.indexOf(SemanticTokenTypes.method);
+  const classType = tokenTypes.indexOf(SemanticTokenTypes.class);
+  const keywordType = tokenTypes.indexOf(SemanticTokenTypes.keyword);
+  const propertyType = tokenTypes.indexOf(SemanticTokenTypes.property);
+
+  beforeAll(() => {
+    setFixtureAnsibleCollectionPathEnv();
+  });
+
+  afterAll(() => {
+    setFixtureAnsibleCollectionPathEnv();
+  });
+
+  it("exports token legend lists", () => {
+    expect(tokenTypes).toContain(SemanticTokenTypes.keyword);
+    expect(tokenModifiers.length).toBeGreaterThan(0);
+  });
+
+  it("returns empty tokens for an empty document", async () => {
+    const emptyDoc = TextDocument.create(
+      "file:///tmp/empty.yml",
+      "ansible",
+      1,
+      "",
+    );
+    const docsLibrary = {
+      findModule: async () => [undefined, undefined],
+    } as unknown as DocsLibrary;
+
+    const tokens = await doSemanticTokens(emptyDoc, docsLibrary);
+    expect(tokens.data).toEqual([]);
+  });
+
+  it("marks play, role, block, task keywords and module options", async () => {
+    expect(context).toBeDefined();
+    if (!context) {
+      return;
+    }
+
+    const tokens = await doSemanticTokens(textDoc, await context.docsLibrary);
+    expect(tokens.data.length % 5).toBe(0);
+
+    const decoded = decodeSemanticTokens(tokens.data);
+    expect(decoded.length).toBeGreaterThan(0);
+
+    const types = tokenTypeIndexes(decoded);
+    // Play/task keywords, module names, and ordinary/nested keys
+    expect(types.has(keywordType)).toBe(true);
+    expect(types.has(classType)).toBe(true);
+    expect(types.has(propertyType)).toBe(true);
+
+    // Representative positions from semanticTokens/playbook.yml
+    // line 1: "name" (play keyword), line 2: "hosts", line 14: module FQCN
+    expect(
+      decoded.some(
+        (t) => t.line === 1 && t.typeIndex === keywordType && t.length === 4,
+      ),
+    ).toBe(true);
+    expect(
+      decoded.some(
+        (t) => t.line === 2 && t.typeIndex === keywordType && t.length === 5,
+      ),
+    ).toBe(true);
+    expect(
+      decoded.some((t) => t.line === 14 && t.typeIndex === classType),
+    ).toBe(true);
+  });
+
+  it("marks module parameters for dict, list, unknown options and args", async () => {
+    const options = new Map<string, IOption>([
+      [
+        "opt_1",
+        {
+          name: "opt_1",
+          required: false,
+          type: "list",
+          suboptions: new Map([
+            ["sub_opt_1", { name: "sub_opt_1", required: true, type: "str" }],
+            [
+              "sub_opt_2",
+              {
+                name: "sub_opt_2",
+                required: false,
+                type: "list",
+                suboptions: new Map([
+                  [
+                    "sub_sub_opt_1",
+                    { name: "sub_sub_opt_1", required: true, type: "str" },
+                  ],
+                ]),
+              },
+            ],
+          ]),
+        },
+      ],
+      ["opt_2", { name: "opt_2", required: false, type: "str" }],
+      [
+        "opt_dict",
+        {
+          name: "opt_dict",
+          required: false,
+          type: "dict",
+          suboptions: new Map([
+            ["nested_a", { name: "nested_a", required: false, type: "int" }],
+            [
+              "nested_b",
+              {
+                name: "nested_b",
+                required: false,
+                type: "dict",
+                suboptions: new Map([
+                  ["deeper", { name: "deeper", required: false, type: "int" }],
+                ]),
+              },
+            ],
+          ]),
+        },
+      ],
+    ]);
+
+    const module: IModuleMetadata = {
+      source: "/tmp/module_1.py",
+      sourceLineRange: [0, 10],
+      fqcn: "org_1.coll_1.module_1",
+      namespace: "org_1",
+      collection: "coll_1",
+      name: "module_1",
+      rawDocumentationFragments: new Map(),
+      documentation: {
+        module: "module_1",
+        deprecated: false,
+        options,
+      },
+      errors: [],
+    };
+
+    const docsLibrary = {
+      findModule: async (name: string) => {
+        if (
+          name === "org_1.coll_1.module_1" ||
+          name === "ansible.builtin.debug"
+        ) {
+          return [module, name];
+        }
+        return [undefined, undefined];
+      },
+    } as unknown as DocsLibrary;
+
+    const tokens = await doSemanticTokens(textDoc, docsLibrary);
+    const decoded = decodeSemanticTokens(tokens.data);
+    const types = tokenTypeIndexes(decoded);
+
+    expect(types.has(methodType)).toBe(true);
+    expect(types.has(propertyType)).toBe(true);
+    expect(types.has(classType)).toBe(true);
+    expect(types.has(keywordType)).toBe(true);
+
+    // Known options / nested suboptions → method
+    expect(
+      decoded.some(
+        (t) => t.line === 15 && t.typeIndex === methodType && t.length === 5,
+      ),
+    ).toBe(true); // opt_1
+    expect(
+      decoded.some(
+        (t) => t.line === 16 && t.typeIndex === methodType && t.length === 9,
+      ),
+    ).toBe(true); // sub_opt_1
+    expect(
+      decoded.some(
+        (t) => t.line === 21 && t.typeIndex === methodType && t.length === 5,
+      ),
+    ).toBe(true); // opt_2
+    expect(
+      decoded.some(
+        (t) => t.line === 24 && t.typeIndex === methodType && t.length === 8,
+      ),
+    ).toBe(true); // nested_a
+    // Unknown option keys under a known module are not classified as method
+    expect(
+      decoded.some(
+        (t) => t.line === 22 && t.typeIndex === methodType && t.length === 11,
+      ),
+    ).toBe(false); // unknown_opt
+    // Ordinary / non-module keys → property (e.g. custom_play_key, env vars)
+    expect(
+      decoded.some(
+        (t) => t.line === 3 && t.typeIndex === propertyType && t.length === 15,
+      ),
+    ).toBe(true); // custom_play_key
+    // args is a task keyword
+    expect(
+      decoded.some(
+        (t) => t.line === 29 && t.typeIndex === keywordType && t.length === 4,
+      ),
+    ).toBe(true); // args
+  });
+
+  it("handles documents without YAML contents", async () => {
+    const commentOnly = TextDocument.create(
+      "file:///tmp/comments.yml",
+      "ansible",
+      1,
+      "# just a comment\n",
+    );
+    const docsLibrary = {
+      findModule: async () => [undefined, undefined],
+    } as unknown as DocsLibrary;
+
+    const tokens = await doSemanticTokens(commentOnly, docsLibrary);
+    expect(tokens.data).toEqual([]);
+  });
+});

--- a/packages/ansible-language-server/test/providers/validationProvider.test.ts
+++ b/packages/ansible-language-server/test/providers/validationProvider.test.ts
@@ -1,6 +1,7 @@
 import { TextDocument } from "vscode-languageserver-textdocument";
-import { expect, beforeAll, afterAll } from "vitest";
-import { Diagnostic, integer } from "vscode-languageserver";
+import { expect, beforeAll, afterAll, afterEach } from "vitest";
+import sinon from "sinon";
+import { Connection, Diagnostic, integer } from "vscode-languageserver";
 import {
   doValidate,
   getYamlValidation,
@@ -16,6 +17,8 @@ import {
   setFixtureAnsibleCollectionPathEnv,
 } from "@test/helper.js";
 import { ValidationManager } from "@src/services/validationManager.js";
+import { SchemaService } from "@src/services/schemaService.js";
+import { CommandRunner } from "@src/utils/commandRunner.js";
 
 function testValidationFromCache(
   validationManager: ValidationManager,
@@ -901,4 +904,188 @@ describe("doValidate()", function () {
       }
     });
   }
+
+  describe("Schema validation and lint availability", function () {
+    afterEach(function () {
+      sinon.restore();
+    });
+
+    async function withLintDisabled(
+      folderContext: WorkspaceFolderContext,
+      uri: string,
+    ) {
+      const settings = await folderContext.documentSettings.get(uri);
+      settings.validation.enabled = true;
+      settings.validation.lint.enabled = false;
+      return settings;
+    }
+
+    it("shows error when ansible-lint is unavailable", async function () {
+      const textDocument = getDoc("diagnostics/lint_errors.yml");
+      const folderContext = workspaceManager.getContext(textDocument.uri);
+      expect(folderContext).toBeDefined();
+      if (!folderContext) return;
+
+      const settings = await folderContext.documentSettings.get(
+        textDocument.uri,
+      );
+      settings.validation.enabled = true;
+      settings.validation.lint.enabled = true;
+      settings.executionEnvironment.enabled = false;
+
+      const showErrorMessage = sinon.stub();
+      const connection = {
+        console: { log: sinon.stub(), error: sinon.stub() },
+        window: { showErrorMessage },
+      } as unknown as Connection;
+
+      sinon
+        .stub(CommandRunner.prototype, "getExecutablePath")
+        .resolves(undefined);
+
+      await doValidate(
+        textDocument,
+        validationManager,
+        false,
+        folderContext,
+        connection,
+      );
+
+      expect(showErrorMessage.called).toBe(true);
+    });
+
+    it("runs schema validation when schema service is provided", async function () {
+      const metaUri = resolveDocUri("roles/dummy/meta/main.yml");
+      const textDocument = TextDocument.create(
+        metaUri,
+        "ansible",
+        1,
+        `galaxy_info:\n  author: test\n`,
+      );
+      const folderContext = workspaceManager.getContext(metaUri);
+      expect(folderContext).toBeDefined();
+      if (!folderContext) return;
+
+      await withLintDisabled(folderContext, textDocument.uri);
+
+      const schemaService = {
+        shouldValidateWithSchema: () => true,
+        getSchemaForDocument: async () => ({
+          type: "object",
+          properties: { galaxy_info: { type: "object" } },
+        }),
+      } as unknown as SchemaService;
+
+      const result = await doValidate(
+        textDocument,
+        validationManager,
+        false,
+        folderContext,
+        undefined,
+        schemaService,
+      );
+
+      expect(result.has(textDocument.uri)).toBe(true);
+    });
+
+    it("returns empty schema diagnostics when schema should not validate", async function () {
+      const textDocument = TextDocument.create(
+        resolveDocUri("roles/y/meta/main.yml"),
+        "ansible",
+        1,
+        `galaxy_info: {}\n`,
+      );
+      const folderContext = workspaceManager.getContext(textDocument.uri);
+      expect(folderContext).toBeDefined();
+      if (!folderContext) return;
+
+      await withLintDisabled(folderContext, textDocument.uri);
+
+      const schemaService = {
+        shouldValidateWithSchema: () => false,
+        getSchemaForDocument: async () => undefined,
+      } as unknown as SchemaService;
+
+      const result = await doValidate(
+        textDocument,
+        validationManager,
+        false,
+        folderContext,
+        undefined,
+        schemaService,
+      );
+      expect(result.get(textDocument.uri)).toEqual([]);
+    });
+
+    it("returns empty when schema is missing", async function () {
+      const textDocument = TextDocument.create(
+        resolveDocUri("roles/x/meta/main.yml"),
+        "ansible",
+        1,
+        `galaxy_info: {}\n`,
+      );
+      const folderContext = workspaceManager.getContext(textDocument.uri);
+      expect(folderContext).toBeDefined();
+      if (!folderContext) return;
+
+      await withLintDisabled(folderContext, textDocument.uri);
+
+      const schemaService = {
+        shouldValidateWithSchema: () => true,
+        getSchemaForDocument: async () => undefined,
+      } as unknown as SchemaService;
+
+      const result = await doValidate(
+        textDocument,
+        validationManager,
+        false,
+        folderContext,
+        undefined,
+        schemaService,
+      );
+      expect(result.get(textDocument.uri)).toEqual([]);
+    });
+
+    it("handles schema validator errors", async function () {
+      const textDocument = TextDocument.create(
+        resolveDocUri("roles/x/meta/main.yml"),
+        "ansible",
+        1,
+        `galaxy_info: {}\n`,
+      );
+      const folderContext = workspaceManager.getContext(textDocument.uri);
+      expect(folderContext).toBeDefined();
+      if (!folderContext) return;
+
+      await withLintDisabled(folderContext, textDocument.uri);
+
+      const consoleError = sinon.stub();
+      const connection = {
+        console: { error: consoleError, log: sinon.stub() },
+      } as unknown as Connection;
+
+      const schemaService = {
+        shouldValidateWithSchema: () => true,
+        getSchemaForDocument: async () => ({ type: "object" }),
+      } as unknown as SchemaService;
+
+      const schemaValidatorMod =
+        await import("@src/services/schemaValidator.js");
+      const validateStub = sinon
+        .stub(schemaValidatorMod.SchemaValidator.prototype, "validate")
+        .throws(new Error("validate failed"));
+
+      await doValidate(
+        textDocument,
+        validationManager,
+        false,
+        folderContext,
+        connection,
+        schemaService,
+      );
+
+      expect(consoleError.called).toBe(true);
+      validateStub.restore();
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Raise ansible-language-server provider unit coverage to 100% statements/lines/functions for all six provider files.

## Changes
- Add semantic-token and vars-utils tests and fixture playbook
- Extend hover/definition/validation/completion/resolve provider tests for remaining gaps
- Extend fixture `module_1` docs with alias, dict, and bool options

## Test plan
- [ ] `SKIP_PODMAN=1 SKIP_DOCKER=1 npm exec -- vitest run --project=als` passes
- [ ] Provider coverage report shows 100% statements/lines/functions under `src/providers`
- [ ] CI green on draft PR
