### PR TITLE
fix: point MCP Learn More links to docs.ansible.com (AAP-73918)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -375,8 +375,8 @@ The extension includes an MCP server that enables AI assistants and LLM-powered 
 
 ### Learn More
 
-- **[MCP Server Overview](mcp/README.md)** - Features, architecture, and getting started guide
-- **[API Reference](mcp/api.md)** - Complete technical API documentation for all tools and resources
+- **[MCP Server Overview](https://docs.ansible.com/projects/vscode-ansible/mcp/)** - Features, architecture, and getting started guide
+- **[API Reference](https://docs.ansible.com/projects/vscode-ansible/mcp/api/)** - Complete technical API documentation for all tools and resources
 
 ## Contact
 


### PR DESCRIPTION
## Summary
- Fix broken MCP "Learn More" links on the VS Code marketplace details page
- Replace relative `mcp/README.md` and `mcp/api.md` paths with published docs.ansible.com URLs
- Matches how other links in `docs/README.md` already point to the docs site (e.g. Contact)

## Context
Fixes [AAP-73918](https://redhat.atlassian.net/browse/AAP-73918). Relative markdown links were resolving to non-existent GitHub URLs (`.../mcp/README.md`) on the marketplace.

## Test plan
- [ ] Open `docs/README.md` and confirm both MCP links resolve to docs.ansible.com
- [ ] Verify https://docs.ansible.com/projects/vscode-ansible/mcp/ loads
- [ ] Verify https://docs.ansible.com/projects/vscode-ansible/mcp/api/ loads

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Updated the MCP “Learn More” links in `docs/README.md` to use published `docs.ansible.com` URLs.
- Fixed broken links on the VS Code Marketplace details page by replacing relative paths with absolute documentation links.
- Addresses AAP-73918.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->