### PR TITLE
test(mcp): add utils coverage tests

### DIFF
--- a/packages/ansible-mcp-server/test/utils/pathValidation.test.ts
+++ b/packages/ansible-mcp-server/test/utils/pathValidation.test.ts
@@ -1,14 +1,14 @@
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import {
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+import fs, {
   mkdtempSync,
   mkdirSync,
   writeFileSync,
   symlinkSync,
   rmSync,
   realpathSync,
-} from "fs";
-import { tmpdir } from "os";
-import { join } from "path";
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   validatePathWithinWorkspace,
   PathTraversalError,
@@ -124,5 +124,28 @@ describe("validatePathWithinWorkspace", () => {
   it("should handle paths with trailing slashes", () => {
     const result = validatePathWithinWorkspace("subdir/", workspaceRoot);
     expect(result).toBe(join(realWorkspaceRoot, "subdir"));
+  });
+
+  it("should reject whitespace-only workspace root", () => {
+    expect(() => validatePathWithinWorkspace("subdir", "   ")).toThrow(
+      PathTraversalError,
+    );
+  });
+
+  it("should accept nested paths when realpathSync is forced to fail", () => {
+    // Intentionally force realpathSync to throw so resolveWithSymlinks walks
+    // parents until parent === path (filesystem root) and uses the fallback.
+    // Expect workspaceRoot (not realWorkspaceRoot): resolution stays logical.
+    const spy = vi.spyOn(fs, "realpathSync").mockImplementation(() => {
+      throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    });
+
+    try {
+      const result = validatePathWithinWorkspace("ghost/nested", workspaceRoot);
+      expect(spy).toHaveBeenCalled();
+      expect(result).toBe(join(workspaceRoot, "ghost", "nested"));
+    } finally {
+      spy.mockRestore();
+    }
   });
 });

--- a/packages/ansible-mcp-server/test/utils/resourcePath.test.ts
+++ b/packages/ansible-mcp-server/test/utils/resourcePath.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { resolveResourcePath } from "@src/utils/resourcePath.js";
+
+const packageRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../..",
+);
+
+describe("resolveResourcePath", () => {
+  const expectedAgentsPath = path.join(
+    packageRoot,
+    "src",
+    "resources",
+    "data",
+    "agents.md",
+  );
+
+  it("resolves an existing resource via utils-to-resources fallback", async () => {
+    // Under Vitest, __dirname short-circuits getResourceBaseDir to src/utils,
+    // then resolveResourcePath falls back to src/resources/data/.
+    const result = await resolveResourcePath("agents.md");
+    expect(result).toBe(expectedAgentsPath);
+  });
+
+  it("throws a descriptive error when the resource file is missing", async () => {
+    await expect(resolveResourcePath("does-not-exist.md")).rejects.toThrow(
+      /Could not resolve resource path[\s\S]*Base directory:/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Add unit coverage for `ansible-mcp-server` utils (`pathValidation`, `resourcePath`) without changing production `resourcePath.ts`.

## Changes
- `pathValidation.test.ts`: cover whitespace-only workspace root and the `resolveWithSymlinks` walk when `realpathSync` always fails.
- `resourcePath.test.ts`: smoke-test resolve success via Vitest `__dirname` utils→resources fallback, and descriptive missing-file errors.

## Test plan
- [x] `pnpm exec vitest run --project=mcp packages/ansible-mcp-server/test/utils/`
- [x] `task lint` (hooks clean on commit)
- [ ] CI green on all jobs



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Adds Vitest unit tests for ansible-mcp-server path/resource utilities (test(mcp): add utils coverage tests) to cover workspace path validation, resolveWithSymlinks fallback when realpathSync fails, and resolveResourcePath success/error behavior—without modifying production code. Uses node:* imports and vi mocking to keep lint/unit checks passing.

- Extend validatePathWithinWorkspace to reject whitespace-only workspace roots
- Spy/mock fs.realpathSync to force failure and verify resolveWithSymlinks fallback resolves nested paths logically
- Add resolveResourcePath tests for utils-to-resources __dirname fallback and descriptive errors for missing resource files

Author: Sudhir Verma <9924513+sudhirverma@users.noreply.github.com>  
Committer: Sudhir Verma  
Related: `#3050`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->