### PR TITLE
fix(docs): use absolute URLs for MCP doc links in README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -375,8 +375,8 @@ The extension includes an MCP server that enables AI assistants and LLM-powered 
 
 ### Learn More
 
-- **[MCP Server Overview](mcp/README.md)** - Features, architecture, and getting started guide
-- **[API Reference](mcp/api.md)** - Complete technical API documentation for all tools and resources
+- **[MCP Server Overview](https://docs.ansible.com/projects/vscode-ansible/mcp/)** - Features, architecture, and getting started guide
+- **[API Reference](https://docs.ansible.com/projects/vscode-ansible/mcp/api/)** - Complete technical API documentation for all tools and resources
 
 ## Contact
 


### PR DESCRIPTION
The relative links mcp/README.md and mcp/api.md resolve to non-existent GitHub blob URLs when docs/README.md is viewed on GitHub or VS Code marketplace. Replace with absolute URLs to docs.ansible.com where the documentation is actually hosted.

fixes: [AAP-73918](https://redhat.atlassian.net/browse/AAP-73918)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Updated MCP documentation links in `docs/README.md` to use absolute `docs.ansible.com` URLs.
- Ensured links resolve correctly on GitHub and in the VS Code Marketplace.

Fixes: Related: AAP-73918

<!-- end of auto-generated comment: release notes by coderabbit.ai -->