### PR TITLE
ci: add on-demand next-branch VSIX workflow

### DIFF
--- a/.github/workflows/nightly-vsix.yml
+++ b/.github/workflows/nightly-vsix.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Stamp nightly version
         run: |
-          stamp=$(date -u +%Y%m%d%H%M)
+          stamp=$(date -u +%Y%m%d%H%M%S)
           pnpm pkg set "version=0.0.1-next.${stamp}"
 
       - name: Package

--- a/.github/workflows/nightly-vsix.yml
+++ b/.github/workflows/nightly-vsix.yml
@@ -1,0 +1,96 @@
+# Package a rolling VSIX from `next` for testers.
+# Manual: Actions → Nightly VSIX → Run workflow (use branch `next`).
+# Nightly cron cannot live here — GitHub only runs schedule from the
+# default branch (`main`). A follow-up on `main` should dispatch this
+# workflow with: gh workflow run nightly-vsix.yml --ref next
+name: Nightly VSIX
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  package:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: next
+
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
+
+      - name: Use Node.js 24
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Stamp nightly version
+        run: |
+          stamp=$(date -u +%Y%m%d%H%M)
+          pnpm pkg set "version=0.0.1-next.${stamp}"
+
+      - name: Package
+        run: pnpm run package
+
+      - name: Rename VSIX
+        run: |
+          set -- ansible-*.vsix
+          if [[ "$#" -ne 1 || ! -f "$1" ]]; then
+            echo "expected exactly one ansible-*.vsix, found: $*"
+            exit 1
+          fi
+          mv "$1" ansible-next.vsix
+          ls -la ansible-next.vsix
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: ansible-next.vsix
+          path: ansible-next.vsix
+          archive: false
+          retention-days: 14
+
+      - name: Publish rolling pre-release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          sha=$(git rev-parse HEAD)
+          stamp=$(date -u +%Y-%m-%dT%H:%MZ)
+          notes="${RUNNER_TEMP}/notes.md"
+          {
+            echo "Nightly VSIX from the \`next\` branch."
+            echo
+            echo "- Commit: ${sha}"
+            echo "- Built: ${stamp}"
+            echo
+            echo "Install this file in VS Code; it is not published to the Marketplace."
+            echo "This asset is overwritten on each run so the download URL stays stable."
+            echo
+            echo "https://github.com/${GITHUB_REPOSITORY}/commits/${sha}"
+          } > "${notes}"
+
+          if gh release view nightly-next >/dev/null 2>&1; then
+            gh release upload nightly-next ansible-next.vsix --clobber
+            gh release edit nightly-next \
+              --prerelease \
+              --latest=false \
+              --notes-file "${notes}"
+          else
+            gh release create nightly-next ansible-next.vsix \
+              --prerelease \
+              --latest=false \
+              --title "Nightly (next)" \
+              --notes-file "${notes}" \
+              --target "${sha}"
+          fi

--- a/.github/workflows/nightly-vsix.yml
+++ b/.github/workflows/nightly-vsix.yml
@@ -1,12 +1,13 @@
 # Package a rolling VSIX from `next` for testers.
 # Manual: Actions → Nightly VSIX → Run workflow (use branch `next`).
 # Nightly cron cannot live here — GitHub only runs schedule from the
-# default branch (`main`). A follow-up on `main` should dispatch this
-# workflow with: gh workflow run nightly-vsix.yml --ref next
+# default branch (`main`). A follow-up on `main` calls this workflow
+# via workflow_call from ansible/vscode-ansible/.github/workflows/nightly-vsix.yml@next.
 name: Nightly VSIX
 
 on:
   workflow_dispatch:
+  workflow_call:
 
 concurrency:
   group: ${{ github.workflow }}

--- a/.github/workflows/nightly-vsix.yml
+++ b/.github/workflows/nightly-vsix.yml
@@ -39,8 +39,13 @@ jobs:
 
       - name: Stamp nightly version
         run: |
-          stamp=$(date -u +%Y%m%d%H%M%S)
-          pnpm pkg set "version=0.0.1-next.${stamp}"
+          built=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          compact=${built//-/}
+          compact=${compact//:/}
+          compact=${compact//T/}
+          compact=${compact%Z}
+          pnpm pkg set "version=0.0.1-next.${compact}"
+          echo "NIGHTLY_BUILT=${built}" >> "$GITHUB_ENV"
 
       - name: Package
         run: pnpm run package
@@ -68,13 +73,12 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           sha=$(git rev-parse HEAD)
-          stamp=$(date -u +%Y-%m-%dT%H:%MZ)
           notes="${RUNNER_TEMP}/notes.md"
           {
             echo "Nightly VSIX from the \`next\` branch."
             echo
             echo "- Commit: ${sha}"
-            echo "- Built: ${stamp}"
+            echo "- Built: ${NIGHTLY_BUILT}"
             echo
             echo "Install this file in VS Code; it is not published to the Marketplace."
             echo "This asset is overwritten on each run so the download URL stays stable."

--- a/.github/workflows/nightly-vsix.yml
+++ b/.github/workflows/nightly-vsix.yml
@@ -23,6 +23,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: next
+          persist-credentials: false
 
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
 
@@ -81,6 +82,9 @@ jobs:
           } > "${notes}"
 
           if gh release view nightly-next >/dev/null 2>&1; then
+            gh api --method PATCH "repos/${GITHUB_REPOSITORY}/git/refs/tags/nightly-next" \
+              -f sha="${sha}" \
+              -F force=true
             gh release upload nightly-next ansible-next.vsix --clobber
             gh release edit nightly-next \
               --prerelease \

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ curl -L -o ansible-next.vsix \
 code --install-extension ansible-next.vsix --force
 ```
 
-This build is not on the Marketplace. To produce one on demand, run **Nightly VSIX** from the Actions tab using branch `next`. A small follow-up workflow on `main` will dispatch that job on a nightly schedule.
+This build is not on the Marketplace. To produce one on demand, run **Nightly VSIX** from the Actions tab using branch `next`. A companion workflow on `main` calls that job on a nightly schedule.
 
 ## Data and Telemetry
 

--- a/README.md
+++ b/README.md
@@ -225,11 +225,11 @@ Stable releases are not wired to this workflow; only pre-releases run the upload
 
 A rolling pre-release tracks the `next` branch. The asset name is stable so the URL does not change:
 
-[ansible-next.vsix](https://github.com/ansible/vscode-ansible/releases/download/nightly-next/ansible-next.vsix)
-
-Install from the Command Palette (**Install from VSIX…**) or:
+Download [ansible-next.vsix](https://github.com/ansible/vscode-ansible/releases/download/nightly-next/ansible-next.vsix), then install it from the Command Palette (**Install from VSIX…**) or:
 
 ```bash
+curl -L -o ansible-next.vsix \
+  https://github.com/ansible/vscode-ansible/releases/download/nightly-next/ansible-next.vsix
 code --install-extension ansible-next.vsix --force
 ```
 

--- a/README.md
+++ b/README.md
@@ -221,6 +221,20 @@ Publishing a **pre-release** on GitHub triggers Actions to build the VSIX and at
 
 Stable releases are not wired to this workflow; only pre-releases run the upload job.
 
+### Nightly next VSIX
+
+A rolling pre-release tracks the `next` branch. The asset name is stable so the URL does not change:
+
+[ansible-next.vsix](https://github.com/ansible/vscode-ansible/releases/download/nightly-next/ansible-next.vsix)
+
+Install from the Command Palette (**Install from VSIX…**) or:
+
+```bash
+code --install-extension ansible-next.vsix --force
+```
+
+This build is not on the Marketplace. To produce one on demand, run **Nightly VSIX** from the Actions tab using branch `next`. A small follow-up workflow on `main` will dispatch that job on a nightly schedule.
+
 ## Data and Telemetry
 
 The Ansible extension collects anonymous [usage data](USAGE_DATA.md) and sends


### PR DESCRIPTION
## Summary
Testers can install a VSIX built from `next` at a URL that stays the same across runs. Maintainers can produce that build from the Actions tab without cutting a tagged pre-release.

The job reuses the same `pnpm run package` path as `next` PR CI, publishes `ansible-next.vsix` to a rolling `nightly-next` pre-release, and stamps `0.0.1-next.YYYYMMDDHHmmss` so the installed extension version is distinguishable.

Nightly schedule lives on `main` in #3121, which calls this workflow via `workflow_call`.

Stable URL after the first successful run: https://github.com/ansible/vscode-ansible/releases/download/nightly-next/ansible-next.vsix

## Quality of life
- No AI-authored ADRs, skills, or templates added in this PR.

## Test plan
- [x] markdownlint, cspell, and actionlint on the changed files
- [ ] After merge, run **Nightly VSIX** from Actions using branch `next` and confirm `ansible-next.vsix` is on the `nightly-next` pre-release

related: #3121

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Add a manually triggered, reusable workflow that packages the `next` branch with `pnpm run package`, stamps one UTC prerelease version, and publishes a rolling `nightly-next` prerelease.
- Retarget the `nightly-next` tag to the packaged commit, replace the VSIX asset, and reuse the build timestamp in release notes.
- Document the stable download URL, installation steps, Marketplace exclusion, and workflow trigger.

Commit message: Retarget `nightly-next` tag to packaged commit SHA and disable persisted checkout credentials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
