### PR TITLE
chore: mark resync inventory todo complete

### DIFF
--- a/.sdlc/todos/complete/add-resync-inventory-command.md
+++ b/.sdlc/todos/complete/add-resync-inventory-command.md
@@ -1,7 +1,8 @@
 ---
 title: Add resync Ansible inventory command
 created: 2026-05-26
-status: pending
+status: done
+completed: 2026-07-28
 priority: low
 scope: extension
 ---
@@ -26,3 +27,5 @@ this as a user-facing command `extension.resync-ansible-inventory`.
 
 Useful when the user modifies inventory files outside the editor or
 changes the active Python environment.
+
+Implemented in #3052 (`ansible.resyncInventory`).


### PR DESCRIPTION
## Summary
- Move `add-resync-inventory-command` todo from `pending/` to `complete/`
- The feature was already implemented in #3052 (`ansible.resyncInventory` command)

## Test plan
- [x] Todo frontmatter updated (`status: done`, `completed: 2026-07-28`)
- [x] No code changes — tracker housekeeping only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Marks the `add-resync-inventory-command` todo as done and moves it to `complete/`.
- Records completion on 2026-07-28 and notes that `ansible.resyncInventory` was implemented in `#3052`.
- Updates documentation only; no code or public entity changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->