### PR TITLE
fix: suppress repeated PET warning using globalState

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -389,6 +389,7 @@ jobs:
             if: ${{ !cancelled() && contains(matrix.name, 'test') }}
             run: |
               set -e
+              mkdir -p out/log
               task build 2>out/log/build-before.txt
               task e2e ${{ matrix.env.TASKFILE_ARGS }}
               task build 2>out/log/build-after.txt

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -109,7 +109,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
 
   // Initialize Python Environment Service early
   const pythonEnvService = PythonEnvironmentService.getInstance();
-  await pythonEnvService.initialize();
+  await pythonEnvService.initialize(context);
   context.subscriptions.push(pythonEnvService);
 
   // Initialize Terminal Service

--- a/src/services/PythonEnvironmentService.ts
+++ b/src/services/PythonEnvironmentService.ts
@@ -33,6 +33,7 @@ export class PythonEnvironmentService implements vscode.Disposable {
   private _pythonExtApi: PythonExtension | undefined;
   private _initialized: boolean = false;
   private _petWarningShown: boolean = false;
+  private _context: vscode.ExtensionContext | undefined;
   private _disposables: vscode.Disposable[] = [];
 
   private _onDidChangeEnvironment =
@@ -53,11 +54,15 @@ export class PythonEnvironmentService implements vscode.Disposable {
    * Initialize the service. Tries the Environments extension first; if PET
    * is missing falls back to the main Python extension's environments API.
    */
-  public async initialize(): Promise<boolean> {
+  public async initialize(context?: vscode.ExtensionContext): Promise<boolean> {
     if (this._initialized) {
       return (
         this._pythonEnvApi !== undefined || this._pythonExtApi !== undefined
       );
+    }
+
+    if (context) {
+      this._context = context;
     }
 
     console.log(
@@ -77,7 +82,7 @@ export class PythonEnvironmentService implements vscode.Disposable {
         console.warn(
           "[Ansible] PET binary not found — environment discovery will be degraded",
         );
-        this._showPetWarning();
+        await this._showPetWarning();
         await this._initFromPythonExtension();
       }
     } else {
@@ -237,52 +242,20 @@ export class PythonEnvironmentService implements vscode.Disposable {
   // Notification
   // ---------------------------------------------------------------------------
 
-  private _showPetWarning(): void {
+  private async _showPetWarning(): Promise<void> {
     if (this._petWarningShown) {
       return;
     }
+
+    if (
+      this._context?.globalState.get<boolean>("ansible.petWarningShown") ===
+      true
+    ) {
+      return;
+    }
+
     this._petWarningShown = true;
-
-    const useEnvsSetting = vscode.workspace
-      .getConfiguration("python")
-      .get<boolean>("useEnvironmentsExtension");
-
-    vscode.window
-      .showWarningMessage(
-        "Python environment discovery is degraded (PET binary missing). " +
-          "This commonly occurs in OpenVSX-based editors (Dev Spaces, VSCodium)." +
-          (useEnvsSetting
-            ? " Disabling the Environments extension delegation may resolve hanging discovery."
-            : ""),
-        ...(useEnvsSetting ? ["Disable Environments Extension"] : []),
-        "Learn More",
-      )
-      .then(async (selection) => {
-        if (selection === "Disable Environments Extension") {
-          await vscode.workspace
-            .getConfiguration("python")
-            .update(
-              "useEnvironmentsExtension",
-              false,
-              vscode.ConfigurationTarget.Global,
-            );
-          const reload = await vscode.window.showInformationMessage(
-            "Setting disabled. Reload VS Code for the change to take effect.",
-            "Reload Now",
-          );
-          if (reload === "Reload Now") {
-            await vscode.commands.executeCommand(
-              "workbench.action.reloadWindow",
-            );
-          }
-        } else if (selection === "Learn More") {
-          vscode.env.openExternal(
-            vscode.Uri.parse(
-              "https://github.com/microsoft/vscode-python/issues/25820",
-            ),
-          );
-        }
-      });
+    await showPetWarningDialog(this._context);
   }
 
   // ---------------------------------------------------------------------------
@@ -545,5 +518,49 @@ export class PythonEnvironmentService implements vscode.Disposable {
     });
     this._disposables = [];
     this._onDidChangeEnvironment.dispose();
+  }
+}
+
+export async function showPetWarningDialog(
+  context: vscode.ExtensionContext | undefined,
+): Promise<void> {
+  const useEnvsSetting = vscode.workspace
+    .getConfiguration("python")
+    .get<boolean>("useEnvironmentsExtension");
+
+  const selection = await vscode.window.showWarningMessage(
+    "Python environment discovery is degraded (PET binary missing). " +
+      "This commonly occurs in OpenVSX-based editors (Dev Spaces, VSCodium)." +
+      (useEnvsSetting
+        ? " Disabling the Environments extension delegation may resolve hanging discovery."
+        : ""),
+    ...(useEnvsSetting ? ["Disable Environments Extension"] : []),
+    "Don't show again",
+    "Learn More",
+  );
+
+  if (selection === "Don't show again") {
+    await context?.globalState.update("ansible.petWarningShown", true);
+  } else if (selection === "Disable Environments Extension") {
+    await vscode.workspace
+      .getConfiguration("python")
+      .update(
+        "useEnvironmentsExtension",
+        false,
+        vscode.ConfigurationTarget.Global,
+      );
+    const reload = await vscode.window.showInformationMessage(
+      "Setting disabled. Reload VS Code for the change to take effect.",
+      "Reload Now",
+    );
+    if (reload === "Reload Now") {
+      await vscode.commands.executeCommand("workbench.action.reloadWindow");
+    }
+  } else if (selection === "Learn More") {
+    vscode.env.openExternal(
+      vscode.Uri.parse(
+        "https://github.com/microsoft/vscode-python/issues/25820",
+      ),
+    );
   }
 }

--- a/test/unit/services/PythonEnvironmentService.test.ts
+++ b/test/unit/services/PythonEnvironmentService.test.ts
@@ -1359,4 +1359,277 @@ describe("PythonEnvironmentService", function () {
       expect(mockShowWarningMessage).not.toHaveBeenCalled();
     });
   });
+
+  describe("getVersion", function () {
+    it("should return version from environment", async function () {
+      const mockEnv = {
+        envId: { id: "test", managerId: "test" },
+        version: "3.11.5",
+        execInfo: { run: { executable: "/usr/bin/python3" } },
+      };
+
+      const mockApi = makeMockEnvsApi({
+        getEnvironment: vi.fn().mockResolvedValue(mockEnv),
+      });
+
+      mockGetExtension.mockReturnValue({
+        isActive: true,
+        extensionPath: "/ext/path",
+        exports: mockApi,
+        activate: vi.fn(),
+      });
+      mockExistsSync.mockReturnValue(true);
+
+      await service.initialize();
+      const result = await service.getVersion();
+
+      expect(result).toBe("3.11.5");
+    });
+
+    it("should return undefined when no environment", async function () {
+      mockGetExtension.mockReturnValue(undefined);
+      mockPythonExtApi.mockRejectedValue(new Error("no ext"));
+
+      const result = await service.getVersion();
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("getDisplayName", function () {
+    it("should return displayName from environment", async function () {
+      const mockEnv = {
+        envId: { id: "test", managerId: "test" },
+        displayName: "Python 3.11.5 (myenv)",
+        execInfo: { run: { executable: "/usr/bin/python3" } },
+      };
+
+      const mockApi = makeMockEnvsApi({
+        getEnvironment: vi.fn().mockResolvedValue(mockEnv),
+      });
+
+      mockGetExtension.mockReturnValue({
+        isActive: true,
+        extensionPath: "/ext/path",
+        exports: mockApi,
+        activate: vi.fn(),
+      });
+      mockExistsSync.mockReturnValue(true);
+
+      await service.initialize();
+      const result = await service.getDisplayName();
+
+      expect(result).toBe("Python 3.11.5 (myenv)");
+    });
+
+    it("should return undefined when no environment", async function () {
+      mockGetExtension.mockReturnValue(undefined);
+      mockPythonExtApi.mockRejectedValue(new Error("no ext"));
+
+      const result = await service.getDisplayName();
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("resolveInterpreterPath", function () {
+    it("should return user-configured path when provided and valid", async function () {
+      const mockApi = makeMockEnvsApi();
+      mockGetExtension.mockReturnValue({
+        isActive: true,
+        extensionPath: "/ext/path",
+        exports: mockApi,
+        activate: vi.fn(),
+      });
+      mockExistsSync.mockReturnValue(true);
+
+      await service.initialize();
+      const result = await service.resolveInterpreterPath(
+        "/custom/python3",
+        vscode.Uri.file("/workspace"),
+      );
+
+      expect(result).toBe("/custom/python3");
+    });
+
+    it("should fall back to getExecutablePath when no user path provided", async function () {
+      const mockEnv = {
+        envId: { id: "test", managerId: "test" },
+        execInfo: { run: { executable: "/usr/bin/python3.11" } },
+      };
+
+      const mockApi = makeMockEnvsApi({
+        getEnvironment: vi.fn().mockResolvedValue(mockEnv),
+      });
+
+      mockGetExtension.mockReturnValue({
+        isActive: true,
+        extensionPath: "/ext/path",
+        exports: mockApi,
+        activate: vi.fn(),
+      });
+      mockExistsSync.mockReturnValue(true);
+
+      await service.initialize();
+      const result = await service.resolveInterpreterPath(undefined);
+
+      expect(result).toBe("/usr/bin/python3.11");
+    });
+
+    it("should fall back to getExecutablePath when user path is empty", async function () {
+      const mockEnv = {
+        envId: { id: "test", managerId: "test" },
+        execInfo: { run: { executable: "/usr/bin/python3.11" } },
+      };
+
+      const mockApi = makeMockEnvsApi({
+        getEnvironment: vi.fn().mockResolvedValue(mockEnv),
+      });
+
+      mockGetExtension.mockReturnValue({
+        isActive: true,
+        extensionPath: "/ext/path",
+        exports: mockApi,
+        activate: vi.fn(),
+      });
+      mockExistsSync.mockReturnValue(true);
+
+      await service.initialize();
+      const result = await service.resolveInterpreterPath("   ");
+
+      expect(result).toBe("/usr/bin/python3.11");
+    });
+  });
+
+  describe("getEnvironments — error handling", function () {
+    it("should return fallback results when envs API throws", async function () {
+      const fallbackApi = makeMockPythonExtApi({
+        known: [],
+      });
+
+      const mockApi = makeMockEnvsApi({
+        getEnvironments: vi.fn().mockRejectedValue(new Error("API error")),
+      });
+
+      mockGetExtension.mockReturnValue({
+        isActive: true,
+        extensionPath: "/ext/path",
+        exports: mockApi,
+        activate: vi.fn(),
+      });
+      mockExistsSync.mockReturnValue(true);
+      mockPythonExtApi.mockResolvedValue(fallbackApi);
+
+      const consoleErrorSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => undefined);
+
+      await service.initialize();
+      const result = await service.getEnvironments();
+
+      expect(result).toEqual([]);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Error getting environments (envs API)"),
+      );
+    });
+  });
+
+  describe("getEnvironmentsFromPythonExt — with known environments", function () {
+    it("should resolve and adapt known environments from fallback API", async function () {
+      const mockKnownEnv = { id: "known-env", path: "/usr/bin/python3" };
+      const mockResolvedEnv = {
+        id: "known-env",
+        path: "/usr/bin/python3",
+        executable: {
+          uri: { fsPath: "/usr/bin/python3" },
+          sysPrefix: "/usr",
+        },
+        environment: {
+          type: "VirtualEnvironment",
+          name: "myenv",
+        },
+        version: {
+          major: 3,
+          minor: 11,
+          micro: 5,
+        },
+      };
+
+      const fallbackApi = makeMockPythonExtApi({
+        known: [mockKnownEnv],
+        resolveEnvironment: vi.fn().mockResolvedValue(mockResolvedEnv),
+      });
+
+      mockGetExtension.mockImplementation((id: string) => {
+        if (id === PYTHON_ENVS_EXTENSION_ID) {
+          return {
+            isActive: true,
+            extensionPath: "/ext/path",
+            exports: makeMockEnvsApi(),
+            activate: vi.fn(),
+          };
+        }
+        if (id === "ms-python.python") {
+          return { isActive: true, activate: vi.fn() };
+        }
+        return undefined;
+      });
+      mockExistsSync.mockReturnValue(false);
+      mockShowWarningMessage.mockResolvedValue(undefined);
+      mockPythonExtApi.mockResolvedValue(fallbackApi);
+
+      await service.initialize();
+      const result = await service.getEnvironments();
+
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe("myenv");
+      expect(result[0].version).toBe("3.11.5");
+      expect(result[0].execInfo.run.executable).toBe("/usr/bin/python3");
+    });
+
+    it("should skip environments that fail to resolve", async function () {
+      const mockKnownEnv1 = { id: "env-1", path: "/usr/bin/python3" };
+      const mockKnownEnv2 = { id: "env-2", path: "/usr/bin/python3.12" };
+
+      const fallbackApi = makeMockPythonExtApi({
+        known: [mockKnownEnv1, mockKnownEnv2],
+        resolveEnvironment: vi
+          .fn()
+          .mockResolvedValueOnce(undefined)
+          .mockResolvedValueOnce({
+            id: "env-2",
+            executable: {
+              uri: { fsPath: "/usr/bin/python3.12" },
+              sysPrefix: "/usr",
+            },
+            environment: { type: "System", name: "system" },
+            version: { major: 3, minor: 12, micro: 0 },
+          }),
+      });
+
+      mockGetExtension.mockImplementation((id: string) => {
+        if (id === PYTHON_ENVS_EXTENSION_ID) {
+          return {
+            isActive: true,
+            extensionPath: "/ext/path",
+            exports: makeMockEnvsApi(),
+            activate: vi.fn(),
+          };
+        }
+        if (id === "ms-python.python") {
+          return { isActive: true, activate: vi.fn() };
+        }
+        return undefined;
+      });
+      mockExistsSync.mockReturnValue(false);
+      mockShowWarningMessage.mockResolvedValue(undefined);
+      mockPythonExtApi.mockResolvedValue(fallbackApi);
+
+      await service.initialize();
+      const result = await service.getEnvironments();
+
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe("system");
+    });
+  });
 });

--- a/test/unit/services/PythonEnvironmentService.test.ts
+++ b/test/unit/services/PythonEnvironmentService.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import * as fs from "fs";
 import * as vscode from "vscode";
-import { PythonEnvironmentService } from "@src/services/PythonEnvironmentService";
+import {
+  PythonEnvironmentService,
+  showPetWarningDialog,
+} from "@src/services/PythonEnvironmentService";
 import { PythonExtension } from "@vscode/python-extension";
 import { PYTHON_ENVS_EXTENSION_ID } from "@src/types/pythonEnvApi";
 
@@ -18,6 +21,23 @@ describe("PythonEnvironmentService", function () {
   let mockExecuteCommand: ReturnType<typeof vi.fn>;
   let mockExistsSync: ReturnType<typeof vi.fn>;
   let mockPythonExtApi: ReturnType<typeof vi.fn>;
+
+  const makeMockContext = (
+    globalStateOverrides: Record<string, unknown> = {},
+  ) => {
+    const store = new Map<string, unknown>(
+      Object.entries(globalStateOverrides),
+    );
+    return {
+      globalState: {
+        get: vi.fn((key: string) => store.get(key)),
+        update: vi.fn((key: string, value: unknown) => {
+          store.set(key, value);
+          return Promise.resolve();
+        }),
+      },
+    } as unknown as import("vscode").ExtensionContext;
+  };
 
   const resetSingleton = () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -175,9 +195,11 @@ describe("PythonEnvironmentService", function () {
       mockExistsSync.mockReturnValue(true);
 
       await service.initialize();
+      const callsAfterFirst = mockGetExtension.mock.calls.length;
       await service.initialize();
 
-      expect(mockGetExtension).toHaveBeenCalledTimes(1);
+      // Second call must not trigger any additional extension lookups
+      expect(mockGetExtension.mock.calls).toHaveLength(callsAfterFirst);
     });
   });
 
@@ -234,6 +256,7 @@ describe("PythonEnvironmentService", function () {
 
       expect(mockShowWarningMessage).toHaveBeenCalledWith(
         expect.stringContaining("PET binary missing"),
+        "Don't show again",
         "Learn More",
       );
     });
@@ -260,9 +283,264 @@ describe("PythonEnvironmentService", function () {
       const mockOpenExternal = vi.mocked(vscode.env.openExternal);
       await service.initialize();
 
-      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(mockOpenExternal).toHaveBeenCalled();
+    });
+
+    it("should not show warning again if already shown in current session", async function () {
+      mockGetExtension.mockImplementation((id: string) => {
+        if (id === PYTHON_ENVS_EXTENSION_ID) {
+          return {
+            isActive: true,
+            extensionPath: "/ext/path",
+            exports: makeMockEnvsApi(),
+            activate: vi.fn(),
+          };
+        }
+        if (id === "ms-python.python") {
+          return { isActive: true, activate: vi.fn() };
+        }
+        return undefined;
+      });
+      mockExistsSync.mockReturnValue(false);
+      mockShowWarningMessage.mockResolvedValue(undefined);
+      mockPythonExtApi.mockResolvedValue(makeMockPythonExtApi());
+
+      await service.initialize();
+      expect(mockShowWarningMessage).toHaveBeenCalledTimes(1);
+
+      // Reset initialized flag to allow a second initialize() call on the same
+      // instance, keeping _petWarningShown=true to exercise the early-return path.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (service as any)._initialized = false;
+      await service.initialize();
+
+      expect(mockShowWarningMessage).toHaveBeenCalledTimes(1);
+    });
+
+    it("should disable environments extension when that button is selected", async function () {
+      mockGetExtension.mockImplementation((id: string) => {
+        if (id === PYTHON_ENVS_EXTENSION_ID) {
+          return {
+            isActive: true,
+            extensionPath: "/ext/path",
+            exports: makeMockEnvsApi(),
+            activate: vi.fn(),
+          };
+        }
+        if (id === "ms-python.python") {
+          return { isActive: true, activate: vi.fn() };
+        }
+        return undefined;
+      });
+      mockExistsSync.mockReturnValue(false);
+      mockShowWarningMessage.mockResolvedValue(
+        "Disable Environments Extension",
+      );
+      mockShowInformationMessage.mockResolvedValue(undefined);
+      mockPythonExtApi.mockResolvedValue(makeMockPythonExtApi());
+
+      const mockConfig = {
+        get: vi.fn().mockReturnValue(true),
+        update: vi.fn().mockResolvedValue(undefined),
+      };
+      mockGetConfiguration.mockReturnValue(mockConfig);
+
+      await service.initialize();
+
+      expect(mockConfig.update).toHaveBeenCalledWith(
+        "useEnvironmentsExtension",
+        false,
+        vscode.ConfigurationTarget.Global,
+      );
+      expect(mockShowInformationMessage).toHaveBeenCalledWith(
+        expect.stringContaining("Reload"),
+        "Reload Now",
+      );
+    });
+
+    it("should reload window when Reload Now selected after disabling environments extension", async function () {
+      mockGetExtension.mockImplementation((id: string) => {
+        if (id === PYTHON_ENVS_EXTENSION_ID) {
+          return {
+            isActive: true,
+            extensionPath: "/ext/path",
+            exports: makeMockEnvsApi(),
+            activate: vi.fn(),
+          };
+        }
+        if (id === "ms-python.python") {
+          return { isActive: true, activate: vi.fn() };
+        }
+        return undefined;
+      });
+      mockExistsSync.mockReturnValue(false);
+      mockShowWarningMessage.mockResolvedValue(
+        "Disable Environments Extension",
+      );
+      mockShowInformationMessage.mockResolvedValue("Reload Now");
+      mockPythonExtApi.mockResolvedValue(makeMockPythonExtApi());
+
+      const mockConfig = {
+        get: vi.fn().mockReturnValue(true),
+        update: vi.fn().mockResolvedValue(undefined),
+      };
+      mockGetConfiguration.mockReturnValue(mockConfig);
+
+      await service.initialize();
+
+      expect(mockExecuteCommand).toHaveBeenCalledWith(
+        "workbench.action.reloadWindow",
+      );
+    });
+  });
+
+  describe("showPetWarningDialog", function () {
+    it("should show warning and persist when Don't show again clicked", async function () {
+      const ctx = makeMockContext();
+      mockShowWarningMessage.mockResolvedValue("Don't show again");
+      mockGetConfiguration.mockReturnValue({
+        get: vi.fn().mockReturnValue(false),
+      });
+
+      await showPetWarningDialog(ctx);
+
+      expect(mockShowWarningMessage).toHaveBeenCalledWith(
+        expect.stringContaining("PET binary missing"),
+        "Don't show again",
+        "Learn More",
+      );
+      expect(
+        ctx.globalState.update as ReturnType<typeof vi.fn>,
+      ).toHaveBeenCalledWith("ansible.petWarningShown", true);
+    });
+
+    it("should not persist when dismissed without action", async function () {
+      const ctx = makeMockContext();
+      mockShowWarningMessage.mockResolvedValue(undefined);
+
+      await showPetWarningDialog(ctx);
+
+      expect(
+        ctx.globalState.update as ReturnType<typeof vi.fn>,
+      ).not.toHaveBeenCalled();
+    });
+
+    it("should open external link when Learn More is selected", async function () {
+      mockGetConfiguration.mockReturnValue({
+        get: vi.fn().mockReturnValue(false),
+      });
+      mockShowWarningMessage.mockResolvedValue("Learn More");
+
+      const mockOpenExternal = vi.mocked(vscode.env.openExternal);
+      await showPetWarningDialog(makeMockContext());
 
       expect(mockOpenExternal).toHaveBeenCalled();
+    });
+
+    it("should include Disable button when useEnvironmentsExtension is enabled", async function () {
+      const mockConfig = {
+        get: vi.fn().mockReturnValue(true),
+        update: vi.fn().mockResolvedValue(undefined),
+      };
+      mockGetConfiguration.mockReturnValue(mockConfig);
+      mockShowWarningMessage.mockResolvedValue(
+        "Disable Environments Extension",
+      );
+      mockShowInformationMessage.mockResolvedValue(undefined);
+
+      await showPetWarningDialog(makeMockContext());
+
+      expect(mockShowWarningMessage).toHaveBeenCalledWith(
+        expect.stringContaining("Disabling the Environments extension"),
+        "Disable Environments Extension",
+        "Don't show again",
+        "Learn More",
+      );
+      expect(mockConfig.update).toHaveBeenCalledWith(
+        "useEnvironmentsExtension",
+        false,
+        vscode.ConfigurationTarget.Global,
+      );
+    });
+
+    it("should reload window when Reload Now selected after disabling", async function () {
+      const mockConfig = {
+        get: vi.fn().mockReturnValue(true),
+        update: vi.fn().mockResolvedValue(undefined),
+      };
+      mockGetConfiguration.mockReturnValue(mockConfig);
+      mockShowWarningMessage.mockResolvedValue(
+        "Disable Environments Extension",
+      );
+      mockShowInformationMessage.mockResolvedValue("Reload Now");
+
+      await showPetWarningDialog(makeMockContext());
+
+      expect(mockExecuteCommand).toHaveBeenCalledWith(
+        "workbench.action.reloadWindow",
+      );
+    });
+
+    it("should handle undefined context gracefully", async function () {
+      mockGetConfiguration.mockReturnValue({
+        get: vi.fn().mockReturnValue(false),
+      });
+      mockShowWarningMessage.mockResolvedValue("Don't show again");
+
+      await showPetWarningDialog(undefined);
+
+      expect(mockShowWarningMessage).toHaveBeenCalled();
+    });
+  });
+
+  describe("initialize — PET warning globalState persistence", function () {
+    it("should skip warning when globalState already set", async function () {
+      mockGetExtension.mockImplementation((id: string) => {
+        if (id === PYTHON_ENVS_EXTENSION_ID) {
+          return {
+            isActive: true,
+            extensionPath: "/envs/ext/path",
+            exports: makeMockEnvsApi(),
+            activate: vi.fn(),
+          };
+        }
+        if (id === "ms-python.python") {
+          return { isActive: true, activate: vi.fn() };
+        }
+        return undefined;
+      });
+      mockExistsSync.mockReturnValue(false);
+      mockPythonExtApi.mockResolvedValue(makeMockPythonExtApi());
+
+      const ctx = makeMockContext({ "ansible.petWarningShown": true });
+      await service.initialize(ctx);
+
+      expect(mockShowWarningMessage).not.toHaveBeenCalled();
+    });
+
+    it("should still fall back to Python extension even when warning suppressed", async function () {
+      mockGetExtension.mockImplementation((id: string) => {
+        if (id === PYTHON_ENVS_EXTENSION_ID) {
+          return {
+            isActive: true,
+            extensionPath: "/envs/ext/path",
+            exports: makeMockEnvsApi(),
+            activate: vi.fn(),
+          };
+        }
+        if (id === "ms-python.python") {
+          return { isActive: true, activate: vi.fn() };
+        }
+        return undefined;
+      });
+      mockExistsSync.mockReturnValue(false);
+      mockPythonExtApi.mockResolvedValue(makeMockPythonExtApi());
+
+      const ctx = makeMockContext({ "ansible.petWarningShown": true });
+      const result = await service.initialize(ctx);
+
+      expect(result).toBe(true);
+      expect(service.hasFullApi()).toBe(false);
     });
   });
 
@@ -356,6 +634,44 @@ describe("PythonEnvironmentService", function () {
       expect(env).toBeDefined();
       expect(env?.execInfo.run.executable).toBe("/usr/bin/python3");
       expect(env?.version).toBe("3.11.5");
+    });
+
+    it("should return undefined and log when fallback resolveEnvironment throws", async function () {
+      const fallbackApi = makeMockPythonExtApi({
+        resolveEnvironment: vi
+          .fn()
+          .mockRejectedValue(new Error("resolve boom")),
+      });
+
+      mockGetExtension.mockImplementation((id: string) => {
+        if (id === PYTHON_ENVS_EXTENSION_ID) {
+          return {
+            isActive: true,
+            extensionPath: "/ext/path",
+            exports: makeMockEnvsApi(),
+            activate: vi.fn(),
+          };
+        }
+        if (id === "ms-python.python") {
+          return { isActive: true, activate: vi.fn() };
+        }
+        return undefined;
+      });
+      mockExistsSync.mockReturnValue(false);
+      mockShowWarningMessage.mockResolvedValue(undefined);
+      mockPythonExtApi.mockResolvedValue(fallbackApi);
+
+      const consoleErrorSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => undefined);
+
+      await service.initialize();
+      const env = await service.getEnvironment();
+
+      expect(env).toBeUndefined();
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Error getting environment (python ext)"),
+      );
     });
 
     it("should return undefined when fallback resolves to nothing", async function () {
@@ -733,6 +1049,43 @@ describe("PythonEnvironmentService", function () {
       const result = await service.getEnvironments();
 
       expect(result).toEqual([]);
+    });
+
+    it("should return empty array and log when fallback resolveEnvironment throws", async function () {
+      const fallbackApi = makeMockPythonExtApi({
+        known: [{ id: "env-1", path: "/usr/bin/python3" }],
+        resolveEnvironment: vi.fn().mockRejectedValue(new Error("list boom")),
+      });
+
+      mockGetExtension.mockImplementation((id: string) => {
+        if (id === PYTHON_ENVS_EXTENSION_ID) {
+          return {
+            isActive: true,
+            extensionPath: "/ext/path",
+            exports: makeMockEnvsApi(),
+            activate: vi.fn(),
+          };
+        }
+        if (id === "ms-python.python") {
+          return { isActive: true, activate: vi.fn() };
+        }
+        return undefined;
+      });
+      mockExistsSync.mockReturnValue(false);
+      mockShowWarningMessage.mockResolvedValue(undefined);
+      mockPythonExtApi.mockResolvedValue(fallbackApi);
+
+      const consoleErrorSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => undefined);
+
+      await service.initialize();
+      const result = await service.getEnvironments();
+
+      expect(result).toEqual([]);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Error getting environments (python ext)"),
+      );
     });
 
     it("should call API getEnvironments with scope", async function () {


### PR DESCRIPTION
On OpenVSX-based editors (VSCodium, Dev Spaces) the PET binary is absent from the ms-python.vscode-python-envs universal build, so the warning fired on every extension host restart rather than once.

- Pass ExtensionContext into PythonEnvironmentService.initialize() so the service can read/write globalState
- Replace the unconditional once-per-process suppression with an explicit "Don't show again" button that persists the decision to globalState; users who dismiss without clicking continue to see the warning on subsequent restarts until they actively choose to suppress
- Add tests covering the new globalState path (persist on click, no persist on dismiss, suppress when already set)

Fixes #2792

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Pass `ExtensionContext` to `PythonEnvironmentService.initialize()` so PET warning preferences persist in `globalState`.
- Add a “Don’t show again” action. Persist that choice, while allowing dismissed warnings to reappear after extension host restarts.
- Add tests for warning persistence, dismissal behavior, existing preferences, and fallback handling.
- Create `out/log` before e2e build log output.

Fixes: `#2792`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->