### PR TITLE
feat: add setting to disable completion

### DIFF
--- a/docs/als/settings.md
+++ b/docs/als/settings.md
@@ -59,6 +59,11 @@ Extra parameters passed to the container engine command example: &#x27;--net&#x3
 . Default value:
 ``""``
 
+## [`ansible.completion.enabled`](#completion.enabled) { #completion.enabled data-toc-label=completion.enabled }
+Toggle completion provider. If disabled, no completion items are offered for Ansible files
+. Default value:
+``true``
+
 ## [`ansible.completion.provideRedirectModules`](#completion.provideRedirectModules) { #completion.provideRedirectModules data-toc-label=completion.provideRedirectModules }
 Toggle redirected module provider when completing modules
 . Default value:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -115,6 +115,8 @@ Existing values from deprecated settings are automatically migrated to the panel
 
 ## Completion & Language Server Settings
 
+- `ansible.completion.enabled`: Enables completion suggestions for Ansible
+  files. When disabled, the extension offers no completion items.
 - `ansible.completion.provideRedirectModules`: Toggle redirected module provider
   when completing modules.
 - `ansible.completion.provideModuleOptionAliases`: Toggle alias provider when

--- a/package.json
+++ b/package.json
@@ -290,17 +290,24 @@
       },
       {
         "properties": {
+          "ansible.completion.enabled": {
+            "default": true,
+            "markdownDescription": "Enables completion suggestions for Ansible files. If disabled, no completion items are offered by this extension.",
+            "order": 0,
+            "scope": "resource",
+            "type": "boolean"
+          },
           "ansible.completion.provideModuleOptionAliases": {
             "default": true,
-            "markdownDescription": "Toggle alias provider when completing module options.",
-            "order": 1,
+            "markdownDescription": "Toggle alias provider when completing module options. Requires `#ansible.completion.enabled#` to be enabled.",
+            "order": 2,
             "scope": "resource",
             "type": "boolean"
           },
           "ansible.completion.provideRedirectModules": {
             "default": true,
-            "markdownDescription": "Toggle redirected module provider when completing modules.",
-            "order": 0,
+            "markdownDescription": "Toggle redirected module provider when completing modules. Requires `#ansible.completion.enabled#` to be enabled.",
+            "order": 1,
             "scope": "resource",
             "type": "boolean"
           }

--- a/packages/ansible-language-server/src/interfaces/extensionSettings.ts
+++ b/packages/ansible-language-server/src/interfaces/extensionSettings.ts
@@ -27,6 +27,7 @@ export interface ExtensionSettings extends ExtensionSettingsType {
     useFullyQualifiedCollectionNames: boolean;
   };
   completion: {
+    enabled: boolean;
     provideRedirectModules: boolean;
     provideModuleOptionAliases: boolean;
   };
@@ -130,6 +131,10 @@ interface PythonSettingsWithDescription extends SettingsEntry {
  * Interface for completion settings
  */
 interface CompletionSettingsWithDescription extends SettingsEntry {
+  enabled: {
+    default: boolean;
+    description: string;
+  };
   provideRedirectModules: {
     default: boolean;
     description: string;

--- a/packages/ansible-language-server/src/providers/completionProvider.ts
+++ b/packages/ansible-language-server/src/providers/completionProvider.ts
@@ -129,6 +129,14 @@ export async function doCompletion(
   context: WorkspaceFolderContext,
   schemaService?: SchemaService,
 ): Promise<CompletionItem[]> {
+  const extensionSettings = await context.documentSettings.get(document.uri);
+
+  // Read before any other work, so that disabling completion also suppresses
+  // the schema-based completions handled right below.
+  if (!extensionSettings.completion.enabled) {
+    return [];
+  }
+
   // Check for schema-based completions first (for meta/main.yml, etc.)
   if (schemaService && schemaService.shouldValidateWithSchema(document)) {
     const schemaCompletions = await getSchemaCompletions(
@@ -170,8 +178,6 @@ export async function doCompletion(
 
   preparedText = insert(preparedText, offset, dummyMappingCharacter);
   const yamlDocs = parseAllDocuments(preparedText);
-
-  const extensionSettings = await context.documentSettings.get(document.uri);
 
   const useFqcn = extensionSettings.ansible.useFullyQualifiedCollectionNames;
   const provideRedirectModulesCompletion =
@@ -604,6 +610,15 @@ export async function doCompletionResolve(
   completionItem: CompletionItem,
   context: WorkspaceFolderContext,
 ): Promise<CompletionItem> {
+  if (hasCompletionDocumentUri(completionItem.data)) {
+    const settings = await context.documentSettings.get(
+      completionItem.data.documentUri,
+    );
+    if (!settings.completion.enabled) {
+      return completionItem;
+    }
+  }
+
   if (isModuleCompletionResolveData(completionItem.data)) {
     const data = completionItem.data;
     // resolve completion for a module

--- a/packages/ansible-language-server/src/services/settingsManager.ts
+++ b/packages/ansible-language-server/src/services/settingsManager.ts
@@ -91,6 +91,11 @@ export class SettingsManager {
       },
     },
     completion: {
+      enabled: {
+        default: true,
+        description:
+          "Toggle completion provider. If disabled, no completion items are offered for Ansible files",
+      },
       provideRedirectModules: {
         default: true,
         description:

--- a/packages/ansible-language-server/test/providers/completionProvider.test.ts
+++ b/packages/ansible-language-server/test/providers/completionProvider.test.ts
@@ -1482,3 +1482,128 @@ describe("doCompletion()", function () {
     });
   });
 });
+
+describe("completion disabled via ansible.completion.enabled", function () {
+  const workspaceManager = createTestWorkspaceManager();
+  const fixtureFileUri = resolveDocUri("completion/simple_tasks.yml");
+
+  function getContextOrThrow(): WorkspaceFolderContext {
+    const context = workspaceManager.getContext(fixtureFileUri);
+    if (!context) {
+      throw new Error(`No workspace context found for ${fixtureFileUri}`);
+    }
+    return context;
+  }
+
+  async function setCompletionEnabled(enabled: boolean): Promise<void> {
+    const settings =
+      await getContextOrThrow().documentSettings.get(fixtureFileUri);
+    settings.completion.enabled = enabled;
+  }
+
+  afterEach(async function () {
+    sinon.restore();
+    // restore the default so the shared settings object does not leak into
+    // other test files
+    await setCompletionEnabled(true);
+  });
+
+  it("offers completion items while enabled", async function () {
+    const context = getContextOrThrow();
+    const textDoc = TextDocument.create(fixtureFileUri, "ansible", 1, "- ");
+
+    const items = await doCompletion(
+      textDoc,
+      { line: 0, character: 2 },
+      context,
+    );
+
+    expect(items.length).toBeGreaterThan(0);
+  });
+
+  it("offers no completion items once disabled", async function () {
+    const context = getContextOrThrow();
+    await setCompletionEnabled(false);
+    const textDoc = TextDocument.create(fixtureFileUri, "ansible", 1, "- ");
+
+    const items = await doCompletion(
+      textDoc,
+      { line: 0, character: 2 },
+      context,
+    );
+
+    expect(items).toEqual([]);
+  });
+
+  it("suppresses schema based completions too", async function () {
+    const context = getContextOrThrow();
+    const textDoc = TextDocument.create(
+      resolveDocUri("roles/demo/meta/main.yml"),
+      "ansible",
+      1,
+      `galaxy_info:\n  `,
+    );
+    const schemaCompleterMod = await import("@src/services/schemaCompleter.js");
+    const completeStub = sinon
+      .stub(schemaCompleterMod.SchemaCompleter.prototype, "complete")
+      .returns([
+        {
+          label: "author",
+          kind: CompletionItemKind.Property,
+        },
+      ]);
+    const schemaService = {
+      shouldValidateWithSchema: () => true,
+      getSchemaForDocument: async () => ({
+        type: "object",
+        properties: {
+          galaxy_info: {
+            type: "object",
+            properties: {
+              author: { type: "string", description: "Author" },
+            },
+          },
+        },
+      }),
+    } as unknown as SchemaService;
+
+    // sanity check: the schema branch does offer completions while enabled
+    const enabledItems = await doCompletion(
+      textDoc,
+      { line: 1, character: 2 },
+      context,
+      schemaService,
+    );
+    expect(enabledItems.map((item) => item.label)).toContain("author");
+
+    await setCompletionEnabled(false);
+    const disabledItems = await doCompletion(
+      textDoc,
+      { line: 1, character: 2 },
+      context,
+      schemaService,
+    );
+
+    // the guard runs before the schema branch, so the completer is never
+    // consulted a second time
+    expect(disabledItems).toEqual([]);
+    expect(completeStub.callCount).toBe(1);
+  });
+
+  it("leaves completion items unresolved when disabled", async function () {
+    const context = getContextOrThrow();
+    await setCompletionEnabled(false);
+    const completionItem: CompletionItem = {
+      label: "sub_opt_1",
+      data: {
+        documentUri: fixtureFileUri,
+        type: "string",
+        atEndOfLine: true,
+      },
+    };
+
+    const resolved = await doCompletionResolve(completionItem, context);
+
+    expect(resolved.insertText).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Adds `ansible.completion.enabled` (default `true`) so users who use the
extension mainly for syntax highlighting can turn off completion entirely.
This was requested in #837, where a maintainer indicated a PR would be
welcome.

## Implementation

Follows the existing `ansible.validation.enabled` pattern:

- `ansible.completion.enabled` declared in the existing **Completion** section
  of `contributes.configuration`. No new configuration section was added, since
  `packages/ansible-language-server/test/globalSetup.ts` reads
  `contributes.configuration[6]` by index.
- Typed in `ExtensionSettings.completion` and `CompletionSettingsWithDescription`,
  with the default and description in `SettingsManager`.
- `doCompletion` reads settings and returns `[]` at the top of the function,
  deliberately **above** the schema-completion branch, so schema-backed files
  such as `meta/main.yml` are covered too.
- `doCompletionResolve` returns the item untouched when the setting is off.
- The two existing `ansible.completion.*` toggles now cross-reference the new
  setting in their descriptions, matching how `ansible.validation.lint.enabled`
  refers to `ansible.validation.enabled`.

Note: this suppresses items offered by this extension. VS Code's own
word-based suggestions remain governed by `editor.wordBasedSuggestions`, and
Lightspeed inline suggestions stay under
`ansible.lightspeed.suggestions.enabled`.

## Tests

Four cases added to `completionProvider.test.ts`:

1. items are offered while enabled (sanity)
2. no items once disabled
3. schema-based completions are suppressed too, asserting the stubbed schema
   completer is not consulted a second time, which pins the guard's position
   ahead of the schema branch
4. `doCompletionResolve` leaves `insertText` undefined when disabled

## Verification

- `vitest run` over `completionProvider`, `completionResolver` and
  `settingsManager` suites: 77 passed, 57 skipped (`@ee` container tests), exit 0
- `task lint`: 19 hooks passed, 0 failed
- `task e2e` and `task wdio` were not run locally; leaving this as a draft for CI

fixes: #837
