### PR TITLE
fix: include all ALS dist chunks in packaged VSIX

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -22,7 +22,7 @@
 !dist/extension/**/*
 !dist/assets/**/*
 !dist/webviews/**/*
-!packages/ansible-language-server/dist/cli.cjs
+!packages/ansible-language-server/dist/**/*
 !packages/ansible-mcp-server/dist/**/*
 !packages/ansible-mcp-server/package.json
 !package.json


### PR DESCRIPTION
## Summary

26.8.1 ships only `packages/ansible-language-server/dist/cli.cjs` in the VSIX. After the tsup to tsdown migration (#2901), the production ALS build is split into multiple chunks (`rolldown-runtime-*.cjs`, `server.cjs`, etc.). `.vscodeignore` still whitelisted only `cli.cjs`, so the language server crashes on startup with exit code 1 and the Ansible panel fails to load.

This aligns ALS packaging with MCP, which already uses `!packages/ansible-mcp-server/dist/**/*` (#2766).

## Test plan

- [ ] `task package`
- [ ] `unzip -l out/ansible-*.vsix | grep ansible-language-server/dist` shows multiple files (not just `cli.cjs`)
- [ ] `node <extracted>/packages/ansible-language-server/dist/cli.cjs --node-ipc` stays running
- [ ] Install VSIX in VS Code, open an Ansible file, confirm Output > Ansible Server has no crash and the Ansible panel loads

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Update `.vscodeignore` to include all files under `packages/ansible-language-server/dist/`.
- This packages the multiple chunks generated by the tsdown build and prevents language server startup failures.
- The change follows the existing MCP packaging pattern.

Original commit message: Update ALS packaging allowlist

<!-- end of auto-generated comment: release notes by coderabbit.ai -->