### PR TITLE
ci: fix publish jobs skipped on release after uv-lock gate

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -733,6 +733,7 @@ jobs:
     # See https://github.com/actions/runner/issues/2205
     if: >
       always() &&
+      !cancelled() &&
       needs.check.result == 'success' &&
       (github.ref_type == 'tag' ||
       (github.event_name == 'release' && github.event.action == 'published') ||
@@ -792,6 +793,7 @@ jobs:
     environment: release
     if: >
       always() &&
+      !cancelled() &&
       needs.check.result == 'success' &&
       needs.build.result == 'success' &&
       needs.build.outputs.can_release_to_npm == 'true' &&

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -728,13 +728,15 @@ jobs:
           slack_webhook_url: ${{ secrets.DEVTOOLS_CI_SLACK_URL }}
 
   publish:
-    # be warned that job will skip if any other job from same workflow is
-    # skipped due to implicit `success() &&` condition GHA is injecting.
-    # Be sure build-image runs too.
+    # always() is required: uv-lock-downgrade is skipped on release/tag runs but
+    # listed in check.needs, which otherwise prevents publish from running.
+    # See https://github.com/actions/runner/issues/2205
     if: >
-      github.ref_type == 'tag' ||
+      always() &&
+      needs.check.result == 'success' &&
+      (github.ref_type == 'tag' ||
       (github.event_name == 'release' && github.event.action == 'published') ||
-      github.event.inputs.publish == 'true'
+      github.event.inputs.publish == 'true')
     runs-on: ubuntu-latest
     environment: release
     needs:
@@ -788,7 +790,15 @@ jobs:
 
   publish-npm:
     environment: release
-    if: needs.build.outputs.can_release_to_npm == 'true' && (github.ref_type == 'tag' || (github.event_name == 'release' && github.event.action == 'published') || github.event.inputs.publish == 'true' || github.event.inputs.publish == true)
+    if: >
+      always() &&
+      needs.check.result == 'success' &&
+      needs.build.result == 'success' &&
+      needs.build.outputs.can_release_to_npm == 'true' &&
+      (github.ref_type == 'tag' ||
+      (github.event_name == 'release' && github.event.action == 'published') ||
+      github.event.inputs.publish == 'true' ||
+      github.event.inputs.publish == true)
     runs-on: ubuntu-latest
     needs:
       - build


### PR DESCRIPTION
## Summary

Release CI for v26.8.0 built the VSIX and passed `check`, but `publish` and `publish-npm` stayed skipped even after re-running all jobs.

The `uv.lock downgrade gate` job only runs on pull requests and merge groups. On release/tag workflows it is always skipped, but it is listed in `check.needs`. Without `always()` on the publish jobs, GitHub Actions skips them when any job in the workflow was skipped (see [actions/runner#2205](https://github.com/actions/runner/issues/2205)).

This regressed when the uv-lock gate was added in #3075. v26.6.0 (June) published successfully because that job did not exist yet.

## Test plan

- [ ] Merge this PR
- [ ] Re-run release CI for v26.8.0 (or dispatch `ci` with `publish: true` on the `v26.8.0` tag) and confirm `publish` runs after `check` succeeds
- [ ] Verify marketplace shows 26.8.0 after publish completes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Fix release publishing jobs skipped when the `uv.lock downgrade gate` is skipped.
- Add `always()` and `!cancelled()` guards to run publishing after successful `check` without publishing cancelled workflows.
- Require successful `check` and `build` before npm publishing.
- Restore publishing for release, tag, and manual workflows.

Original commit message: Add `!cancelled()` alongside `always()` so marketplace publishing does not run after a release workflow is cancelled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->