### PR TITLE
feat(ls): open PluginDocPanel on go-to-def

### DIFF
--- a/.sdlc/todos/complete/add-goto-definition-provider.md
+++ b/.sdlc/todos/complete/add-goto-definition-provider.md
@@ -1,7 +1,7 @@
 ---
 title: Add go-to-definition that opens PluginDocPanel
 created: 2026-05-26
-status: pending
+status: complete
 priority: medium
 scope: ls
 ---
@@ -20,12 +20,15 @@ targeted FQCN.
 
 ## Acceptance criteria
 
-- [ ] Ctrl+click / F12 on a module FQCN in a task opens PluginDocPanel
-- [ ] The language server registers a `definitionProvider` capability
-- [ ] Works for both short names and FQCNs
+- [x] Ctrl+click / F12 on a module FQCN in a task opens PluginDocPanel
+- [x] The language server registers a `definitionProvider` capability
+- [x] Works for both short names and FQCNs
 
 ## Notes
 
 The LS will need to send a custom notification or command link to the
 client since webview panels can only be opened from the extension host,
 not from the language server process directly.
+
+Implemented via `ansible/openPluginDoc` notification from the language
+server; the extension host opens `PluginDocPanel.show`.

--- a/packages/language-server/src/ansibleLanguageService.ts
+++ b/packages/language-server/src/ansibleLanguageService.ts
@@ -9,6 +9,7 @@ import {
 } from 'vscode-languageserver';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { doCompletion, doCompletionResolve } from './providers/completionProvider';
+import { doDefinition } from './providers/definitionProvider';
 import { doHover } from './providers/hoverProvider';
 import { doSemanticTokens, tokenModifiers, tokenTypes } from './providers/semanticTokenProvider';
 import { doValidate } from './providers/validationProvider';
@@ -68,6 +69,7 @@ export class AnsibleLanguageService {
                         },
                     },
                     hoverProvider: true,
+                    definitionProvider: true,
                     completionProvider: {
                         resolveProvider: true,
                     },
@@ -229,6 +231,32 @@ export class AnsibleLanguageService {
                 }
             } catch (error) {
                 this.handleError(error, 'onHover');
+            }
+            return null;
+        });
+
+        this.connection.onDefinition(async (params) => {
+            try {
+                const document = this.documents.get(params.textDocument.uri);
+                if (document) {
+                    const context = this.workspaceManager.getContext(params.textDocument.uri);
+                    if (context) {
+                        const collectionsService = CollectionsService.getInstance();
+                        return await doDefinition(
+                            document,
+                            params.position,
+                            collectionsService,
+                            (openParams) => {
+                                void this.connection.sendNotification(
+                                    'ansible/openPluginDoc',
+                                    openParams,
+                                );
+                            },
+                        );
+                    }
+                }
+            } catch (error) {
+                this.handleError(error, 'onDefinition');
             }
             return null;
         });

--- a/packages/language-server/src/providers/definitionProvider.ts
+++ b/packages/language-server/src/providers/definitionProvider.ts
@@ -1,0 +1,94 @@
+import { DefinitionLink } from 'vscode-languageserver';
+import { Position, TextDocument } from 'vscode-languageserver-textdocument';
+import { isScalar } from 'yaml';
+import { isTaskKeyword } from '../utils/ansible';
+import { toLspRange } from '../utils/misc';
+import {
+    AncestryBuilder,
+    getOrigRange,
+    getPathAt,
+    isTaskParam,
+    parseAllDocuments,
+} from '../utils/yaml';
+import { CollectionsService } from '@ansible/developer-services';
+
+/** Payload for the `ansible/openPluginDoc` LS → client notification. */
+export interface OpenPluginDocParams {
+    /** Fully qualified collection name of the plugin. */
+    fqcn: string;
+    /** Plugin type (always `module` for task keys). */
+    pluginType: string;
+}
+
+/**
+ * Resolves go-to-definition for a task module key by notifying the client
+ * to open PluginDocPanel, returning a self DefinitionLink so the editor
+ * does not show "No definition found".
+ *
+ * @param document - Text document under the cursor.
+ * @param position - Cursor position in the document.
+ * @param collectionsService - Source of cached plugin documentation.
+ * @param sendOpenPluginDoc - Callback that notifies the extension host.
+ * @returns A self DefinitionLink when docs exist, otherwise null.
+ */
+export async function doDefinition(
+    document: TextDocument,
+    position: Position,
+    collectionsService: CollectionsService,
+    sendOpenPluginDoc: (params: OpenPluginDocParams) => void,
+): Promise<DefinitionLink[] | null> {
+    const yamlDocs = parseAllDocuments(document.getText());
+    const path = getPathAt(document, position, yamlDocs);
+    if (!path) return null;
+
+    const node = path[path.length - 1];
+    if (!isScalar(node) || !new AncestryBuilder(path).parentOfKey().get()) {
+        return null;
+    }
+
+    if (!isTaskParam(path)) {
+        return null;
+    }
+
+    if (isTaskKeyword(node.value as string)) {
+        return null;
+    }
+
+    const moduleName = node.value as string;
+    const fqcn = resolveFqcn(moduleName);
+    const pluginData = await collectionsService.getPluginDocumentation(fqcn, 'module');
+    if (!pluginData?.doc) {
+        return null;
+    }
+
+    sendOpenPluginDoc({ fqcn, pluginType: 'module' });
+
+    const origRange = getOrigRange(node);
+    const range = origRange ? toLspRange(origRange, document) : undefined;
+    if (!range) {
+        return null;
+    }
+
+    return [
+        {
+            targetUri: document.uri,
+            originSelectionRange: range,
+            targetRange: range,
+            targetSelectionRange: range,
+        },
+    ];
+}
+
+/**
+ * Normalizes a short module name to its fully qualified collection name.
+ *
+ * @param name - Module name from the playbook YAML.
+ * @returns FQCN suitable for documentation lookup.
+ */
+function resolveFqcn(name: string): string {
+    const dotCount = (name.match(/\./g) ?? []).length;
+    if (dotCount >= 2) {
+        return name;
+    }
+    return `ansible.builtin.${name}`;
+}

--- a/packages/language-server/src/providers/definitionProvider.ts
+++ b/packages/language-server/src/providers/definitionProvider.ts
@@ -1,10 +1,11 @@
 import { DefinitionLink } from 'vscode-languageserver';
 import { Position, TextDocument } from 'vscode-languageserver-textdocument';
-import { isScalar } from 'yaml';
+import { type Node, isScalar } from 'yaml';
 import { isTaskKeyword } from '../utils/ansible';
 import { toLspRange } from '../utils/misc';
 import {
     AncestryBuilder,
+    getDeclaredCollections,
     getOrigRange,
     getPathAt,
     isTaskParam,
@@ -42,7 +43,11 @@ export async function doDefinition(
     if (!path) return null;
 
     const node = path[path.length - 1];
-    if (!isScalar(node) || !new AncestryBuilder(path).parentOfKey().get()) {
+    if (
+        !isScalar(node) ||
+        typeof node.value !== 'string' ||
+        !new AncestryBuilder(path).parentOfKey().get()
+    ) {
         return null;
     }
 
@@ -50,12 +55,12 @@ export async function doDefinition(
         return null;
     }
 
-    if (isTaskKeyword(node.value as string)) {
+    if (isTaskKeyword(node.value)) {
         return null;
     }
 
-    const moduleName = node.value as string;
-    const fqcn = resolveFqcn(moduleName);
+    const moduleName = node.value;
+    const fqcn = await resolveFqcn(moduleName, path, collectionsService);
     const pluginData = await collectionsService.getPluginDocumentation(fqcn, 'module');
     if (!pluginData?.doc) {
         return null;
@@ -80,15 +85,35 @@ export async function doDefinition(
 }
 
 /**
- * Normalizes a short module name to its fully qualified collection name.
+ * Resolves a module name to its FQCN using play/role collection context.
+ *
+ * Already-qualified names (>=2 dots) pass through unchanged. Short names
+ * are resolved by checking each collection declared via the `collections`
+ * keyword in scope, then falling back to `ansible.builtin`.
  *
  * @param name - Module name from the playbook YAML.
- * @returns FQCN suitable for documentation lookup.
+ * @param path - YAML node ancestry at the module key.
+ * @param collectionsService - Source of cached plugin documentation.
+ * @returns FQCN with confirmed documentation, or the builtin fallback.
  */
-function resolveFqcn(name: string): string {
+async function resolveFqcn(
+    name: string,
+    path: Node[],
+    collectionsService: CollectionsService,
+): Promise<string> {
     const dotCount = (name.match(/\./g) ?? []).length;
     if (dotCount >= 2) {
         return name;
     }
+
+    const declaredCollections = getDeclaredCollections(path);
+    for (const collection of declaredCollections) {
+        const candidate = `${collection}.${name}`;
+        const pluginData = await collectionsService.getPluginDocumentation(candidate, 'module');
+        if (pluginData?.doc) {
+            return candidate;
+        }
+    }
+
     return `ansible.builtin.${name}`;
 }

--- a/packages/language-server/test/providers/definitionProvider.test.ts
+++ b/packages/language-server/test/providers/definitionProvider.test.ts
@@ -76,6 +76,64 @@ describe('doDefinition', () => {
         expect(result).toHaveLength(1);
     });
 
+    it('resolves short name via play-level collections keyword', async () => {
+        const content = [
+            '- hosts: all',
+            '  collections:',
+            '    - acme.tools',
+            '  tasks:',
+            '    - foo:',
+            '        opt: val',
+        ].join('\n');
+        const d = doc(content);
+        const pluginData = {
+            doc: {
+                module: 'foo',
+                short_description: 'Acme foo module',
+                options: {},
+            },
+        };
+        const svc = mockCollectionsService({ 'acme.tools.foo': pluginData });
+        const sendOpenPluginDoc = vi.fn();
+
+        const result = await doDefinition(d, { line: 4, character: 6 }, svc, sendOpenPluginDoc);
+
+        expect(sendOpenPluginDoc).toHaveBeenCalledWith({
+            fqcn: 'acme.tools.foo',
+            pluginType: 'module',
+        });
+        expect(result).toHaveLength(1);
+    });
+
+    it('falls back to ansible.builtin when collections keyword has no match', async () => {
+        const content = [
+            '- hosts: all',
+            '  collections:',
+            '    - acme.tools',
+            '  tasks:',
+            '    - copy:',
+            '        src: a',
+        ].join('\n');
+        const d = doc(content);
+        const pluginData = {
+            doc: {
+                module: 'copy',
+                short_description: 'Copy files',
+                options: {},
+            },
+        };
+        const svc = mockCollectionsService({ 'ansible.builtin.copy': pluginData });
+        const sendOpenPluginDoc = vi.fn();
+
+        const result = await doDefinition(d, { line: 4, character: 6 }, svc, sendOpenPluginDoc);
+
+        expect(sendOpenPluginDoc).toHaveBeenCalledWith({
+            fqcn: 'ansible.builtin.copy',
+            pluginType: 'module',
+        });
+        expect(result).toHaveLength(1);
+    });
+
     it('returns null for unknown modules without docs', async () => {
         const content = '- hosts: all\n  tasks:\n    - unknown_module:\n        opt: val';
         const d = doc(content);

--- a/packages/language-server/test/providers/definitionProvider.test.ts
+++ b/packages/language-server/test/providers/definitionProvider.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi } from 'vitest';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { doDefinition, type OpenPluginDocParams } from '../../src/providers/definitionProvider';
+
+/**
+ * Creates a TextDocument from YAML content for definition tests.
+ *
+ * @param content - YAML source text.
+ * @param uri - Document URI.
+ * @returns A language-server TextDocument instance.
+ */
+function doc(content: string, uri = 'file:///test.yml'): TextDocument {
+    return TextDocument.create(uri, 'ansible', 1, content);
+}
+
+/**
+ * Builds a stub CollectionsService that resolves plugin docs from the map.
+ *
+ * @param pluginMap - Map of FQCN to plugin data stubs.
+ * @returns A mock CollectionsService.
+ */
+function mockCollectionsService(pluginMap: Record<string, unknown> = {}) {
+    return {
+        getPluginDocumentation: vi.fn((fqcn: string) => {
+            return Promise.resolve(pluginMap[fqcn] ?? null);
+        }),
+    } as never;
+}
+
+describe('doDefinition', () => {
+    it('opens plugin doc for FQCN modules and returns a self DefinitionLink', async () => {
+        const content = '- hosts: all\n  tasks:\n    - ansible.builtin.copy:\n        src: a';
+        const d = doc(content);
+        const pluginData = {
+            doc: {
+                module: 'copy',
+                short_description: 'Copy files',
+                options: {},
+            },
+        };
+        const svc = mockCollectionsService({ 'ansible.builtin.copy': pluginData });
+        const sendOpenPluginDoc = vi.fn();
+
+        const result = await doDefinition(d, { line: 2, character: 6 }, svc, sendOpenPluginDoc);
+
+        expect(sendOpenPluginDoc).toHaveBeenCalledOnce();
+        expect(sendOpenPluginDoc).toHaveBeenCalledWith({
+            fqcn: 'ansible.builtin.copy',
+            pluginType: 'module',
+        } satisfies OpenPluginDocParams);
+        expect(result).toHaveLength(1);
+        expect(result?.[0]?.targetUri).toBe(d.uri);
+        expect(result?.[0]?.targetRange).toEqual(result?.[0]?.originSelectionRange);
+        expect(result?.[0]?.targetSelectionRange).toEqual(result?.[0]?.originSelectionRange);
+    });
+
+    it('resolves short module names via ansible.builtin prefix', async () => {
+        const content = '- hosts: all\n  tasks:\n    - copy:\n        src: a';
+        const d = doc(content);
+        const pluginData = {
+            doc: {
+                module: 'copy',
+                short_description: 'Copy files',
+                options: {},
+            },
+        };
+        const svc = mockCollectionsService({ 'ansible.builtin.copy': pluginData });
+        const sendOpenPluginDoc = vi.fn();
+
+        const result = await doDefinition(d, { line: 2, character: 6 }, svc, sendOpenPluginDoc);
+
+        expect(sendOpenPluginDoc).toHaveBeenCalledWith({
+            fqcn: 'ansible.builtin.copy',
+            pluginType: 'module',
+        });
+        expect(result).toHaveLength(1);
+    });
+
+    it('returns null for unknown modules without docs', async () => {
+        const content = '- hosts: all\n  tasks:\n    - unknown_module:\n        opt: val';
+        const d = doc(content);
+        const svc = mockCollectionsService();
+        const sendOpenPluginDoc = vi.fn();
+
+        const result = await doDefinition(d, { line: 2, character: 6 }, svc, sendOpenPluginDoc);
+
+        expect(result).toBeNull();
+        expect(sendOpenPluginDoc).not.toHaveBeenCalled();
+    });
+
+    it('returns null for task keywords', async () => {
+        const content = '- hosts: all\n  tasks:\n    - name: test\n      register: out';
+        const d = doc(content);
+        const svc = mockCollectionsService();
+        const sendOpenPluginDoc = vi.fn();
+
+        const result = await doDefinition(d, { line: 2, character: 6 }, svc, sendOpenPluginDoc);
+
+        expect(result).toBeNull();
+        expect(sendOpenPluginDoc).not.toHaveBeenCalled();
+    });
+
+    it('returns null for empty documents', async () => {
+        const d = doc('');
+        const svc = mockCollectionsService();
+        const sendOpenPluginDoc = vi.fn();
+
+        const result = await doDefinition(d, { line: 0, character: 0 }, svc, sendOpenPluginDoc);
+
+        expect(result).toBeNull();
+        expect(sendOpenPluginDoc).not.toHaveBeenCalled();
+    });
+
+    it('returns null for non-scalar positions', async () => {
+        const content = '- hosts: all\n  tasks: []';
+        const d = doc(content);
+        const svc = mockCollectionsService();
+        const sendOpenPluginDoc = vi.fn();
+
+        const result = await doDefinition(d, { line: 1, character: 11 }, svc, sendOpenPluginDoc);
+
+        expect(result).toBeNull();
+        expect(sendOpenPluginDoc).not.toHaveBeenCalled();
+    });
+
+    it('returns null for play-level keys', async () => {
+        const content = '- hosts: all\n  gather_facts: false';
+        const d = doc(content);
+        const svc = mockCollectionsService();
+        const sendOpenPluginDoc = vi.fn();
+
+        const result = await doDefinition(d, { line: 0, character: 2 }, svc, sendOpenPluginDoc);
+
+        expect(result).toBeNull();
+        expect(sendOpenPluginDoc).not.toHaveBeenCalled();
+    });
+});

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -285,6 +285,17 @@ export async function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(languageClient);
     log('Ansible Language Server started');
 
+    // LS go-to-definition opens PluginDocPanel via custom notification
+    // (webview panels can only be created on the extension host).
+    context.subscriptions.push(
+        languageClient.onNotification(
+            'ansible/openPluginDoc',
+            (params: { fqcn: string; pluginType: string }) => {
+                PluginDocPanel.show(context.extensionUri, params.fqcn, params.pluginType);
+            },
+        ),
+    );
+
     // Initialize centralized Python environment service (handles PET detection,
     // ms-python.python fallback, and environment change events)
     const pythonEnvService = PythonEnvironmentService.getInstance();


### PR DESCRIPTION
F12/Ctrl+click on a task module resolves FQCN via the doc cache and notifies the extension host to open the panel instead of jumping to Python source.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Adds go-to-definition for Ansible task modules by resolving module FQCN from cached collections docs (short or already-qualified) and using an LSP→extension notification to open `PluginDocPanel` instead of jumping to Python source. Needed to provide accurate module documentation navigation. Original commit message: Adds go-to-definition support for task modules.

- Enable LSP `definitionProvider` in `AnsibleLanguageService` and implement `onDefinition` delegating to `doDefinition`
- Add a YAML-scoped definition provider that validates cursor position, resolves the module’s FQCN, and triggers `ansible/openPluginDoc`
- Use cached `CollectionsService` to fetch module documentation and derive the definition link
- Register an `ansible/openPluginDoc` notification handler in the extension host to open `PluginDocPanel` with `{ fqcn, pluginType }`
- Add Vitest coverage for definition resolution and notification behavior (including resolution and “no definition” cases)
- Update the SDL C TODO entry to mark the go-to-definition behavior as complete
<!-- end of auto-generated comment: release notes by coderabbit.ai -->