### PR TITLE
feat(extension): add open language server logs command

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,6 +2,7 @@
   "version": "2.0.0",
   "tasks": [
     {
+      "label": "watch",
       "type": "shell",
       "command": "pnpm run watch",
       "problemMatcher": "$tsc-watch",

--- a/package.json
+++ b/package.json
@@ -474,7 +474,7 @@
       },
       {
         "command": "ansible.open-language-server-logs",
-        "title": "Ansible: Open Language Server Logs",
+        "title": "Ansible: Show Language Server Logs",
         "category": "Ansible",
         "icon": "$(output)"
       },

--- a/package.json
+++ b/package.json
@@ -473,6 +473,12 @@
         "icon": "$(output)"
       },
       {
+        "command": "ansible.open-language-server-logs",
+        "title": "Ansible: Open Language Server Logs",
+        "category": "Ansible",
+        "icon": "$(output)"
+      },
+      {
         "command": "ansible.statusBar.refresh",
         "title": "Ansible: Refresh Status",
         "category": "Ansible",

--- a/package.json
+++ b/package.json
@@ -767,6 +767,10 @@
       ],
       "commandPalette": [
         {
+          "command": "ansible.open-language-server-logs",
+          "when": "workspaceFolderCount != 0"
+        },
+        {
           "command": "ansible.lightspeed.oauth",
           "when": "config.ansible.lightspeed.enabled"
         },

--- a/packages/ui/src/bridge/diagnostics.ts
+++ b/packages/ui/src/bridge/diagnostics.ts
@@ -54,4 +54,5 @@ export interface DiagnosticsBridge extends HostBridgeCore {
     upgradeDevTools(): void;
     resyncMetadata(): void;
     openOutput(): void;
+    openLanguageServerLogs(): void;
 }

--- a/packages/ui/src/views/DiagnosticsView.tsx
+++ b/packages/ui/src/views/DiagnosticsView.tsx
@@ -408,6 +408,15 @@ export function DiagnosticsView() {
                         >
                             Open Ansible Output
                         </button>
+                        <button
+                            type="button"
+                            style={styles.refreshBtn}
+                            onClick={() => {
+                                bridge.openLanguageServerLogs();
+                            }}
+                        >
+                            Open Language Server Logs
+                        </button>
                     </div>
                 </div>
             </div>

--- a/packages/ui/src/views/DiagnosticsView.tsx
+++ b/packages/ui/src/views/DiagnosticsView.tsx
@@ -406,7 +406,7 @@ export function DiagnosticsView() {
                                 bridge.openOutput();
                             }}
                         >
-                            Open Ansible Output
+                            Show Ansible Output
                         </button>
                         <button
                             type="button"
@@ -415,7 +415,7 @@ export function DiagnosticsView() {
                                 bridge.openLanguageServerLogs();
                             }}
                         >
-                            Open Language Server Logs
+                            Show Language Server Logs
                         </button>
                     </div>
                 </div>

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -312,6 +312,17 @@ export async function activate(context: vscode.ExtensionContext) {
         vscode.commands.registerCommand('ansible.open-output', () => {
             outputChannel.show(true);
         }),
+        vscode.commands.registerCommand('ansible.open-language-server-logs', () => {
+            // Always reveal the LS client channel — startup/crash logs are most
+            // useful when the server is not Running. Inform when not ready so
+            // the action never fails silently (AAP-82121).
+            languageClient.outputChannel.show(true);
+            if (!languageClient.isRunning()) {
+                void vscode.window.showInformationMessage(
+                    'Ansible Language Server is not running. Logs may be incomplete until the server starts.',
+                );
+            }
+        }),
         vscode.commands.registerCommand('ansible.statusBar.refresh', () => {
             ansibleStatusBar.forceRefresh();
         }),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -239,6 +239,16 @@ export async function activate(context: vscode.ExtensionContext) {
 
     // Check if workspace is open
     if (!vscode.workspace.workspaceFolders || vscode.workspace.workspaceFolders.length === 0) {
+        // package.json contributes this command globally; register a handler
+        // before early return so Command Palette / executeCommand never hit
+        // an unbound command when no workspace is open.
+        context.subscriptions.push(
+            vscode.commands.registerCommand('ansible.open-language-server-logs', () => {
+                void vscode.window.showWarningMessage(
+                    'Ansible Language Server logs require an open workspace folder.',
+                );
+            }),
+        );
         vscode.window.showWarningMessage('Ansible requires an open workspace folder.');
         return;
     }

--- a/src/panels/DiagnosticsPanel.ts
+++ b/src/panels/DiagnosticsPanel.ts
@@ -166,6 +166,9 @@ export class DiagnosticsPanel {
             case 'openOutput':
                 outputChannel.show();
                 return;
+            case 'openLanguageServerLogs':
+                void vscode.commands.executeCommand('ansible.open-language-server-logs');
+                return;
             case 'showToast': {
                 const text = msg.params?.message;
                 if (typeof text === 'string' && text) {

--- a/src/panels/bridges/VsCodeBridge.ts
+++ b/src/panels/bridges/VsCodeBridge.ts
@@ -266,4 +266,8 @@ export class VsCodeBridge implements EEBridge, PluginDocBridge, CreatorBridge, P
     openOutput(): void {
         this._vscode.postMessage({ method: 'openOutput' });
     }
+
+    openLanguageServerLogs(): void {
+        this._vscode.postMessage({ method: 'openLanguageServerLogs' });
+    }
 }

--- a/src/statusBar/ansibleStatusBar.ts
+++ b/src/statusBar/ansibleStatusBar.ts
@@ -35,7 +35,7 @@ interface AnsibleMetadata {
  * warning when ansible-lint is missing, error when ansible is not
  * found). Hovering shows a Markdown tooltip with clickable command
  * links for quick actions (get started, sidebar, diagnostics, LLM
- * config, output log, refresh).
+ * config, output log, language server logs, refresh).
  *
  * Exposes {@link getMetadata} and {@link getEnvironmentInfo} for
  * telemetry and the diagnostics panel.
@@ -312,6 +312,7 @@ export class AnsibleStatusBar implements vscode.Disposable {
                 'ansible.showDiagnostics',
                 llmCmd,
                 'ansible.open-output',
+                'ansible.open-language-server-logs',
                 'ansible.statusBar.refresh',
             ],
         };
@@ -321,6 +322,9 @@ export class AnsibleStatusBar implements vscode.Disposable {
         md.appendMarkdown(`$(pulse) [Diagnostics](command:ansible.showDiagnostics)\n\n`);
         md.appendMarkdown(`$(hubot) [Configure LLM](command:${llmCmd})\n\n`);
         md.appendMarkdown(`$(output) [Output Log](command:ansible.open-output)\n\n`);
+        md.appendMarkdown(
+            `$(output) [Language Server Logs](command:ansible.open-language-server-logs)\n\n`,
+        );
         md.appendMarkdown(`$(refresh) [Refresh](command:ansible.statusBar.refresh)`);
 
         return md;

--- a/test/unit/statusBar/ansibleStatusBar.test.ts
+++ b/test/unit/statusBar/ansibleStatusBar.test.ts
@@ -6,6 +6,7 @@ interface MockStatusBarItem {
     text: string;
     command: string | undefined;
     backgroundColor: unknown;
+    tooltip: unknown;
     show: ReturnType<typeof vi.fn>;
     hide: ReturnType<typeof vi.fn>;
     dispose: ReturnType<typeof vi.fn>;
@@ -28,6 +29,7 @@ const { mockCreateStatusBarItem, mockRegisterCommand, mockWindow, mockWorkspace 
             text: '',
             command: undefined,
             backgroundColor: undefined,
+            tooltip: undefined,
             show: vi.fn(),
             hide: vi.fn(),
             dispose: vi.fn(),
@@ -181,6 +183,7 @@ describe('AnsibleStatusBar', () => {
             text: '',
             command: undefined,
             backgroundColor: undefined,
+            tooltip: undefined,
             show: vi.fn(),
             hide: vi.fn(),
             dispose: vi.fn(),
@@ -216,6 +219,28 @@ describe('AnsibleStatusBar', () => {
 
         const item = mockCreateStatusBarItem.mock.results[0].value as MockStatusBarItem;
         expect(item.command).toBe('ansible.showDiagnostics');
+    });
+
+    it('includes language server logs command in the tooltip', () => {
+        mockWindow.activeTextEditor = { document: { languageId: 'typescript' } };
+
+        const ctx = createMockContext();
+        const client = createMockClient();
+        const envService = createMockEnvService();
+        const bar = new AnsibleStatusBar(
+            ctx as unknown as ExtensionContext,
+            client as unknown as LanguageClient,
+            envService as unknown as PythonEnvironmentService,
+        );
+        bar.update();
+
+        const item = mockCreateStatusBarItem.mock.results[0].value as MockStatusBarItem;
+        const tooltip = item.tooltip as {
+            value: string;
+            isTrusted: { enabledCommands: string[] };
+        };
+        expect(tooltip.value).toContain('command:ansible.open-language-server-logs');
+        expect(tooltip.isTrusted.enabledCommands).toContain('ansible.open-language-server-logs');
     });
 
     it('registers the metadata notification handler', () => {


### PR DESCRIPTION
## Summary
- Restore `ansible.open-language-server-logs` on `next` (parity with `main`) so users can show the Language Client output channel when debugging validation, completion, or ansible-lint issues
- Keep `ansible.open-output` for the extension-level Ansible channel; LS logs are a separate channel
- Handle no-workspace activation: register a safe fallback and hide the command from the Command Palette when no folder is open

## Changes
- Register **Ansible: Show Language Server Logs** command (`package.json` + `extension.ts`)
- Always show `languageClient.outputChannel`; show an info message when the LS is not running (does not block access to startup/crash logs)
- Add status bar tooltip link and Diagnostics panel button
- No-workspace: fallback handler + `commandPalette` `when: workspaceFolderCount != 0`
- Unit test covering tooltip command wiring

## Quality of life
- None (no ADRs, skills, or docs templates in this PR)

## Test plan
- [x] `pnpm run ci` passes (compile + lint + test:coverage + build)
- [x] Command Palette → **Ansible: Show Language Server Logs** opens the Language Server output channel (not extension Ansible output)
- [x] Status bar tooltip and Diagnostics → **Show Language Server Logs** invoke the same command
- [x] When LS is not running, channel still opens and an informational message is shown
- [x] Without a workspace folder, command is hidden from the palette; if invoked, shows a warning instead of an unbound-command error

related: AAP-82121

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Restores parity with main by adding an Ansible “Show Language Server Logs” command that always opens the language client output channel (or warns when unavailable) and is reachable from the status bar tooltip and diagnostics. Registers a workspace-safe fallback and updates UI labels; tooltip wiring is covered by a unit test. fix(extension): handle LS logs command without a workspace.

- Registers `ansible.open-language-server-logs` and opens the Language Server output channel, with informational/warning messages when the language client/server isn’t running; hides the command from the Command Palette when no workspace folder is open to avoid an unbound contributed command
- Adds end-to-end wiring from the status bar tooltip and Diagnostics panel, including new diagnostics/RPC and bridge support (`openLanguageServerLogs`)
- Updates Diagnostics view button text to “Show …” and adds a unit test asserting the tooltip includes `ansible.open-language-server-logs` in trusted enabled commands
- Adds the explicit `label` field for the local `watch` task in `.vscode/tasks.json`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->