### PR TITLE
fix: resolve first 50 SonarCloud leak issues

### DIFF
--- a/packages/ansible-language-server/src/providers/completionProviderUtils.ts
+++ b/packages/ansible-language-server/src/providers/completionProviderUtils.ts
@@ -85,11 +85,12 @@ export function getVarsCompletion(
         typeof parentKeyNode["value"] === "string"
       ) {
         path = parentKeyPath;
-        const scopedNode: Record<string, unknown> = path[
-          path.length - 3
-        ].toJSON() as Record<string, unknown>;
-        if (hasOwnProperty(scopedNode, "vars")) {
-          collectVarsKeys(scopedNode.vars, varPriority, varsCompletion);
+        const scopedPathNode = path.at(-3);
+        if (scopedPathNode) {
+          const scopedNode = scopedPathNode.toJSON() as Record<string, unknown>;
+          if (hasOwnProperty(scopedNode, "vars")) {
+            collectVarsKeys(scopedNode.vars, varPriority, varsCompletion);
+          }
         }
 
         continue;
@@ -109,11 +110,12 @@ export function getVarsCompletion(
         typeof parentKeyNode["value"] === "string"
       ) {
         path = parentKeyPath;
-        const scopedNode: Record<string, unknown> = path[
-          path.length - 3
-        ].toJSON() as Record<string, unknown>;
-        if (hasOwnProperty(scopedNode, "vars")) {
-          collectVarsKeys(scopedNode.vars, varPriority, varsCompletion);
+        const scopedPathNode = path.at(-3);
+        if (scopedPathNode) {
+          const scopedNode = scopedPathNode.toJSON() as Record<string, unknown>;
+          if (hasOwnProperty(scopedNode, "vars")) {
+            collectVarsKeys(scopedNode.vars, varPriority, varsCompletion);
+          }
         }
 
         continue;
@@ -128,10 +130,11 @@ export function getVarsCompletion(
 
   // handling vars_prompt
   varPriority = varPriority + 1;
-  const playNode: Record<string, unknown> = path[
-    path.length - 3
-  ].toJSON() as Record<string, unknown>;
-  if (hasOwnProperty(playNode, "vars_prompt")) {
+  const playPathNode = path.at(-3);
+  const playNode = playPathNode
+    ? (playPathNode.toJSON() as Record<string, unknown>)
+    : undefined;
+  if (playNode && hasOwnProperty(playNode, "vars_prompt")) {
     const varsPromptObject = playNode.vars_prompt;
     if (isVarsPromptArray(varsPromptObject)) {
       varsPromptObject.forEach((element) => {
@@ -142,7 +145,7 @@ export function getVarsCompletion(
 
   // handling vars_files
   varPriority = varPriority + 1;
-  if (hasOwnProperty(playNode, "vars_files")) {
+  if (playNode && hasOwnProperty(playNode, "vars_files")) {
     const varsFiles = playNode.vars_files;
     if (isVarsFilesArray(varsFiles)) {
       const currentDirectory = pathUri.dirname(URI.parse(documentUri).path);

--- a/packages/ansible-language-server/src/services/executionEnvironment.ts
+++ b/packages/ansible-language-server/src/services/executionEnvironment.ts
@@ -329,9 +329,12 @@ export class ExecutionEnvironment {
         containerCommand.push(containerOption);
       });
     }
-    containerCommand.push("--name", `als_${uuidv4()}`);
-    containerCommand.push(this._container_image);
-    containerCommand.push(...splitCommandString(command));
+    containerCommand.push(
+      "--name",
+      `als_${uuidv4()}`,
+      this._container_image,
+      ...splitCommandString(command),
+    );
     this.connection.console.log(
       `container engine invocation: ${containerCommand.join(" ")}`,
     );

--- a/packages/ansible-language-server/src/services/settingsManager.ts
+++ b/packages/ansible-language-server/src/services/settingsManager.ts
@@ -1,4 +1,6 @@
-import _ from "lodash";
+import cloneDeep from "lodash/cloneDeep";
+import isEqual from "lodash/isEqual";
+import merge from "lodash/merge";
 import { Connection } from "vscode-languageserver";
 import { DidChangeConfigurationParams } from "vscode-languageserver-protocol";
 import type {
@@ -19,9 +21,10 @@ function hasLegacyAnsibleSettings(
 }
 
 export class SettingsManager {
-  private connection: Connection | null;
-  private clientSupportsConfigRequests;
-  private configurationChangeHandlers: Map<string, () => void> = new Map();
+  private readonly connection: Connection | null;
+  private readonly clientSupportsConfigRequests;
+  private readonly configurationChangeHandlers: Map<string, () => void> =
+    new Map();
 
   // cache of document settings per workspace file
   private documentSettings: Map<string, Thenable<ExtensionSettings>> =
@@ -131,9 +134,10 @@ export class SettingsManager {
   };
 
   // Structure the settings similar to the ExtensionSettings interface for usage in the code
-  private defaultSettings: ExtensionSettings = this._settingsAdjustment(
-    _.cloneDeep(this.defaultSettingsWithDescription),
-  ) as unknown as ExtensionSettings;
+  private readonly defaultSettings: ExtensionSettings =
+    this._settingsAdjustment(
+      cloneDeep(this.defaultSettingsWithDescription),
+    ) as unknown as ExtensionSettings;
 
   public globalSettings: ExtensionSettings = this.defaultSettings;
 
@@ -169,8 +173,8 @@ export class SettingsManager {
       // Recursively merge globalSettings with clientSettings to use:
       //  - setting from client when provided
       //  - default value of setting otherwise
-      const mergedSettings: ExtensionSettings = _.merge(
-        _.cloneDeep(this.globalSettings),
+      const mergedSettings: ExtensionSettings = merge(
+        cloneDeep(this.globalSettings),
         clientSettings,
       );
       result = Promise.resolve(mergedSettings);
@@ -204,7 +208,7 @@ export class SettingsManager {
         });
         newDocumentSettings.set(uri, newConfigPromise);
 
-        if (!_.isEqual(config, await newConfigPromise)) {
+        if (!isEqual(config, await newConfigPromise)) {
           handlersToFire.push(handler);
         }
       }

--- a/packages/ansible-language-server/src/utils/docsParser.ts
+++ b/packages/ansible-language-server/src/utils/docsParser.ts
@@ -17,6 +17,40 @@ import {
 
 const DOCUMENTATION = "DOCUMENTATION";
 
+function resolveDocFragmentNames(rawFragments: unknown): string[] {
+  if (Array.isArray(rawFragments)) {
+    return rawFragments.filter(
+      (fragment): fragment is string => typeof fragment === "string",
+    );
+  }
+  if (typeof rawFragments === "string") {
+    return [rawFragments];
+  }
+  return [];
+}
+
+function resolveFragmentParts(docFragmentName: string): {
+  catalogueName: string;
+  partName: string;
+} {
+  const fragmentNameArray = docFragmentName.split(".");
+  let partName = DOCUMENTATION;
+  if (fragmentNameArray.length === 2 || fragmentNameArray.length === 4) {
+    partName = fragmentNameArray.pop()?.toUpperCase() as string;
+  }
+  return { catalogueName: fragmentNameArray.join("."), partName };
+}
+
+function lookupDocFragment(
+  docFragments: Map<string, IModuleMetadata>,
+  catalogueName: string,
+): IModuleMetadata | undefined {
+  return (
+    docFragments.get(catalogueName) ||
+    docFragments.get(`ansible.builtin.${catalogueName}`)
+  );
+}
+
 export function processDocumentationFragments(
   module: IModuleMetadata,
   docFragments: Map<string, IModuleMetadata>,
@@ -25,50 +59,35 @@ export function processDocumentationFragments(
   const mainDocumentationFragment =
     module.rawDocumentationFragments.get(DOCUMENTATION);
   if (
-    mainDocumentationFragment &&
-    hasOwnProperty(mainDocumentationFragment, "extends_documentation_fragment")
+    !mainDocumentationFragment ||
+    !hasOwnProperty(mainDocumentationFragment, "extends_documentation_fragment")
   ) {
-    const rawFragments =
-      mainDocumentationFragment.extends_documentation_fragment;
-    const docFragmentNames: string[] = Array.isArray(rawFragments)
-      ? rawFragments.filter(
-          (fragment): fragment is string => typeof fragment === "string",
-        )
-      : typeof rawFragments === "string"
-        ? [rawFragments]
-        : [];
-    const resultContents = {};
-    for (const docFragmentName of docFragmentNames) {
-      const fragmentNameArray = docFragmentName.split(".");
-      let fragmentPartName: string;
-      if (fragmentNameArray.length === 2 || fragmentNameArray.length === 4) {
-        fragmentPartName = fragmentNameArray.pop()?.toUpperCase() as string;
-      } else {
-        fragmentPartName = DOCUMENTATION;
-      }
-      const docFragmentCatalogueName = fragmentNameArray.join(".");
-      const docFragment =
-        docFragments.get(docFragmentCatalogueName) ||
-        docFragments.get(`ansible.builtin.${docFragmentCatalogueName}`);
-      if (
-        docFragment &&
-        docFragment.rawDocumentationFragments.has(fragmentPartName)
-      ) {
-        module.fragments.push(docFragment); // currently used only as indicator
-        _.mergeWith(
-          resultContents,
-          docFragment.rawDocumentationFragments.get(fragmentPartName),
-          docFragmentMergeCustomizer,
-        );
-      }
+    return;
+  }
+
+  const docFragmentNames = resolveDocFragmentNames(
+    mainDocumentationFragment.extends_documentation_fragment,
+  );
+  const resultContents = {};
+  for (const docFragmentName of docFragmentNames) {
+    const { catalogueName, partName } = resolveFragmentParts(docFragmentName);
+    const docFragment = lookupDocFragment(docFragments, catalogueName);
+    if (!docFragment?.rawDocumentationFragments.has(partName)) {
+      continue;
     }
+    module.fragments.push(docFragment); // currently used only as indicator
     _.mergeWith(
       resultContents,
-      mainDocumentationFragment,
+      docFragment.rawDocumentationFragments.get(partName),
       docFragmentMergeCustomizer,
     );
-    module.rawDocumentationFragments.set(DOCUMENTATION, resultContents);
   }
+  _.mergeWith(
+    resultContents,
+    mainDocumentationFragment,
+    docFragmentMergeCustomizer,
+  );
+  module.rawDocumentationFragments.set(DOCUMENTATION, resultContents);
 }
 
 function docFragmentMergeCustomizer(
@@ -226,8 +245,11 @@ function parseRawDeprecationOrTombstone(
 }
 
 export class LazyModuleDocumentation implements IModuleMetadata {
+  // Opening assignment only; closing quotes located with indexOf to avoid
+  // Sonar S8786 backtracking on tempered-greedy doc body matching.
+  // Consumers must clone before exec — see rawDocumentationFragments.
   public static docsRegex =
-    /(?<pre>[ \t]*(?<name>[A-Z0-9_]+)\s*=\s*r?(?<quotes>'''|""")(?:\n---)?\n?)(?<doc>(?:(?!\k<quotes>)[\s\S])*)\k<quotes>/g;
+    /(?<pre>[ \t]*(?<name>[A-Z0-9_]+)\s*=\s*r?(?<quotes>'''|""")(?:\n---)?\n?)/g;
 
   source: string;
   sourceLineRange: [number, number] = [0, 0];
@@ -257,20 +279,38 @@ export class LazyModuleDocumentation implements IModuleMetadata {
     if (!this._contents) {
       this._contents = new Map<string, Record<string, unknown>>();
       const contents = fs.readFileSync(this.source, { encoding: "utf8" });
+      // Per-parse instance so a stuck /g lastIndex cannot leak across modules.
+      const docsRegex = new RegExp(
+        LazyModuleDocumentation.docsRegex.source,
+        "g",
+      );
       let m;
-      while ((m = LazyModuleDocumentation.docsRegex.exec(contents)) !== null) {
-        if (m && m.groups && m.groups.name && m.groups.doc && m.groups.pre) {
+      while ((m = docsRegex.exec(contents)) !== null) {
+        if (m?.groups?.name && m.groups.pre && m.groups.quotes) {
+          const contentStart = m.index + m[0].length;
+          const closeIndex = contents.indexOf(m.groups.quotes, contentStart);
+          if (closeIndex === -1) {
+            // Unclosed opener: keep scanning from after this match (lastIndex).
+            continue;
+          }
+          const doc = contents.substring(contentStart, closeIndex);
+          docsRegex.lastIndex = closeIndex + m.groups.quotes.length;
+
+          // Preserve prior behavior: empty doc bodies were skipped.
+          if (!doc) {
+            continue;
+          }
+
           if (m.groups.name === DOCUMENTATION) {
             // determine documentation start/end lines for definition provider
             let startLine =
               contents.substring(0, m.index).match(/\n/g)?.length || 0;
             startLine += m.groups.pre.match(/\n/g)?.length || 0;
-            const endLine =
-              startLine + (m.groups.doc.match(/\n/g)?.length || 0);
+            const endLine = startLine + (doc.match(/\n/g)?.length || 0);
             this.sourceLineRange = [startLine, endLine];
           }
 
-          const document = parseDocument(m.groups.doc);
+          const document = parseDocument(doc);
           // There's about 20 modules (out of ~3200) in Ansible 2.9 libs that contain YAML syntax errors
           // Still, document.toJSON() works on them
           this._contents.set(

--- a/packages/ansible-language-server/src/utils/misc.ts
+++ b/packages/ansible-language-server/src/utils/misc.ts
@@ -1,9 +1,9 @@
-import * as child_process from "child_process";
+import * as child_process from "node:child_process";
 import { Buffer } from "node:buffer";
 import { existsSync, statSync, promises as fs } from "node:fs";
 import { homedir } from "node:os";
 import { promisify } from "util";
-import type { SpawnOptions } from "child_process";
+import type { SpawnOptions } from "node:child_process";
 import { TextDocument } from "vscode-languageserver-textdocument";
 import { Range } from "vscode-languageserver-types";
 import * as path from "node:path";

--- a/packages/ansible-language-server/test/interfaces.test.ts
+++ b/packages/ansible-language-server/test/interfaces.test.ts
@@ -1,13 +1,16 @@
 import { IPullPolicy } from "@src/interfaces/extensionSettings.js";
-import { expect } from "vitest";
+import { expect, expectTypeOf } from "vitest";
 
 describe("interfaces", function () {
   describe("IPullPolicy", function () {
     it("should exist as a type", function () {
       // Type existence is verified by TypeScript at compile time.
       // If IPullPolicy doesn't exist, this file won't compile.
-      const _test: IPullPolicy = "always";
-      expect(_test).toBe("always");
+      expectTypeOf<IPullPolicy>().toEqualTypeOf<
+        "always" | "missing" | "never" | "tag"
+      >();
+      const policies: IPullPolicy[] = ["always", "missing", "never", "tag"];
+      expect(policies).toContain("always");
     });
   });
 });

--- a/packages/ansible-language-server/test/providers/hoverProvider.test.ts
+++ b/packages/ansible-language-server/test/providers/hoverProvider.test.ts
@@ -284,7 +284,10 @@ describe("doHover()", function () {
 
   const textDoc = getDoc(fixtureFilePath);
   const docSettings = context?.documentSettings.get(textDoc.uri);
-  expect(docSettings).toBeDefined();
+
+  beforeAll(() => {
+    expect(docSettings).toBeDefined();
+  });
 
   describe("Play keywords hover", function () {
     describe("@ee", function () {

--- a/packages/ansible-language-server/test/utils/docsParser.test.ts
+++ b/packages/ansible-language-server/test/utils/docsParser.test.ts
@@ -1,0 +1,117 @@
+import { expect, describe, it, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { LazyModuleDocumentation } from "@src/utils/docsParser.js";
+
+describe("LazyModuleDocumentation", function () {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  function writeModule(fileName: string, source: string): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "als-docs-"));
+    tempDirs.push(dir);
+    const filePath = path.join(dir, fileName);
+    fs.writeFileSync(filePath, source);
+    return filePath;
+  }
+
+  it("parses DOCUMENTATION from a well-formed module", function () {
+    const filePath = writeModule(
+      "good.py",
+      [
+        "DOCUMENTATION = '''",
+        "module: ping",
+        "short_description: Test",
+        "'''",
+        "",
+      ].join("\n"),
+    );
+
+    const docs = new LazyModuleDocumentation(
+      filePath,
+      "ansible.builtin.ping",
+      "ansible",
+      "builtin",
+      "ping",
+    );
+
+    expect(docs.rawDocumentationFragments.has("DOCUMENTATION")).toBe(true);
+    expect(docs.rawDocumentationFragments.get("DOCUMENTATION")).toMatchObject({
+      module: "ping",
+      short_description: "Test",
+    });
+  });
+
+  it("does not leak regex state when a prior module has unclosed quotes", function () {
+    const brokenPath = writeModule(
+      "broken.py",
+      ["DOCUMENTATION = '''", "module: broken", "short_description: oops"].join(
+        "\n",
+      ),
+    );
+    const goodPath = writeModule(
+      "good.py",
+      [
+        "DOCUMENTATION = '''",
+        "module: ping",
+        "short_description: Test",
+        "'''",
+        "",
+      ].join("\n"),
+    );
+
+    const broken = new LazyModuleDocumentation(
+      brokenPath,
+      "ns.col.broken",
+      "ns",
+      "col",
+      "broken",
+    );
+    expect(broken.rawDocumentationFragments.has("DOCUMENTATION")).toBe(false);
+
+    const good = new LazyModuleDocumentation(
+      goodPath,
+      "ansible.builtin.ping",
+      "ansible",
+      "builtin",
+      "ping",
+    );
+    expect(good.rawDocumentationFragments.has("DOCUMENTATION")).toBe(true);
+    expect(good.rawDocumentationFragments.get("DOCUMENTATION")).toMatchObject({
+      module: "ping",
+    });
+  });
+
+  it("keeps scanning after an unclosed opener in the same file", function () {
+    // Use a different quote style for EXAMPLES so the unclosed DOCUMENTATION
+    // opener cannot be closed by the EXAMPLES terminator.
+    const filePath = writeModule(
+      "partial.py",
+      [
+        "DOCUMENTATION = '''",
+        "module: broken",
+        'EXAMPLES = """',
+        "- ping:",
+        '"""',
+        "",
+      ].join("\n"),
+    );
+
+    const docs = new LazyModuleDocumentation(
+      filePath,
+      "ns.col.partial",
+      "ns",
+      "col",
+      "partial",
+    );
+
+    expect(docs.rawDocumentationFragments.has("DOCUMENTATION")).toBe(false);
+    expect(docs.rawDocumentationFragments.has("EXAMPLES")).toBe(true);
+  });
+});

--- a/packages/ansible-language-server/test/utils/withInterpreter.test.ts
+++ b/packages/ansible-language-server/test/utils/withInterpreter.test.ts
@@ -169,23 +169,29 @@ describe("withInterpreter", function () {
   });
 
   describe("activation script validation", function () {
-    it("should reject activation script with shell metacharacters", function () {
+    it.each([
+      {
+        name: "activation script with shell metacharacters",
+        activationScript: "/tmp/activate; rm -rf /",
+      },
+      {
+        name: "activation script that does not exist",
+        activationScript: "/nonexistent/path/to/activate",
+      },
+      {
+        name: "tilde path with shell metacharacters",
+        activationScript: "~/activate; rm -rf /",
+      },
+      {
+        name: "tilde path that does not exist after expansion",
+        activationScript: "~/nonexistent/venv/bin/activate",
+      },
+    ])("should reject $name", ({ activationScript }) => {
       const result = withInterpreter(
         "ansible-lint",
         "playbook.yml",
         "",
-        "/tmp/activate; rm -rf /",
-      );
-
-      expect(result.command).toBe("ansible-lint playbook.yml");
-    });
-
-    it("should reject activation script that does not exist", function () {
-      const result = withInterpreter(
-        "ansible-lint",
-        "playbook.yml",
-        "",
-        "/nonexistent/path/to/activate",
+        activationScript,
       );
 
       expect(result.command).toBe("ansible-lint playbook.yml");
@@ -274,28 +280,6 @@ describe("withInterpreter", function () {
         fs.unlinkSync(scriptPath);
         fs.rmdirSync(tmpDir);
       }
-    });
-
-    it("should reject tilde path with shell metacharacters", function () {
-      const result = withInterpreter(
-        "ansible-lint",
-        "playbook.yml",
-        "",
-        "~/activate; rm -rf /",
-      );
-
-      expect(result.command).toBe("ansible-lint playbook.yml");
-    });
-
-    it("should reject tilde path that does not exist after expansion", function () {
-      const result = withInterpreter(
-        "ansible-lint",
-        "playbook.yml",
-        "",
-        "~/nonexistent/venv/bin/activate",
-      );
-
-      expect(result.command).toBe("ansible-lint playbook.yml");
     });
   });
 });

--- a/packages/ansible-language-server/test/utils/yaml.test.ts
+++ b/packages/ansible-language-server/test/utils/yaml.test.ts
@@ -1,5 +1,5 @@
 // codespell:ignore isPlay
-import { expect, beforeEach } from "vitest";
+import { expect, beforeEach, describe, it } from "vitest";
 import { Position } from "vscode-languageserver";
 import { Node, Scalar, YAMLMap, YAMLSeq } from "yaml";
 import {
@@ -155,70 +155,22 @@ describe("yaml", function () {
   });
 
   describe("getDeclaredCollections", function () {
-    it("canGetCollections", async function () {
-      const path = getPathInFile("getDeclaredCollections.yml", 13, 7);
-      const collections = getDeclaredCollections(path);
-      expect(collections).toEqual(
-        expect.arrayContaining([
-          "mynamespace.mycollection",
-          "mynamespace2.mycollection2",
-        ]),
-      );
-    });
+    const declaredCollections = [
+      "mynamespace.mycollection",
+      "mynamespace2.mycollection2",
+    ];
 
-    it("canGetCollectionsFromPreTasks", async function () {
-      const path = getPathInFile("getDeclaredCollections.yml", 9, 7);
+    it.each([
+      { name: "canGetCollections", line: 13, character: 7 },
+      { name: "canGetCollectionsFromPreTasks", line: 9, character: 7 },
+      { name: "canGetCollectionsFromBlock", line: 12, character: 11 },
+      { name: "canGetCollectionsFromNestedBlock", line: 23, character: 15 },
+      { name: "canGetCollectionsFromRescue", line: 27, character: 11 },
+      { name: "canGetCollectionsFromAlways", line: 31, character: 11 },
+    ])("$name", async ({ line, character }) => {
+      const path = getPathInFile("getDeclaredCollections.yml", line, character);
       const collections = getDeclaredCollections(path);
-      expect(collections).toEqual(
-        expect.arrayContaining([
-          "mynamespace.mycollection",
-          "mynamespace2.mycollection2",
-        ]),
-      );
-    });
-
-    it("canGetCollectionsFromBlock", async function () {
-      const path = getPathInFile("getDeclaredCollections.yml", 12, 11);
-      const collections = getDeclaredCollections(path);
-      expect(collections).toEqual(
-        expect.arrayContaining([
-          "mynamespace.mycollection",
-          "mynamespace2.mycollection2",
-        ]),
-      );
-    });
-
-    it("canGetCollectionsFromNestedBlock", async function () {
-      const path = getPathInFile("getDeclaredCollections.yml", 23, 15);
-      const collections = getDeclaredCollections(path);
-      expect(collections).toEqual(
-        expect.arrayContaining([
-          "mynamespace.mycollection",
-          "mynamespace2.mycollection2",
-        ]),
-      );
-    });
-
-    it("canGetCollectionsFromRescue", async function () {
-      const path = getPathInFile("getDeclaredCollections.yml", 27, 11);
-      const collections = getDeclaredCollections(path);
-      expect(collections).toEqual(
-        expect.arrayContaining([
-          "mynamespace.mycollection",
-          "mynamespace2.mycollection2",
-        ]),
-      );
-    });
-
-    it("canGetCollectionsFromAlways", async function () {
-      const path = getPathInFile("getDeclaredCollections.yml", 31, 11);
-      const collections = getDeclaredCollections(path);
-      expect(collections).toEqual(
-        expect.arrayContaining([
-          "mynamespace.mycollection",
-          "mynamespace2.mycollection2",
-        ]),
-      );
+      expect(collections).toEqual(expect.arrayContaining(declaredCollections));
     });
 
     it("canWorkWithoutCollections", async function () {
@@ -253,38 +205,49 @@ describe("yaml", function () {
       expect(test).to.be.eq(false);
     });
 
-    it("canCorrectlyNegateTaskParamForPlay", async function () {
-      const path = getPathInFile("isTaskParamInPlaybook.yml", 4, 3) as Node[];
+    it.each([
+      {
+        name: "canCorrectlyNegateTaskParamForPlay",
+        line: 4,
+        character: 3,
+        expected: false,
+      },
+      {
+        name: "canCorrectlyNegateTaskParamForBlock",
+        line: 14,
+        character: 7,
+        expected: false,
+      },
+      {
+        name: "canCorrectlyNegateTaskParamForRole",
+        line: 17,
+        character: 7,
+        expected: false,
+      },
+    ])("$name", async ({ line, character, expected }) => {
+      const path = getPathInFile(
+        "isTaskParamInPlaybook.yml",
+        line,
+        character,
+      ) as Node[];
       const test = isTaskParam(path);
-      expect(test).to.be.eq(false);
+      expect(test).to.be.eq(expected);
     });
 
-    it("canCorrectlyNegateTaskParamForBlock", async function () {
-      const path = getPathInFile("isTaskParamInPlaybook.yml", 14, 7) as Node[];
-      const test = isTaskParam(path);
-      expect(test).to.be.eq(false);
-    });
-
-    it("canCorrectlyNegateTaskParamForRole", async function () {
-      const path = getPathInFile("isTaskParamInPlaybook.yml", 17, 7) as Node[];
-      const test = isTaskParam(path);
-      expect(test).to.be.eq(false);
-    });
-
-    it("canCorrectlyConfirmTaskParamInPreTasks", async function () {
-      const path = getPathInFile("isTaskParamInPlaybook.yml", 6, 7) as Node[];
-      const test = isTaskParam(path);
-      expect(test).to.be.eq(true);
-    });
-
-    it("canCorrectlyConfirmTaskParamInTasks", async function () {
-      const path = getPathInFile("isTaskParamInPlaybook.yml", 9, 7) as Node[];
-      const test = isTaskParam(path);
-      expect(test).to.be.eq(true);
-    });
-
-    it("canCorrectlyConfirmTaskParamInBlock", async function () {
-      const path = getPathInFile("isTaskParamInPlaybook.yml", 13, 11) as Node[];
+    it.each([
+      {
+        name: "canCorrectlyConfirmTaskParamInPreTasks",
+        line: 6,
+        character: 7,
+      },
+      { name: "canCorrectlyConfirmTaskParamInTasks", line: 9, character: 7 },
+      { name: "canCorrectlyConfirmTaskParamInBlock", line: 13, character: 11 },
+    ])("$name", async ({ line, character }) => {
+      const path = getPathInFile(
+        "isTaskParamInPlaybook.yml",
+        line,
+        character,
+      ) as Node[];
       const test = isTaskParam(path);
       expect(test).to.be.eq(true);
     });

--- a/packages/ansible-mcp-server/src/utils/pathValidation.ts
+++ b/packages/ansible-mcp-server/src/utils/pathValidation.ts
@@ -36,11 +36,11 @@ export function validatePathWithinWorkspace(
   inputPath: string,
   workspaceRoot: string,
 ): string {
-  if (!inputPath || !inputPath.trim()) {
+  if (!inputPath?.trim()) {
     throw new PathTraversalError("Path must not be empty");
   }
 
-  if (!workspaceRoot || !workspaceRoot.trim()) {
+  if (!workspaceRoot?.trim()) {
     throw new PathTraversalError("Workspace root must not be empty");
   }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -202,7 +202,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
   context.subscriptions.push(
     pythonEnvService.onDidChangeEnvironment(async () => {
       try {
-        if (client && client.isRunning()) {
+        if (client?.isRunning()) {
           const refreshResult = await client.sendRequest<{
             success: boolean;
           }>("ansible/refreshConfiguration", {});
@@ -1283,8 +1283,6 @@ const startClient = async (
           docsReady = newDocsReadyGate();
         }
       }),
-    );
-    context.subscriptions.push(
       vscode.commands.registerCommand("ansible.awaitDocsLibraryReady", () =>
         docsLibraryIsReady ? Promise.resolve() : docsReady.promise,
       ),
@@ -1473,8 +1471,12 @@ export function makeConfigurationMiddleware(
     }
 
     if (lastLoggedUserByScope.get(scopeUri) !== rawInterpreterPath) {
+      const resolvedSuffix =
+        resolvedUserPath !== rawInterpreterPath
+          ? ` (resolved: ${resolvedUserPath})`
+          : "";
       outputChannel.appendLine(
-        `[Ansible] Using user-configured interpreterPath: ${rawInterpreterPath}${resolvedUserPath !== rawInterpreterPath ? ` (resolved: ${resolvedUserPath})` : ""}`,
+        `[Ansible] Using user-configured interpreterPath: ${rawInterpreterPath}${resolvedSuffix}`,
       );
       lastLoggedUserByScope.set(scopeUri, rawInterpreterPath);
     }

--- a/src/extensionConflicts.ts
+++ b/src/extensionConflicts.ts
@@ -30,7 +30,7 @@ function extensionDisplayName(ext: Extension<unknown>): string {
 
 function isExtensionPresent(obj: unknown): obj is Extension<unknown> {
   return (
-    typeof obj !== "undefined" &&
+    obj !== undefined &&
     typeof obj === "object" &&
     obj !== null &&
     "id" in obj &&

--- a/src/features/ansibleTox/runner.ts
+++ b/src/features/ansibleTox/runner.ts
@@ -4,7 +4,7 @@ import * as vscode from "vscode";
 import * as child_process from "child_process";
 import * as util from "util";
 import * as os from "os";
-import * as path from "path";
+import * as path from "node:path";
 import { getTerminal } from "@src/features/ansibleTox/utils";
 import {
   ANSIBLE_TOX_FILE_NAME,
@@ -76,23 +76,31 @@ export async function runTox(
   targetTerminal.sendText(terminalCommand);
 }
 
+function coerceProcessStream(
+  err: unknown,
+  stream: "stderr" | "stdout",
+): string {
+  if (!isExecProcessError(err)) {
+    return "";
+  }
+  const value = err[stream];
+  if (typeof value === "string") {
+    return value;
+  }
+  if (value != null) {
+    return String(value);
+  }
+  return "";
+}
+
 function extractProcessOutput(err: unknown): {
   stderr: string;
   stdout: string;
 } {
-  const stderr =
-    isExecProcessError(err) && typeof err.stderr === "string"
-      ? err.stderr
-      : isExecProcessError(err) && err.stderr != null
-        ? String(err.stderr)
-        : "";
-  const stdout =
-    isExecProcessError(err) && typeof err.stdout === "string"
-      ? err.stdout
-      : isExecProcessError(err) && err.stdout != null
-        ? String(err.stdout)
-        : "";
-  return { stderr, stdout };
+  return {
+    stderr: coerceProcessStream(err, "stderr"),
+    stdout: coerceProcessStream(err, "stdout"),
+  };
 }
 
 function logToxError(err: unknown): void {

--- a/src/features/lightspeed/contentMatchesWebview.ts
+++ b/src/features/lightspeed/contentMatchesWebview.ts
@@ -17,11 +17,11 @@ import {
 
 function escapeHtml(value: string): string {
   return value
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#39;");
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
 }
 
 export class ContentMatchesWebview implements vscode.WebviewViewProvider {

--- a/src/features/lightspeed/utils/explanationUtils.ts
+++ b/src/features/lightspeed/utils/explanationUtils.ts
@@ -24,8 +24,7 @@ export function getObjectKeys(content: string): string[] {
     ) {
       return [];
     }
-    const lastObject: unknown =
-      parsedAnsibleDocument[parsedAnsibleDocument.length - 1];
+    const lastObject: unknown = parsedAnsibleDocument.at(-1);
     if (typeof lastObject === "object") {
       return Object.keys(lastObject as object);
     }

--- a/src/features/runner.ts
+++ b/src/features/runner.ts
@@ -1,5 +1,5 @@
 /* "stdlib" */
-import { existsSync } from "fs";
+import { existsSync } from "node:fs";
 import * as vscode from "vscode";
 
 /* local */
@@ -15,7 +15,7 @@ import { TerminalService } from "@src/services/TerminalService";
 export const SHELL_METACHARACTERS_PATTERN = /[\x00\n\r$`;&|(){}<>!]/;
 
 export function shellQuote(s: string): string {
-  return "'" + s.replace(/'/g, "'\\''") + "'";
+  return "'" + s.replaceAll("'", String.raw`'\''`) + "'";
 }
 
 function validatePlaybookPath(fsPath: string): string | undefined {
@@ -33,11 +33,11 @@ function validatePlaybookPath(fsPath: string): string | undefined {
  * `ansible-navigator run` and `ansible-playbook` commands.
  */
 export class AnsiblePlaybookRunProvider implements vscode.Disposable {
-  private extensionSettings: SettingsManager;
-  private telemetry: TelemetryManager;
+  private readonly extensionSettings: SettingsManager;
+  private readonly telemetry: TelemetryManager;
 
   constructor(
-    private vsCodeExtCtx: vscode.ExtensionContext,
+    private readonly vsCodeExtCtx: vscode.ExtensionContext,
     extensionSettings: SettingsManager,
     telemetry: TelemetryManager,
   ) {
@@ -95,12 +95,12 @@ export class AnsiblePlaybookRunProvider implements vscode.Disposable {
       vscode.window.showErrorMessage(message);
       return false;
     }
-    commandLineArgs.push("--ee true");
-    commandLineArgs.push("--pae false");
     commandLineArgs.push(
+      "--ee true",
+      "--pae false",
       `--ce ${getContainerEngine(eeSettings.containerEngine as string)}`,
+      `--eei ${shellQuote(eeSettings.image)}`,
     );
-    commandLineArgs.push(`--eei ${shellQuote(eeSettings.image)}`);
     if (eeSettings.containerOptions !== "") {
       commandLineArgs.push(`--co ${shellQuote(eeSettings.containerOptions)}`);
     }
@@ -181,8 +181,7 @@ export class AnsiblePlaybookRunProvider implements vscode.Disposable {
       return;
     }
 
-    commandLineArgs.push(playbookArguments);
-    commandLineArgs.push(shellQuote(playbookFsPath));
+    commandLineArgs.push(playbookArguments, shellQuote(playbookFsPath));
     const cmdArgs = commandLineArgs.map((arg) => arg).join(" ");
     const command = `${runExecutable} ${cmdArgs}`;
 

--- a/src/features/utils/ansible.ts
+++ b/src/features/utils/ansible.ts
@@ -37,8 +37,7 @@ export function getAnsibleFileType(
   ) {
     return "other";
   }
-  const lastObject: unknown =
-    parsedAnsibleDocument[parsedAnsibleDocument.length - 1];
+  const lastObject: unknown = parsedAnsibleDocument.at(-1);
   if (lastObject === null || typeof lastObject !== "object") {
     return "other";
   }

--- a/src/features/utils/commandRunner.ts
+++ b/src/features/utils/commandRunner.ts
@@ -1,5 +1,5 @@
 /* local */
-import * as path from "path";
+import * as path from "node:path";
 import * as vscode from "vscode";
 import type { ExtensionSettings } from "@src/interfaces/extensionSettings";
 import { PythonEnvironmentService } from "@src/services/PythonEnvironmentService";
@@ -28,10 +28,11 @@ export async function withInterpreter(
   const command = `${runExecutable} ${cmdArgs}`;
 
   // Start with base environment and Ansible-specific vars
-  const env = Object.assign({}, process.env, {
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
     ANSIBLE_FORCE_COLOR: "0", // ensure output is parsable (no ANSI)
     PYTHONBREAKPOINT: "0", // prevent debugger from being triggered
-  });
+  };
 
   // Resolve Python environment and add venv bin to PATH
   const pythonEnvService = PythonEnvironmentService.getInstance();

--- a/src/features/vault.ts
+++ b/src/features/vault.ts
@@ -48,7 +48,7 @@ function displayInvalidConfigError(): void {
 }
 
 export class Vault {
-  constructor(private extSettings: SettingsManager) {}
+  constructor(private readonly extSettings: SettingsManager) {}
 
   private async ansibleVaultCmd(args: string): Promise<{
     command: string;
@@ -288,7 +288,7 @@ export class Vault {
     return encryptedText.trim();
   }
 
-  private decryptInline = async (
+  private readonly decryptInline = async (
     text: string,
     rootPath: string | undefined,
     indentationLevel: number,
@@ -379,7 +379,10 @@ export class Vault {
     return execCwd(cmd, rootPath, env);
   }
 
-  private decryptFile = async (f: string, rootPath: string | undefined) => {
+  private readonly decryptFile = async (
+    f: string,
+    rootPath: string | undefined,
+  ) => {
     console.log(`Decrypt file: ${f}`);
     const args = `decrypt "${f}"`;
     const { command: cmd, env } = await this.ansibleVaultCmd(args);

--- a/src/services/PythonEnvironmentService.ts
+++ b/src/services/PythonEnvironmentService.ts
@@ -13,8 +13,8 @@
  * SettingsManager and the language server — this service does not read it.
  */
 
-import * as fs from "fs";
-import * as path from "path";
+import * as fs from "node:fs";
+import * as path from "node:path";
 import * as vscode from "vscode";
 import { PythonExtension, ResolvedEnvironment } from "@vscode/python-extension";
 import {
@@ -35,7 +35,7 @@ export class PythonEnvironmentService implements vscode.Disposable {
   private _petWarningShown: boolean = false;
   private _disposables: vscode.Disposable[] = [];
 
-  private _onDidChangeEnvironment =
+  private readonly _onDidChangeEnvironment =
     new vscode.EventEmitter<DidChangeEnvironmentEventArgs>();
   public readonly onDidChangeEnvironment = this._onDidChangeEnvironment.event;
 
@@ -43,9 +43,7 @@ export class PythonEnvironmentService implements vscode.Disposable {
   private constructor() {}
 
   public static getInstance(): PythonEnvironmentService {
-    if (!PythonEnvironmentService._instance) {
-      PythonEnvironmentService._instance = new PythonEnvironmentService();
-    }
+    PythonEnvironmentService._instance ??= new PythonEnvironmentService();
     return PythonEnvironmentService._instance;
   }
 
@@ -418,7 +416,7 @@ export class PythonEnvironmentService implements vscode.Disposable {
     scope?: vscode.Uri,
   ): Promise<string | undefined> {
     // Priority 1: User-configured ansible.python.interpreterPath
-    if (userConfiguredPath && userConfiguredPath.trim()) {
+    if (userConfiguredPath?.trim()) {
       const { resolveInterpreterPath } =
         await import("@src/features/utils/interpreterPathResolver");
       const resolved = resolveInterpreterPath(userConfiguredPath, scope);

--- a/src/services/TerminalService.ts
+++ b/src/services/TerminalService.ts
@@ -6,7 +6,7 @@
  * PET detection and fallback logic are handled in one place.
  */
 
-import * as path from "path";
+import * as path from "node:path";
 import * as vscode from "vscode";
 import { TerminalActivationStateEventArgs } from "@src/types/pythonEnvApi";
 import { PythonEnvironmentService } from "@src/services/PythonEnvironmentService";
@@ -54,9 +54,7 @@ export class TerminalService implements vscode.Disposable {
   private constructor() {}
 
   public static getInstance(): TerminalService {
-    if (!TerminalService._instance) {
-      TerminalService._instance = new TerminalService();
-    }
+    TerminalService._instance ??= new TerminalService();
     return TerminalService._instance;
   }
 

--- a/src/webviewHtml.ts
+++ b/src/webviewHtml.ts
@@ -119,7 +119,7 @@ export function getWebviewHtml(options: WebviewHtmlOptions): string {
   html = html.replace("<head>", `<head>\n    ${csp}`);
 
   // Add nonce to all <script> tags
-  html = html.replace(/<script /g, `<script nonce="${nonce}" `);
+  html = html.replaceAll("<script ", `<script nonce="${nonce}" `);
 
   // Rewrite absolute /assets/ paths to webview URIs
   html = html.replace(

--- a/test/unit/lightspeed/ansibleContext.test.ts
+++ b/test/unit/lightspeed/ansibleContext.test.ts
@@ -437,17 +437,27 @@ describe("AnsibleContextProcessor", () => {
       expect(result.errors.length).toBeGreaterThan(0);
     });
 
-    it("should validate playbook with hosts", () => {
-      const content =
-        "---\n- hosts: all\n  tasks:\n    - name: Test\n      debug:\n        msg: test";
-      const result = AnsibleContextProcessor.validateAnsibleContent(content);
-
-      expect(result.valid).toBe(true);
-      expect(result.errors).toHaveLength(0);
-    });
-
-    it("should validate role structure", () => {
-      const content = "---\nmain: []";
+    it.each([
+      {
+        name: "playbook with hosts",
+        content:
+          "---\n- hosts: all\n  tasks:\n    - name: Test\n      debug:\n        msg: test",
+      },
+      { name: "role structure", content: "---\nmain: []" },
+      {
+        name: "task with name field only",
+        content: "---\n- name: Simple task",
+      },
+      {
+        name: "task with module key (no name)",
+        content: "---\n- ansible.builtin.debug:\n    msg: 'hello'",
+      },
+      {
+        name: "task with non-underscore key but no name",
+        content:
+          "---\n- ansible.builtin.copy:\n    src: /tmp/a\n    dest: /tmp/b",
+      },
+    ])("should validate $name", ({ content }) => {
       const result = AnsibleContextProcessor.validateAnsibleContent(content);
 
       expect(result.valid).toBe(true);
@@ -471,60 +481,47 @@ describe("AnsibleContextProcessor", () => {
       expect(result.errors.length).toBeGreaterThan(0);
     });
 
-    it("should reject task missing name or module", () => {
-      const content = "---\n- _meta: {}\n  _some_other: value";
+    it.each([
+      {
+        name: "task missing name or module",
+        content: "---\n- _meta: {}\n  _some_other: value",
+        error: "Task missing name or module",
+      },
+      {
+        name: "invalid playbook or role structure",
+        content: "---\ninvalid_key: value\nanother_key: test",
+        error: "Invalid playbook or role structure",
+      },
+      {
+        name: "null items in task list",
+        content: "---\n- null\n- name: Valid task",
+        error: "Invalid task or play structure",
+      },
+      {
+        name: "numeric items in task list",
+        content: "---\n- 42\n- name: Valid task",
+        error: "Invalid task or play structure",
+      },
+      {
+        name: "task with only underscore-prefixed keys",
+        content: "---\n- _internal: data\n  _meta: info",
+        error: "Task missing name or module",
+      },
+      {
+        name: "empty object in task list as missing name/module",
+        content: "---\n- {}",
+        error: "Task missing name or module",
+      },
+      {
+        name: "boolean items in array as invalid structure",
+        content: "---\n- true\n- false",
+        error: "Invalid task or play structure",
+      },
+    ])("should reject $name", ({ content, error }) => {
       const result = AnsibleContextProcessor.validateAnsibleContent(content);
 
       expect(result.valid).toBe(false);
-      expect(result.errors).toContain("Task missing name or module");
-    });
-
-    it("should reject invalid playbook or role structure", () => {
-      const content = "---\ninvalid_key: value\nanother_key: test";
-      const result = AnsibleContextProcessor.validateAnsibleContent(content);
-
-      expect(result.valid).toBe(false);
-      expect(result.errors).toContain("Invalid playbook or role structure");
-    });
-
-    it("should validate task with name field only", () => {
-      const content = "---\n- name: Simple task";
-      const result = AnsibleContextProcessor.validateAnsibleContent(content);
-
-      expect(result.valid).toBe(true);
-      expect(result.errors).toHaveLength(0);
-    });
-
-    it("should validate task with module key (no name)", () => {
-      const content = "---\n- ansible.builtin.debug:\n    msg: 'hello'";
-      const result = AnsibleContextProcessor.validateAnsibleContent(content);
-
-      expect(result.valid).toBe(true);
-      expect(result.errors).toHaveLength(0);
-    });
-
-    it("should reject null items in task list", () => {
-      const content = "---\n- null\n- name: Valid task";
-      const result = AnsibleContextProcessor.validateAnsibleContent(content);
-
-      expect(result.valid).toBe(false);
-      expect(result.errors).toContain("Invalid task or play structure");
-    });
-
-    it("should reject numeric items in task list", () => {
-      const content = "---\n- 42\n- name: Valid task";
-      const result = AnsibleContextProcessor.validateAnsibleContent(content);
-
-      expect(result.valid).toBe(false);
-      expect(result.errors).toContain("Invalid task or play structure");
-    });
-
-    it("should reject task with only underscore-prefixed keys", () => {
-      const content = "---\n- _internal: data\n  _meta: info";
-      const result = AnsibleContextProcessor.validateAnsibleContent(content);
-
-      expect(result.valid).toBe(false);
-      expect(result.errors).toContain("Task missing name or module");
+      expect(result.errors).toContain(error);
     });
 
     it("should collect multiple errors from mixed invalid items", () => {
@@ -533,14 +530,6 @@ describe("AnsibleContextProcessor", () => {
 
       expect(result.valid).toBe(false);
       expect(result.errors).toContain("Invalid task or play structure");
-      expect(result.errors).toContain("Task missing name or module");
-    });
-
-    it("should validate empty object in task list as missing name/module", () => {
-      const content = "---\n- {}";
-      const result = AnsibleContextProcessor.validateAnsibleContent(content);
-
-      expect(result.valid).toBe(false);
       expect(result.errors).toContain("Task missing name or module");
     });
 
@@ -556,15 +545,6 @@ describe("AnsibleContextProcessor", () => {
       expect(invalidStructureCount).toBeGreaterThanOrEqual(2);
     });
 
-    it("should accept task with non-underscore key but no name", () => {
-      const content =
-        "---\n- ansible.builtin.copy:\n    src: /tmp/a\n    dest: /tmp/b";
-      const result = AnsibleContextProcessor.validateAnsibleContent(content);
-
-      expect(result.valid).toBe(true);
-      expect(result.errors).toHaveLength(0);
-    });
-
     it("should validate single object with hosts key as valid playbook", () => {
       const content =
         "---\nhosts: webservers\ntasks:\n  - name: Ping\n    ansible.builtin.ping:";
@@ -578,14 +558,6 @@ describe("AnsibleContextProcessor", () => {
       const result = AnsibleContextProcessor.validateAnsibleContent(content);
 
       expect(result.valid).toBe(true);
-    });
-
-    it("should reject boolean items in array as invalid structure", () => {
-      const content = "---\n- true\n- false";
-      const result = AnsibleContextProcessor.validateAnsibleContent(content);
-
-      expect(result.valid).toBe(false);
-      expect(result.errors).toContain("Invalid task or play structure");
     });
   });
 

--- a/test/unit/lightspeed/utils/scanner.test.ts
+++ b/test/unit/lightspeed/utils/scanner.test.ts
@@ -21,7 +21,7 @@ describe("CollectionFinder", () => {
       const finder = new CollectionFinder([SAMPLES_PATH]);
       await finder.refreshCache();
 
-      expect(finder.cache.length).toBe(4);
+      expect(finder.cache).toHaveLength(4);
       expect(finder.initialized).toBe(true);
     });
 
@@ -39,7 +39,7 @@ describe("CollectionFinder", () => {
       const finder = new CollectionFinder([SAMPLES_PATH]);
       const collections = await finder.searchNestedCollections();
 
-      expect(collections.length).toBe(4);
+      expect(collections).toHaveLength(4);
       expect(collections.every((c) => c instanceof AnsibleCollection)).toBe(
         true,
       );

--- a/test/unit/webviewHtml.test.ts
+++ b/test/unit/webviewHtml.test.ts
@@ -81,35 +81,25 @@ describe("getDevServerUrl", () => {
     expect(getDevServerUrl(tmpDir)).toBeUndefined();
   });
 
-  it("returns undefined for a non-http protocol", () => {
-    fs.writeFileSync(
-      path.join(tmpDir, "out", ".vite-dev-server-url"),
-      "https://localhost:5173",
-    );
-    expect(getDevServerUrl(tmpDir)).toBeUndefined();
-  });
-
-  it("returns undefined for a non-localhost hostname", () => {
-    fs.writeFileSync(
-      path.join(tmpDir, "out", ".vite-dev-server-url"),
-      "http://example.com:5173",
-    );
-    expect(getDevServerUrl(tmpDir)).toBeUndefined();
-  });
-
-  it("returns undefined when URL has no port", () => {
-    fs.writeFileSync(
-      path.join(tmpDir, "out", ".vite-dev-server-url"),
-      "http://localhost",
-    );
-    expect(getDevServerUrl(tmpDir)).toBeUndefined();
-  });
-
-  it("returns undefined for malformed content", () => {
-    fs.writeFileSync(
-      path.join(tmpDir, "out", ".vite-dev-server-url"),
-      "not-a-url",
-    );
+  it.each([
+    {
+      name: "a non-http protocol",
+      content: "https://localhost:5173",
+    },
+    {
+      name: "a non-localhost hostname",
+      content: "http://example.com:5173",
+    },
+    {
+      name: "a URL with no port",
+      content: "http://localhost",
+    },
+    {
+      name: "malformed content",
+      content: "not-a-url",
+    },
+  ])("returns undefined for $name", ({ content }) => {
+    fs.writeFileSync(path.join(tmpDir, "out", ".vite-dev-server-url"), content);
     expect(getDevServerUrl(tmpDir)).toBeUndefined();
   });
 });

--- a/test/wdio/webviews.spec.ts
+++ b/test/wdio/webviews.spec.ts
@@ -126,28 +126,28 @@ describe("Webview tests", () => {
       await closeAllEditors();
     });
 
-    it("should display the welcome page header", async function () {
-      this.timeout(60_000);
-      const text = await waitForWebviewText(/Ansible Development Tools/, (t) =>
-        t.includes("Ansible Development Tools"),
-      );
-      assert.ok(text.includes("Ansible Development Tools"));
-    });
-
-    it("should display the welcome page subtitle", async function () {
-      this.timeout(60_000);
-      const text = await waitForWebviewText(/Ansible Development Tools/, (t) =>
-        t.includes("Create, test and deploy"),
-      );
-      assert.ok(text.includes("Create, test and deploy"));
-    });
-
-    it("should display the MCP Server section", async function () {
-      this.timeout(60_000);
-      const text = await waitForWebviewText(/Ansible Development Tools/, (t) =>
-        t.includes("MCP Server"),
-      );
-      assert.ok(text.includes("MCP Server"));
+    [
+      {
+        name: "welcome page header",
+        needle: "Ansible Development Tools",
+      },
+      {
+        name: "welcome page subtitle",
+        needle: "Create, test and deploy",
+      },
+      {
+        name: "MCP Server section",
+        needle: "MCP Server",
+      },
+    ].forEach(({ name, needle }) => {
+      it(`should display the ${name}`, async function () {
+        this.timeout(60_000);
+        const text = await waitForWebviewText(
+          /Ansible Development Tools/,
+          (t) => t.includes(needle),
+        );
+        assert.ok(text.includes(needle));
+      });
     });
   });
 


### PR DESCRIPTION
## Summary
- Fix the first 50 open SonarCloud leak-period issues on `main` (readonly members, ReDoS-safe docs parsing, nested ternaries, `node:` imports, `replaceAll`/`.at()`/optional-chain cleanups, and parameterized tests).

## Changes
- ALS: safer `LazyModuleDocumentation` parsing (per-parse regex, no shared `/g` `lastIndex` leak), fragment helper extract, lodash subpath imports, `readonly` settings fields
- Extension: `readonly`/env spread/`node:` imports, HTML escape and script-nonce `replaceAll`, tox nested-ternary cleanup, completion path `.at(-3)` guards
- Tests: `it.each` consolidation, `toHaveLength`, hover assertion moved into `beforeAll`, new `docsParser` isolation tests

## Test plan
- [x] `task lint` hooks (eslint/cspell/biome/prek) pass on changed files
- [x] `vitest` docsParser + related ALS/unit suites for touched tests
- [ ] CI green on draft PR
- [ ] SonarCloud leak-period count drops for the addressed findings after scan

related: sonarcloud leak period

Made with [Cursor](https://cursor.com)