### PR TITLE
feat(extension): add Create Simple Playbook command

### DIFF
--- a/.sdlc/todos/pending/creator-simple-playbook-template.md
+++ b/.sdlc/todos/pending/creator-simple-playbook-template.md
@@ -4,6 +4,7 @@ created: 2026-05-26
 status: pending
 priority: low
 scope: extension
+jira: AAP-81422
 ---
 
 # Support simple playbook creation via Creator
@@ -15,14 +16,20 @@ template. Rather than hardcoding a template in the extension, the
 Creator should be the source of truth for content examples.
 
 ansible-creator should support generating a simple example playbook
-(not just a full project), and the extension should expose that via
-a command or Creator tree entry.
+(not just a full project), and the extension should expose that via a
+command or Creator tree entry.
 
 ## Acceptance criteria
 
 - [ ] ansible-creator supports a simple/example playbook scaffold
-- [ ] Extension exposes a command to create a playbook from Creator
+  (`add resource playbook`) — implemented in ansible-creator branch
+  `feat/AAP-81422-add-simple-playbook-resource` (needs merge/release)
+- [x] Extension exposes a command to create a playbook from Creator
+  (`ansibleCreator.createSimplePlaybook`)
 - [ ] Generated playbook uses best-practice structure from Creator
+  (requires released ansible-creator with the resource)
+- [x] MCP picks up the resource automatically via schema
+  (`ac_add_res_play` once creator is upgraded)
 
 ## Notes
 
@@ -30,3 +37,6 @@ This depends on ansible-creator adding support for single-file
 playbook generation. Coordinate with the ansible-creator project.
 The extension's role is to expose the Creator capability, not to
 own the template content.
+
+Extension branch: `feat/AAP-81422-simple-playbook-creation`
+Creator branch: `feat/AAP-81422-add-simple-playbook-resource`

--- a/.sdlc/todos/pending/creator-simple-playbook-template.md
+++ b/.sdlc/todos/pending/creator-simple-playbook-template.md
@@ -27,7 +27,7 @@ command or Creator tree entry.
 - [x] Extension exposes a command to create a playbook from Creator
   (`ansibleCreator.createSimplePlaybook`)
 - [ ] Generated playbook uses best-practice structure from Creator
-  (requires released ansible-creator with the resource)
+  (requires a released ansible-creator with the resource)
 - [x] MCP picks up the resource automatically via schema
   (`ac_add_res_play` once creator is upgraded)
 

--- a/.sdlc/user-stories.yaml
+++ b/.sdlc/user-stories.yaml
@@ -380,7 +380,7 @@ stories:
     criteria:
       - Command palette exposes Ansible: Create Simple Playbook
       - The command opens the Creator form for add resource playbook
-      - When ansible-creator lacks the resource, the user is guided to upgrade
+      - When ansible-creator is missing, outdated, or lacks the resource, the user gets actionable remediation (install, upgrade, or refresh)
 
   # ---------------------------------------------------------------------------
   # PLB — Playbook Execution & Visualization

--- a/.sdlc/user-stories.yaml
+++ b/.sdlc/user-stories.yaml
@@ -368,6 +368,20 @@ stories:
       - Schema is read at runtime from the installed ansible-creator
       - New subcommands appear in the Creator view automatically
 
+  - id: SCF-004
+    title: Create a simple playbook from Creator
+    story: >
+      As an Ansible developer, I want to create a single example
+      playbook file through Creator (not a full project), so that I
+      can start writing tasks quickly with a best-practice starter
+      instead of a hardcoded extension template (AAP-81422).
+    prd_refs: [US-5, AC-3]
+    requires_ai: false
+    criteria:
+      - Command palette exposes Ansible: Create Simple Playbook
+      - The command opens the Creator form for add resource playbook
+      - When ansible-creator lacks the resource, the user is guided to upgrade
+
   # ---------------------------------------------------------------------------
   # PLB — Playbook Execution & Visualization
   # PRD: Section 4 (Playbook Execution), US-6, AC-4

--- a/docs/src/content/docs/python-tools/ansible-creator.mdx
+++ b/docs/src/content/docs/python-tools/ansible-creator.mdx
@@ -41,6 +41,7 @@ Beyond full projects, ansible-creator can add individual components to existing 
 
 | Command | What it adds |
 |---------|--------------|
+| `ansible-creator add resource playbook` | Sample single-file `playbook.yml` |
 | `ansible-creator add resource devcontainer` | `.devcontainer/` directory with Docker and Podman variants |
 | `ansible-creator add resource devfile` | `devfile.yaml` |
 | `ansible-creator add resource execution-environment` | Sample `execution-environment.yml` |
@@ -135,6 +136,9 @@ Generates:
 Add a resource to an existing project.
 
 ```bash
+# Add a sample single-file playbook
+ansible-creator add resource playbook /path/to/project
+
 # Add a devcontainer with upstream image
 ansible-creator add resource devcontainer /path/to/project --image upstream
 

--- a/docs/src/content/docs/python-tools/ansible-creator/reference.mdx
+++ b/docs/src/content/docs/python-tools/ansible-creator/reference.mdx
@@ -93,6 +93,7 @@ ansible-creator add resource <type> <path> [options]
 | `devcontainer` | `.devcontainer/` directory | `--image <auto\|upstream\|aap>` |
 | `devfile` | `devfile.yaml` | — |
 | `execution-environment` | Sample `execution-environment.yml` | — |
+| `playbook` | Sample single-file `playbook.yml` | — |
 | `play-argspec` | Playbook argspec examples | — |
 | `role` | Role scaffold | Takes role name as additional positional arg |
 | `ee-ci` | CI workflow for EE builds | `--scm-provider <github\|gitlab>` |

--- a/package.json
+++ b/package.json
@@ -455,6 +455,12 @@
         "icon": "$(window)"
       },
       {
+        "command": "ansibleCreator.createSimplePlaybook",
+        "title": "Ansible: Create Simple Playbook",
+        "category": "Ansible",
+        "icon": "$(new-file)"
+      },
+      {
         "command": "ansible.walkthrough.openGettingStarted",
         "title": "Ansible: Get Started",
         "category": "Ansible",

--- a/packages/services/src/CreatorService.ts
+++ b/packages/services/src/CreatorService.ts
@@ -22,6 +22,8 @@ export class CreatorService {
     private _loaded = false;
     private _status: CreatorStatus = 'unknown';
     private _installedVersion: string | undefined;
+    /** Shared in-flight load so concurrent callers await the same completion. */
+    private _loadPromise: Promise<SchemaNode | null> | null = null;
     private _onDidChange: SimpleEventEmitter<void> | { fire: () => void; event: unknown };
     public readonly onDidChange: unknown;
     private _logFn: (message: string) => void = console.error;
@@ -128,6 +130,9 @@ export class CreatorService {
      * Refresh the schema
      */
     public async refresh(): Promise<void> {
+        if (this._loadPromise) {
+            await this._loadPromise;
+        }
         this._schema = null;
         this._loaded = false;
         this._status = 'unknown';
@@ -138,20 +143,38 @@ export class CreatorService {
     /**
      * Load the ansible-creator schema.
      *
+     * Concurrent callers share one in-flight promise so remediation UI does not
+     * race ahead of a load that is already in progress.
+     *
      * @returns Parsed schema node, or null when ansible-creator is unavailable.
      */
     public async loadSchema(): Promise<SchemaNode | null> {
-        if (this._loading) {
+        if (this._loaded && this._schema) {
             return this._schema;
         }
 
-        if (this._loaded && this._schema) {
-            return this._schema;
+        if (this._loadPromise) {
+            return this._loadPromise;
         }
 
         this._loading = true;
         (this._onDidChange as { fire: () => void }).fire();
 
+        this._loadPromise = this._fetchSchema().finally(() => {
+            this._loading = false;
+            this._loadPromise = null;
+            (this._onDidChange as { fire: () => void }).fire();
+        });
+
+        return this._loadPromise;
+    }
+
+    /**
+     * Fetch and parse the ansible-creator schema (single flight body).
+     *
+     * @returns Parsed schema node, or null when ansible-creator is unavailable.
+     */
+    private async _fetchSchema(): Promise<SchemaNode | null> {
         try {
             const { getCommandService } = await import('./CommandService');
             const commandService = getCommandService();
@@ -198,9 +221,6 @@ export class CreatorService {
             );
             this._status = 'not-installed';
             return null;
-        } finally {
-            this._loading = false;
-            (this._onDidChange as { fire: () => void }).fire();
         }
     }
 

--- a/packages/services/src/CreatorService.ts
+++ b/packages/services/src/CreatorService.ts
@@ -281,20 +281,30 @@ export class CreatorService {
      * @returns Human-readable description from the schema, or undefined when missing.
      */
     public getCommandDescription(path: string[]): string | undefined {
+        return this.getSchemaNode(path)?.description;
+    }
+
+    /**
+     * Resolve a schema node for a command path.
+     *
+     * @param path - Command path segments identifying the target subcommand.
+     * @returns Schema node at the path, or null when not found / schema unloaded.
+     */
+    public getSchemaNode(path: string[]): SchemaNode | null {
         if (!this._schema || path.length === 0) {
-            return undefined;
+            return null;
         }
 
         let node: SchemaNode | undefined = this._schema;
 
         for (const segment of path) {
             if (!node.subcommands?.[segment]) {
-                return undefined;
+                return null;
             }
             node = node.subcommands[segment];
         }
 
-        return node.description;
+        return node;
     }
 
     /**

--- a/packages/services/test/services/CreatorService.test.ts
+++ b/packages/services/test/services/CreatorService.test.ts
@@ -125,7 +125,7 @@ describe('CreatorService', () => {
         expect(svc.getSchema()).toBeNull();
     });
 
-    it('loadSchema handles concurrent calls without duplicate CommandService runs', async () => {
+    it('loadSchema coalesces concurrent callers onto one in-flight promise', async () => {
         let release!: () => void;
         const gate = new Promise<void>((r) => {
             release = r;
@@ -145,11 +145,11 @@ describe('CreatorService', () => {
         expect(svc.isLoading()).toBe(true);
         expect(mocks.mockRunTool).toHaveBeenCalledTimes(1);
         const p2 = svc.loadSchema();
-        const early = await p2;
-        expect(early).toBeNull();
         expect(mocks.mockRunTool).toHaveBeenCalledTimes(1);
         release();
-        await p1;
+        const [schema1, schema2] = await Promise.all([p1, p2]);
+        expect(schema1).toEqual(MOCK_SCHEMA);
+        expect(schema2).toEqual(MOCK_SCHEMA);
         expect(svc.getSchema()).toEqual(MOCK_SCHEMA);
         expect(mocks.mockRunTool).toHaveBeenCalledTimes(1);
     });

--- a/packages/services/test/services/CreatorService.test.ts
+++ b/packages/services/test/services/CreatorService.test.ts
@@ -223,6 +223,19 @@ describe('CreatorService', () => {
         );
     });
 
+    it('getSchemaNode returns the schema node at a path', async () => {
+        mocks.mockRunTool.mockResolvedValue({
+            exitCode: 0,
+            stdout: JSON.stringify(MOCK_SCHEMA),
+            stderr: '',
+        });
+        const svc = CreatorService.getInstance();
+        await svc.loadSchema();
+        expect(svc.getSchemaNode(['init', 'playbook'])?.name).toBe('playbook');
+        expect(svc.getSchemaNode(['init', 'missing'])).toBeNull();
+        expect(svc.getSchemaNode([])).toBeNull();
+    });
+
     it('buildCommandString constructs correct CLI string with positional and flag args', () => {
         const svc = CreatorService.getInstance();
         const s = svc.buildCommandString(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,6 +14,7 @@ import { CollectionsProvider } from '@src/views/CollectionsProvider';
 import { ExecutionEnvironmentsProvider } from '@src/views/ExecutionEnvironmentsProvider';
 import { CreatorProvider } from '@src/views/CreatorProvider';
 import { CreatorFormPanel } from '@src/panels/CreatorFormPanel';
+import { openSimplePlaybookCreatorForm } from '@src/features/createSimplePlaybook';
 import { PlaybooksProvider } from '@src/views/PlaybooksProvider';
 import { PlaybookConfigPanel } from '@src/panels/PlaybookConfigPanel';
 import { PlaybookProgressPanel } from '@src/panels/PlaybookProgressPanel';
@@ -1059,6 +1060,18 @@ export async function activate(context: vscode.ExtensionContext) {
         },
     );
 
+    const creatorCreateSimplePlaybookCommand = vscode.commands.registerCommand(
+        'ansibleCreator.createSimplePlaybook',
+        async () => {
+            const opened = await openSimplePlaybookCreatorForm(context.extensionUri);
+            if (opened) {
+                telemetry.sendEvent(TelemetryEvents.CREATOR_FORM_OPEN, {
+                    command: 'add/resource/playbook',
+                });
+            }
+        },
+    );
+
     // Register Playbooks commands
     const playbooksRefreshCommand = vscode.commands.registerCommand(
         'ansiblePlaybooks.refresh',
@@ -1684,6 +1697,7 @@ export async function activate(context: vscode.ExtensionContext) {
         galaxyCacheRefreshCommand,
         creatorRefreshCommand,
         creatorOpenFormCommand,
+        creatorCreateSimplePlaybookCommand,
         creatorAiSummaryCommand,
         creatorAiEntrySummaryCommand,
         playbooksRefreshCommand,

--- a/src/features/createSimplePlaybook.ts
+++ b/src/features/createSimplePlaybook.ts
@@ -1,0 +1,62 @@
+import * as vscode from 'vscode';
+import { CreatorService } from '@ansible/developer-services';
+import { CreatorFormPanel } from '@src/panels/CreatorFormPanel';
+
+/** Schema path for ansible-creator single-file playbook scaffolding. */
+export const SIMPLE_PLAYBOOK_COMMAND_PATH = ['add', 'resource', 'playbook'] as const;
+
+/**
+ * Open the Creator form for simple playbook creation when the installed
+ * ansible-creator schema exposes `add resource playbook`.
+ *
+ * @param extensionUri - Extension root URI for the Creator webview
+ * @returns True when the form was opened; false when creator support is missing
+ */
+export async function openSimplePlaybookCreatorForm(extensionUri: vscode.Uri): Promise<boolean> {
+    const service = CreatorService.getInstance();
+    await service.loadSchema();
+
+    const schema = service.getSchemaNode([...SIMPLE_PLAYBOOK_COMMAND_PATH]);
+    if (!schema) {
+        return handleMissingSimplePlaybookSupport(service.getStatus());
+    }
+
+    CreatorFormPanel.show(extensionUri, [...SIMPLE_PLAYBOOK_COMMAND_PATH], schema);
+    return true;
+}
+
+/**
+ * Guide the user when `add resource playbook` is unavailable.
+ *
+ * @param status - Current ansible-creator readiness from CreatorService
+ * @returns Always false (form was not opened)
+ */
+async function handleMissingSimplePlaybookSupport(
+    status: 'unknown' | 'not-installed' | 'outdated' | 'ready',
+): Promise<false> {
+    if (status === 'not-installed') {
+        const action = await vscode.window.showErrorMessage(
+            'ansible-creator is required to create a simple playbook. ' +
+                'Install ansible-dev-tools, then try again.',
+            'Install ansible-dev-tools',
+        );
+        if (action === 'Install ansible-dev-tools') {
+            await vscode.commands.executeCommand('ansibleDevToolsPackages.install');
+        }
+        return false;
+    }
+
+    const action = await vscode.window.showErrorMessage(
+        'Simple playbook creation requires ansible-creator with ' +
+            '`add resource playbook` support. Upgrade ansible-dev-tools, ' +
+            'then refresh Creator.',
+        'Upgrade ansible-dev-tools',
+        'Refresh Creator',
+    );
+    if (action === 'Upgrade ansible-dev-tools') {
+        await vscode.commands.executeCommand('ansibleDevToolsPackages.upgrade');
+    } else if (action === 'Refresh Creator') {
+        await vscode.commands.executeCommand('ansibleCreator.refresh');
+    }
+    return false;
+}

--- a/test/unit/features/createSimplePlaybook.test.ts
+++ b/test/unit/features/createSimplePlaybook.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Uri } from 'vscode';
+
+const mocks = vi.hoisted(() => ({
+    loadSchema: vi.fn(),
+    getSchemaNode: vi.fn(),
+    getStatus: vi.fn(),
+    showErrorMessage: vi.fn(),
+    executeCommand: vi.fn(),
+    showForm: vi.fn(),
+    getInstance: vi.fn(),
+}));
+
+vi.mock('vscode', () => ({
+    window: {
+        showErrorMessage: mocks.showErrorMessage,
+    },
+    commands: {
+        executeCommand: mocks.executeCommand,
+    },
+    Uri: {
+        file: (p: string) => ({ fsPath: p }) as Uri,
+    },
+}));
+
+vi.mock('@ansible/developer-services', () => ({
+    CreatorService: {
+        getInstance: () => mocks.getInstance(),
+    },
+}));
+
+vi.mock('@src/panels/CreatorFormPanel', () => ({
+    CreatorFormPanel: {
+        show: mocks.showForm,
+    },
+}));
+
+import {
+    openSimplePlaybookCreatorForm,
+    SIMPLE_PLAYBOOK_COMMAND_PATH,
+} from '../../../src/features/createSimplePlaybook';
+
+describe('openSimplePlaybookCreatorForm', () => {
+    const extensionUri = { fsPath: '/ext' } as Uri;
+
+    beforeEach(() => {
+        mocks.loadSchema.mockReset();
+        mocks.getSchemaNode.mockReset();
+        mocks.getStatus.mockReset();
+        mocks.showErrorMessage.mockReset();
+        mocks.executeCommand.mockReset();
+        mocks.showForm.mockReset();
+        mocks.getInstance.mockReturnValue({
+            loadSchema: mocks.loadSchema,
+            getSchemaNode: mocks.getSchemaNode,
+            getStatus: mocks.getStatus,
+        });
+        mocks.loadSchema.mockResolvedValue(null);
+        mocks.getStatus.mockReturnValue('ready');
+        mocks.showErrorMessage.mockResolvedValue(undefined);
+    });
+
+    it('opens the Creator form when add resource playbook is available', async () => {
+        const schema = {
+            name: 'playbook',
+            description: 'Add a sample Ansible playbook file',
+        };
+        mocks.getSchemaNode.mockReturnValue(schema);
+
+        const opened = await openSimplePlaybookCreatorForm(extensionUri);
+
+        expect(opened).toBe(true);
+        expect(mocks.loadSchema).toHaveBeenCalled();
+        expect(mocks.getSchemaNode).toHaveBeenCalledWith([...SIMPLE_PLAYBOOK_COMMAND_PATH]);
+        expect(mocks.showForm).toHaveBeenCalledWith(
+            extensionUri,
+            [...SIMPLE_PLAYBOOK_COMMAND_PATH],
+            schema,
+        );
+        expect(mocks.showErrorMessage).not.toHaveBeenCalled();
+    });
+
+    it('prompts to install when ansible-creator is not installed', async () => {
+        mocks.getSchemaNode.mockReturnValue(null);
+        mocks.getStatus.mockReturnValue('not-installed');
+        mocks.showErrorMessage.mockResolvedValue('Install ansible-dev-tools');
+
+        const opened = await openSimplePlaybookCreatorForm(extensionUri);
+
+        expect(opened).toBe(false);
+        expect(mocks.showForm).not.toHaveBeenCalled();
+        expect(mocks.executeCommand).toHaveBeenCalledWith('ansibleDevToolsPackages.install');
+    });
+
+    it('prompts to upgrade when ansible-creator lacks playbook resource support', async () => {
+        mocks.getSchemaNode.mockReturnValue(null);
+        mocks.getStatus.mockReturnValue('ready');
+        mocks.showErrorMessage.mockResolvedValue('Upgrade ansible-dev-tools');
+
+        const opened = await openSimplePlaybookCreatorForm(extensionUri);
+
+        expect(opened).toBe(false);
+        expect(mocks.showForm).not.toHaveBeenCalled();
+        expect(mocks.executeCommand).toHaveBeenCalledWith('ansibleDevToolsPackages.upgrade');
+    });
+
+    it('refreshes Creator when the user chooses refresh', async () => {
+        mocks.getSchemaNode.mockReturnValue(null);
+        mocks.getStatus.mockReturnValue('outdated');
+        mocks.showErrorMessage.mockResolvedValue('Refresh Creator');
+
+        const opened = await openSimplePlaybookCreatorForm(extensionUri);
+
+        expect(opened).toBe(false);
+        expect(mocks.executeCommand).toHaveBeenCalledWith('ansibleCreator.refresh');
+    });
+});


### PR DESCRIPTION
## Summary
- Add **Ansible: Create Simple Playbook** (`ansibleCreator.createSimplePlaybook`) to restore feature parity with `main`'s empty-playbook flow without hardcoding a template (AAP-81422 / ADR-004).
- Opens the schema-driven Creator form for `ansible-creator add resource playbook` when that resource is available; otherwise guides install/upgrade/refresh of ansible-dev-tools.
- MCP picks up the same resource automatically via schema once a supporting ansible-creator is installed (`ac_add_res_play`).

## Changes
- New helper `src/features/createSimplePlaybook.ts` with status-aware remediation (`install` vs `upgrade`/`refresh`)
- `CreatorService.getSchemaNode()` for path-based schema lookup
- `CreatorService.loadSchema()` coalesces concurrent callers onto one in-flight promise
- User story **SCF-004**, docs updates for `add resource playbook`, pending todo notes for the creator dependency
- Unit tests for the command helper, `getSchemaNode`, and concurrent schema loads

## Dependency
Requires ansible-creator support for `add resource playbook`:
https://github.com/ansible/ansible-creator/pull/634

Until that lands/is released, the command shows upgrade guidance instead of opening a form.

## Quality of life
- AI-authored additions: SCF-004 user story, todo tracking updates, docs examples for the new resource

## Test plan
- [x] `pnpm run ci` passes (compile + lint + test:coverage + build)
- [x] Concurrent `loadSchema()` callers share one in-flight promise (unit tested)
- [ ] With upgraded ansible-creator: command palette → **Ansible: Create Simple Playbook** opens Creator form and scaffolds `playbook.yml`
- [ ] With missing/outdated creator: Install / Upgrade / Refresh actions behave correctly
- [ ] Creator tree shows **Add → Resource → Playbook** when schema includes the resource
- [ ] MCP lists `ac_add_res_play` after creator upgrade

related: AAP-81422