### PR TITLE
fix(deps): minimatch override for brace-expansion v5 on renovate branch

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,8 @@ overrides:
   brace-expansion@1: '>=5.0.8 <6.0.0'
   brace-expansion@2: '>=5.0.9 <6.0.0'
   brace-expansion@5: '>=5.0.8 <6.0.0'
+  minimatch@5: '>=10.2.6 <11'
+  minimatch@9: '>=10.2.6 <11'
   fast-uri@3: <5.0.0
   fast-xml-parser: '>=5.10.1 <6.0.0'
   fastify: '>=5.8.3 <6.0.0'
@@ -5270,16 +5272,12 @@ packages:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
 
+  minimatch@10.2.6:
+    resolution: {integrity: sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==}
+    engines: {node: 18 || 20 || >=22}
+
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
-
-  minimatch@5.1.9:
-    resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
-    engines: {node: '>=10'}
-
-  minimatch@9.0.9:
-    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
-    engines: {node: '>=16 || 14 >=14.17'}
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
@@ -10398,7 +10396,7 @@ snapshots:
     dependencies:
       '@one-ini/wasm': 0.1.1
       commander: 10.0.1
-      minimatch: 9.0.9
+      minimatch: 10.2.6
       semver: 7.8.5
 
   ee-first@1.1.1: {}
@@ -11047,7 +11045,7 @@ snapshots:
 
   filelist@1.0.6:
     dependencies:
-      minimatch: 5.1.9
+      minimatch: 10.2.6
 
   filename-reserved-regex@3.0.0: {}
 
@@ -11281,7 +11279,7 @@ snapshots:
     dependencies:
       foreground-child: 3.3.1
       jackspeak: 3.4.3
-      minimatch: 9.0.9
+      minimatch: 10.2.6
       minipass: 7.1.3
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
@@ -11297,7 +11295,7 @@ snapshots:
       fs.realpath: 1.0.0
       inflight: 1.0.6
       inherits: 2.0.4
-      minimatch: 5.1.9
+      minimatch: 10.2.6
       once: 1.4.0
 
   global-directory@5.0.0:
@@ -12432,15 +12430,11 @@ snapshots:
     dependencies:
       brace-expansion: 5.0.9
 
+  minimatch@10.2.6:
+    dependencies:
+      brace-expansion: 5.0.9
+
   minimatch@3.1.5:
-    dependencies:
-      brace-expansion: 5.0.9
-
-  minimatch@5.1.9:
-    dependencies:
-      brace-expansion: 5.0.9
-
-  minimatch@9.0.9:
     dependencies:
       brace-expansion: 5.0.9
 
@@ -12491,7 +12485,7 @@ snapshots:
       he: 1.2.0
       js-yaml: 4.3.0
       log-symbols: 4.1.0
-      minimatch: 5.1.9
+      minimatch: 10.2.6
       ms: 2.1.3
       serialize-javascript: 7.0.7
       strip-json-comments: 3.1.1
@@ -12514,7 +12508,7 @@ snapshots:
       is-path-inside: 3.0.3
       js-yaml: 4.3.0
       log-symbols: 4.1.0
-      minimatch: 9.0.9
+      minimatch: 10.2.6
       ms: 2.1.3
       picocolors: 1.1.1
       serialize-javascript: 7.0.7
@@ -13162,7 +13156,7 @@ snapshots:
 
   readdir-glob@1.1.3:
     dependencies:
-      minimatch: 5.1.9
+      minimatch: 10.2.6
 
   readdirp@3.6.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -27,6 +27,9 @@ overrides:
   "brace-expansion@1": ">=5.0.8 <6.0.0"
   "brace-expansion@2": ">=5.0.9 <6.0.0"
   "brace-expansion@5": ">=5.0.8 <6.0.0"
+  # minimatch@5/@9 default-import brace-expansion; v5 is named export only
+  "minimatch@5": ">=10.2.6 <11"
+  "minimatch@9": ">=10.2.6 <11"
   "fast-uri@3": "<5.0.0"
   "fast-xml-parser": ">=5.10.1 <6.0.0"
   "fastify": ">=5.8.3 <6.0.0"


### PR DESCRIPTION
## Summary

Follow-up fix for [PR #3128](https://github.com/ansible/vscode-ansible/pull/3128).

macOS wdio e2e fails because `minimatch@5/@9` default-import `brace-expansion`, but v5 only exports named `expand`. Override those minimatch ranges to `10.2.6`.

## Test plan

- [x] CI green on #3128 after merge