### PR TITLE
fix(ci): match VS Code install-dir naming for Windows and Intel Mac

### DIFF
--- a/tools/ensure-chromedriver.mts
+++ b/tools/ensure-chromedriver.mts
@@ -232,7 +232,13 @@ function driverPaths(
 }
 
 /**
- *
+ * Prefix of the directory @vscode/test-electron creates for a downloaded
+ * VS Code build, e.g. `vscode-win32-x64-archive-1.131.0`. Must match
+ * `systemDefaultPlatform` in @vscode/test-electron's util.ts, which is
+ * NOT simply `${process.platform}-${process.arch}`: Windows downloads
+ * ship as a zip "archive" and get an `-archive` suffix, and Intel Mac
+ * (unlike Apple Silicon) gets no arch suffix at all (`darwin`, not
+ * `darwin-x64`).
  */
 function vscodeInstallDirPrefix(): string {
     const key = `${process.platform}-${process.arch}`;
@@ -242,9 +248,9 @@ function vscodeInstallDirPrefix(): string {
         case 'darwin-arm64':
             return 'vscode-darwin-arm64';
         case 'darwin-x64':
-            return 'vscode-darwin-x64';
+            return 'vscode-darwin';
         case 'win32-x64':
-            return 'vscode-win32-x64';
+            return 'vscode-win32-x64-archive';
         default:
             throw new Error(`Unsupported platform: ${key}`);
     }


### PR DESCRIPTION
## Summary
- `windows-tests` CI (`.github/workflows/wsl2-ui.yml`) was failing with `SevereServiceError: Couldn't set up VSCode: Invalid version archive-1.131.0` during `pnpm exec wdio run wdio.conf.wsl.ts`.
- Root cause: `vscodeInstallDirPrefix()` in `tools/ensure-chromedriver.mts` assumed `@vscode/test-electron` always names its download directory `vscode-${platform}-${arch}-${version}`, but Windows zip builds get an extra `-archive` suffix (`vscode-win32-x64-archive-<version>`).
- The mismatched prefix caused `listInstalledVscodeVersions()` to strip only `vscode-win32-x64-`, leaving `archive-<version>` as the "installed version" string, which got written into `.wdio-vscode/versions.txt` and later crashed `wdio-vscode-service` when it tried to validate/download that bogus version.

## Changes
- Fix the `win32-x64` case to use the correct `vscode-win32-x64-archive` prefix, matching `@vscode/test-electron`'s `systemDefaultPlatform` naming.
- Fix the `darwin-x64` (Intel Mac) case too — same class of bug (prefix never matched actual `vscode-darwin-<version>` dir names since Intel Mac gets no arch suffix at all), which silently caused a permanent cache-miss rather than a crash. Found during self/cold-subagent review of this fix.

## Test plan
- [x] `pnpm run ci` passes (compile + lint + test:coverage + build)
- [ ] `pnpm run test:ui` (n/a — this only affects Windows CI tooling, not covered by local/WSL wdio runs)