### PR TITLE
ci: add uv.lock downgrade gate

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -331,12 +331,15 @@ jobs:
             exit 98
           }
 
-      - parallel:
-          - name: task lint
-            if: runner.os == 'Linux'
-            id: lint
-            run: task lint && task lint --status
+      # Lint must not run in parallel with package: als:package regenerates
+      # docs/als/settings.md and prek treats that dirty worktree as a failure
+      # ("Files were modified by following hooks").
+      - name: task lint
+        if: runner.os == 'Linux'
+        id: lint
+        run: task lint && task lint --status
 
+      - parallel:
           - name: task build / package
             # Warning: ensure that conditional templates have a negative condition
             # expanding to an empty string because otherwise it will fail the command

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -579,17 +579,26 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
           show-progress: false
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v8.3.2
+        with:
+          enable-cache: false
 
       - name: Fetch base branch lockfile
         env:
-          BASE_REF: ${{ github.base_ref || 'main' }}
+          # pull_request provides github.base_ref; merge_group uses event.merge_group.base_ref
+          BASE_REF: ${{ github.base_ref || github.event.merge_group.base_ref || 'main' }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          git fetch --no-tags --depth=1 origin "$BASE_REF"
+          BASE_REF="${BASE_REF#refs/heads/}"
+          # Token is passed only for this fetch (persist-credentials is false).
+          git fetch --no-tags --depth=1 \
+            "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+            "refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
           git show "origin/${BASE_REF}:uv.lock" > /tmp/base-uv.lock
 
       - name: Run unit tests
@@ -613,7 +622,9 @@ jobs:
           code=${PIPESTATUS[0]}
           set -e
           if [[ "$code" -eq 0 ]]; then
-            if grep -q "downgrades detected" /tmp/uv-lock-downgrade-report.md; then
+            # Match the report heading only; the success message also contains
+            # the substring "downgrades detected".
+            if grep -q "^### uv.lock downgrades detected" /tmp/uv-lock-downgrade-report.md; then
               echo "has_downgrades=true" >> "$GITHUB_OUTPUT"
             else
               echo "has_downgrades=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -563,11 +563,95 @@ jobs:
             docker push "$tag"
           done <<< "${{ steps.meta.outputs.tags }}"
 
+  # Prevent silent uv.lock pin regressions on PRs (AAP-83826).
+  uv-lock-downgrade:
+    name: uv.lock downgrade gate
+    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+    runs-on: ubuntu-26.04
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout Source
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          show-progress: false
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.3.2
+
+      - name: Fetch base branch lockfile
+        env:
+          BASE_REF: ${{ github.base_ref || 'main' }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --depth=1 origin "$BASE_REF"
+          git show "origin/${BASE_REF}:uv.lock" > /tmp/base-uv.lock
+
+      - name: Run unit tests
+        run: |
+          set -euo pipefail
+          cd tools
+          uv run --with packaging --no-project python -m unittest -v test_check_uv_lock_downgrades.py
+
+      - name: Check for uv.lock downgrades
+        id: check
+        env:
+          ALLOW_DOWNGRADE: ${{ contains(join(github.event.pull_request.labels.*.name, ','), 'allow-lock-downgrade') }}
+        run: |
+          set -euo pipefail
+          args=(--base /tmp/base-uv.lock --head uv.lock --github-step-summary)
+          if [[ "${ALLOW_DOWNGRADE}" == "true" ]]; then
+            args+=(--allow-downgrade)
+          fi
+          set +e
+          uv run --with packaging --no-project python tools/check_uv_lock_downgrades.py "${args[@]}" | tee /tmp/uv-lock-downgrade-report.md
+          code=${PIPESTATUS[0]}
+          set -e
+          if [[ "$code" -eq 0 ]]; then
+            if grep -q "downgrades detected" /tmp/uv-lock-downgrade-report.md; then
+              echo "has_downgrades=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "has_downgrades=false" >> "$GITHUB_OUTPUT"
+            fi
+            exit 0
+          fi
+          echo "has_downgrades=true" >> "$GITHUB_OUTPUT"
+          exit "$code"
+
+      - name: Comment downgrades on PR
+        if: >
+          always() &&
+          github.event_name == 'pull_request' &&
+          steps.check.outputs.has_downgrades == 'true'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          marker="<!-- uv-lock-downgrade-gate -->"
+          body="$(printf '%s\n%s\n' "${marker}" "$(cat /tmp/uv-lock-downgrade-report.md)")"
+          # Replace previous bot comment with the same marker, if any.
+          existing="$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+            --jq ".[] | select(.body | contains(\"${marker}\")) | .id" | head -n1 || true)"
+          payload="$(jq -n --arg body "${body}" '{body: $body}')"
+          if [[ -n "${existing}" ]]; then
+            gh api --method PATCH \
+              "repos/${{ github.repository }}/issues/comments/${existing}" \
+              --input - <<<"${payload}"
+          else
+            gh api --method POST \
+              "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+              --input - <<<"${payload}"
+          fi
+
   check: # This job does nothing and is only used for the branch protection
     needs:
       - package
       - build
       - mcp-server-image
+      - uv-lock-downgrade
     if: always() && !cancelled() && needs.build.result == 'success'
 
     permissions:
@@ -617,7 +701,7 @@ jobs:
         uses: re-actors/alls-green@release/v1 # that is a branch, not a tag
         id: alls-green
         with:
-          allowed-skips: mcp-server-image
+          allowed-skips: mcp-server-image, uv-lock-downgrade
           jobs: ${{ toJSON(needs) }}
 
       - name: Report unexpected failures

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,15 @@ select = ["ALL"]
 
 [tool.ruff.lint.per-file-ignores]
 "test/**/*.py" = ["DOC201", "DOC501", "PLC2701", "S"]
-"tools/test_*.py" = ["DOC201", "DOC501", "PLC2701", "PLR6301", "PT017", "PT027", "S"]
+"tools/test_*.py" = [
+  "DOC201",
+  "DOC501",
+  "PLC2701",
+  "PLR6301",
+  "PT017",
+  "PT027",
+  "S"
+]
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,7 @@ select = ["ALL"]
 
 [tool.ruff.lint.per-file-ignores]
 "test/**/*.py" = ["DOC201", "DOC501", "PLC2701", "S"]
-"tools/test_*.py" = ["DOC201", "DOC501", "PLC2701", "PLR6301", "S"]
+"tools/test_*.py" = ["DOC201", "DOC501", "PLC2701", "PLR6301", "PT017", "PT027", "S"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,7 @@ select = ["ALL"]
 
 [tool.ruff.lint.per-file-ignores]
 "test/**/*.py" = ["DOC201", "DOC501", "PLC2701", "S"]
+"tools/test_*.py" = ["DOC201", "DOC501", "PLC2701", "PLR6301", "S"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"

--- a/tools/check_uv_lock_downgrades.py
+++ b/tools/check_uv_lock_downgrades.py
@@ -117,6 +117,11 @@ def locked_versions(
         try:
             version = Version(str(version_raw))
         except InvalidVersion:
+            logger.warning(
+                "Skipping unparsable version %r for %s",
+                version_raw,
+                name,
+            )
             continue
         # Prefer first occurrence; uv.lock should not duplicate keys.
         result.setdefault(key, version)

--- a/tools/check_uv_lock_downgrades.py
+++ b/tools/check_uv_lock_downgrades.py
@@ -1,0 +1,305 @@
+"""Fail when uv.lock downgrades direct dependency pins vs a base lockfile.
+
+Compares locked package versions between a head uv.lock (PR branch) and a base
+uv.lock (typically origin/main). By default only direct dependencies declared
+under the root package's dependency groups are checked.
+
+Exit codes:
+  0 — no downgrades (or --allow-downgrade was set)
+  1 — one or more downgrades detected
+  2 — usage / parse error
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TextIO
+
+import tomllib
+from packaging.version import InvalidVersion, Version
+
+ROOT_PACKAGE = "vscode-ansible"
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, order=True)
+class PackageKey:
+    """Identity for a locked package resolution."""
+
+    name: str
+    markers: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class Downgrade:
+    """A package whose locked version decreased."""
+
+    key: PackageKey
+    base_version: str
+    head_version: str
+
+    def format(self) -> str:
+        """Return a human-readable downgrade line.
+
+        Returns:
+            Formatted package downgrade description.
+        """
+        marker = f" [{', '.join(self.key.markers)}]" if self.key.markers else ""
+        return f"{self.key.name}{marker}: {self.base_version} -> {self.head_version}"
+
+
+def _load_lock(path: Path) -> dict:
+    try:
+        with path.open("rb") as handle:
+            return tomllib.load(handle)
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        logger.exception("Failed to parse lockfile %s", path)
+        raise SystemExit(2) from exc
+
+
+def direct_dependency_names(lock: dict, root_package: str = ROOT_PACKAGE) -> set[str]:
+    """Return direct dependency names from the root package metadata.
+
+    Args:
+        lock: Parsed uv.lock document.
+        root_package: Name of the workspace root package.
+
+    Returns:
+        Set of direct dependency distribution names.
+    """
+    names: set[str] = set()
+    for package in lock.get("package") or []:
+        if package.get("name") != root_package:
+            continue
+        metadata = package.get("metadata") or {}
+        requires_dev = metadata.get("requires-dev") or {}
+        for deps in requires_dev.values():
+            for dep in deps or []:
+                name = dep.get("name")
+                if name:
+                    names.add(name)
+        for dep in metadata.get("requires-dist") or []:
+            name = dep.get("name") if isinstance(dep, dict) else None
+            if name:
+                names.add(name)
+    return names
+
+
+def locked_versions(
+    lock: dict,
+    *,
+    only_names: set[str] | None = None,
+) -> dict[PackageKey, Version]:
+    """Map locked package keys to parsed versions.
+
+    Args:
+        lock: Parsed uv.lock document.
+        only_names: Optional allow-list of package names.
+
+    Returns:
+        Mapping of package keys to locked versions.
+    """
+    result: dict[PackageKey, Version] = {}
+    for package in lock.get("package") or []:
+        name = package.get("name")
+        version_raw = package.get("version")
+        if not name or version_raw is None:
+            continue
+        if only_names is not None and name not in only_names:
+            continue
+        markers = tuple(package.get("resolution-markers") or [])
+        key = PackageKey(name=name, markers=markers)
+        try:
+            version = Version(str(version_raw))
+        except InvalidVersion:
+            continue
+        # Prefer first occurrence; uv.lock should not duplicate keys.
+        result.setdefault(key, version)
+    return result
+
+
+def find_downgrades(
+    base_lock: dict,
+    head_lock: dict,
+    *,
+    direct_only: bool = True,
+    root_package: str = ROOT_PACKAGE,
+) -> list[Downgrade]:
+    """Return downgrades of locked versions from base to head.
+
+    Args:
+        base_lock: Parsed base-branch uv.lock.
+        head_lock: Parsed PR-branch uv.lock.
+        direct_only: When True, only check direct dependencies.
+        root_package: Name of the workspace root package.
+
+    Returns:
+        Sorted list of detected downgrades.
+
+    Raises:
+        SystemExit: If direct_only is set and no direct deps are found.
+    """
+    only_names: set[str] | None = None
+    if direct_only:
+        only_names = direct_dependency_names(base_lock, root_package) | (
+            direct_dependency_names(head_lock, root_package)
+        )
+        if not only_names:
+            msg = (
+                f"No direct dependencies found for root package "
+                f"{root_package!r} in either lockfile"
+            )
+            logger.error(msg)
+            raise SystemExit(2)
+
+    base_versions = locked_versions(base_lock, only_names=only_names)
+    head_versions = locked_versions(head_lock, only_names=only_names)
+
+    downgrades: list[Downgrade] = []
+    for key, base_version in sorted(base_versions.items()):
+        head_version = head_versions.get(key)
+        if head_version is None:
+            continue
+        if head_version < base_version:
+            downgrades.append(
+                Downgrade(
+                    key=key,
+                    base_version=str(base_version),
+                    head_version=str(head_version),
+                )
+            )
+    return downgrades
+
+
+def format_report(downgrades: list[Downgrade]) -> str:
+    """Format downgrades for logs / PR comments.
+
+    Args:
+        downgrades: Detected downgrades.
+
+    Returns:
+        Markdown report body.
+    """
+    lines = [
+        "### uv.lock downgrades detected",
+        "",
+        (
+            "The following locked package versions decreased relative to "
+            "the base branch:"
+        ),
+        "",
+    ]
+    lines.extend(f"- `{item.format()}`" for item in downgrades)
+    lines.extend([
+        "",
+        (
+            "If this rollback is intentional, add the maintainer-only "
+            "`allow-lock-downgrade` label and re-run the "
+            "**uv.lock downgrade gate** job."
+        ),
+    ])
+    return "\n".join(lines)
+
+
+def _read_lock_arg(value: str) -> dict:
+    path = Path(value)
+    if path.exists():
+        return _load_lock(path)
+    msg = f"Lockfile not found: {value}"
+    logger.error(msg)
+    raise SystemExit(2)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Create the CLI argument parser.
+
+    Returns:
+        Configured argument parser.
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--base",
+        required=True,
+        help="Path to base uv.lock (e.g. from origin/main)",
+    )
+    parser.add_argument(
+        "--head",
+        required=True,
+        help="Path to head uv.lock (PR branch)",
+    )
+    parser.add_argument(
+        "--allow-downgrade",
+        action="store_true",
+        help="Report downgrades but exit 0 (escape hatch)",
+    )
+    parser.add_argument(
+        "--transitive",
+        action="store_true",
+        help="Also check transitive packages (default: direct deps only)",
+    )
+    parser.add_argument(
+        "--root-package",
+        default=ROOT_PACKAGE,
+        help=f"Root package name in the lockfile (default: {ROOT_PACKAGE})",
+    )
+    parser.add_argument(
+        "--github-step-summary",
+        action="store_true",
+        help="Append a markdown report to $GITHUB_STEP_SUMMARY when set",
+    )
+    return parser
+
+
+def _write_step_summary(report: str) -> None:
+    summary_path = Path(sys.environ["GITHUB_STEP_SUMMARY"])
+    with summary_path.open("a", encoding="utf-8") as handle:
+        handle.write(report)
+        handle.write("\n")
+
+
+def main(argv: list[str] | None = None, stdout: TextIO = sys.stdout) -> int:
+    """CLI entry point.
+
+    Args:
+        argv: Optional CLI arguments (defaults to sys.argv).
+        stdout: Stream used for report output.
+
+    Returns:
+        Process exit code.
+    """
+    args = build_parser().parse_args(argv)
+    base_lock = _read_lock_arg(args.base)
+    head_lock = _read_lock_arg(args.head)
+
+    downgrades = find_downgrades(
+        base_lock,
+        head_lock,
+        direct_only=not args.transitive,
+        root_package=args.root_package,
+    )
+
+    if not downgrades:
+        stdout.write("No uv.lock direct-dependency downgrades detected.\n")
+        return 0
+
+    report = format_report(downgrades)
+    stdout.write(f"{report}\n")
+
+    if args.github_step_summary and "GITHUB_STEP_SUMMARY" in sys.environ:
+        _write_step_summary(report)
+
+    if args.allow_downgrade:
+        stdout.write(
+            "\nallow-lock-downgrade enabled; not failing the check.\n",
+        )
+        return 0
+    return 1
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+    sys.exit(main())

--- a/tools/check_uv_lock_downgrades.py
+++ b/tools/check_uv_lock_downgrades.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import argparse
 import logging
+import os
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -255,7 +256,7 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def _write_step_summary(report: str) -> None:
-    summary_path = Path(sys.environ["GITHUB_STEP_SUMMARY"])
+    summary_path = Path(os.environ["GITHUB_STEP_SUMMARY"])
     with summary_path.open("a", encoding="utf-8") as handle:
         handle.write(report)
         handle.write("\n")
@@ -289,7 +290,7 @@ def main(argv: list[str] | None = None, stdout: TextIO = sys.stdout) -> int:
     report = format_report(downgrades)
     stdout.write(f"{report}\n")
 
-    if args.github_step_summary and "GITHUB_STEP_SUMMARY" in sys.environ:
+    if args.github_step_summary and "GITHUB_STEP_SUMMARY" in os.environ:
         _write_step_summary(report)
 
     if args.allow_downgrade:

--- a/tools/test_check_uv_lock_downgrades.py
+++ b/tools/test_check_uv_lock_downgrades.py
@@ -1,0 +1,254 @@
+"""Unit tests for check_uv_lock_downgrades."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import tomllib
+from check_uv_lock_downgrades import find_downgrades, format_report, main
+
+
+def _lock(*packages: str, root_deps: list[str] | None = None) -> str:
+    """Build a minimal uv.lock TOML document.
+
+    Args:
+        packages: Raw ``[[package]]`` TOML blocks.
+        root_deps: Direct dependency names for the root package.
+
+    Returns:
+        Complete uv.lock document text.
+    """
+    parts = ["version = 1", "revision = 1", ""]
+    for block in packages:
+        parts.extend((block.strip(), ""))
+    deps = root_deps or ["ruff", "mypy"]
+    requires = ",\n".join(
+        f'    {{ name = "{name}", specifier = ">=0" }}' for name in deps
+    )
+    # Match uv.lock shape: std tables, not multiline inline tables.
+    root_block = f"""\
+[[package]]
+name = "vscode-ansible"
+source = {{ virtual = "." }}
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+lint = [
+{requires}
+]
+"""
+    parts.extend((root_block, ""))
+    return "\n".join(parts)
+
+
+RUFF_010 = """\
+[[package]]
+name = "ruff"
+version = "0.10.0"
+source = { registry = "https://pypi.org/simple" }
+"""
+
+RUFF_014 = """\
+[[package]]
+name = "ruff"
+version = "0.14.3"
+source = { registry = "https://pypi.org/simple" }
+"""
+
+MYPY_110 = """\
+[[package]]
+name = "mypy"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+"""
+
+MYPY_117 = """\
+[[package]]
+name = "mypy"
+version = "1.17.1"
+source = { registry = "https://pypi.org/simple" }
+"""
+
+TRANSITIVE_OLD = """\
+[[package]]
+name = "click"
+version = "8.0.0"
+source = { registry = "https://pypi.org/simple" }
+"""
+
+TRANSITIVE_NEW = """\
+[[package]]
+name = "click"
+version = "8.1.0"
+source = { registry = "https://pypi.org/simple" }
+"""
+
+ANSIBLE_CORE_BASE = """\
+[[package]]
+name = "ansible-core"
+version = "2.19.11"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.12'",
+]
+
+[[package]]
+name = "ansible-core"
+version = "2.21.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+]
+"""
+
+ANSIBLE_CORE_DOWN = """\
+[[package]]
+name = "ansible-core"
+version = "2.19.10"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.12'",
+]
+
+[[package]]
+name = "ansible-core"
+version = "2.21.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+]
+"""
+
+
+def _parse(text: str) -> dict:
+    """Parse lockfile TOML text.
+
+    Args:
+        text: uv.lock document contents.
+
+    Returns:
+        Parsed TOML dictionary.
+    """
+    return tomllib.loads(text)
+
+
+class FindDowngradesTests(unittest.TestCase):
+    """Tests for find_downgrades()."""
+
+    def test_no_change(self) -> None:
+        """Equal lockfiles produce no downgrades."""
+        base = _lock(RUFF_014, MYPY_117)
+        head = _lock(RUFF_014, MYPY_117)
+        assert find_downgrades(_parse(base), _parse(head)) == []
+
+    def test_upgrade_ok(self) -> None:
+        """Version increases are allowed."""
+        base = _lock(RUFF_010, MYPY_110)
+        head = _lock(RUFF_014, MYPY_117)
+        assert find_downgrades(_parse(base), _parse(head)) == []
+
+    def test_direct_downgrade_fails(self) -> None:
+        """A direct dependency version decrease is reported."""
+        base = _lock(RUFF_014, MYPY_117)
+        head = _lock(RUFF_010, MYPY_117)
+        downs = find_downgrades(_parse(base), _parse(head))
+        assert len(downs) == 1
+        assert downs[0].key.name == "ruff"
+        assert downs[0].base_version == "0.14.3"
+        assert downs[0].head_version == "0.10.0"
+
+    def test_transitive_ignored_by_default(self) -> None:
+        """Transitive package downgrades are ignored in direct-only mode."""
+        base = _lock(RUFF_014, MYPY_117, TRANSITIVE_NEW)
+        head = _lock(RUFF_014, MYPY_117, TRANSITIVE_OLD)
+        assert find_downgrades(_parse(base), _parse(head)) == []
+
+    def test_transitive_checked_when_requested(self) -> None:
+        """Transitive package downgrades are reported with direct_only=False."""
+        base = _lock(RUFF_014, MYPY_117, TRANSITIVE_NEW)
+        head = _lock(RUFF_014, MYPY_117, TRANSITIVE_OLD)
+        downs = find_downgrades(
+            _parse(base),
+            _parse(head),
+            direct_only=False,
+        )
+        assert len(downs) == 1
+        assert downs[0].key.name == "click"
+
+    def test_marker_specific_downgrade(self) -> None:
+        """Multi-version packages compare matching resolution markers."""
+        base = _lock(
+            ANSIBLE_CORE_BASE,
+            RUFF_014,
+            root_deps=["ansible-core", "ruff"],
+        )
+        head = _lock(
+            ANSIBLE_CORE_DOWN,
+            RUFF_014,
+            root_deps=["ansible-core", "ruff"],
+        )
+        downs = find_downgrades(_parse(base), _parse(head))
+        assert len(downs) == 1
+        assert downs[0].key.name == "ansible-core"
+        assert downs[0].key.markers == ("python_full_version < '3.12'",)
+        assert downs[0].base_version == "2.19.11"
+        assert downs[0].head_version == "2.19.10"
+
+    def test_format_report(self) -> None:
+        """Report includes package names and escape-hatch guidance."""
+        downs = find_downgrades(
+            _parse(_lock(RUFF_014, MYPY_117)),
+            _parse(_lock(RUFF_010, MYPY_117)),
+        )
+        report = format_report(downs)
+        assert "ruff" in report
+        assert "0.14.3 -> 0.10.0" in report
+        assert "allow-lock-downgrade" in report
+
+
+class MainCliTests(unittest.TestCase):
+    """Tests for the CLI entry point."""
+
+    def test_main_fails_on_downgrade(self) -> None:
+        """CLI exits 1 when a downgrade is present."""
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp) / "base.lock"
+            head = Path(tmp) / "head.lock"
+            base.write_text(_lock(RUFF_014, MYPY_117), encoding="utf-8")
+            head.write_text(_lock(RUFF_010, MYPY_117), encoding="utf-8")
+            code = main(["--base", str(base), "--head", str(head)])
+            assert code == 1
+
+    def test_main_allow_downgrade(self) -> None:
+        """CLI exits 0 when --allow-downgrade is set."""
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp) / "base.lock"
+            head = Path(tmp) / "head.lock"
+            base.write_text(_lock(RUFF_014, MYPY_117), encoding="utf-8")
+            head.write_text(_lock(RUFF_010, MYPY_117), encoding="utf-8")
+            code = main([
+                "--base",
+                str(base),
+                "--head",
+                str(head),
+                "--allow-downgrade",
+            ])
+            assert code == 0
+
+    def test_main_ok(self) -> None:
+        """CLI exits 0 when lockfiles match."""
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp) / "base.lock"
+            head = Path(tmp) / "head.lock"
+            content = _lock(RUFF_014, MYPY_117)
+            base.write_text(content, encoding="utf-8")
+            head.write_text(content, encoding="utf-8")
+            code = main(["--base", str(base), "--head", str(head)])
+            assert code == 0
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_check_uv_lock_downgrades.py
+++ b/tools/test_check_uv_lock_downgrades.py
@@ -2,12 +2,20 @@
 
 from __future__ import annotations
 
+import logging
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 import tomllib
-from check_uv_lock_downgrades import find_downgrades, format_report, main
+from check_uv_lock_downgrades import (
+    PackageKey,
+    find_downgrades,
+    format_report,
+    locked_versions,
+    main,
+)
 
 
 def _lock(*packages: str, root_deps: list[str] | None = None) -> str:
@@ -248,6 +256,74 @@ class MainCliTests(unittest.TestCase):
             head.write_text(content, encoding="utf-8")
             code = main(["--base", str(base), "--head", str(head)])
             assert code == 0
+
+    def test_main_missing_lockfile(self) -> None:
+        """CLI exits 2 when a lockfile path does not exist."""
+        with tempfile.TemporaryDirectory() as tmp:
+            head = Path(tmp) / "head.lock"
+            head.write_text(_lock(RUFF_014, MYPY_117), encoding="utf-8")
+            with self.assertRaises(SystemExit) as ctx:
+                main(["--base", str(Path(tmp) / "missing.lock"), "--head", str(head)])
+            assert ctx.exception.code == 2
+
+    def test_main_malformed_lockfile(self) -> None:
+        """CLI exits 2 when a lockfile cannot be parsed."""
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp) / "base.lock"
+            head = Path(tmp) / "head.lock"
+            base.write_text("not: valid: toml [[[", encoding="utf-8")
+            head.write_text(_lock(RUFF_014, MYPY_117), encoding="utf-8")
+            with self.assertRaises(SystemExit) as ctx:
+                main(["--base", str(base), "--head", str(head)])
+            assert ctx.exception.code == 2
+
+    def test_main_github_step_summary(self) -> None:
+        """CLI appends the downgrade report to GITHUB_STEP_SUMMARY."""
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp) / "base.lock"
+            head = Path(tmp) / "head.lock"
+            summary = Path(tmp) / "summary.md"
+            base.write_text(_lock(RUFF_014, MYPY_117), encoding="utf-8")
+            head.write_text(_lock(RUFF_010, MYPY_117), encoding="utf-8")
+            summary.write_text("existing\n", encoding="utf-8")
+            with mock.patch.dict(
+                "os.environ",
+                {"GITHUB_STEP_SUMMARY": str(summary)},
+            ):
+                code = main([
+                    "--base",
+                    str(base),
+                    "--head",
+                    str(head),
+                    "--allow-downgrade",
+                    "--github-step-summary",
+                ])
+            assert code == 0
+            text = summary.read_text(encoding="utf-8")
+            assert text.startswith("existing\n")
+            assert "### uv.lock downgrades detected" in text
+
+
+class LockedVersionsTests(unittest.TestCase):
+    """Tests for locked_versions() edge cases."""
+
+    def test_unparsable_version_is_skipped_with_warning(self) -> None:
+        """Invalid version strings are skipped and logged."""
+        lock = _parse(
+            _lock(
+                """\
+[[package]]
+name = "ruff"
+version = "not-a-version"
+source = { registry = "https://pypi.org/simple" }
+""",
+                MYPY_117,
+            )
+        )
+        with self.assertLogs("check_uv_lock_downgrades", level=logging.WARNING) as logs:
+            versions = locked_versions(lock, only_names={"ruff", "mypy"})
+        assert PackageKey("ruff", ()) not in versions
+        assert any("not-a-version" in message for message in logs.output)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add a CI gate that diffs locked direct dependency versions in `uv.lock` against the PR base branch and fails on any downgrade
- Escape hatch via the maintainer-only `allow-lock-downgrade` label (re-run the **uv.lock downgrade gate** job after labeling)
- Optional PR comment / step summary listing detected downgrades for reviewers

## Test plan
- [ ] Open this PR and confirm the `uv.lock downgrade gate` job passes against `main`
- [ ] Locally: `cd tools && uv run --with packaging --no-project python -m unittest -v test_check_uv_lock_downgrades.py`
- [ ] Simulate a downgrade (lower a direct dep version in `uv.lock`) and confirm the job fails and comments on the PR
- [ ] Add `allow-lock-downgrade`, re-run the gate job, and confirm it passes while still reporting the downgrade

related: AAP-83826

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Add a CI gate that compares base and head `uv.lock` files.
- Fail when direct dependencies are downgraded, unless `allow-lock-downgrade` is present.
- Report detected downgrades in PR comments or step summaries.
- Handle merge-group references, credentials, caches, false-positive comments, and CLI errors.
- Add tests and run lint before package and documentation jobs.
- H hardens downgrade-job credential and cache handling, fixes `merge_group` base-ref handling and false-positive PR comments, and covers CLI error paths.

Commit message: Add CI check for uv lockfile downgrades
<!-- end of auto-generated comment: release notes by coderabbit.ai -->