### PR TITLE
fix(deps): cspell dictionary for minimatch override

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -87,6 +87,7 @@ lineinfile
 linkify
 llmprovider
 microdnf
+minimatch
 myorg
 noconfirm
 npmjs


### PR DESCRIPTION
## Summary

Follow-up for [#3128](https://github.com/ansible/vscode-ansible/pull/3128).

Linux CI `task lint` failed because cspell flagged `minimatch` in `pnpm-workspace.yaml` (override keys and comment from #3142).

## Test plan

- [ ] Linux lint passes on #3128 after merge