### PR TITLE
fix(deps): bump @vscode/test-electron to 3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1098,7 +1098,7 @@
     "@vitest/coverage-v8": "^4.1.9",
     "@vitest/ui": "^4.1.9",
     "@vscode/test-cli": "^0.0.15",
-    "@vscode/test-electron": "^3.0.0",
+    "@vscode/test-electron": "^3.1.0",
     "@vscode/vsce": "^3.9.2",
     "@vue/test-utils": "^2.4.11",
     "@wdio/cli": "^9.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   rollup: npm:@rollup/wasm-node@*
+  '@vscode/test-electron': 3.1.0
   '@xhmikosr/decompress@10': 11.1.3
   fast-uri@3: '>=3.1.2'
   fastify: '>=5.8.3'
@@ -148,8 +149,8 @@ importers:
         specifier: ^0.0.15
         version: 0.0.15(patch_hash=e13bd8d1cf6524096a6c3fd50b9e914526c46186f440e041139203de06f23ea2)
       '@vscode/test-electron':
-        specifier: ^3.0.0
-        version: 3.0.0(supports-color@8.1.1)
+        specifier: 3.1.0
+        version: 3.1.0(supports-color@8.1.1)
       '@vscode/vsce':
         specifier: ^3.9.2
         version: 3.9.2(supports-color@8.1.1)
@@ -2557,12 +2558,8 @@ packages:
     engines: {node: '>=22'}
     hasBin: true
 
-  '@vscode/test-electron@2.5.2':
-    resolution: {integrity: sha512-8ukpxv4wYe0iWMRQU18jhzJOHkeGKbnw7xWRX3Zw1WJA4cEKbHcmmLPdPrPtL6rhDcrlCZN+xKRpv09n4gRHYg==}
-    engines: {node: '>=16'}
-
-  '@vscode/test-electron@3.0.0':
-    resolution: {integrity: sha512-TY5mC7aAjxSLDXsyjhrG8cJHgc/HLdiE5lvtW7hABYQrY24Qwozzr5UoO3HiuAM4Hzz4b7K/eZlwrCILj94CcA==}
+  '@vscode/test-electron@3.1.0':
+    resolution: {integrity: sha512-CRqv5u+YYoseuNVJ6Tyo4k0sF0mx4qnKMihRB0PjsUF8Dc0WKtCXo6CNL6nWWm5esfFQsQA/pejMj4ZbpJVLTw==}
     engines: {node: '>=22'}
 
   '@vscode/vsce-sign-alpine-arm64@2.0.6':
@@ -9321,17 +9318,7 @@ snapshots:
     transitivePeerDependencies:
       - monocart-coverage-reports
 
-  '@vscode/test-electron@2.5.2(supports-color@8.1.1)':
-    dependencies:
-      http-proxy-agent: 7.0.2(supports-color@8.1.1)
-      https-proxy-agent: 7.0.6(supports-color@8.1.1)
-      jszip: 3.10.1
-      ora: 8.2.0
-      semver: 7.8.5
-    transitivePeerDependencies:
-      - supports-color
-
-  '@vscode/test-electron@3.0.0(supports-color@8.1.1)':
+  '@vscode/test-electron@3.1.0(supports-color@8.1.1)':
     dependencies:
       http-proxy-agent: 7.0.2(supports-color@8.1.1)
       https-proxy-agent: 7.0.6(supports-color@8.1.1)
@@ -14615,7 +14602,7 @@ snapshots:
       '@fastify/cors': 9.0.1
       '@fastify/static': 7.0.4
       '@types/ws': 8.18.1
-      '@vscode/test-electron': 2.5.2(supports-color@8.1.1)
+      '@vscode/test-electron': 3.1.0(supports-color@8.1.1)
       '@wdio/logger': 9.18.0
       '@xhmikosr/downloader': 15.2.0(supports-color@8.1.1)
       decamelize: 6.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,6 +14,11 @@ allowBuilds:
 
 overrides:
   rollup: "npm:@rollup/wasm-node@*"
+  # VS Code 1.110+ renamed macOS Electron -> Code; Electron symlink removed in
+  # 1.131 (microsoft/vscode#326502). @vscode/test-electron 3.1.0 resolves via
+  # Info.plist / Contents/MacOS (microsoft/vscode-test#348). Force all
+  # consumers (incl. wdio-vscode-service@^2.4.1) onto the fixed release.
+  "@vscode/test-electron": "3.1.0"
   # Security overrides
   "@xhmikosr/decompress@10": "11.1.3"
   "fast-uri@3": ">=3.1.2"
@@ -39,3 +44,5 @@ packageExtensions:
 minimumReleaseAgeExclude:
   # Renovate security update: js-yaml@5.2.1 || 5.2.2
   - js-yaml@5.2.1 || 5.2.2
+  # Unblocks macOS e2e/wdio after Electron binary rename (see overrides above)
+  - "@vscode/test-electron"


### PR DESCRIPTION
## Summary
- VS Code 1.131 removed the macOS `Electron` symlink; the binary is now `Code`.
- `@vscode/test-electron` ≤3.0.0 still spawns `.../Electron` → ENOENT on `test (macos)`.
- That failure trips `fail-fast: true`, cancels `test (linux)`, and breaks Codecov uploads.

## Changes
- Bump `@vscode/test-electron` from `^3.0.0` to `^3.1.0` (resolves via Info.plist / `Code`).
- Add a pnpm override so `wdio-vscode-service` also uses 3.1.0 (was pinned to 2.5.2).

## Test plan
- [x] Locally reproduced ENOENT on `.../MacOS/Electron` with VS Code 1.131
- [x] After upgrade, `downloadAndUnzipVSCode('stable')` returns `.../MacOS/Code` and spawn succeeds
- [ ] CI: `test (macos)` e2e/wdio get past spawn; `test (linux)` completes and Codecov uploads

related: microsoft/vscode-test#348

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Upgrade `@vscode/test-electron` to `^3.1.0` to support VS Code 1.131’s macOS `Code` binary rename and prevent `ENOENT` test failures.
- Add a pnpm override and release-age exemption to ensure `wdio-vscode-service` resolves version 3.1.0.

The commit implements the dependency upgrade and pnpm override described in the PR.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->