### PR TITLE
feat(ls): complete modules in module_defaults

### DIFF
--- a/.sdlc/user-stories.yaml
+++ b/.sdlc/user-stories.yaml
@@ -168,6 +168,20 @@ stories:
       - Requesting completions under a module key returns its options
       - Options come from ansible-doc (real schema, not training data)
 
+  - id: LSP-009
+    title: Auto-completion under module_defaults
+    story: >
+      As an Ansible developer, I want autocomplete for module names and
+      options inside module_defaults, so that I can set module defaults
+      without guessing FQCNs or leaving the editor.
+    prd_refs: [US-3, US-18, AC-8]
+    requires_ai: false
+    jira: AAP-89099
+    criteria:
+      - Completing a key under module_defaults suggests module names
+      - Completing under a module key in module_defaults suggests options
+      - Task and play keyword completion remain unchanged
+
   - id: LSP-005
     title: Hover documentation
     story: >

--- a/packages/language-server/src/providers/completionProvider.ts
+++ b/packages/language-server/src/providers/completionProvider.ts
@@ -26,6 +26,7 @@ import {
     getOrigRange,
     getYamlMapKeys,
     isBlockParam,
+    isModuleDefaultsKey,
     isPlayParam,
     isRoleParam,
     isTaskParam,
@@ -152,6 +153,25 @@ export async function doCompletion(
             completionItems.push(...moduleCompletionItems);
         }
         return completionItems;
+    }
+
+    // Keys under module_defaults are module names (issue #773 / AAP-89099).
+    if (isModuleDefaultsKey(path)) {
+        const cursorAtEnd = atEndOfLine(document, position);
+        const nodeRange = getNodeRange(node, document);
+        const cursorAtFirst = firstElementOfList(document, nodeRange);
+        let textEdit: TextEdit | undefined;
+        if (nodeRange) {
+            textEdit = { range: nodeRange, newText: '' };
+        }
+        return getModuleCompletions(
+            collectionsService,
+            useFqcn,
+            cursorAtEnd,
+            cursorAtFirst,
+            textEdit,
+            document.uri,
+        );
     }
 
     if (isAnsiblePlaybook && isCursorInsideJinjaBrackets(document, position, path)) {

--- a/packages/language-server/src/utils/yaml.ts
+++ b/packages/language-server/src/utils/yaml.ts
@@ -436,7 +436,21 @@ async function resolveModuleName(
 }
 
 /**
+ * Determines whether the cursor is a key under a `module_defaults` map.
+ *
+ * @param path - YAML node ancestry path to test.
+ * @returns True when completing a key whose enclosing map is the value of module_defaults.
+ */
+export function isModuleDefaultsKey(path: Node[]): boolean {
+    return (
+        new AncestryBuilder(path).parentOfKey().parent(YAMLMap).getStringKey() === 'module_defaults'
+    );
+}
+
+/**
  * Returns possible options/suboptions at the current path level.
+ *
+ * Supports both task module parameters and keys nested under `module_defaults`.
  *
  * @param path - YAML node ancestry path at the cursor.
  * @param document - Text document containing the task.
@@ -448,20 +462,52 @@ export async function getPossibleOptionsForPath(
     document: TextDocument,
     collectionsService: CollectionsService,
 ): Promise<Record<string, PluginOption> | null> {
-    const [taskParamPath, suboptionTrace] = getTaskParamPathWithTrace(path);
-    if (taskParamPath.length === 0) return null;
+    // Walk module_defaults first. A task-level `module_defaults` key is also a
+    // task param, so the task walk would stop on that keyword and miss options.
+    const [defaultsParamPath, defaultsTrace] = getModuleDefaultsParamPathWithTrace(path);
+    if (defaultsParamPath.length > 0) {
+        return resolveOptionsFromModulePath(
+            defaultsParamPath,
+            defaultsTrace,
+            document,
+            collectionsService,
+        );
+    }
 
+    const [taskParamPath, taskTrace] = getTaskParamPathWithTrace(path);
+    if (taskParamPath.length > 0) {
+        return resolveOptionsFromModulePath(taskParamPath, taskTrace, document, collectionsService);
+    }
+
+    return null;
+}
+
+/**
+ * Resolves module options from a module-name key path and option-type trace.
+ *
+ * @param moduleParamPath - Path ending at the module name key.
+ * @param suboptionTrace - Dict/list steps walked from the cursor to the module key.
+ * @param document - Text document containing the YAML.
+ * @param collectionsService - Source of cached plugin documentation.
+ * @returns Option map for the current level, or null when the module/options are unavailable.
+ */
+async function resolveOptionsFromModulePath(
+    moduleParamPath: Node[],
+    suboptionTrace: [string, 'list' | 'dict'][],
+    document: TextDocument,
+    collectionsService: CollectionsService,
+): Promise<Record<string, PluginOption> | null> {
     const optionTraceElement = suboptionTrace.pop();
     if (optionTraceElement?.[1] !== 'dict') {
         return null;
     }
 
-    const taskParamNode = taskParamPath[taskParamPath.length - 1];
+    const taskParamNode = moduleParamPath[moduleParamPath.length - 1];
     if (!isScalar(taskParamNode)) return null;
 
     const pluginData =
         taskParamNode.value === 'args'
-            ? await findProvidedModule(taskParamPath, document, collectionsService)
+            ? await findProvidedModule(moduleParamPath, document, collectionsService)
             : await resolveModuleName(taskParamNode.value as string, collectionsService);
 
     if (!pluginData?.doc?.options) return null;
@@ -481,14 +527,18 @@ export async function getPossibleOptionsForPath(
 }
 
 /**
- * Walks upward from a nested option path to the enclosing task and records dict/list steps.
+ * Walks upward from a nested option path until a stop condition matches.
  *
- * @param path - YAML node ancestry path starting inside a task option.
- * @returns Task parameter path and reversed trace of parent option types.
+ * @param path - YAML node ancestry path starting inside nested options.
+ * @param isStop - Returns true when `path` is at the module-name key.
+ * @returns Module parameter path and trace of parent option types.
  */
-function getTaskParamPathWithTrace(path: Node[]): [Node[], [string, 'list' | 'dict'][]] {
+function getParamPathWithTrace(
+    path: Node[],
+    isStop: (candidate: Node[]) => boolean,
+): [Node[], [string, 'list' | 'dict'][]] {
     const trace: [string, 'list' | 'dict'][] = [];
-    while (!isTaskParam(path)) {
+    while (!isStop(path)) {
         let parentKeyPath = new AncestryBuilder(path).parentOfKey().parent(YAMLMap).getKeyPath();
         if (parentKeyPath) {
             const parentKeyNode = parentKeyPath[parentKeyPath.length - 1];
@@ -514,6 +564,26 @@ function getTaskParamPathWithTrace(path: Node[]): [Node[], [string, 'list' | 'di
         return [[], []];
     }
     return [path, trace];
+}
+
+/**
+ * Walks upward from a nested option path to the enclosing task and records dict/list steps.
+ *
+ * @param path - YAML node ancestry path starting inside a task option.
+ * @returns Task parameter path and reversed trace of parent option types.
+ */
+function getTaskParamPathWithTrace(path: Node[]): [Node[], [string, 'list' | 'dict'][]] {
+    return getParamPathWithTrace(path, isTaskParam);
+}
+
+/**
+ * Walks upward from a nested option path to the module key under `module_defaults`.
+ *
+ * @param path - YAML node ancestry path starting inside a module_defaults option.
+ * @returns Module key path and reversed trace of parent option types.
+ */
+function getModuleDefaultsParamPathWithTrace(path: Node[]): [Node[], [string, 'list' | 'dict'][]] {
+    return getParamPathWithTrace(path, isModuleDefaultsKey);
 }
 
 /**

--- a/packages/language-server/test/providers/completionProvider.test.ts
+++ b/packages/language-server/test/providers/completionProvider.test.ts
@@ -196,6 +196,83 @@ describe('doCompletion', () => {
         expect(labels).toContain('dest');
     });
 
+    it('offers module names as keys under module_defaults', async () => {
+        const content = ['- hosts: all', '  module_defaults:', '    '].join('\n');
+        const d = doc(content);
+        const svc = mockCollectionsService(
+            {},
+            new Map([
+                [
+                    'ansible.builtin',
+                    {
+                        pluginTypes: new Map([['module', [{ fullName: 'ansible.builtin.copy' }]]]),
+                    },
+                ],
+            ]),
+        );
+        CollectionsServiceMock._setMockInstance(svc);
+        const ctx = mockContext();
+
+        const items = await doCompletion(d, { line: 2, character: 4 }, ctx as never);
+        expect(items.map((i) => i.label)).toContain('ansible.builtin.copy');
+    });
+
+    it('offers module options under a module_defaults module key', async () => {
+        const content = [
+            '- hosts: all',
+            '  module_defaults:',
+            '    ansible.builtin.copy:',
+            '      ',
+        ].join('\n');
+        const d = doc(content);
+        const pluginData = {
+            doc: {
+                module: 'copy',
+                options: {
+                    src: { type: 'str', required: true, description: ['Source'] },
+                    dest: { type: 'str', required: true, description: ['Dest'] },
+                },
+            },
+        };
+        const svc = mockCollectionsService({ 'ansible.builtin.copy': pluginData });
+        CollectionsServiceMock._setMockInstance(svc);
+        const ctx = mockContext();
+
+        const items = await doCompletion(d, { line: 3, character: 6 }, ctx as never);
+        const labels = items.map((i) => i.label);
+        expect(labels).toContain('src');
+        expect(labels).toContain('dest');
+    });
+
+    it('offers module options under task-level module_defaults', async () => {
+        const content = [
+            '- hosts: all',
+            '  tasks:',
+            '    - name: example',
+            '      module_defaults:',
+            '        ansible.builtin.copy:',
+            '          ',
+        ].join('\n');
+        const d = doc(content);
+        const pluginData = {
+            doc: {
+                module: 'copy',
+                options: {
+                    src: { type: 'str', required: true, description: ['Source'] },
+                    dest: { type: 'str', required: true, description: ['Dest'] },
+                },
+            },
+        };
+        const svc = mockCollectionsService({ 'ansible.builtin.copy': pluginData });
+        CollectionsServiceMock._setMockInstance(svc);
+        const ctx = mockContext();
+
+        const items = await doCompletion(d, { line: 5, character: 10 }, ctx as never);
+        const labels = items.map((i) => i.label);
+        expect(labels).toContain('src');
+        expect(labels).toContain('dest');
+    });
+
     it('filters already-provided keywords', async () => {
         const content = '- hosts: all\n  gather_facts: true\n  ';
         const d = doc(content);

--- a/packages/language-server/test/utils/yaml.test.ts
+++ b/packages/language-server/test/utils/yaml.test.ts
@@ -5,6 +5,7 @@ import {
     AncestryBuilder,
     getPathAt,
     isTaskParam,
+    isModuleDefaultsKey,
     isPlayParam,
     isBlockParam,
     isRoleParam,
@@ -185,6 +186,45 @@ describe('isTaskParam', () => {
             if (isPlay === false || isPlay === undefined) {
                 expect(isTaskParam(path)).toBe(true);
             }
+        }
+    });
+});
+
+describe('isModuleDefaultsKey', () => {
+    it('returns true for a key under play-level module_defaults', () => {
+        const content = ['- hosts: all', '  module_defaults:', '    _:'].join('\n');
+        const d = doc(content);
+        const docs = parseAllDocuments(content);
+        const path = getPathAt(d, { line: 2, character: 4 }, docs, true);
+        expect(path).not.toBeNull();
+        if (path) {
+            expect(isModuleDefaultsKey(path)).toBe(true);
+        }
+    });
+
+    it('returns false for a key under a module inside module_defaults', () => {
+        const content = [
+            '- hosts: all',
+            '  module_defaults:',
+            '    ansible.builtin.copy:',
+            '      _:',
+        ].join('\n');
+        const d = doc(content);
+        const docs = parseAllDocuments(content);
+        const path = getPathAt(d, { line: 3, character: 6 }, docs, true);
+        expect(path).not.toBeNull();
+        if (path) {
+            expect(isModuleDefaultsKey(path)).toBe(false);
+        }
+    });
+
+    it('returns false for a normal task key', () => {
+        const content = '- hosts: all\n  tasks:\n    - name: test';
+        const d = doc(content);
+        const docs = parseAllDocuments(content);
+        const path = getPathAt(d, { line: 2, character: 6 }, docs, true);
+        if (path) {
+            expect(isModuleDefaultsKey(path)).toBe(false);
         }
     });
 });

--- a/test/ui/fixtures/completion-test.ansible.yml
+++ b/test/ui/fixtures/completion-test.ansible.yml
@@ -2,6 +2,11 @@
 - name: Completion test playbook
   hosts: localhost
   gather_facts: false
+  module_defaults:
+    ans:
+    ansible.builtin.debug:
+      verbosity: 0
+      m:
   tasks:
     - name: Test debug options
       ansible.builtin.debug:

--- a/test/ui/languageServerFullStack.spec.ts
+++ b/test/ui/languageServerFullStack.spec.ts
@@ -31,6 +31,7 @@ function shell(cmd: string, opts: Record<string, unknown> = {}): string {
  * @covers COL-007
  * @covers LSP-003
  * @covers LSP-004
+ * @covers LSP-009
  */
 describe('Language Server full stack e2e', function () {
     before(function () {
@@ -109,7 +110,7 @@ describe('Language Server full stack e2e', function () {
         const fixtureUri = path.resolve(FIXTURES_DIR, COMPLETION_PLAYBOOK);
 
         // Open the playbook and request completions at a task-level position.
-        // Line 10 (0-indexed) is "    - " — a new task entry where task
+        // Line 15 (0-indexed) is "    - " — a new task entry where task
         // keywords (name, become, register, …) and module names are valid.
         const labels: string[] = await browser.executeWorkbench(
             async (vscode: typeof VsCode, uri: string) => {
@@ -119,7 +120,7 @@ describe('Language Server full stack e2e', function () {
                 // Wait for the LS to be ready
                 await new Promise((r) => setTimeout(r, 3000));
 
-                const pos = new vscode.Position(10, 6);
+                const pos = new vscode.Position(15, 6);
                 const result: { items?: { label: string | { label: string } }[] } | undefined =
                     await vscode.commands.executeCommand(
                         'vscode.executeCompletionItemProvider',
@@ -150,11 +151,9 @@ describe('Language Server full stack e2e', function () {
 
         const fixtureUri = path.resolve(FIXTURES_DIR, COMPLETION_PLAYBOOK);
 
-        // Line 7 (0-indexed) is '        msg: "hello"' — this is under the
-        // ansible.builtin.debug module. Requesting completions at line 7,
-        // column 8 should trigger the LS to call ansible-doc for module
-        // options.  If ansible-doc is reachable, we'll get options like
-        // "msg", "var", "verbosity".
+        // Line 12 (0-indexed) is '        msg: "hello"' — under
+        // ansible.builtin.debug in tasks. Requesting completions at line 12,
+        // column 8 should return module options such as msg/var/verbosity.
         const labels: string[] = await browser.executeWorkbench(
             async (vscode: typeof VsCode, uri: string) => {
                 const doc = await vscode.workspace.openTextDocument(vscode.Uri.file(uri));
@@ -162,7 +161,76 @@ describe('Language Server full stack e2e', function () {
 
                 await new Promise((r) => setTimeout(r, 5000));
 
-                const pos = new vscode.Position(7, 8);
+                const pos = new vscode.Position(12, 8);
+                const result: { items?: { label: string | { label: string } }[] } | undefined =
+                    await vscode.commands.executeCommand(
+                        'vscode.executeCompletionItemProvider',
+                        doc.uri,
+                        pos,
+                    );
+
+                if (!result?.items) return [];
+                return result.items.map((i) =>
+                    typeof i.label === 'string' ? i.label : i.label.label,
+                );
+            },
+            fixtureUri,
+        );
+
+        const debugOptions = ['msg', 'var', 'verbosity'];
+        const foundOptions = debugOptions.filter((opt) => labels.includes(opt));
+        expect(foundOptions.length).toBeGreaterThan(0);
+    });
+
+    it('should return module name completions under module_defaults', async function () {
+        this.timeout(60_000);
+
+        const fixtureUri = path.resolve(FIXTURES_DIR, COMPLETION_PLAYBOOK);
+
+        // Line 5 is partial module token "ans" under module_defaults.
+        const labels: string[] = await browser.executeWorkbench(
+            async (vscode: typeof VsCode, uri: string) => {
+                const doc = await vscode.workspace.openTextDocument(vscode.Uri.file(uri));
+                await vscode.window.showTextDocument(doc);
+
+                await new Promise((r) => setTimeout(r, 5000));
+
+                const pos = new vscode.Position(5, 7);
+                const result: { items?: { label: string | { label: string } }[] } | undefined =
+                    await vscode.commands.executeCommand(
+                        'vscode.executeCompletionItemProvider',
+                        doc.uri,
+                        pos,
+                    );
+
+                if (!result?.items) return [];
+                return result.items.map((i) =>
+                    typeof i.label === 'string' ? i.label : i.label.label,
+                );
+            },
+            fixtureUri,
+        );
+
+        const hasModule = labels.some(
+            (l) => l === 'ansible.builtin.debug' || l === 'debug' || l.startsWith('ansible.'),
+        );
+        expect(hasModule).toBe(true);
+    });
+
+    it('should return module options under module_defaults', async function () {
+        this.timeout(60_000);
+
+        const fixtureUri = path.resolve(FIXTURES_DIR, COMPLETION_PLAYBOOK);
+
+        // Line 8 is partial option token "m" under module_defaults → debug.
+        const labels: string[] = await browser.executeWorkbench(
+            async (vscode: typeof VsCode, uri: string) => {
+                const doc = await vscode.workspace.openTextDocument(vscode.Uri.file(uri));
+                await vscode.window.showTextDocument(doc);
+
+                await new Promise((r) => setTimeout(r, 5000));
+
+                const pos = new vscode.Position(8, 7);
                 const result: { items?: { label: string | { label: string } }[] } | undefined =
                     await vscode.commands.executeCommand(
                         'vscode.executeCompletionItemProvider',


### PR DESCRIPTION
## Summary
- Add language-server completion for **module names and options** under `module_defaults` so playbooks can set defaults without a dedicated command.
- Reuses existing CollectionsService module/option completion (no new palette command).

## Changes
- Detect `module_defaults` keys in YAML ancestry (`isModuleDefaultsKey`)
- Offer the same module list used for tasks when completing those keys
- Resolve options under a `module_defaults` module key (play- and task-level); walk `module_defaults` before task params so a task-level `module_defaults` keyword is not treated as a module name
- Unit tests for keys, play-level options, and task-level options
- WDIO coverage in `languageServerFullStack.spec.ts` (`@covers LSP-009`) plus fixture keys
- User story **LSP-009** in `.sdlc/user-stories.yaml`

## Quality of life
- AI-authored: LSP-009 user story text and this PR description

## Test plan
- [x] `pnpm run ci` passes (compile + lint + test:coverage + build)
- [x] Unit tests: module names under `module_defaults`, options under play- and task-level `module_defaults`
- [ ] `pnpm run test:ui -- --spec test/ui/languageServerFullStack.spec.ts` (local WDIO failed to create a Chrome/VS Code session; confirm on CI)
- [ ] Manual: open a playbook, complete a key under `module_defaults:`, then complete options under e.g. `ansible.builtin.copy:`

## Out of scope
- `group/<module>` keys
- `module_defaults` as a list of maps
- Legacy ALS on `main`

related: AAP-89099
Fixes #773

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Adds module and option autocompletion under `module_defaults`.
- Detects `module_defaults` YAML keys and resolves options at play and task levels.
- Reuses `CollectionsService` completion logic and shared YAML path traversal.
- Adds unit, full-stack, and `LSP-009` coverage.
- Commit message: Reuse existing module and option completion for `module_defaults`.

Related: `#773`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->